### PR TITLE
refactor!: Use camel-case for URLs in function names

### DIFF
--- a/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
+++ b/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
@@ -243,7 +243,7 @@ class OpossumReporter : Reporter {
             filesWithChildren += resolvePath(fileWithChildren, isDirectory = true)
         }
 
-        fun addBaseURL(path: String, vcs: VcsInfo) {
+        fun addBaseUrl(path: String, vcs: VcsInfo) {
             val idFromPath = resolvePath(path, isDirectory = true)
 
             if (idFromPath in baseUrlsForSources) return
@@ -272,7 +272,7 @@ class OpossumReporter : Reporter {
             mapOfId[path] = min(level, oldLevel)
 
             resources.addResource(path)
-            addBaseURL(path, vcs)
+            addBaseUrl(path, vcs)
         }
 
         private fun addSignal(signal: OpossumSignal, paths: SortedSet<String>) {
@@ -511,7 +511,7 @@ class OpossumReporter : Reporter {
     ): OpossumInput {
         val opossumInput = OpossumInput()
 
-        opossumInput.addBaseURL("/", ortResult.repository.vcs)
+        opossumInput.addBaseUrl("/", ortResult.repository.vcs)
 
         SpdxLicense.values().forEach {
             val licenseText = getLicenseText(it.id)

--- a/utils/ort/src/main/kotlin/OrtProxySelector.kt
+++ b/utils/ort/src/main/kotlin/OrtProxySelector.kt
@@ -101,11 +101,11 @@ class OrtProxySelector(private val fallback: ProxySelector? = null) : ProxySelec
             addProxy("properties", "https", it)
         }
 
-        determineProxyFromURL(Os.env["http_proxy"])?.let {
+        determineProxyFromUrl(Os.env["http_proxy"])?.let {
             addProxy("environment", "http", it)
         }
 
-        determineProxyFromURL(Os.env["https_proxy"])?.let {
+        determineProxyFromUrl(Os.env["https_proxy"])?.let {
             addProxy("environment", "https", it)
         }
     }
@@ -224,7 +224,7 @@ fun determineProxyFromProperties(protocol: String?): AuthenticatedProxy? {
  * Return a [proxy][Proxy] with optional [password authentication][PasswordAuthentication] as encoded in the [url], or
  * null if the string does not represent a URL with a supported [proxy type][Proxy.Type].
  */
-fun determineProxyFromURL(url: String?): AuthenticatedProxy? {
+fun determineProxyFromUrl(url: String?): AuthenticatedProxy? {
     if (url == null) return null
 
     val uri = runCatching {

--- a/utils/ort/src/test/kotlin/OrtProxySelectorTest.kt
+++ b/utils/ort/src/test/kotlin/OrtProxySelectorTest.kt
@@ -111,7 +111,7 @@ class OrtProxySelectorTest : WordSpec({
 
 private fun createProxySelector(protocol: String): OrtProxySelector {
     // Using a non-null assertion is fine here as we know the URL to be parsable.
-    val proxy = determineProxyFromURL("http://fake-proxy:8080")!!
+    val proxy = determineProxyFromUrl("http://fake-proxy:8080")!!
 
     return OrtProxySelector().removeAllProxies().addProxy("test", protocol, proxy)
 }


### PR DESCRIPTION
Adhere to Java naming conventions and do not upper-case "URL" as part of function names.