### PR TITLE
fix(FileListStorageConfiguration): Fix-up the database table name

### DIFF
--- a/model/src/main/kotlin/config/FileListStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/FileListStorageConfiguration.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
 
-private const val TABLE_NAME = "provenance_file_listings"
+private const val TABLE_NAME = "provenance_file_lists"
 private const val FILENAME = "file_list.xz"
 
 data class FileListStorageConfiguration(


### PR DESCRIPTION
This is a fix-up for 92acfc8ae730693f86e88612e524997024b3faa5.

BREAKING CHANGE: It still works if you don't do anything. However, if you want to re-use your existing table entries, then just rename your database table accordingly.

