### PR TITLE
fix(fossid-webapp): Make some Snippet properties nullable 

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/result/Snippet.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/result/Snippet.kt
@@ -28,9 +28,9 @@ data class Snippet(
     val matchType: MatchType,
 
     val reason: String?,
-    val author: String,
-    val artifact: String,
-    val version: String,
+    val author: String?,
+    val artifact: String?,
+    val version: String?,
     val purl: String? = null,
 
     val artifactLicense: String?,
@@ -40,14 +40,14 @@ data class Snippet(
 
     val file: String,
     val fileLicense: String?,
-    val url: String,
-    val hits: String,
+    val url: String?,
+    val hits: String?,
     val size: Int?,
 
     val updated: String?,
     val cpe: String?,
     val score: String,
-    val matchFileId: String,
+    val matchFileId: String?,
     val classification: String?,
     val highlighting: String?
 )

--- a/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-list_scan_ignored_snippets.json
+++ b/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-list_scan_ignored_snippets.json
@@ -1,0 +1,26 @@
+{
+  "id" : "892411ab-7982-4496-8394-e351e3e01549",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{  \"action\" : \"get_fossid_results\",  \"group\" : \"files_and_folders\",  \"data\" : {    \"username\":\"\",    \"key\":\"\",    \"scan_code\": \"semver4j_20201203_090342\",    \"path\" : \"c3JjL21haW4vamF2YS9jb20vdmR1cm1vbnQvc2VtdmVyNGovUmVxdWlyZW1lbnQuamF2YQ==\"  }}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{  \"operation\": \"files_and_folders_get_fossid_results\",  \"status\": \"1\",  \"data\": {    \"223\": {      \"id\": \"223\",      \"created\": \"2023-05-24 14:09:29\",      \"scan_id\": \"0\",      \"scan_file_id\": \"25435949\",      \"file_id\": \"8269975\",      \"match_type\": \"ignored\",      \"reason\": \"file not found\",      \"author\": null,      \"artifact\": null,      \"version\": null,      \"purl\": null,      \"artifact_license\": null,      \"artifact_license_category\": null,      \"release_date\": null,      \"mirror\": null,      \"file\": \"\",      \"file_license\": null,      \"url\": null,      \"hits\": null,      \"size\": \"0\",      \"updated\": \"2023-05-24 14:09:29\",      \"cpe\": null,      \"score\": \"\",      \"match_file_id\": null,      \"classification\": \"null\",      \"highlighting\": \"null\"    }  },  \"message\": \"Success\"}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 03 Dec 2020 08:04:04 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "892411ab-7982-4496-8394-e351e3e01549",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -151,6 +151,23 @@ class FossIdClientReturnTypeTest : StringSpec({
         }
     }
 
+    "Ignored snippets can be mapped" {
+        service.listSnippets(
+            "",
+            "",
+            SCAN_CODE_1,
+            "src/main/java/com/vdurmont/semver4j/Requirement.java"
+        ).shouldNotBeNull().run {
+            checkResponse("list snippets")
+            data.shouldNotBeNull().run {
+                this shouldNot beEmpty()
+                forEach {
+                    it.shouldBeTypeOf<Snippet>()
+                }
+            }
+        }
+    }
+
     "Matched lines can be listed" {
         service.listMatchedLines(
             "",

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -834,8 +834,11 @@ class FossId internal constructor(
 
                 // FossID does not return the hash of the remote artifact. Instead, it returns the MD5 hash of the
                 // matched file in the remote artifact as part of the "match_file_id" property.
-                val snippetProvenance = ArtifactProvenance(RemoteArtifact(it.url, Hash.NONE))
-                val purl = it.purl ?: "pkg:${urlToPackageType(it.url)}/${it.author}/${it.artifact}@${it.version}"
+                val url = checkNotNull(it.url) {
+                    "The URL of snippet ${it.id} must not be null."
+                }
+                val snippetProvenance = ArtifactProvenance(RemoteArtifact(url, Hash.NONE))
+                val purl = it.purl ?: "pkg:${urlToPackageType(url)}/${it.author}/${it.artifact}@${it.version}"
 
                 val additionalSnippetData = mapOf(
                     SNIPPET_DATA_ID to it.id.toString(),

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -54,6 +54,7 @@ import org.ossreviewtoolkit.clients.fossid.listScansForProject
 import org.ossreviewtoolkit.clients.fossid.listSnippets
 import org.ossreviewtoolkit.clients.fossid.model.Project
 import org.ossreviewtoolkit.clients.fossid.model.Scan
+import org.ossreviewtoolkit.clients.fossid.model.result.MatchType
 import org.ossreviewtoolkit.clients.fossid.model.rules.RuleScope
 import org.ossreviewtoolkit.clients.fossid.model.rules.RuleType
 import org.ossreviewtoolkit.clients.fossid.model.status.DownloadStatus
@@ -787,7 +788,7 @@ class FossId internal constructor(
                     }
                     logger.info { "${snippets.size} snippets." }
 
-                    it to snippets.toSet()
+                    it to snippets.filterNot { it.matchType == MatchType.IGNORED }.toSet()
                 }
             }.awaitAll().toMap()
         }


### PR DESCRIPTION
Today, FossID has returned me the following snippet:
```
"223": {
			"id": "223",
			"created": "2023-05-24 14:09:29",
			"scan_id": "0",
			"scan_file_id": "25435949",
			"file_id": "8269975",
			"match_type": "ignored",
			"reason": "file not found",
			"author": null,
			"artifact": null,
			"version": null,
			"purl": null,
			"artifact_license": null,
			"artifact_license_category": null,
			"release_date": null,
			"mirror": null,
			"file": "",
			"file_license": null,
			"url": null,
			"hits": null,
			"size": "0",
			"updated": "2023-05-24 14:09:29",
			"cpe": null,
			"score": "",
			"match_file_id": null,
			"classification": "null",
			"highlighting": "null"
		},
```
This pull request adapts ORT to support such snippets.


