### PR TITLE
docs: Comment which comparators are in line with `equals()`

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -63,6 +63,7 @@ data class Identifier(
             version = ""
         )
 
+        // This comparator is consistent with `equals()` as all properties are taken into account.
         private val COMPARATOR = compareBy<Identifier>({ it.type }, { it.namespace }, { it.name })
             .thenComparing({ it.version }, AlphaNumericComparator)
     }

--- a/model/src/main/kotlin/TextLocation.kt
+++ b/model/src/main/kotlin/TextLocation.kt
@@ -43,6 +43,8 @@ data class TextLocation(
 ) : Comparable<TextLocation> {
     companion object {
         const val UNKNOWN_LINE = -1
+
+        // This comparator is consistent with `equals()` as all properties are taken into account.
         private val COMPARATOR = compareBy<TextLocation>({ it.path }, { it.startLine }, { it.endLine })
     }
 


### PR DESCRIPTION
At least for these classes, no risk is imposed by implementing `Comparable` and putting instances in sorted collections.