### PR TITLE
Stop `Scope` to implement `Comparable`

### DIFF
--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -24,7 +24,6 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.containExactly
@@ -369,7 +368,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
                 analyzerResult.withResolvedScopes().apply {
                     projects.find { it.id == project.id } shouldNotBeNull {
-                        scopes shouldContainExactly sortedSetOf(
+                        scopes should containExactlyInAnyOrder(
                             Scope(
                                 name = "scope",
                                 dependencies = setOf(

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -367,7 +367,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
                 analyzerResult.withResolvedScopes().apply {
                     projects.find { it.id == project.id } shouldNotBeNull {
-                        project.scopes shouldContainExactly sortedSetOf(
+                        scopes shouldContainExactly sortedSetOf(
                             Scope(
                                 name = "scope",
                                 dependencies = setOf(

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -375,18 +375,16 @@ class AnalyzerResultBuilderTest : WordSpec() {
                                 dependencies = setOf(
                                     PackageReference(
                                         id = project1.id,
-                                        dependencies = setOf(
-                                            PackageReference(id = package1.id)
-                                        )
+                                        linkage = PackageLinkage.PROJECT_DYNAMIC,
+                                        dependencies = setOf(pkgRef1)
                                     ),
                                     PackageReference(
                                         id = package1.id,
                                         dependencies = setOf(
                                             PackageReference(
                                                 id = project1.id,
-                                                dependencies = setOf(
-                                                    PackageReference(id = package1.id)
-                                                )
+                                                linkage = PackageLinkage.PROJECT_DYNAMIC,
+                                                dependencies = setOf(pkgRef1)
                                             )
                                         )
                                     )

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -32,6 +32,8 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beTheSameInstanceAs
 
+import java.time.Instant
+
 import org.ossreviewtoolkit.analyzer.managers.utils.PackageManagerDependencyHandler
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.DependencyGraph
@@ -54,11 +56,11 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class AnalyzerResultBuilderTest : WordSpec() {
-    private val issue1 = Issue(source = "source-1", message = "message-1")
-    private val issue2 = Issue(source = "source-2", message = "message-2")
-    private val issue3 = Issue(source = "source-3", message = "message-3")
-    private val issue4 = Issue(source = "source-4", message = "message-4")
-    private val issue5 = Issue(source = "source-5", message = "message-5")
+    private val issue1 = Issue(timestamp = Instant.EPOCH, source = "source-1", message = "message-1")
+    private val issue2 = Issue(timestamp = Instant.EPOCH, source = "source-2", message = "message-2")
+    private val issue3 = Issue(timestamp = Instant.EPOCH, source = "source-3", message = "message-3")
+    private val issue4 = Issue(timestamp = Instant.EPOCH, source = "source-4", message = "message-4")
+    private val issue5 = Issue(timestamp = Instant.EPOCH, source = "source-5", message = "message-5")
 
     private val package1 = Package.EMPTY.copy(id = Identifier("type-1", "namespace-1", "package-1", "version-1"))
     private val package2 = Package.EMPTY.copy(id = Identifier("type-2", "namespace-2", "package-2", "version-2"))

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -344,7 +344,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
                     dependencies = setOf(
                         packageManagerDependency,
                         PackageReference(
-                            id = pkgRef1.id,
+                            id = package1.id,
                             dependencies = setOf(packageManagerDependency)
                         )
                     )

--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -43,7 +43,7 @@ data class Scope(
      */
     @JsonSerialize(converter = PackageReferenceSortedSetConverter::class)
     val dependencies: Set<PackageReference> = emptySet()
-) : Comparable<Scope> {
+) {
     /**
      * Return the set of package [Identifier]s in this [Scope], up to and including a depth of [maxDepth] where counting
      * starts at 0 (for the [Scope] itself) and 1 are direct dependencies etc. A value below 0 means to not limit the
@@ -62,11 +62,6 @@ data class Scope(
                 }
             }
         }
-
-    /**
-     * A comparison function to sort scopes by their name.
-     */
-    override fun compareTo(other: Scope) = compareValuesBy(this, other) { it.name }
 
     /**
      * Return whether the package identified by [id] is contained as a (transitive) dependency in this scope.

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -54,7 +54,7 @@ class ProjectSortedSetConverter : StdConverter<Set<Project>, SortedSet<Project>>
 }
 
 class ScopeSortedSetConverter : StdConverter<Set<Scope>, SortedSet<Scope>>() {
-    override fun convert(value: Set<Scope>) = value.toSortedSet()
+    override fun convert(value: Set<Scope>) = value.toSortedSet(compareBy { it.name })
 }
 
 class SnippetFindingSortedSetConverter : StdConverter<Set<SnippetFinding>, SortedSet<SnippetFinding>>() {


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 