### PR TITLE
Project: Do not use a sorted set for `scopeDependencies` / `scopeNames`

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -332,7 +332,7 @@ abstract class PackageManager(
                         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                         vcsProcessed = processProjectVcs(definitionFile.parentFile),
                         scopeDependencies = null,
-                        scopeNames = sortedSetOf()
+                        scopeNames = emptySet()
                     )
 
                     val issues = listOf(

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -185,7 +185,7 @@ class GoDep(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = projectVcs,
                     homepageUrl = "",
-                    scopeDependencies = sortedSetOf(scope)
+                    scopeDependencies = setOf(scope)
                 ),
                 packages = packages
             )

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -124,7 +124,7 @@ class GoMod(
                 graph.nodes.filterTo(mutableSetOf()) { it.name in moduleNames }
             }
 
-            val scopes = sortedSetOf(
+            val scopes = setOf(
                 Scope(
                     name = "main",
                     dependencies = graph.subgraph(dependenciesScopePackageIds).toPackageReferenceForest(projectId)

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -74,12 +74,12 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
     private val project1 = Project.EMPTY.copy(
         id = Identifier("type-1", "namespace-1", "project-1", "version-1"),
-        scopeDependencies = sortedSetOf(scope1),
+        scopeDependencies = setOf(scope1),
         definitionFilePath = "project1"
     )
     private val project2 = Project.EMPTY.copy(
         id = Identifier("type-2", "namespace-2", "project-2", "version-2"),
-        scopeDependencies = sortedSetOf(scope1, scope2)
+        scopeDependencies = setOf(scope1, scope2)
     )
     private val project3 = Project.EMPTY.copy(
         id = Identifier("type-1", "namespace-3", "project-1.2", "version-1"),
@@ -350,7 +350,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
                 val project = Project.EMPTY.copy(
                     id = Identifier("type", "namespace", "project", "version"),
-                    scopeDependencies = sortedSetOf(scope),
+                    scopeDependencies = setOf(scope),
                     definitionFilePath = "project"
                 )
 

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -83,7 +83,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
     )
     private val project3 = Project.EMPTY.copy(
         id = Identifier("type-1", "namespace-3", "project-1.2", "version-1"),
-        scopeNames = sortedSetOf("scope-2"),
+        scopeNames = setOf("scope-2"),
         scopeDependencies = null
     )
 
@@ -137,8 +137,8 @@ class AnalyzerResultBuilderTest : WordSpec() {
             }
 
             "be serialized and deserialized correctly with a dependency graph" {
-                val p1 = project1.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope1"))
-                val p2 = project2.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope3"))
+                val p1 = project1.copy(scopeDependencies = null, scopeNames = setOf("scope1"))
+                val p2 = project2.copy(scopeDependencies = null, scopeNames = setOf("scope3"))
                 val result = AnalyzerResult(
                     projects = setOf(p1, p2, project3),
                     packages = emptySet(),
@@ -154,8 +154,8 @@ class AnalyzerResultBuilderTest : WordSpec() {
             }
 
             "not change its representation when serialized again" {
-                val p1 = project1.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope1"))
-                val p2 = project2.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope3"))
+                val p1 = project1.copy(scopeDependencies = null, scopeNames = setOf("scope1"))
+                val p2 = project2.copy(scopeDependencies = null, scopeNames = setOf("scope3"))
                 val result = AnalyzerResult(
                     projects = setOf(p1, p2, project3),
                     packages = emptySet(),
@@ -188,8 +188,8 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
             "be serialized and deserialized correctly with an empty dependency graph" {
                 val emptyGraph = DependencyGraph(packages = emptyList(), scopes = emptyMap())
-                val p1 = project1.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope1"))
-                val p2 = project2.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope3"))
+                val p1 = project1.copy(scopeDependencies = null, scopeNames = setOf("scope1"))
+                val p2 = project2.copy(scopeDependencies = null, scopeNames = setOf("scope3"))
                 val result = AnalyzerResult(
                     projects = setOf(p1, p2, project3),
                     packages = emptySet(),
@@ -234,8 +234,8 @@ class AnalyzerResultBuilderTest : WordSpec() {
             }
 
             "resolve the dependency information in affected projects" {
-                val p1 = project1.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope-1"))
-                val p2 = project2.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope-3"))
+                val p1 = project1.copy(scopeDependencies = null, scopeNames = setOf("scope-1"))
+                val p2 = project2.copy(scopeDependencies = null, scopeNames = setOf("scope-3"))
                 val analyzerResult = AnalyzerResultBuilder()
                     .addResult(ProjectAnalyzerResult(p1, emptySet()))
                     .addDependencyGraph(p1.id.type, graph1)

--- a/analyzer/src/testFixtures/kotlin/Extensions.kt
+++ b/analyzer/src/testFixtures/kotlin/Extensions.kt
@@ -116,7 +116,7 @@ fun Collection<PackageReference>.withInvariantIssues(): SortedSet<PackageReferen
 
 fun ProjectAnalyzerResult.withInvariantIssues() = copy(
     project = project.copy(
-        scopeDependencies = project.scopeDependencies?.mapTo(sortedSetOf()) { scope ->
+        scopeDependencies = project.scopeDependencies?.mapTo(mutableSetOf()) { scope ->
             scope.copy(dependencies = scope.dependencies.withInvariantIssues())
         }
     ),

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -145,7 +145,7 @@ val scopeExcluded = Scope(
 val projectExcluded = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-excluded:1.0"),
     definitionFilePath = "excluded/pom.xml",
-    scopeDependencies = sortedSetOf(scopeExcluded)
+    scopeDependencies = setOf(scopeExcluded)
 )
 
 val packageRefDynamicallyLinked = packageDynamicallyLinked.toReference(PackageLinkage.DYNAMIC)
@@ -168,7 +168,7 @@ val scopeIncluded = Scope(
 val projectIncluded = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
-    scopeDependencies = sortedSetOf(scopeIncluded)
+    scopeDependencies = setOf(scopeIncluded)
 )
 
 val allProjects = setOf(

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -154,22 +154,22 @@ data class DependencyGraph(
      * Transform the data stored in this object to the classical layout of dependency information, which is a set of
      * [Scope]s referencing the packages they depend on.
      */
-    fun createScopes(): SortedSet<Scope> = createScopesFor(scopes, unqualify = true)
+    fun createScopes(): Set<Scope> = createScopesFor(scopes, unqualify = true)
 
     /**
      * Transform a subset of the data stored in this object to the classical layout of dependency information. This is
      * analogous to [createScopes], but only the provided [scopeNames] are taken into account. If [unqualify] is
      * *true*, remove qualifiers from scope names before constructing the [Scope]s.
      */
-    fun createScopes(scopeNames: Set<String>, unqualify: Boolean = true): SortedSet<Scope> =
+    fun createScopes(scopeNames: Set<String>, unqualify: Boolean = true): Set<Scope> =
         createScopesFor(scopes.filterKeys { it in scopeNames }, unqualify)
 
     /**
      * Convert the given [map] with scope information to a set of [Scope]s. [Optionally][unqualify] remove qualifiers
      * from scope names.
      */
-    private fun createScopesFor(map: Map<String, List<RootDependencyIndex>>, unqualify: Boolean): SortedSet<Scope> =
-        map.mapTo(sortedSetOf()) { entry ->
+    private fun createScopesFor(map: Map<String, List<RootDependencyIndex>>, unqualify: Boolean): Set<Scope> =
+        map.mapTo(mutableSetOf()) { entry ->
             val dependencies = entry.value.mapTo(sortedSetOf()) { index ->
                 referenceMapping[index.toKey()] ?: error("Could not resolve dependency index $index.")
             }

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
-import java.util.SortedSet
-
 import org.ossreviewtoolkit.model.utils.ScopeSortedSetConverter
 import org.ossreviewtoolkit.utils.common.StringSortedSetConverter
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -108,7 +106,7 @@ data class Project(
      * graph.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val scopeNames: SortedSet<String>? = null
+    val scopeNames: Set<String>? = null
 ) {
     companion object {
         /**

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -138,7 +138,7 @@ data class Project(
      * matter whether this information has been initialized directly or has been encoded in a [DependencyGraph].
      */
     @get:JsonIgnore
-    val scopes by lazy { scopeDependencies.orEmpty() }
+    val scopes: Set<Scope> by lazy { scopeDependencies.orEmpty() }
 
     /**
      * Return a [Project] instance that has its scope information directly available, resolved from the given [graph].

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 import java.util.SortedSet
 
+import org.ossreviewtoolkit.model.utils.ScopeSortedSetConverter
 import org.ossreviewtoolkit.utils.common.StringSortedSetConverter
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
@@ -98,7 +99,8 @@ data class Project(
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("scopes")
-    val scopeDependencies: SortedSet<Scope>? = null,
+    @JsonSerialize(converter = ScopeSortedSetConverter::class)
+    val scopeDependencies: Set<Scope>? = null,
 
     /**
      * Contains dependency information as a set of scope names in case a shared [DependencyGraph] is used. The scopes
@@ -122,7 +124,7 @@ data class Project(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = VcsInfo.EMPTY,
             homepageUrl = "",
-            scopeDependencies = sortedSetOf()
+            scopeDependencies = emptySet()
         )
     }
 
@@ -138,7 +140,7 @@ data class Project(
      * matter whether this information has been initialized directly or has been encoded in a [DependencyGraph].
      */
     @get:JsonIgnore
-    val scopes by lazy { scopeDependencies ?: sortedSetOf() }
+    val scopes by lazy { scopeDependencies.orEmpty() }
 
     /**
      * Return a [Project] instance that has its scope information directly available, resolved from the given [graph].

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.model.utils
 
 import java.util.LinkedList
-import java.util.SortedSet
 
 import org.apache.logging.log4j.kotlin.Logging
 
@@ -219,10 +218,11 @@ class DependencyGraphBuilder<D>(
      * Return a set of all the scope names known to this builder that start with the given [prefix]. If [unqualify] is
      * *true*, remove this prefix from the returned scope names.
      */
-    fun scopesFor(prefix: String, unqualify: Boolean = true): SortedSet<String> {
-        val qualifiedScopes = scopeMapping.keys.filter { it.startsWith(prefix) }
-        val scopes = qualifiedScopes.takeUnless { unqualify } ?: qualifiedScopes.map { it.substring(prefix.length) }
-        return scopes.toSortedSet()
+    fun scopesFor(prefix: String, unqualify: Boolean = true): Set<String> {
+        val qualifiedScopes = scopeMapping.keys.filterTo(mutableSetOf()) { it.startsWith(prefix) }
+
+        return qualifiedScopes.takeUnless { unqualify }
+            ?: qualifiedScopes.mapTo(mutableSetOf()) { it.substring(prefix.length) }
     }
 
     /**
@@ -231,7 +231,7 @@ class DependencyGraphBuilder<D>(
      * shared between multiple projects, scope names are given a project-specific prefix to make them unique. Using
      * this function, the scope names of a specific project can be retrieved.
      */
-    fun scopesFor(projectId: Identifier, unqualify: Boolean = true): SortedSet<String> =
+    fun scopesFor(projectId: Identifier, unqualify: Boolean = true): Set<String> =
         scopesFor(DependencyGraph.qualifyScope(projectId, ""), unqualify)
 
     /**

--- a/model/src/main/kotlin/utils/DependencyGraphConverter.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphConverter.kt
@@ -120,7 +120,7 @@ object DependencyGraphConverter {
      */
     private fun Project.convertToScopeNames(excludes: Excludes): Project =
         takeIf { scopeNames != null } ?: copy(
-            scopeNames = scopes.filterNot { excludes.isScopeExcluded(it.name) }.mapTo(sortedSetOf()) { it.name },
+            scopeNames = scopes.filterNot { excludes.isScopeExcluded(it.name) }.mapTo(mutableSetOf()) { it.name },
             scopeDependencies = null
         )
 

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Scope
 
 class CopyrightFindingSortedSetConverter : StdConverter<Set<CopyrightFinding>, SortedSet<CopyrightFinding>>() {
     override fun convert(value: Set<CopyrightFinding>) = value.toSortedSet(CopyrightFinding.COMPARATOR)
@@ -44,6 +45,10 @@ class PackageSortedSetConverter : StdConverter<Set<Package>, SortedSet<Package>>
 
 class ProjectSortedSetConverter : StdConverter<Set<Project>, SortedSet<Project>>() {
     override fun convert(value: Set<Project>) = value.toSortedSet(compareBy { it.id })
+}
+
+class ScopeSortedSetConverter : StdConverter<Set<Scope>, SortedSet<Scope>>() {
+    override fun convert(value: Set<Scope>) = value.toSortedSet()
 }
 
 class SnippetFindingSortedSetConverter : StdConverter<Set<SnippetFinding>, SortedSet<SnippetFinding>>() {

--- a/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
@@ -27,11 +27,9 @@ import io.kotest.matchers.types.instanceOf
 import io.mockk.every
 import io.mockk.mockk
 
-import java.util.SortedSet
-
 class CompatibilityDependencyNavigatorTest : WordSpec() {
     private val treeProject = createProject("tree", scopes = setOf(createScope("scope")))
-    private val graphProject = createProject("graph", scopeNames = sortedSetOf("scope"))
+    private val graphProject = createProject("graph", scopeNames = setOf("scope"))
 
     init {
         "create" should {
@@ -46,8 +44,8 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
             }
 
             "return a DependencyGraphNavigator if all projects use the graph format" {
-                val project1 = createProject("test1", scopeNames = sortedSetOf("scope1"))
-                val project2 = createProject("test2", scopeNames = sortedSetOf("scope2", "scope3"))
+                val project1 = createProject("test1", scopeNames = setOf("scope1"))
+                val project2 = createProject("test2", scopeNames = setOf("scope2", "scope3"))
                 val result = createOrtResult(project1, project2)
 
                 val navigator = CompatibilityDependencyNavigator.create(result)
@@ -57,7 +55,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
 
             "return a CompatibilityGraphNavigator if mixed representations are used" {
                 val project1 = createProject("test1", scopes = setOf(createScope("scope1")))
-                val project2 = createProject("test2", scopeNames = sortedSetOf("scope2", "scope3"))
+                val project2 = createProject("test2", scopeNames = setOf("scope2", "scope3"))
                 val result = createOrtResult(project1, project2)
 
                 when (val navigator = CompatibilityDependencyNavigator.create(result)) {
@@ -77,7 +75,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
             }
 
             "return a DependencyTreeNavigator for a result that does not contain any dependency graphs" {
-                val project = createProject("dummy", scopeNames = sortedSetOf())
+                val project = createProject("dummy", scopeNames = setOf())
 
                 val analyzerResult = AnalyzerResult(
                     projects = setOf(project),
@@ -246,7 +244,7 @@ private fun createOrtResult(vararg projects: Project): OrtResult =
 private fun createProject(
     name: String,
     scopes: Set<Scope>? = null,
-    scopeNames: SortedSet<String>? = null
+    scopeNames: Set<String>? = null
 ): Project {
     val id = Identifier.EMPTY.copy(name = name)
     return Project.EMPTY.copy(id = id, scopeDependencies = scopes, scopeNames = scopeNames)

--- a/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
@@ -30,14 +30,14 @@ import io.mockk.mockk
 import java.util.SortedSet
 
 class CompatibilityDependencyNavigatorTest : WordSpec() {
-    private val treeProject = createProject("tree", scopes = sortedSetOf(createScope("scope")))
+    private val treeProject = createProject("tree", scopes = setOf(createScope("scope")))
     private val graphProject = createProject("graph", scopeNames = sortedSetOf("scope"))
 
     init {
         "create" should {
             "return a DependencyTreeNavigator if all projects use the tree format" {
-                val project1 = createProject("test1", scopes = sortedSetOf(createScope("scope1")))
-                val project2 = createProject("test2", scopes = sortedSetOf(createScope("scope2")))
+                val project1 = createProject("test1", scopes = setOf(createScope("scope1")))
+                val project2 = createProject("test2", scopes = setOf(createScope("scope2")))
                 val result = createOrtResult(project1, project2)
 
                 val navigator = CompatibilityDependencyNavigator.create(result)
@@ -56,7 +56,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
             }
 
             "return a CompatibilityGraphNavigator if mixed representations are used" {
-                val project1 = createProject("test1", scopes = sortedSetOf(createScope("scope1")))
+                val project1 = createProject("test1", scopes = setOf(createScope("scope1")))
                 val project2 = createProject("test2", scopeNames = sortedSetOf("scope2", "scope3"))
                 val result = createOrtResult(project1, project2)
 
@@ -245,7 +245,7 @@ private fun createOrtResult(vararg projects: Project): OrtResult =
  */
 private fun createProject(
     name: String,
-    scopes: SortedSet<Scope>? = null,
+    scopes: Set<Scope>? = null,
     scopeNames: SortedSet<String>? = null
 ): Project {
     val id = Identifier.EMPTY.copy(name = name)

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -50,7 +51,7 @@ class DependencyGraphTest : WordSpec({
             val graph = DependencyGraph(ids, fragments, scopeMap)
             val scopes = graph.createScopes()
 
-            scopes.map { it.name } should containExactly("p1:scope1", "p2:scope2")
+            scopes.map { it.name } should containExactlyInAnyOrder("p1:scope1", "p2:scope2")
             scopeDependencies(scopes, "p1:scope1") shouldBe "${ids[1]}${ids[0]}"
             scopeDependencies(scopes, "p2:scope2") shouldBe "${ids[1]}${ids[2]}"
         }

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -27,8 +27,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import java.util.SortedSet
-
 class DependencyGraphTest : WordSpec({
     "createScopes()" should {
         "construct a simple tree with scopes" {
@@ -242,7 +240,7 @@ private fun id(group: String, artifact: String, version: String): Identifier =
 /**
  * Output the dependency tree of the given scope as a string.
  */
-private fun scopeDependencies(scopes: SortedSet<Scope>, name: String): String = buildString {
+private fun scopeDependencies(scopes: Set<Scope>, name: String): String = buildString {
     scopes.find { it.name == name }?.let { scope ->
         scope.dependencies.forEach { dumpDependencies(it) }
     }

--- a/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
+++ b/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
@@ -64,7 +64,7 @@ class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
                     )
                 )
 
-                val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
+                val project = Project.EMPTY.copy(scopeDependencies = setOf(scope))
                 val paths = navigator.getShortestPaths(project).getValue(scope.name)
 
                 paths should containExactly(
@@ -84,7 +84,7 @@ class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
         "dependencyTreeDepth" should {
             "return 0 if the scope does not contain any package" {
                 val scope = Scope(name = "test", dependencies = sortedSetOf())
-                val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
+                val project = Project.EMPTY.copy(scopeDependencies = setOf(scope))
 
                 navigator.dependencyTreeDepth(project, scope.name) shouldBe 0
             }
@@ -97,7 +97,7 @@ class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
                         PackageReference(id = Identifier("b"))
                     )
                 )
-                val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
+                val project = Project.EMPTY.copy(scopeDependencies = setOf(scope))
 
                 navigator.dependencyTreeDepth(project, scope.name) shouldBe 1
             }
@@ -111,7 +111,7 @@ class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
                         }
                     )
                 )
-                val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
+                val project = Project.EMPTY.copy(scopeDependencies = setOf(scope))
 
                 navigator.dependencyTreeDepth(project, scope.name) shouldBe 2
             }
@@ -129,7 +129,7 @@ class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
                         pkg("b")
                     )
                 )
-                val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
+                val project = Project.EMPTY.copy(scopeDependencies = setOf(scope))
 
                 navigator.dependencyTreeDepth(project, scope.name) shouldBe 3
             }

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -85,7 +85,7 @@ class ProjectTest : WordSpec({
         "fail if both scopeDependencies and scopeNames are provided" {
             shouldThrow<IllegalArgumentException> {
                 Project.EMPTY.copy(
-                    scopeDependencies = sortedSetOf(mockk()),
+                    scopeDependencies = setOf(mockk()),
                     scopeNames = sortedSetOf("test", "compile", "other")
                 )
             }

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -86,7 +86,7 @@ class ProjectTest : WordSpec({
             shouldThrow<IllegalArgumentException> {
                 Project.EMPTY.copy(
                     scopeDependencies = setOf(mockk()),
-                    scopeNames = sortedSetOf("test", "compile", "other")
+                    scopeNames = setOf("test", "compile", "other")
                 )
             }
         }
@@ -127,7 +127,7 @@ class ProjectTest : WordSpec({
                 definitionFilePath = "/some/path",
                 homepageUrl = "https//www.test-project.org",
                 scopeDependencies = null,
-                scopeNames = sortedSetOf("partial")
+                scopeNames = setOf("partial")
             )
 
             val graph = createDependencyGraph(qualified = true)

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -141,7 +141,7 @@ class ExcludesTest : WordSpec() {
         "isExcluded" should {
             "return false if the project is not found" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = setOf(scope1))
                 )
 
                 ortResult.isExcluded(project2.id) shouldBe false
@@ -157,7 +157,7 @@ class ExcludesTest : WordSpec() {
 
             "return false if the package is not excluded" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = setOf(scope1))
                 )
 
                 ortResult.isExcluded(id) shouldBe false
@@ -165,8 +165,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -178,8 +178,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -191,8 +191,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -204,8 +204,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -217,8 +217,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all dependencies on the package are excluded by path or scope excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -244,7 +244,7 @@ class ExcludesTest : WordSpec() {
             "return true if a project and all dependencies on the project are excluded by path excludes" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = setOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -257,7 +257,7 @@ class ExcludesTest : WordSpec() {
             "return true if a project is excluded by path excludes and all dependencies on the project are excluded by scope excludes" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = setOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -271,7 +271,7 @@ class ExcludesTest : WordSpec() {
             "return false if a project is excluded by path excludes but not all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = setOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -284,7 +284,7 @@ class ExcludesTest : WordSpec() {
             "return false if a project is not excluded but all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = setOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -306,7 +306,7 @@ class ExcludesTest : WordSpec() {
 
             "return false if the package is not excluded" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = setOf(scope1))
                 )
 
                 ortResult.isPackageExcluded(id) shouldBe false
@@ -314,8 +314,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -327,8 +327,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -340,8 +340,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -353,8 +353,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -366,8 +366,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all dependencies on the package are excluded by path or scope excludes" {
                 setProjects(
-                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
-                    project2.copy(scopeDependencies = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = setOf(scope1)),
+                    project2.copy(scopeDependencies = setOf(scope2))
                 )
 
                 setExcludes(
@@ -381,7 +381,7 @@ class ExcludesTest : WordSpec() {
             "return true if all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
+                    project2.copy(scopeDependencies = setOf(scopeProject1, scopeProject1.copy(name = "scope")))
                 )
 
                 setExcludes(
@@ -394,7 +394,7 @@ class ExcludesTest : WordSpec() {
             "return false if not all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
+                    project2.copy(scopeDependencies = setOf(scopeProject1, scopeProject1.copy(name = "scope")))
                 )
 
                 setExcludes(
@@ -407,7 +407,7 @@ class ExcludesTest : WordSpec() {
             "return false if no dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = setOf(scopeProject1))
                 )
 
                 ortResult.isPackageExcluded(project1.id) shouldBe false

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -129,7 +129,7 @@ val project = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
     authors = projectAuthors,
-    scopeDependencies = sortedSetOf(scope)
+    scopeDependencies = setOf(scope)
 )
 
 val provenance = UnknownProvenance

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -31,8 +31,6 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
-import java.util.SortedSet
-
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyGraphEdge
 import org.ossreviewtoolkit.model.Identifier
@@ -395,7 +393,7 @@ private fun createDependency(
  * Return the package references from the given [scopes] associated with the scope with the given [scopeName].
  */
 private fun scopeDependencies(
-    scopes: SortedSet<Scope>,
+    scopes: Set<Scope>,
     scopeName: String
 ): Set<PackageReference> =
     scopes.find { it.name == scopeName }?.dependencies.orEmpty()

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -296,7 +296,7 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency(scope1, createDependency("g1", "a1", "1"))
                 .addDependency("anotherScope", createDependency("g2", "a2", "2"))
 
-            builder.scopesFor(projectId) shouldBe sortedSetOf("compile", "test")
+            builder.scopesFor(projectId) should containExactlyInAnyOrder("compile", "test")
         }
 
         "collect information about qualified scopes of projects" {
@@ -310,7 +310,7 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency(scope1, createDependency("g1", "a1", "1"))
                 .addDependency("anotherScope", createDependency("g2", "a2", "2"))
 
-            builder.scopesFor(projectId, unqualify = false) shouldBe sortedSetOf(scope2, scope1)
+            builder.scopesFor(projectId, unqualify = false) should containExactlyInAnyOrder(scope2, scope1)
         }
     }
 

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -168,7 +168,7 @@ class DependencyGraphConverterTest : WordSpec({
 
         "not override a dependency graph for an empty project" {
             val gradleProject = createProject("Gradle", index = 1)
-            val gradleEmptyProject = createProject("Gradle", index = 2).copy(scopeDependencies = sortedSetOf())
+            val gradleEmptyProject = createProject("Gradle", index = 2).copy(scopeDependencies = emptySet())
 
             val orgResult = createAnalyzerResult(gradleProject.createResult())
             val resultWithGraph = DependencyGraphConverter.convert(orgResult)
@@ -201,7 +201,7 @@ private fun createProject(managerName: String, index: Int): Project {
 
     return Project.EMPTY.copy(
         id = createIdentifier(managerName, index, forProject = true),
-        scopeDependencies = sortedSetOf(mainScope, testScope)
+        scopeDependencies = setOf(mainScope, testScope)
     )
 }
 

--- a/plugins/package-managers/bower/src/main/kotlin/Bower.kt
+++ b/plugins/package-managers/bower/src/main/kotlin/Bower.kt
@@ -105,7 +105,7 @@ class Bower(
                 vcs = projectPackage.vcs,
                 vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
                 homepageUrl = projectPackage.homepageUrl,
-                scopeDependencies = sortedSetOf(dependenciesScope, devDependenciesScope)
+                scopeDependencies = setOf(dependenciesScope, devDependenciesScope)
             )
 
             return listOf(ProjectAnalyzerResult(project, packages.values.toSet()))

--- a/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
+++ b/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
@@ -221,7 +221,7 @@ class Bundler(
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, homepageUrl),
                 homepageUrl = homepageUrl,
-                scopeDependencies = scopes.toSortedSet()
+                scopeDependencies = scopes
             )
 
             val allProjectDeps = groupedDeps.values.flatten().toSet()

--- a/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
@@ -208,7 +208,7 @@ class Cargo(
             return Scope(scope, transitiveDependencies)
         }
 
-        val scopes = listOfNotNull(
+        val scopes = setOfNotNull(
             getTransitiveDependencies(groupedDependencies[""], "dependencies"),
             getTransitiveDependencies(groupedDependencies["dev"], "dev-dependencies"),
             getTransitiveDependencies(groupedDependencies["build"], "build-dependencies")
@@ -231,7 +231,7 @@ class Cargo(
             vcs = projectPkg.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopeDependencies = scopes.toSortedSet()
+            scopeDependencies = scopes
         )
 
         val nonProjectPackages = packages

--- a/plugins/package-managers/carthage/src/main/kotlin/Carthage.kt
+++ b/plugins/package-managers/carthage/src/main/kotlin/Carthage.kt
@@ -85,7 +85,7 @@ class Carthage(
                     declaredLicenses = emptySet(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY),
-                    scopeDependencies = sortedSetOf(),
+                    scopeDependencies = emptySet(),
                     homepageUrl = ""
                 ),
                 packages = parseCarthageDependencies(definitionFile)

--- a/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
@@ -123,7 +123,7 @@ class CocoaPods(
         val workingDir = definitionFile.parentFile
         val lockfile = workingDir.resolve(LOCKFILE_FILENAME)
 
-        val scopes = sortedSetOf<Scope>()
+        val scopes = mutableSetOf<Scope>()
         val packages = mutableSetOf<Package>()
         val issues = mutableListOf<Issue>()
 

--- a/plugins/package-managers/composer/src/main/kotlin/Composer.kt
+++ b/plugins/package-managers/composer/src/main/kotlin/Composer.kt
@@ -124,7 +124,7 @@ class Composer(
         }
 
         if (!hasDependencies) {
-            val project = parseProject(definitionFile, scopes = sortedSetOf())
+            val project = parseProject(definitionFile, scopes = emptySet())
             val result = ProjectAnalyzerResult(project, packages = emptySet())
 
             return listOf(result)
@@ -145,7 +145,7 @@ class Composer(
         // the "replacing" package.
         val virtualPackages = parseVirtualPackageNames(packages, manifest, json)
 
-        val scopes = sortedSetOf(
+        val scopes = setOf(
             parseScope("require", manifest, json, packages, virtualPackages),
             parseScope("require-dev", manifest, json, packages, virtualPackages)
         )
@@ -212,7 +212,7 @@ class Composer(
         return packageReferences.toSortedSet()
     }
 
-    private fun parseProject(definitionFile: File, scopes: SortedSet<Scope>): Project {
+    private fun parseProject(definitionFile: File, scopes: Set<Scope>): Project {
         logger.info { "Parsing project metadata from '$definitionFile'..." }
 
         val json = definitionFile.readTree()

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -197,7 +197,7 @@ class Conan(
                             projectPackage.homepageUrl
                         ),
                         homepageUrl = projectPackage.homepageUrl,
-                        scopeDependencies = sortedSetOf(dependenciesScope, devDependenciesScope)
+                        scopeDependencies = setOf(dependenciesScope, devDependenciesScope)
                     ),
                     packages = packages.values.toSet()
                 )

--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
@@ -208,7 +208,7 @@ class GradleInspector(
 
         val scopes = dependencyTreeModel.configurations.filterNot {
             excludes.isScopeExcluded(it.name)
-        }.mapTo(sortedSetOf()) {
+        }.mapTo(mutableSetOf()) {
             Scope(name = it.name, dependencies = it.dependencies.toPackageRefs(packageDependencies))
         }
 

--- a/plugins/package-managers/gradle/src/test/kotlin/utils/GradleDependencyHandlerTest.kt
+++ b/plugins/package-managers/gradle/src/test/kotlin/utils/GradleDependencyHandlerTest.kt
@@ -41,7 +41,6 @@ import io.mockk.slot
 
 import java.io.IOException
 import java.lang.IllegalArgumentException
-import java.util.SortedSet
 
 import org.apache.maven.project.ProjectBuildingException
 
@@ -409,7 +408,7 @@ private fun OrtDependency.toId() = Identifier(type(), groupId, artifactId, versi
  * Return the package references from the given [scopes] associated with the scope with the given [scopeName].
  */
 private fun scopeDependencies(
-    scopes: SortedSet<Scope>,
+    scopes: Set<Scope>,
     scopeName: String
 ): Set<PackageReference> =
     scopes.find { it.name == scopeName }?.dependencies.orEmpty()

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -208,7 +208,7 @@ open class Npm(
         val packages = parseInstalledModules(workingDir)
         graphBuilder.addPackages(packages.values)
 
-        val scopeNames = listOfNotNull(
+        val scopeNames = setOfNotNull(
             // Optional dependencies are just like regular dependencies except that NPM ignores failures when
             // installing them (see https://docs.npmjs.com/files/package.json#optionaldependencies), i.e. they are
             // not a separate scope in our semantics.
@@ -231,7 +231,7 @@ open class Npm(
 
         return listOf(
             ProjectAnalyzerResult(
-                project = project.copy(scopeNames = scopeNames.toSortedSet()),
+                project = project.copy(scopeNames = scopeNames),
                 // Packages are set later by createPackageManagerResult().
                 packages = emptySet(),
                 issues = issues

--- a/plugins/package-managers/node/src/main/kotlin/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Yarn2.kt
@@ -237,7 +237,7 @@ class Yarn2(
             logger.info { "Parsing packages..." }
 
             val allProjects = parseAllPackages(iterator, definitionFile, packagesHeaders, packagedDetails)
-            val scopeNames = YarnDependencyType.values().map { it.type }.toSortedSet()
+            val scopeNames = YarnDependencyType.values().mapTo(mutableSetOf()) { it.type }
             return allProjects.values.map { project ->
                 ProjectAnalyzerResult(project.copy(scopeNames = scopeNames), emptySet(), issues)
             }.toList()

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspector.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspector.kt
@@ -170,7 +170,7 @@ internal fun NuGetInspector.Result.toOrtProject(
     }
 
     val packageReferences = nestedPackages.toPackageReferences()
-    val scopes = sortedSetOf(Scope(headers.first().projectFramework, packageReferences))
+    val scopes = setOf(Scope(headers.first().projectFramework, packageReferences))
 
     return Project(
         id = id,

--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -245,7 +245,7 @@ class Pub(
         }
 
         val packages = mutableMapOf<Identifier, Package>()
-        val scopes = sortedSetOf<Scope>()
+        val scopes = mutableSetOf<Scope>()
         val issues = mutableListOf<Issue>()
         val projectAnalyzerResults = mutableListOf<ProjectAnalyzerResult>()
 
@@ -472,7 +472,7 @@ class Pub(
         return ProjectAnalyzerResult(Project.EMPTY, emptySet(), listOf(issue))
     }
 
-    private fun parseProject(definitionFile: File, pubspec: JsonNode, scopes: SortedSet<Scope>): Project {
+    private fun parseProject(definitionFile: File, pubspec: JsonNode, scopes: Set<Scope>): Project {
         // See https://dart.dev/tools/pub/pubspec for supported fields.
         val rawName = pubspec["name"]?.textValue() ?: definitionFile.parentFile.name
         val homepageUrl = pubspec["homepage"].textValueOrEmpty()

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
@@ -197,7 +197,7 @@ internal fun PythonInspector.Result.toOrtProject(
     val projectData = setupProject?.packageData?.singleOrNull()
     val homepageUrl = projectData?.homepageUrl.orEmpty()
 
-    val scopes = sortedSetOf(Scope("install", resolvedDependenciesGraph.toPackageReferences()))
+    val scopes = setOf(Scope("install", resolvedDependenciesGraph.toPackageReferences()))
 
     return Project(
         id = id,

--- a/plugins/package-managers/spdx/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
+++ b/plugins/package-managers/spdx/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
@@ -95,7 +95,7 @@ class SpdxDocumentFileFunTest : WordSpec({
                         path = vcsDir.getPathToRoot(curlPackageFile.parentFile)
                     ),
                     homepageUrl = "https://curl.haxx.se/",
-                    scopeDependencies = sortedSetOf(
+                    scopeDependencies = setOf(
                         Scope("default")
                     )
                 ),
@@ -116,7 +116,7 @@ class SpdxDocumentFileFunTest : WordSpec({
                         path = vcsDir.getPathToRoot(opensslPackageFile.parentFile)
                     ),
                     homepageUrl = "https://www.openssl.org/",
-                    scopeDependencies = sortedSetOf(
+                    scopeDependencies = setOf(
                         Scope("default")
                     )
                 ),
@@ -137,7 +137,7 @@ class SpdxDocumentFileFunTest : WordSpec({
                         path = vcsDir.getPathToRoot(zlibPackageFile.parentFile)
                     ),
                     homepageUrl = "http://zlib.net",
-                    scopeDependencies = sortedSetOf(
+                    scopeDependencies = setOf(
                         Scope("default")
                     )
                 ),

--- a/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
+++ b/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
@@ -503,7 +503,7 @@ class SpdxDocumentFile(
                     "'${projectPackage.name}'."
         }
 
-        scopes += SPDX_SCOPE_RELATIONSHIPS.mapNotNullTo(sortedSetOf()) { type ->
+        SPDX_SCOPE_RELATIONSHIPS.mapNotNullTo(scopes) { type ->
             createScope(transitiveDocument, projectPackage.spdxId, type, packages)
         }
 

--- a/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
+++ b/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
@@ -488,7 +488,7 @@ class SpdxDocumentFile(
         val spdxDocument = transitiveDocument.rootDocument.document
 
         val packages = mutableSetOf<Package>()
-        val scopes = sortedSetOf<Scope>()
+        val scopes = mutableSetOf<Scope>()
 
         val projectPackage = if (!spdxDocument.isProject()) {
             spdxDocument.packages.first()

--- a/plugins/package-managers/stack/src/main/kotlin/Stack.kt
+++ b/plugins/package-managers/stack/src/main/kotlin/Stack.kt
@@ -205,7 +205,7 @@ class Stack(
         fun List<Dependency>.getProjectDependencies(): List<String> =
             single { it.location?.type == PROJECT_PACKAGE_TYPE }.dependencies
 
-        val scopes = sortedSetOf(
+        val scopes = setOf(
             Scope(EXTERNAL_SCOPE_NAME, externalDependencyList.getProjectDependencies().toPackageReferences()),
             Scope(TEST_SCOPE_NAME, testDependencyList.getProjectDependencies().toPackageReferences()),
             Scope(BENCH_SCOPE_NAME, benchDependencyList.getProjectDependencies().toPackageReferences())

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -89,10 +89,13 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
      */
     fun build(deduplicateDependencyTree: Boolean = false): EvaluatedModel {
         createExcludeInfo()
-        createScopes()
 
         val resultProjects = input.ortResult.getProjects().sortedBy { it.id }
         val resultPackages = input.ortResult.getPackages().sortedBy { it.metadata.id }
+
+        resultProjects.forEach { project ->
+            createScopes(project)
+        }
 
         resultProjects.forEach { project ->
             addProject(project)
@@ -199,10 +202,8 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         }
     }
 
-    private fun createScopes() {
-        input.ortResult.getProjects().flatMap { project ->
-            input.ortResult.dependencyNavigator.scopeNames(project)
-        }.forEach { scope ->
+    private fun createScopes(project: Project) {
+        input.ortResult.dependencyNavigator.scopeNames(project).forEach { scope ->
             scopes[scope] = EvaluatedScope(
                 name = scope,
                 excludes = scopeExcludes.addIfRequired(input.ortResult.getExcludes().findScopeExcludes(scope))

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -203,7 +203,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun createScopes(project: Project) {
-        input.ortResult.dependencyNavigator.scopeNames(project).forEach { scope ->
+        input.ortResult.dependencyNavigator.scopeNames(project).sorted().forEach { scope ->
             scopes[scope] = EvaluatedScope(
                 name = scope,
                 excludes = scopeExcludes.addIfRequired(input.ortResult.getExcludes().findScopeExcludes(scope))
@@ -507,7 +507,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             return createDependencyNode(dependency, linkage, issues, children)
         }
 
-        val scopeTrees = input.ortResult.dependencyNavigator.scopeNames(project).map { scope ->
+        val scopeTrees = input.ortResult.dependencyNavigator.scopeNames(project).sorted().map { scope ->
             // Deduplication should not happen across scopes.
             visitedNodes.clear()
 
@@ -690,7 +690,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addShortestPaths(project: Project) {
-        input.ortResult.dependencyNavigator.getShortestPaths(project).forEach { (scopeName, scopePaths) ->
+        input.ortResult.dependencyNavigator.getShortestPaths(project).toSortedMap().forEach { (scopeName, scopePaths) ->
             scopePaths.forEach { (id, path) ->
                 val pkg = packages.getValue(id)
 

--- a/plugins/reporters/gitlab/src/funTest/kotlin/GitLabLicenseModelReporterFunTest.kt
+++ b/plugins/reporters/gitlab/src/funTest/kotlin/GitLabLicenseModelReporterFunTest.kt
@@ -92,7 +92,7 @@ private fun createOrtResult(): OrtResult {
                     Project.EMPTY.copy(
                         id = Identifier("Gradle:some-group:some-gradle-project:0.0.1"),
                         definitionFilePath = "some/path/build.gradle",
-                        scopeDependencies = sortedSetOf(
+                        scopeDependencies = setOf(
                             Scope(
                                 name = "compile",
                                 dependencies = sortedSetOf(
@@ -113,7 +113,7 @@ private fun createOrtResult(): OrtResult {
                     ),
                     Project.EMPTY.copy(
                         id = Identifier("PIP::some-pip-project:0.0.2"),
-                        scopeDependencies = sortedSetOf(
+                        scopeDependencies = setOf(
                             Scope(
                                 name = "install",
                                 dependencies = sortedSetOf(

--- a/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
+++ b/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
@@ -263,7 +263,7 @@ private fun createOrtResult(): OrtResult {
                         declaredLicenses = setOf("MIT"),
                         definitionFilePath = "pom.xml",
                         homepageUrl = "first project's homepage",
-                        scopeDependencies = sortedSetOf(
+                        scopeDependencies = setOf(
                             Scope(
                                 name = "compile",
                                 dependencies = sortedSetOf(
@@ -300,7 +300,7 @@ private fun createOrtResult(): OrtResult {
                         declaredLicenses = setOf("BSD-3-Clause"),
                         definitionFilePath = "npm-project/package.json",
                         homepageUrl = "first project's homepage",
-                        scopeDependencies = sortedSetOf(
+                        scopeDependencies = setOf(
                             Scope(
                                 name = "devDependencies",
                                 dependencies = sortedSetOf(

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -162,7 +162,7 @@ private val ortResult = OrtResult(
                     declaredLicenses = setOf("MIT"),
                     definitionFilePath = "",
                     homepageUrl = "first project's homepage",
-                    scopeDependencies = sortedSetOf(
+                    scopeDependencies = setOf(
                         Scope(
                             name = "compile",
                             dependencies = sortedSetOf(

--- a/reporter/src/testFixtures/kotlin/TestData.kt
+++ b/reporter/src/testFixtures/kotlin/TestData.kt
@@ -93,7 +93,7 @@ val ORT_RESULT = OrtResult(
                     declaredLicenses = emptySet(),
                     vcs = VcsInfo.EMPTY,
                     homepageUrl = "https://github.com/oss-review-toolkit/ort",
-                    scopeDependencies = sortedSetOf(
+                    scopeDependencies = setOf(
                         Scope(
                             name = "dependencies",
                             dependencies = sortedSetOf(
@@ -130,7 +130,7 @@ val ORT_RESULT = OrtResult(
                     declaredLicenses = emptySet(),
                     vcs = VcsInfo.EMPTY,
                     homepageUrl = "https://github.com/oss-review-toolkit/ort",
-                    scopeDependencies = sortedSetOf(
+                    scopeDependencies = setOf(
                         Scope(
                             name = "dependencies",
                             dependencies = sortedSetOf()
@@ -143,7 +143,7 @@ val ORT_RESULT = OrtResult(
                     declaredLicenses = setOf("BSD-2-Clause"),
                     vcs = VcsInfo.EMPTY,
                     homepageUrl = "https://github.com/oss-review-toolkit/ort",
-                    scopeDependencies = sortedSetOf()
+                    scopeDependencies = emptySet()
                 )
             ),
             packages = setOf(

--- a/utils/test/src/main/kotlin/OrtResultDsl.kt
+++ b/utils/test/src/main/kotlin/OrtResultDsl.kt
@@ -75,7 +75,7 @@ class OrtResultBuilder {
                 id = Identifier(id),
                 declaredLicenses = declaredLicenses,
                 declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses),
-                scopeDependencies = sortedSetOf(scope)
+                scopeDependencies = setOf(scope)
             )
         }
     }


### PR DESCRIPTION
See individual commits.

Part of #6235.