### PR TITLE
feat(gradle-inspector): Replace deprecated JVM arguments for projects

### DIFF
--- a/utils/common/src/main/kotlin/Extensions.kt
+++ b/utils/common/src/main/kotlin/Extensions.kt
@@ -131,31 +131,6 @@ fun File.safeMkdirs(): File {
 }
 
 /**
- * Search [this] directory upwards towards the root until a file called [searchFileName] is found and return this file,
- * or return null if no such file is found.
- */
-fun File.searchUpwardsForFile(searchFileName: String, ignoreCase: Boolean = false): File? {
-    fun resolveFile(dir: File, fileName: String, ignoreCase: Boolean): File? {
-        val files = dir.list() ?: return null
-
-        return files.filter { it.equals(fileName, ignoreCase = ignoreCase) }
-            .map { dir.resolve(it) }
-            .find { it.isFile }
-    }
-
-    if (!isDirectory) return null
-
-    var currentDir: File? = absoluteFile
-    var currentFile = currentDir?.let { resolveFile(it, searchFileName, ignoreCase) }
-    while (currentDir != null && currentFile == null) {
-        currentDir = currentDir.parentFile ?: break
-        currentFile = resolveFile(currentDir, searchFileName, ignoreCase)
-    }
-
-    return currentFile
-}
-
-/**
  * Search [this] directory upwards towards the root until a contained subdirectory called [searchDirName] is found and
  * return the parent of [searchDirName], or return null if no such directory is found.
  */

--- a/utils/common/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/common/src/test/kotlin/ExtensionsTest.kt
@@ -30,7 +30,6 @@ import io.kotest.matchers.file.aDirectory
 import io.kotest.matchers.file.aFile
 import io.kotest.matchers.file.exist
 import io.kotest.matchers.maps.containExactly
-import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -209,30 +208,6 @@ class ExtensionsTest : WordSpec({
             file shouldBe aFile()
             shouldThrow<IOException> { file.safeMkdirs() }
             file shouldBe aFile() // should still be a file afterwards
-        }
-    }
-
-    "File.searchUpwardsForFile" should {
-        "find the README.md file case insensitive" {
-            val readmeFile = File(".").searchUpwardsForFile("ReadMe.MD", true)
-
-            readmeFile shouldNotBeNull {
-                this shouldBe File("../..").absoluteFile.normalize().resolve("README.md")
-            }
-        }
-
-        "find the README.md file case sensitive" {
-            val readmeFile = File(".").searchUpwardsForFile("README.md", false)
-
-            readmeFile shouldNotBeNull {
-                this shouldBe File("../..").absoluteFile.normalize().resolve("README.md")
-            }
-        }
-
-        "not find the README.md with wrong cases" {
-            val readmeFile = File(".").searchUpwardsForFile("ReadMe.MD", false)
-
-            readmeFile should beNull()
         }
     }
 


### PR DESCRIPTION
Some projects like [1] use JVM arguments that are deprecated. For example, `MaxPermSize` has been deprecated since Java 1.8, but the project still uses it despite targeting Java 11 [2]. As the Gradle Tooling API would fail to launch in such cases, replace `MaxPermSize` with its successor `MaxMetaspaceSize`.

Note that while by default the Gradle Tooling API "will use the JVM and JVM arguments that the target build is configured to use" [3], both `setJvmArguments()` and `addJvmArguments()` override that default [4]. So in order to modify the JVM arguments configured for a project, they need to be read and changed manually.

[1]: https://github.com/vector-im/element-android/blob/591b08f/gradle.properties#L11
[2]: https://github.com/vector-im/element-android/blob/591b08f/dependencies.gradle#L5-L6
[3]: https://docs.gradle.org/current/javadoc/org/gradle/tooling/GradleConnector.html
[4]: https://github.com/gradle/gradle/issues/25155