### PR TITLE
build(jitpack): Change the excluded Dokka task name

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -2,5 +2,5 @@ jdk:
   - openjdk11
 
 install:
-  # Exclude dokkaJavadoc tasks to save build time.
-  - ./gradlew --no-daemon --stacktrace -x dokkaJavadoc publishToMavenLocal
+  # Exclude generation of docs artifacts to save build time.
+  - ./gradlew --no-daemon --stacktrace -x docsJavadocJar publishToMavenLocal


### PR DESCRIPTION
In https://github.com/oss-review-toolkit/ort/pull/6993, the Dokka task has been replaced by `dokkatoo`. Hence the Jitpack configuration must be adapted.

Example of failing Jitpack build:
https://jitpack.io/com/github/oss-review-toolkit/ort/48888c6b17/build.log