### PR TITLE
build(JitPack): Fix the docs task exclusion

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -3,4 +3,4 @@ jdk:
 
 install:
   # Exclude generation of docs artifacts to save build time.
-  - ./gradlew --no-daemon --stacktrace -x docsJavadocJar publishToMavenLocal
+  - ./gradlew --no-daemon --stacktrace -x dokkatooGeneratePublicationJavadoc publishToMavenLocal


### PR DESCRIPTION
Exclude the `dokkatooGeneratePublicationJavadoc` task which `docsJavadocJar` depends on instead to fix a build error.