### PR TITLE
build(github): Disable caching for Qodana checks

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -76,6 +76,8 @@ jobs:
         fetch-depth: 0
     - name: Qodana Scan
       uses: JetBrains/qodana-action@v2023.1.0
+      with:
+        use-caches: false
     - uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: ${{runner.temp}}/qodana/results/qodana.sarif.json


### PR DESCRIPTION
As the Qodana caches can grow massive (larger than 1 GiB, see [1]) and we have long-running checks anyway, disable caching to see how it impacts runtime.

[1]: https://github.com/oss-review-toolkit/ort/actions/caches?query=sort%3Asize-desc