### PR TITLE
fix(Gradle): Avoid a JVM >= 17 warning when running tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -300,7 +300,11 @@ subprojects {
 
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
             // See https://kotest.io/docs/next/extensions/system_extensions.html#system-environment.
-            jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+            jvmArgs(
+                "--add-opens", "java.base/java.io=ALL-UNNAMED",
+                "--add-opens", "java.base/java.util=ALL-UNNAMED",
+                "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED"
+            )
         }
 
         val testSystemProperties = mutableListOf("gradle.build.dir" to project.buildDir.path)


### PR DESCRIPTION
This is a fixup for c903fbf to allow more packages to be accessible at runtime via reflection. While at it, slightly align the argument syntax to other similar code.