### PR TITLE
OrtResult: Remove several serialized `has_issues` properties

### DIFF
--- a/advisor/src/test/assets/ort-analyzer-result.yml
+++ b/advisor/src/test/assets/ort-analyzer-result.yml
@@ -566,7 +566,6 @@ analyzer:
         url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
         revision: ""
         path: ""
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -1291,7 +1291,6 @@ analyzer:
         url: "ssh://git@github.com/milessabin/macro-compat.git"
         revision: ""
         path: ""
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/sbt-http4s-template-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/sbt-http4s-template-expected-output.yml
@@ -1717,7 +1717,6 @@ analyzer:
         url: "ssh://git@github.com/typelevel/simulacrum-scalafix.git"
         revision: ""
         path: ""
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -183,8 +183,6 @@ class AnalyzerResultBuilderTest : WordSpec() {
                 resultTree["dependency_graphs"] shouldNotBeNull {
                     count() shouldBe 2
                 }
-
-                resultTree["has_issues"].asBoolean() shouldBe true
             }
 
             "be serialized and deserialized correctly with an empty dependency graph" {

--- a/cli/src/funTest/assets/git-repo-expected-output.yml
+++ b/cli/src/funTest/assets/git-repo-expected-output.yml
@@ -4123,7 +4123,6 @@ analyzer:
           \ This potentially results in unstable versions of dependencies. To support\
           \ this, enable the 'allowDynamicVersions' option in 'config.yml'."
         severity: "ERROR"
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/cli/src/funTest/assets/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/cli/src/funTest/assets/gradle-all-dependencies-expected-result-with-curations.yml
@@ -455,7 +455,6 @@ analyzer:
         url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
         revision: ""
         path: ""
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/cli/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml
+++ b/cli/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml
@@ -114,4 +114,3 @@ packages:
     revision: ""
     path: ""
   is_modified: true
-has_issues: false

--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -341,7 +341,6 @@ advisor:
           - url: "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250"
             scoring_system: "CVSS2"
             severity: "5.5"
-    has_issues: false
 evaluator: null
 resolved_configuration:
   package_curations:

--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -151,7 +151,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner:
   start_time: "2020-10-26T20:00:50.163356Z"
   end_time: "2020-10-26T20:00:59.349366Z"

--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -306,7 +306,6 @@ scanner:
   storage_stats:
     num_reads: 4
     num_hits: 4
-  has_issues: false
 advisor:
   start_time: "2021-04-29T14:54:16.562951Z"
   end_time: "2021-04-29T14:54:18.969210Z"

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -80,11 +80,6 @@ data class AdvisorRecord(
         }
 
     /**
-     * True if any of the [advisorResults] contain [Issue]s.
-     */
-    val hasIssues by lazy { getIssues().isNotEmpty() }
-
-    /**
      * Return a map of all [Package]s and the associated [Vulnerabilities][Vulnerability].
      */
     @JsonIgnore

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -102,11 +102,6 @@ data class AnalyzerResult(
         }
 
     /**
-     * True if there were any issues during the analysis, false otherwise.
-     */
-    val hasIssues by lazy { getAllIssues().isNotEmpty() }
-
-    /**
      * Return a result, in which all contained [Project]s have their scope information resolved. If this result
      * has shared dependency graphs, the projects referring to one of these graphs are replaced by corresponding
      * instances that store their dependencies in the classic [Scope]-based format. Otherwise, this instance is

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -109,11 +109,6 @@ data class PackageReference(
         dependencies.filter { it.id == id } + dependencies.flatMap { it.findReferences(id) }
 
     /**
-     * Return whether this package reference or any of its dependencies has issues.
-     */
-    fun hasIssues(): Boolean = issues.isNotEmpty() || dependencies.any { it.hasIssues() }
-
-    /**
      * Apply the provided [transform] to each node in the dependency tree represented by this [PackageReference] and
      * return the modified [PackageReference]. The tree is traversed depth-first (post-order).
      */

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -93,9 +93,4 @@ data class ScannerRun(
                 }
             }
         }
-
-    /**
-     * True if any of the [scanResults] contain [Issue]s.
-     */
-    val hasIssues by lazy { getIssues().isNotEmpty() }
 }

--- a/model/src/test/assets/analyzer-result-with-dependency-graph.yml
+++ b/model/src/test/assets/analyzer-result-with-dependency-graph.yml
@@ -171,7 +171,6 @@ analyzer:
           com.vdurmont:semver4j:3.1.0:test:
           - root: 0
           - root: 2
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/gradle-all-dependencies-expected-result.yml
+++ b/model/src/test/assets/gradle-all-dependencies-expected-result.yml
@@ -454,7 +454,6 @@ analyzer:
         url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
         revision: ""
         path: ""
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/result-with-issues-graph-old.yml
+++ b/model/src/test/assets/result-with-issues-graph-old.yml
@@ -1306,7 +1306,6 @@ analyzer:
           - root: 19
           com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:
           - root: 15
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/result-with-issues-graph.yml
+++ b/model/src/test/assets/result-with-issues-graph.yml
@@ -1335,7 +1335,6 @@ analyzer:
           to: 29
         - from: 28
           to: 30
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/result-with-issues-scopes.yml
+++ b/model/src/test/assets/result-with-issues-scopes.yml
@@ -1302,7 +1302,6 @@ analyzer:
         url: "ssh://git@github.com/milessabin/macro-compat.git"
         revision: ""
         path: ""
-    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/sbt-multi-project-example-graph-old.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph-old.yml
@@ -1296,7 +1296,6 @@ analyzer:
           - root: 19
           com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:
           - root: 15
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/sbt-multi-project-example-graph.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph.yml
@@ -1325,7 +1325,6 @@ analyzer:
           to: 29
         - from: 28
           to: 30
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/kotlin/AdvisorRecordTest.kt
+++ b/model/src/test/kotlin/AdvisorRecordTest.kt
@@ -25,7 +25,6 @@ import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.should
-import io.kotest.matchers.shouldBe
 
 import java.net.URI
 import java.time.Instant
@@ -33,28 +32,6 @@ import java.time.Instant
 import org.ossreviewtoolkit.utils.common.enumSetOf
 
 class AdvisorRecordTest : WordSpec({
-    "hasIssues" should {
-        "return false given the record has no issues" {
-            val record = advisorRecordOf(
-                langId to listOf(createResult())
-            )
-
-            record.hasIssues shouldBe false
-        }
-
-        "return true given the record has issues" {
-            val record = advisorRecordOf(
-                queryId to listOf(
-                    createResult(
-                        issues = listOf(Issue(source = "Advisor", message = "Failure"))
-                    )
-                )
-            )
-
-            record.hasIssues shouldBe true
-        }
-    }
-
     "collectIssues" should {
         "return a map which does not contain entries for IDs without any issues" {
             val record = advisorRecordOf(

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
@@ -784,7 +784,6 @@ analyzer:
         url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a"
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2-workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2-workspaces-expected-output.yml
@@ -155,4 +155,3 @@ packages:
     url: "https://github.com/heremaps/harp.gl.git"
     revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
     path: "@here/harp-fetch"
-has_issues: false

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-multi-module.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-multi-module.yml
@@ -101,4 +101,3 @@ packages:
     url: "https://github.com/dart-lang/typed_data.git"
     revision: ""
     path: ""
-has_issues: false

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-with-flutter-android-and-cocoapods.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-with-flutter-android-and-cocoapods.yml
@@ -1474,4 +1474,3 @@ packages:
     url: "https://github.com/dart-lang/lints.git"
     revision: ""
     path: ""
-has_issues: false

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -596,7 +596,6 @@ advisor:
           - url: "https://registry.vulnerability-url/"
             scoring_system: "SCORING_SYSTEM_NAME"
             severity: "ERROR"
-    has_issues: true
 evaluator:
   start_time: "1970-01-01T01:09:00Z"
   end_time: "1970-01-01T01:11:00Z"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -337,7 +337,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner:
   start_time: "1970-01-01T00:40:00Z"
   end_time: "1970-01-01T00:48:00Z"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -555,7 +555,6 @@ scanner:
   storage_stats:
     num_reads: 5
     num_hits: 0
-  has_issues: true
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -596,7 +596,6 @@ advisor:
           - url: "https://registry.vulnerability-url/"
             scoring_system: "SCORING_SYSTEM_NAME"
             severity: "ERROR"
-    has_issues: true
 evaluator:
   start_time: "1970-01-01T01:09:00Z"
   end_time: "1970-01-01T01:11:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -337,7 +337,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner:
   start_time: "1970-01-01T00:40:00Z"
   end_time: "1970-01-01T00:48:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -555,7 +555,6 @@ scanner:
   storage_stats:
     num_reads: 5
     num_hits: 0
-  has_issues: true
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -596,7 +596,6 @@ advisor:
           - url: "https://registry.vulnerability-url/"
             scoring_system: "SCORING_SYSTEM_NAME"
             severity: "ERROR"
-    has_issues: true
 evaluator:
   start_time: "1970-01-01T01:09:00Z"
   end_time: "1970-01-01T01:11:00Z"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -337,7 +337,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner:
   start_time: "1970-01-01T00:40:00Z"
   end_time: "1970-01-01T00:48:00Z"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -555,7 +555,6 @@ scanner:
   storage_stats:
     num_reads: 5
     num_hits: 0
-  has_issues: true
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -359,7 +359,6 @@ scanner:
   storage_stats:
     num_reads: 0
     num_hits: 0
-  has_issues: true
 advisor: null
 evaluator: null
 resolved_configuration:

--- a/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -183,7 +183,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -180,7 +180,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner: null
 advisor: null
 evaluator: null

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -358,7 +358,6 @@ scanner:
   storage_stats:
     num_reads: 0
     num_hits: 0
-  has_issues: true
 advisor: null
 evaluator: null
 resolved_configuration:

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -183,7 +183,6 @@ analyzer:
         url: ""
         revision: ""
         path: ""
-    has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
See individual commits.

Besides removing redundancy, this prepares for introducing logic inside `OrtResult` on which `hasIssues()` would need to depend on, which is not possible, because the `*Run` classes do not have access to the enclosing `OrtResult` instance.

Context: #5950.