### PR TITLE
fix(fossid-webapp): Fix FossID license mapping 

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -828,7 +828,7 @@ class FossId internal constructor(
             Issue(source = name, message = "Pending identification for '$it'.", severity = Severity.HINT)
         }
 
-        val snippetFindings = mapSnippetFindings(rawResults, scannerConfig, issues)
+        val snippetFindings = mapSnippetFindings(rawResults, issues)
 
         val ignoredFiles = rawResults.listIgnoredFiles.associateBy { it.path }
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
@@ -36,7 +36,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Snippet as OrtSnippet
 import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.PurlType
 import org.ossreviewtoolkit.utils.common.collapseToRanges
@@ -114,20 +113,13 @@ internal fun <T : Summarizable> List<T>.mapSummary(
  */
 internal fun mapSnippetFindings(
     rawResults: RawResults,
-    scannerConfig: ScannerConfiguration,
     issues: MutableList<Issue>
 ): Set<SnippetFinding> {
-    val fakeLocation = TextLocation(".", TextLocation.UNKNOWN_LINE)
-
     return rawResults.listSnippets.flatMap { (file, rawSnippets) ->
         rawSnippets.map { snippet ->
             val license = snippet.artifactLicense?.let {
                 runCatching {
-                    LicenseFinding.createAndMap(
-                        it,
-                        fakeLocation,
-                        detectedLicenseMapping = scannerConfig.detectedLicenseMapping
-                    ).license
+                    it.toSpdx()
                 }.onFailure { spdxException ->
                     issues += FossId.createAndLogIssue(
                         source = "FossId",

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdLicenseMappingTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdLicenseMappingTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+
+import org.ossreviewtoolkit.clients.fossid.model.identification.common.LicenseMatchType
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.File
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.License
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.LicenseFile
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
+import org.ossreviewtoolkit.clients.fossid.model.result.LicenseCategory
+import org.ossreviewtoolkit.clients.fossid.model.result.MatchType
+import org.ossreviewtoolkit.clients.fossid.model.result.Snippet
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
+import org.ossreviewtoolkit.utils.spdx.toSpdx
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+private const val FILE_PATH = "filePath"
+private const val FILE_PATH_SNIPPET = "filePathSnippet"
+
+class FossIdLicenseMappingTest : WordSpec({
+    "FossIdScanResults" should {
+        "create an issue when a license in an identified file cannot be mapped" {
+            val sampleFile = createMarkAsIdentifiedFile("invalid license")
+            val issues = mutableListOf<Issue>()
+
+            val findings = listOf(sampleFile).mapSummary(emptyMap(), issues, emptyMap())
+
+            issues should haveSize(1)
+            issues.first() shouldNotBeNull {
+                message shouldStartWith "Failed to parse license 'invalid license' as an SPDX expression:"
+            }
+            findings.licenseFindings should beEmpty()
+        }
+
+        "map non-SPDX compliant FossId licenses in a snippet to snippet findings" {
+            val rawResults = createSnippet("Apache 2.0")
+            val issues = mutableListOf<Issue>()
+
+            val findings = mapSnippetFindings(rawResults, issues)
+
+            issues should beEmpty()
+            findings should haveSize(1)
+            findings.first() shouldNotBeNull {
+                snippet.licenses.toString() shouldBe "Apache-2.0"
+            }
+        }
+
+        "map SPDX compliant FossId licenses in a snippet to snippet findings" {
+            val rawResults = createSnippet("Apache-2.0")
+            val issues = mutableListOf<Issue>()
+
+            val findings = mapSnippetFindings(rawResults, issues)
+
+            issues should beEmpty()
+            findings should haveSize(1)
+            findings.first() shouldNotBeNull {
+                snippet.licenses.toString() shouldBe "Apache-2.0"
+            }
+        }
+
+        "create an issue when a license in a snippet cannot be mapped" {
+            val rawResults = createSnippet("invalid license")
+            val issues = mutableListOf<Issue>()
+
+            val findings = mapSnippetFindings(rawResults, issues)
+
+            issues should haveSize(1)
+            issues.first() shouldNotBeNull {
+                message shouldStartWith "Failed to map license 'invalid license' as an SPDX expression."
+            }
+            findings should haveSize(1)
+            findings.first() shouldNotBeNull {
+                snippet.licenses shouldBe SpdxConstants.NOASSERTION.toSpdx()
+            }
+        }
+    }
+})
+
+private fun createMarkAsIdentifiedFile(license: String): MarkedAsIdentifiedFile {
+    val fileLicense = License(
+        1,
+        LicenseMatchType.FILE,
+        1,
+        1,
+        1,
+        created = "created",
+        updated = "updated",
+        licenseId = 1
+    ).also {
+        it.file = LicenseFile(
+            license,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+    }
+
+    return MarkedAsIdentifiedFile(
+        "comment",
+        1,
+        "copyright",
+        1,
+        1
+    ).also {
+        it.file = File(
+            "fileId",
+            "fileMd5",
+            FILE_PATH,
+            "fileSha1",
+            "fileSha256",
+            0,
+            mutableMapOf(1 to fileLicense)
+        )
+    }
+}
+
+private fun createSnippet(license: String): RawResults {
+    val snippet = Snippet(
+        1,
+        "created",
+        1,
+        1,
+        1,
+        MatchType.PARTIAL,
+        null,
+        "author",
+        "artifact",
+        "version",
+        "pkg:maven/com.vdurmont/semver4j@3.1.0",
+        license,
+        LicenseCategory.UNCATEGORIZED,
+        "releaseDate",
+        null,
+        FILE_PATH_SNIPPET,
+        null,
+        "url",
+        null,
+        null,
+        null,
+        null,
+        "1.0",
+        null,
+        null,
+        null
+    )
+    return RawResults(emptyList(), emptyList(), emptyList(), emptyList(), mapOf(FILE_PATH to setOf(snippet)))
+}

--- a/utils/ort/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/ort/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -81,7 +81,7 @@ object DeclaredLicenseProcessor : Logging {
      * it as something that is not a license, like a copyright that was accidentally entered as a license. Return the
      * successfully mapped license expression, or null if the declared license could not be mapped.
      */
-    internal fun process(
+    fun process(
         declaredLicense: String,
         customLicenseMapping: Map<String, SpdxExpression> = emptyMap()
     ): SpdxExpression? {


### PR DESCRIPTION
Currently, the mapping of licenses from FossID identified / "marked as
identified" files and from FossID's snippets fails if the license cannot
be mapped to SPDX, for instance 'Apache 2.0'.
In this case, the FossID scanner creates issues in the scan results.

This commit changes the logic to use the `DeclaredLicenseProcessor` to
map these licenses to syntactically correct SPDX expressions. It also
adds a unit test to cover this part of the code that was previously
uncovered.

Please note that mapping of non-mappable license from identified /
"marked as identified" files still leads to the creation of an issue.
However, fewer issues should be now created with the new logic.