### PR TITLE
fix: Remove several sorted map left-overs for `scanResults`

### DIFF
--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -220,7 +220,7 @@ private fun createOrtResult(
             )
         ),
         scanner = ScannerRun.EMPTY.copy(
-            scanResults = sortedMapOf(
+            scanResults = mapOf(
                 id to listOf(
                     ScanResult(
                         provenance = RepositoryProvenance(vcsInfo, vcsInfo.revision),

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -253,7 +253,7 @@ val ortResult = OrtResult(
         )
     ),
     scanner = ScannerRun.EMPTY.copy(
-        scanResults = sortedMapOf(
+        scanResults = mapOf(
             Identifier("Maven:org.ossreviewtoolkit:package-with-only-detected-license:1.0") to listOf(
                 ScanResult(
                     provenance = UnknownProvenance,

--- a/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
@@ -71,7 +71,7 @@ internal class SubtractScanResultsCommand : CliktCommand(
             valueTransform = { it.summary }
         )
 
-        val scanResults = lhsOrtResult.getScanResults().mapValuesTo(sortedMapOf()) { (_, results) ->
+        val scanResults = lhsOrtResult.getScanResults().mapValues { (_, results) ->
             results.map { lhsScanResult ->
                 val lhsSummary = lhsScanResult.summary
                 val rhsSummary = rhsScanSummaries[lhsScanResult.provenance.key()]

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -26,7 +26,6 @@ import freemarker.template.DefaultObjectWrapper
 import freemarker.template.TemplateExceptionHandler
 
 import java.io.File
-import java.util.SortedMap
 
 import org.apache.logging.log4j.kotlin.Logging
 
@@ -459,7 +458,7 @@ internal fun OrtResult.deduplicateProjectScanResults(targetProjects: Set<Identif
 
     val projectsToFilter = getProjects().mapTo(mutableSetOf()) { it.id } - targetProjects
 
-    val scanResults = getScanResults().mapValuesTo(sortedMapOf()) { (id, results) ->
+    val scanResults = getScanResults().mapValues { (id, results) ->
         if (id !in projectsToFilter) {
             results
         } else {
@@ -487,7 +486,7 @@ internal fun OrtResult.deduplicateProjectScanResults(targetProjects: Set<Identif
 /**
  * Return a copy of this [OrtResult] with the scan results replaced by the given [scanResults].
  */
-private fun OrtResult.replaceScanResults(scanResults: SortedMap<Identifier, List<ScanResult>>): OrtResult =
+private fun OrtResult.replaceScanResults(scanResults: Map<Identifier, List<ScanResult>>): OrtResult =
     copy(
         scanner = scanner?.copy(
             scanResults = scanResults

--- a/plugins/reporters/freemarker/src/test/kotlin/FreeMarkerTemplateProcessorTest.kt
+++ b/plugins/reporters/freemarker/src/test/kotlin/FreeMarkerTemplateProcessorTest.kt
@@ -142,7 +142,7 @@ private val ORT_RESULT = OrtResult(
         )
     ),
     scanner = ScannerRun.EMPTY.copy(
-        scanResults = sortedMapOf(
+        scanResults = mapOf(
             idRootProject to scanResults(
                 vcsInfo = PROJECT_VCS_INFO,
                 findingsPaths = listOf(

--- a/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
+++ b/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
@@ -438,7 +438,7 @@ private fun createOrtResult(): OrtResult {
             ),
         ),
         scanner = ScannerRun.EMPTY.copy(
-            scanResults = sortedMapOf(
+            scanResults = mapOf(
                 Identifier("Maven:first-package-group:first-package:0.0.1") to listOf(
                     ScanResult(
                         provenance = ArtifactProvenance(

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -265,7 +265,7 @@ private val ortResult = OrtResult(
         )
     ),
     scanner = ScannerRun.EMPTY.copy(
-        scanResults = sortedMapOf(
+        scanResults = mapOf(
             Identifier("Maven:first-package-group:first-package:0.0.1") to listOf(
                 ScanResult(
                     provenance = ArtifactProvenance(

--- a/reporter/src/testFixtures/kotlin/TestData.kt
+++ b/reporter/src/testFixtures/kotlin/TestData.kt
@@ -221,7 +221,7 @@ val ORT_RESULT = OrtResult(
         )
     ),
     scanner = ScannerRun.EMPTY.copy(
-        scanResults = sortedMapOf(
+        scanResults = mapOf(
             Identifier("NPM:@ort:project-with-findings:1.0") to listOf(
                 ScanResult(
                     provenance = UnknownProvenance,


### PR DESCRIPTION
This is a fix-up for c2c6926.
