### PR TITLE
OrtResult: Store scan results "by provenance"

### DIFF
--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -184,125 +184,140 @@ scanner:
     - "postgresStorage"
     storage_writers:
     - "postgresStorage"
+  provenances:
+  - id: "Maven:com.vdurmont:semver4j:3.1.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/vdurmont/semver4j.git"
+        revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+        path: ""
+      resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+  - id: "Maven:junit:junit:4.12"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/junit-team/junit.git"
+        revision: "r4.12"
+        path: ""
+      resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
   scan_results:
-    Maven:com.vdurmont:semver4j:3.1.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://github.com/vdurmont/semver4j.git"
-          revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-          path: ""
-        resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-      scanner:
-        name: "ScanCode"
-        version: "3.2.1-rc2"
-        configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
-          \ --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
-      summary:
-        start_time: "2020-09-30T09:27:12.023451Z"
-        end_time: "2020-09-30T09:28:20.525647Z"
-        package_verification_code: "48ba11487d53ce933b5d4db1d069b70a803ff19b"
-        licenses:
-        - license: "BSD-3-Clause"
-          location:
-            path: "pom.xml"
-            start_line: 28
-            end_line: 34
-        - license: "MIT"
-          location:
-            path: "LICENSE.md"
-            start_line: 1
-            end_line: 1
-        - license: "MIT"
-          location:
-            path: "LICENSE.md"
-            start_line: 5
-            end_line: 21
-        - license: "MIT"
-          location:
-            path: "pom.xml"
-            start_line: 30
-            end_line: 31
-        copyrights:
-        - statement: "Copyright (c) 2015-present Vincent DURMONT <vdurmont@gmail.com>"
-          location:
-            path: "LICENSE.md"
-            start_line: 3
-            end_line: 3
-    Maven:junit:junit:4.12:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://github.com/junit-team/junit.git"
-          revision: "r4.12"
-          path: ""
-        resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
-      scanner:
-        name: "ScanCode"
-        version: "3.2.1-rc2"
-        configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
-          \ --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
-      summary:
-        start_time: "2020-09-30T09:28:32.817956Z"
-        end_time: "2020-09-30T09:29:02.889213Z"
-        package_verification_code: "2acb4f0b06b706fa94e9159c2f9abc1397c46ba0"
-        licenses:
-        - license: "Apache-2.0"
-          location:
-            path: "pom.xml"
-            start_line: 19
-            end_line: 23
-        - license: "Apache-2.0"
-          location:
-            path: "src/site/resources/css/hopscotch-0.1.2.min.css"
-            start_line: 5
-            end_line: 15
-        - license: "Apache-2.0"
-          location:
-            path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
-            start_line: 5
-            end_line: 15
-        - license: "EPL-1.0"
-          location:
-            path: "LICENSE-junit.txt"
-            start_line: 3
-            end_line: 213
-        - license: "EPL-1.0"
-          location:
-            path: "epl-v10.html"
-            start_line: 7
-            end_line: 257
-        - license: "EPL-1.0"
-          location:
-            path: "pom.xml"
-            start_line: 18
-            end_line: 20
-        - license: "EPL-1.0"
-          location:
-            path: "src/site/fml/faq.fml"
-            start_line: 157
-            end_line: 157
-        - license: "EPL-2.0"
-          location:
-            path: "pom.xml"
-            start_line: 19
-            end_line: 23
-        - license: "NOASSERTION"
-          location:
-            path: "src/site/fml/faq.fml"
-            start_line: 156
-            end_line: 156
-        copyrights:
-        - statement: "Copyright 2013 LinkedIn Corp."
-          location:
-            path: "src/site/resources/css/hopscotch-0.1.2.min.css"
-            start_line: 3
-            end_line: 3
-        - statement: "Copyright 2013 LinkedIn Corp."
-          location:
-            path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
-            start_line: 3
-            end_line: 3
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/junit-team/junit.git"
+        revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+        path: ""
+      resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+    scanner:
+      name: "ScanCode"
+      version: "3.2.1-rc2"
+      configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
+        \ --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
+    summary:
+      start_time: "2020-09-30T09:28:32.817956Z"
+      end_time: "2020-09-30T09:29:02.889213Z"
+      package_verification_code: ""
+      licenses:
+      - license: "Apache-2.0"
+        location:
+          path: "pom.xml"
+          start_line: 19
+          end_line: 23
+      - license: "Apache-2.0"
+        location:
+          path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+          start_line: 5
+          end_line: 15
+      - license: "Apache-2.0"
+        location:
+          path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+          start_line: 5
+          end_line: 15
+      - license: "EPL-1.0"
+        location:
+          path: "LICENSE-junit.txt"
+          start_line: 3
+          end_line: 213
+      - license: "EPL-1.0"
+        location:
+          path: "epl-v10.html"
+          start_line: 7
+          end_line: 257
+      - license: "EPL-1.0"
+        location:
+          path: "pom.xml"
+          start_line: 18
+          end_line: 20
+      - license: "EPL-1.0"
+        location:
+          path: "src/site/fml/faq.fml"
+          start_line: 157
+          end_line: 157
+      - license: "EPL-2.0"
+        location:
+          path: "pom.xml"
+          start_line: 19
+          end_line: 23
+      - license: "NOASSERTION"
+        location:
+          path: "src/site/fml/faq.fml"
+          start_line: 156
+          end_line: 156
+      copyrights:
+      - statement: "Copyright 2013 LinkedIn Corp."
+        location:
+          path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+          start_line: 3
+          end_line: 3
+      - statement: "Copyright 2013 LinkedIn Corp."
+        location:
+          path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+          start_line: 3
+          end_line: 3
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/vdurmont/semver4j.git"
+        revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+        path: ""
+      resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    scanner:
+      name: "ScanCode"
+      version: "3.2.1-rc2"
+      configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
+        \ --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
+    summary:
+      start_time: "2020-09-30T09:27:12.023451Z"
+      end_time: "2020-09-30T09:28:20.525647Z"
+      package_verification_code: ""
+      licenses:
+      - license: "BSD-3-Clause"
+        location:
+          path: "pom.xml"
+          start_line: 28
+          end_line: 34
+      - license: "MIT"
+        location:
+          path: "LICENSE.md"
+          start_line: 1
+          end_line: 1
+      - license: "MIT"
+        location:
+          path: "LICENSE.md"
+          start_line: 5
+          end_line: 21
+      - license: "MIT"
+        location:
+          path: "pom.xml"
+          start_line: 30
+          end_line: 31
+      copyrights:
+      - statement: "Copyright (c) 2015-present Vincent DURMONT <vdurmont@gmail.com>"
+        location:
+          path: "LICENSE.md"
+          start_line: 3
+          end_line: 3
 advisor:
   start_time: "2021-04-29T14:54:16.562951Z"
   end_time: "2021-04-29T14:54:18.969210Z"

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 
 /**
@@ -31,7 +30,6 @@ typealias AdvisorResultFilter = (AdvisorResult) -> Boolean
 /**
  * A record of a single run of the advisor tool, containing the input and the [Vulnerability] for every checked package.
  */
-@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
 data class AdvisorRecord(
     /**
      * The [AdvisorResult]s for all [Package]s.

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
@@ -31,7 +30,6 @@ import org.ossreviewtoolkit.model.utils.ProjectSortedSetConverter
 /**
  * A class that merges all information from individual [ProjectAnalyzerResult]s created for each found definition file.
  */
-@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
 data class AnalyzerResult(
     /**
      * Sorted set of the projects, as they appear in the individual analyzer results.

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -161,8 +161,6 @@ data class OrtResult(
         getProjects().associateBy({ it.id }, { repository.getRelativePath(it.vcsProcessed) })
     }
 
-    private val scanResultsById: Map<Identifier, List<ScanResult>> by lazy { scanner?.scanResults.orEmpty() }
-
     /**
      * Return all [AdvisorResult]s contained in this [OrtResult] or only the non-excluded ones if [omitExcluded] is
      * true.
@@ -405,10 +403,10 @@ data class OrtResult(
     /**
      * Return the list of [ScanResult]s for the given [id].
      */
-    fun getScanResultsForId(id: Identifier): List<ScanResult> = scanResultsById[id].orEmpty()
+    fun getScanResultsForId(id: Identifier): List<ScanResult> = scanner?.getScanResults(id).orEmpty()
 
     @JsonIgnore
-    fun getScanResults(): Map<Identifier, List<ScanResult>> = scanResultsById
+    fun getScanResults(): Map<Identifier, List<ScanResult>> = scanner?.getAllScanResults().orEmpty()
 
     /**
      * Return an uncurated [Package] which represents either a [Package] if the given [id] corresponds to a [Package],

--- a/model/src/main/kotlin/ProvenanceResolutionResult.kt
+++ b/model/src/main/kotlin/ProvenanceResolutionResult.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2017 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+/**
+ * This class holds the results of the provenance resolution for the package denoted by [id]. The provenance
+ * resolution consists of root provenance resolution and nested provenance resolution - that is, determining the
+ * sub-repositories of the root provenance. The information tells what has been scanned, or in case of an issues, what
+ * problems happened during provenance resolution.
+ */
+data class ProvenanceResolutionResult(
+    /**
+     * The identifier of package.
+     */
+    val id: Identifier,
+
+    /**
+     * The resolved provenance of the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val packageProvenance: KnownProvenance? = null,
+
+    /**
+     * The (recursive) sub-repositories of [packageProvenance]. The listing is only empty if a
+     * [packageProvenanceResolutionIssue] or a [nestedProvenanceResolutionIssue] happened.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val subRepositories: Map<String, VcsInfo> = emptyMap(),
+
+    /**
+     * The issue which happened during package provenance resolution.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val packageProvenanceResolutionIssue: Issue? = null,
+
+    /**
+     * The issue which happened during nested provenance resolution.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val nestedProvenanceResolutionIssue: Issue? = null
+) {
+    init {
+        require((packageProvenance != null).xor(packageProvenanceResolutionIssue != null)) {
+            "Either package provenance or package provenance resolution issue must be null, but not neither or both."
+        }
+
+        subRepositories.forEach { (path, vcsInfo) ->
+            // TODO: Check if Git-Repo allows to include sub directories of repositories.
+            require(vcsInfo.path.isEmpty()) {
+                "The resolved sub-repository for package ${id.toCoordinates()} under path '$path' has a non-empty " +
+                        "VCS path which is not allowed."
+            }
+        }
+
+        if (packageProvenanceResolutionIssue != null) {
+            require(nestedProvenanceResolutionIssue == null) {
+                "Nested provenance resolution issue is not null, even though nested provenance resolution was not " +
+                        "executed."
+            }
+        }
+    }
+}

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 import java.time.Instant
@@ -37,7 +36,6 @@ import org.ossreviewtoolkit.utils.ort.Environment
 /**
  * The summary of a single run of the scanner.
  */
-@JsonIgnoreProperties(value = ["has_issues", "storage_stats"], allowGetters = true)
 data class ScannerRun(
     /**
      * The [Instant] the scanner was started.

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -21,11 +21,17 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 import java.time.Instant
 
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.utils.ProvenanceResolutionResultSortedSetConverter
+import org.ossreviewtoolkit.model.utils.ScanResultSortedSetConverter
+import org.ossreviewtoolkit.model.utils.alignRevisions
+import org.ossreviewtoolkit.model.utils.clearVcsPath
+import org.ossreviewtoolkit.model.utils.mergeScanResultsByScanner
+import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.Environment
 
 /**
@@ -54,10 +60,17 @@ data class ScannerRun(
     val config: ScannerConfiguration,
 
     /**
-     * The [ScanResult]s for all [Package]s.
+     * The results of the provenance resolution for all projects and packages.
      */
-    @JsonPropertyOrder(alphabetic = true)
-    val scanResults: Map<Identifier, List<ScanResult>>
+
+    @JsonSerialize(converter = ProvenanceResolutionResultSortedSetConverter::class)
+    val provenances: Set<ProvenanceResolutionResult>,
+
+    /**
+     * The scan results for each resolved provenance.
+     */
+    @JsonSerialize(converter = ScanResultSortedSetConverter::class)
+    val scanResults: Set<ScanResult>
 ) {
     companion object {
         /**
@@ -69,22 +82,142 @@ data class ScannerRun(
             endTime = Instant.EPOCH,
             environment = Environment(),
             config = ScannerConfiguration(),
-            scanResults = emptyMap()
+            provenances = emptySet(),
+            scanResults = emptySet()
         )
     }
 
-    /**
-     * Return a map of all de-duplicated [Issue]s associated by [Identifier].
-     */
-    @JsonIgnore
-    fun getIssues(): Map<Identifier, Set<Issue>> =
-        buildMap<Identifier, MutableSet<Issue>> {
-            scanResults.forEach { (id, results) ->
-                results.forEach { result ->
-                    if (result.summary.issues.isNotEmpty()) {
-                        getOrPut(id) { mutableSetOf() } += result.summary.issues
-                    }
+    init {
+        scanResults.forEach { scanResult ->
+            require(scanResult.provenance is KnownProvenance) {
+                "Found a scan result with an unknown provenance, which is not allowed."
+            }
+
+            (scanResult.provenance as? RepositoryProvenance)?.let { repositoryProvenance ->
+                require(repositoryProvenance.vcsInfo.path.isEmpty()) {
+                    "Found a scan result with a non-empty VCS path, which is not allowed."
+                }
+
+                require(repositoryProvenance.vcsInfo.revision == repositoryProvenance.resolvedRevision) {
+                    "The revision and resolved revision of a scan result are not equal, which is not allowed."
                 }
             }
+
+            require(scanResult.summary.packageVerificationCode.isEmpty()) {
+                "Found a scan result with a non-empty package verification code, which is not allowed."
+            }
+        }
+
+        provenances.getDuplicates { it.id }.keys.let { idsForDuplicateProvenanceResolutionResults ->
+            require(idsForDuplicateProvenanceResolutionResults.isEmpty()) {
+                "Found multiple provenance resolution results for the following ids: " +
+                        "${idsForDuplicateProvenanceResolutionResults.joinToString { it.toCoordinates() }}."
+            }
+        }
+
+        val scannedProvenances = scanResults.mapTo(mutableSetOf()) { it.provenance }
+        val resolvedProvenances = provenances.flatMapTo(mutableSetOf()) {
+            it.getKnownProvenancesWithoutVcsPath().values
+        }
+
+        (scannedProvenances - resolvedProvenances).let {
+            require(it.isEmpty()) {
+                "Found scan results which do not correspond to any resolved provenances, which is not allowed: \n" +
+                        it.toYaml()
+            }
+        }
+    }
+
+    private val provenancesById: Map<Identifier, ProvenanceResolutionResult> by lazy {
+        provenances.associateBy { it.id }
+    }
+
+    private val scanResultsByProvenance: Map<KnownProvenance, List<ScanResult>> by lazy {
+        scanResults.groupBy { it.provenance as KnownProvenance }
+    }
+
+    private val scanResultsById: Map<Identifier, List<ScanResult>> by lazy {
+        provenances.map { it.id }.associateWith { id -> getMergedResultsForId(id) }
+    }
+
+    /**
+     * Return all scan results related to [id] with the internal sub-repository scan results merged into the root
+     * repository scan results. ScanResults for different scanners are not merged, so that the output contains exactly
+     * one scan result per scanner.
+     */
+    private fun getMergedResultsForId(id: Identifier): List<ScanResult> {
+        // Algorithm:
+        // 1. If package provenance could not be resolved, create a scan result with the resolution issue.
+        // 2. If nested provenance could not be resolved, take the scan results for the package provenance and each
+        //    scanner and add the resolution issue.
+        // 3. Else, merge the scan results for each scanner based on the nested provenance of the package.
+        val resolutionResult = provenancesById.getValue(id)
+
+        resolutionResult.packageProvenanceResolutionIssue?.let {
+            return listOf(scanResultForProvenanceResolutionIssue(resolutionResult.packageProvenance, it))
+        }
+
+        val packageProvenance = resolutionResult.packageProvenance!!
+
+        val scanResultsByPath = resolutionResult.getKnownProvenancesWithoutVcsPath().mapValues { (_, provenance) ->
+            scanResultsByProvenance[provenance].orEmpty()
+        }
+
+        val scanResults = mergeScanResultsByScanner(scanResultsByPath).map { scanResult ->
+            scanResult.filterByPath(packageProvenance.vcsPath).filterByIgnorePatterns(config.ignorePatterns)
+        }.map { scanResult ->
+            // The VCS revision of scan result is equal to the resolved revision. So, use the package provenance
+            // to re-align the VCS revision with the package's metadata.
+            scanResult.copy(
+                provenance = packageProvenance,
+                summary = scanResult.summary.addIssue(resolutionResult.nestedProvenanceResolutionIssue)
+            )
+
+            // TODO: Compute and set the package verification code of the scan summary.
+        }
+
+        return scanResults.takeIf { it.isNotEmpty() }
+            ?: resolutionResult.nestedProvenanceResolutionIssue?.let { issue ->
+                listOf(scanResultForProvenanceResolutionIssue(packageProvenance, issue))
+            }.orEmpty()
+    }
+
+    @JsonIgnore
+    fun getAllScanResults(): Map<Identifier, List<ScanResult>> = scanResultsById
+
+    fun getScanResults(id: Identifier): List<ScanResult> = scanResultsById[id].orEmpty()
+
+    @JsonIgnore
+    fun getIssues(): Map<Identifier, Set<Issue>> =
+        scanResultsById.mapValues { (_, scanResults) ->
+            scanResults.flatMapTo(mutableSetOf()) { it.summary.issues }
         }
 }
+
+private fun ProvenanceResolutionResult.getKnownProvenancesWithoutVcsPath(): Map<String, KnownProvenance> =
+    buildMap {
+        when (packageProvenance) {
+            is RepositoryProvenance -> put("", packageProvenance.clearVcsPath().alignRevisions())
+            is ArtifactProvenance -> put("", packageProvenance)
+            else -> { }
+        }
+
+        subRepositories.mapValuesTo(this) { (_, vcsInfo) ->
+            RepositoryProvenance(vcsInfo = vcsInfo, resolvedRevision = vcsInfo.revision)
+        }
+    }
+
+private val Provenance.vcsPath: String
+    get() = (this as? RepositoryProvenance)?.vcsInfo?.path.orEmpty()
+
+private fun scanResultForProvenanceResolutionIssue(packageProvenance: KnownProvenance?, issue: Issue): ScanResult =
+    ScanResult(
+        packageProvenance ?: UnknownProvenance,
+        scanner = ScannerDetails(name = "ProvenanceResolver", version = "", configuration = ""),
+        summary = ScanSummary.EMPTY.copy(
+            issues = listOf(issue)
+        )
+    )
+
+private fun ScanSummary.addIssue(issue: Issue?): ScanSummary =
+    if (issue == null) this else copy(issues = (issues + issue).distinct())

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+@file:Suppress("TooManyFunctions")
+
 package org.ossreviewtoolkit.model.utils
 
 import java.net.URI
@@ -29,6 +31,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageProvider
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.utils.common.percentEncode
@@ -232,6 +235,18 @@ fun createPurl(
         append(value)
     }
 }
+
+/**
+ * Return a copy of this [RepositoryProvenance] with an empty VCS path.
+ */
+fun RepositoryProvenance.clearVcsPath() = copy(vcsInfo = vcsInfo.copy(path = ""))
+
+/**
+ * Return a copy of this [RepositoryProvenance] with [VcsInfo] revision set to the resolved revision of this
+ * [RepositoryProvenance].
+ */
+fun RepositoryProvenance.alignRevisions(): RepositoryProvenance =
+    copy(vcsInfo = vcsInfo.copy(revision = resolvedRevision))
 
 /**
  * Return the repo manifest path parsed from this string. The string is interpreted as a URL and the manifest path is

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -94,7 +94,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
   issues:
   - 0
 - _id: 1
@@ -111,7 +110,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 2
   provenance:
     source_artifact:
@@ -125,7 +123,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 3
   provenance:
     source_artifact:
@@ -139,7 +136,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 4
   provenance:
     source_artifact:
@@ -153,7 +149,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 5
   provenance:
     source_artifact:
@@ -167,7 +162,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 6
   provenance:
     source_artifact:
@@ -181,7 +175,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 packages:
 - _id: 0
   id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -119,7 +119,6 @@
     },
     "start_time" : "1970-01-01T00:00:00Z",
     "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000",
     "issues" : [ 0 ]
   }, {
     "_id" : 1,
@@ -138,8 +137,7 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000"
+    "end_time" : "1970-01-01T00:00:00Z"
   }, {
     "_id" : 2,
     "provenance" : {
@@ -157,8 +155,7 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000"
+    "end_time" : "1970-01-01T00:00:00Z"
   }, {
     "_id" : 3,
     "provenance" : {
@@ -176,8 +173,7 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000"
+    "end_time" : "1970-01-01T00:00:00Z"
   }, {
     "_id" : 4,
     "provenance" : {
@@ -195,8 +191,7 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000"
+    "end_time" : "1970-01-01T00:00:00Z"
   }, {
     "_id" : 5,
     "provenance" : {
@@ -214,8 +209,7 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000"
+    "end_time" : "1970-01-01T00:00:00Z"
   }, {
     "_id" : 6,
     "provenance" : {
@@ -233,8 +227,7 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "package_verification_code" : "0000000000000000000000000000000000000000"
+    "end_time" : "1970-01-01T00:00:00Z"
   } ],
   "packages" : [ {
     "_id" : 0,

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -94,7 +94,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
   issues:
   - 0
 - _id: 1
@@ -111,7 +110,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 2
   provenance:
     source_artifact:
@@ -125,7 +123,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 3
   provenance:
     source_artifact:
@@ -139,7 +136,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 4
   provenance:
     source_artifact:
@@ -153,7 +149,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 5
   provenance:
     source_artifact:
@@ -167,7 +162,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 - _id: 6
   provenance:
     source_artifact:
@@ -181,7 +175,6 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
-  package_verification_code: "0000000000000000000000000000000000000000"
 packages:
 - _id: 0
   id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -376,182 +376,227 @@ scanner:
     - "**/META-INF/DEPENDENCIES.txt"
     - "**/META-INF/NOTICE"
     - "**/META-INF/NOTICE.txt"
+  provenances:
+  - id: "Ant:junit:junit:4.12"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+  - id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "master"
+        path: "project"
+      resolved_revision: "0000000000000000000000000000000000000000"
+  - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "master"
+        path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+  - id: "Maven:com.h2database:h2:1.4.200"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-text:1.1"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+  - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
   scan_results:
-    Ant:junit:junit:4.12:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash:
-            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://example.com/git"
-          revision: "master"
-          path: "project"
-        resolved_revision: "0000000000000000000000000000000000000000"
-      scanner:
-        name: "FakeScanner"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-        licenses:
-        - license: "Apache-2.0"
-          location:
-            path: "project/file.java"
-            start_line: 1
-            end_line: 2
-        - license: "Apache-2.0"
-          location:
-            path: "project/file.kt"
-            start_line: 1
-            end_line: 2
-        - license: "MIT"
-          location:
-            path: "project/file1.java"
-            start_line: 1
-            end_line: 2
-        - license: "MIT"
-          location:
-            path: "project/file2.java"
-            start_line: 1
-            end_line: 2
-        copyrights:
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "project/file.java"
-            start_line: 1
-            end_line: 1
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "project/file1.java"
-            start_line: 1
-            end_line: 1
-    Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://github.com/oss-review-toolkit/ort.git"
-          revision: "master"
-          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
-        resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
-      scanner:
-        name: "FakeScanner"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-        licenses:
-        - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
-            \ MIT"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
-            start_line: 1
-            end_line: 1
-        - license: "LicenseRef-test-Apache-2.0-multi-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 19
-            end_line: 20
-        - license: "LicenseRef-test-Apache-2.0-single-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 19
-            end_line: 19
-        - license: "LicenseRef-test-Apache-2.0-single-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 20
-            end_line: 20
-        copyrights:
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 20
-            end_line: 20
-        issues:
-        - timestamp: "1970-01-01T00:00:00Z"
-          source: "Dummy"
-          message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
-            Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
-            \ Please make sure the published POM file includes the SCM connection,\
-            \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
-          severity: "ERROR"
-    Maven:com.h2database:h2:1.4.200:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
-          hash:
-            value: "3b5883b7a5a05b932c699760f0854ca565785a84"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.apache.commons:commons-lang3:3.5:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash:
-            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.apache.commons:commons-text:1.1:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash:
-            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.hamcrest:hamcrest-core:1.3:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash:
-            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "0000000000000000000000000000000000000000"
+        path: ""
+      resolved_revision: "0000000000000000000000000000000000000000"
+    scanner:
+      name: "FakeScanner"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "Apache-2.0"
+        location:
+          path: "project/file.java"
+          start_line: 1
+          end_line: 2
+      - license: "Apache-2.0"
+        location:
+          path: "project/file.kt"
+          start_line: 1
+          end_line: 2
+      - license: "MIT"
+        location:
+          path: "project/file1.java"
+          start_line: 1
+          end_line: 2
+      - license: "MIT"
+        location:
+          path: "project/file2.java"
+          start_line: 1
+          end_line: 2
+      copyrights:
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "project/file.java"
+          start_line: 1
+          end_line: 1
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "project/file1.java"
+          start_line: 1
+          end_line: 1
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        path: ""
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+    scanner:
+      name: "FakeScanner"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
+          \ MIT"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+          start_line: 1
+          end_line: 1
+      - license: "LicenseRef-test-Apache-2.0-multi-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 19
+          end_line: 20
+      - license: "LicenseRef-test-Apache-2.0-single-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 19
+          end_line: 19
+      - license: "LicenseRef-test-Apache-2.0-single-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 20
+          end_line: 20
+      copyrights:
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 20
+          end_line: 20
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Dummy"
+        message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
+          Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
+          \ Please make sure the published POM file includes the SCM connection, see:\
+          \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
+        severity: "ERROR"
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -376,182 +376,227 @@ scanner:
     - "**/META-INF/DEPENDENCIES.txt"
     - "**/META-INF/NOTICE"
     - "**/META-INF/NOTICE.txt"
+  provenances:
+  - id: "Ant:junit:junit:4.12"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+  - id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "master"
+        path: "project"
+      resolved_revision: "0000000000000000000000000000000000000000"
+  - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "master"
+        path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+  - id: "Maven:com.h2database:h2:1.4.200"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-text:1.1"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+  - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
   scan_results:
-    Ant:junit:junit:4.12:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash:
-            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://example.com/git"
-          revision: "master"
-          path: "project"
-        resolved_revision: "0000000000000000000000000000000000000000"
-      scanner:
-        name: "FakeScanner"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-        licenses:
-        - license: "Apache-2.0"
-          location:
-            path: "project/file.java"
-            start_line: 1
-            end_line: 2
-        - license: "Apache-2.0"
-          location:
-            path: "project/file.kt"
-            start_line: 1
-            end_line: 2
-        - license: "MIT"
-          location:
-            path: "project/file1.java"
-            start_line: 1
-            end_line: 2
-        - license: "MIT"
-          location:
-            path: "project/file2.java"
-            start_line: 1
-            end_line: 2
-        copyrights:
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "project/file.java"
-            start_line: 1
-            end_line: 1
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "project/file1.java"
-            start_line: 1
-            end_line: 1
-    Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://github.com/oss-review-toolkit/ort.git"
-          revision: "master"
-          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
-        resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
-      scanner:
-        name: "FakeScanner"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-        licenses:
-        - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
-            \ MIT"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
-            start_line: 1
-            end_line: 1
-        - license: "LicenseRef-test-Apache-2.0-multi-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 19
-            end_line: 20
-        - license: "LicenseRef-test-Apache-2.0-single-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 19
-            end_line: 19
-        - license: "LicenseRef-test-Apache-2.0-single-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 20
-            end_line: 20
-        copyrights:
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 20
-            end_line: 20
-        issues:
-        - timestamp: "1970-01-01T00:00:00Z"
-          source: "Dummy"
-          message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
-            Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
-            \ Please make sure the published POM file includes the SCM connection,\
-            \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
-          severity: "ERROR"
-    Maven:com.h2database:h2:1.4.200:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
-          hash:
-            value: "3b5883b7a5a05b932c699760f0854ca565785a84"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.apache.commons:commons-lang3:3.5:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash:
-            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.apache.commons:commons-text:1.1:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash:
-            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.hamcrest:hamcrest-core:1.3:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash:
-            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "0000000000000000000000000000000000000000"
+        path: ""
+      resolved_revision: "0000000000000000000000000000000000000000"
+    scanner:
+      name: "FakeScanner"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "Apache-2.0"
+        location:
+          path: "project/file.java"
+          start_line: 1
+          end_line: 2
+      - license: "Apache-2.0"
+        location:
+          path: "project/file.kt"
+          start_line: 1
+          end_line: 2
+      - license: "MIT"
+        location:
+          path: "project/file1.java"
+          start_line: 1
+          end_line: 2
+      - license: "MIT"
+        location:
+          path: "project/file2.java"
+          start_line: 1
+          end_line: 2
+      copyrights:
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "project/file.java"
+          start_line: 1
+          end_line: 1
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "project/file1.java"
+          start_line: 1
+          end_line: 1
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        path: ""
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+    scanner:
+      name: "FakeScanner"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
+          \ MIT"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+          start_line: 1
+          end_line: 1
+      - license: "LicenseRef-test-Apache-2.0-multi-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 19
+          end_line: 20
+      - license: "LicenseRef-test-Apache-2.0-single-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 19
+          end_line: 19
+      - license: "LicenseRef-test-Apache-2.0-single-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 20
+          end_line: 20
+      copyrights:
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 20
+          end_line: 20
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Dummy"
+        message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
+          Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
+          \ Please make sure the published POM file includes the SCM connection, see:\
+          \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
+        severity: "ERROR"
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -60,15 +60,12 @@
       "referenceType" : "purl",
       "referenceLocator" : "pkg:maven/first-package-group/first-package@0.0.1"
     } ],
-    "filesAnalyzed" : true,
+    "filesAnalyzed" : false,
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
     "licenseInfoFromFiles" : [ "Apache-2.0", "BSD-2-Clause" ],
     "name" : "first-package",
-    "packageVerificationCode" : {
-      "packageVerificationCodeValue" : "0000000000000000000000000000000000000000"
-    },
     "summary" : "A package with all supported attributes set, with a VCS URL containing a user name, and with two scan results for the VCS containing copyright findings matched to a license finding.",
     "versionInfo" : "0.0.1"
   }, {

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -73,7 +73,7 @@ packages:
   - referenceCategory: "PACKAGE_MANAGER"
     referenceType: "purl"
     referenceLocator: "pkg:maven/first-package-group/first-package@0.0.1"
-  filesAnalyzed: true
+  filesAnalyzed: false
   homepage: "first package's homepage URL"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
@@ -81,8 +81,6 @@ packages:
   - "Apache-2.0"
   - "BSD-2-Clause"
   name: "first-package"
-  packageVerificationCode:
-    packageVerificationCodeValue: "0000000000000000000000000000000000000000"
   summary: "A package with all supported attributes set, with a VCS URL containing\
     \ a user name, and with two scan results for the VCS containing copyright findings\
     \ matched to a license finding."

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -376,182 +376,227 @@ scanner:
     - "**/META-INF/DEPENDENCIES.txt"
     - "**/META-INF/NOTICE"
     - "**/META-INF/NOTICE.txt"
+  provenances:
+  - id: "Ant:junit:junit:4.12"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+  - id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "master"
+        path: "project"
+      resolved_revision: "0000000000000000000000000000000000000000"
+  - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    package_provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "master"
+        path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+  - id: "Maven:com.h2database:h2:1.4.200"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-text:1.1"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+  - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
   scan_results:
-    Ant:junit:junit:4.12:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash:
-            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://example.com/git"
-          revision: "master"
-          path: "project"
-        resolved_revision: "0000000000000000000000000000000000000000"
-      scanner:
-        name: "FakeScanner"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-        licenses:
-        - license: "Apache-2.0"
-          location:
-            path: "project/file.java"
-            start_line: 1
-            end_line: 2
-        - license: "Apache-2.0"
-          location:
-            path: "project/file.kt"
-            start_line: 1
-            end_line: 2
-        - license: "MIT"
-          location:
-            path: "project/file1.java"
-            start_line: 1
-            end_line: 2
-        - license: "MIT"
-          location:
-            path: "project/file2.java"
-            start_line: 1
-            end_line: 2
-        copyrights:
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "project/file.java"
-            start_line: 1
-            end_line: 1
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "project/file1.java"
-            start_line: 1
-            end_line: 1
-    Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
-    - provenance:
-        vcs_info:
-          type: "Git"
-          url: "https://github.com/oss-review-toolkit/ort.git"
-          revision: "master"
-          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
-        resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
-      scanner:
-        name: "FakeScanner"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-        licenses:
-        - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
-            \ MIT"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
-            start_line: 1
-            end_line: 1
-        - license: "LicenseRef-test-Apache-2.0-multi-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 19
-            end_line: 20
-        - license: "LicenseRef-test-Apache-2.0-single-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 19
-            end_line: 19
-        - license: "LicenseRef-test-Apache-2.0-single-line"
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 20
-            end_line: 20
-        copyrights:
-        - statement: "Copyright (c) example authors."
-          location:
-            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-            start_line: 20
-            end_line: 20
-        issues:
-        - timestamp: "1970-01-01T00:00:00Z"
-          source: "Dummy"
-          message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
-            Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
-            \ Please make sure the published POM file includes the SCM connection,\
-            \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
-          severity: "ERROR"
-    Maven:com.h2database:h2:1.4.200:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
-          hash:
-            value: "3b5883b7a5a05b932c699760f0854ca565785a84"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.apache.commons:commons-lang3:3.5:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash:
-            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.apache.commons:commons-text:1.1:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash:
-            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
-    Maven:org.hamcrest:hamcrest-core:1.3:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash:
-            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: "0000000000000000000000000000000000000000"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "0000000000000000000000000000000000000000"
+        path: ""
+      resolved_revision: "0000000000000000000000000000000000000000"
+    scanner:
+      name: "FakeScanner"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "Apache-2.0"
+        location:
+          path: "project/file.java"
+          start_line: 1
+          end_line: 2
+      - license: "Apache-2.0"
+        location:
+          path: "project/file.kt"
+          start_line: 1
+          end_line: 2
+      - license: "MIT"
+        location:
+          path: "project/file1.java"
+          start_line: 1
+          end_line: 2
+      - license: "MIT"
+        location:
+          path: "project/file2.java"
+          start_line: 1
+          end_line: 2
+      copyrights:
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "project/file.java"
+          start_line: 1
+          end_line: 1
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "project/file1.java"
+          start_line: 1
+          end_line: 1
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        path: ""
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+    scanner:
+      name: "FakeScanner"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
+          \ MIT"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+          start_line: 1
+          end_line: 1
+      - license: "LicenseRef-test-Apache-2.0-multi-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 19
+          end_line: 20
+      - license: "LicenseRef-test-Apache-2.0-single-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 19
+          end_line: 19
+      - license: "LicenseRef-test-Apache-2.0-single-line"
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 20
+          end_line: 20
+      copyrights:
+      - statement: "Copyright (c) example authors."
+        location:
+          path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+          start_line: 20
+          end_line: 20
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Dummy"
+        message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
+          Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
+          \ Please make sure the published POM file includes the SCM connection, see:\
+          \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
+        severity: "ERROR"
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -223,139 +223,154 @@ scanner:
     - "**/META-INF/DEPENDENCIES.txt"
     - "**/META-INF/NOTICE"
     - "**/META-INF/NOTICE.txt"
+  provenances:
+  - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    package_provenance_resolution_issue:
+      timestamp: "1970-01-01T00:00:00Z"
+      source: "scanner"
+      message: "IOException: Could not resolve provenance for package 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'\
+        \ for source code origins [VCS, ARTIFACT].\nResolution of VCS failed with:\n\
+        URISyntaxException: Cannot parse Git URI-ish: The uri was empty or null"
+      severity: "ERROR"
+  - id: "Maven:junit:junit:4.12"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-text:1.1"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+  - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
   scan_results:
-    Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
-    - provenance: {}
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        issues:
-        - timestamp: "1970-01-01T00:00:00Z"
-          source: "scanner"
-          message: "Could not resolve provenance for package 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0':\
-            \ IOException: Could not resolve provenance for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'\
-            \ for source code origins [VCS, ARTIFACT].\nResolution of VCS failed with:\n\
-            URISyntaxException: Cannot parse Git URI-ish: The uri was empty or null"
-          severity: "ERROR"
-    Maven:junit:junit:4.12:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash:
-            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "LICENSE-junit.txt"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "junit"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
-    Maven:org.apache.commons:commons-lang3:3.5:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash:
-            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
-    Maven:org.apache.commons:commons-text:1.1:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash:
-            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
-    Maven:org.hamcrest:hamcrest-core:1.3:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash:
-            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "LICENSE-junit.txt"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "junit"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
 advisor: null
 evaluator: null
 resolved_configuration:

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -223,138 +223,154 @@ scanner:
     - "**/META-INF/DEPENDENCIES.txt"
     - "**/META-INF/NOTICE"
     - "**/META-INF/NOTICE.txt"
+  provenances:
+  - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    package_provenance_resolution_issue:
+      timestamp: "1970-01-01T00:00:00Z"
+      source: "scanner"
+      message: "IOException: Could not resolve provenance for package 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'\
+        \ for source code origins [VCS, ARTIFACT].\nResolution of VCS failed with:\n\
+        URISyntaxException: Cannot parse Git URI-ish: The uri was empty or null"
+      severity: "ERROR"
+  - id: "Maven:junit:junit:4.12"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+  - id: "Maven:org.apache.commons:commons-text:1.1"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+  - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    package_provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
   scan_results:
-    Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
-    - provenance: {}
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        issues:
-        - timestamp: "1970-01-01T00:00:00Z"
-          source: "scanner"
-          message: "IOException: Could not resolve provenance for package 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'\
-            \ for source code origins [VCS, ARTIFACT].\nResolution of VCS failed with:\n\
-            URISyntaxException: Cannot parse Git URI-ish: The uri was empty or null"
-          severity: "ERROR"
-    Maven:junit:junit:4.12:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash:
-            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "LICENSE-junit.txt"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "junit"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
-    Maven:org.apache.commons:commons-lang3:3.5:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash:
-            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
-    Maven:org.apache.commons:commons-text:1.1:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash:
-            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
-    Maven:org.hamcrest:hamcrest-core:1.3:
-    - provenance:
-        source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash:
-            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-            algorithm: "SHA-1"
-      scanner:
-        name: "Dummy"
-        version: "1.0.0"
-        configuration: ""
-      summary:
-        start_time: "1970-01-01T00:00:00Z"
-        end_time: "1970-01-01T00:00:00Z"
-        package_verification_code: ""
-        licenses:
-        - license: "NONE"
-          location:
-            path: "META-INF"
-            start_line: -1
-            end_line: -1
-        - license: "NONE"
-          location:
-            path: "org"
-            start_line: -1
-            end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "LICENSE-junit.txt"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "junit"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+      licenses:
+      - license: "NONE"
+        location:
+          path: "META-INF"
+          start_line: -1
+          end_line: -1
+      - license: "NONE"
+        location:
+          path: "org"
+          start_line: -1
+          end_line: -1
 advisor: null
 evaluator: null
 resolved_configuration:

--- a/scanner/src/funTest/assets/dummy-expected-scan-results-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-scan-results-for-analyzer-result.yml
@@ -2,8 +2,8 @@
 Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
 - provenance: {}
   scanner:
-    name: "Dummy"
-    version: "1.0.0"
+    name: "ProvenanceResolver"
+    version: ""
     configuration: ""
   summary:
     start_time: "1970-01-01T00:00:00Z"

--- a/scanner/src/funTest/assets/dummy-expected-scan-results-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-scan-results-for-analyzer-result.yml
@@ -1,0 +1,132 @@
+---
+Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
+- provenance: {}
+  scanner:
+    name: "Dummy"
+    version: "1.0.0"
+    configuration: ""
+  summary:
+    start_time: "1970-01-01T00:00:00Z"
+    end_time: "1970-01-01T00:00:00Z"
+    package_verification_code: ""
+    issues:
+    - timestamp: "1970-01-01T00:00:00Z"
+      source: "scanner"
+      message: "IOException: Could not resolve provenance for package 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'\
+        \ for source code origins [VCS, ARTIFACT].\nResolution of VCS failed with:\n\
+        URISyntaxException: Cannot parse Git URI-ish: The uri was empty or null"
+      severity: "ERROR"
+Maven:junit:junit:4.12:
+- provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0.0"
+    configuration: ""
+  summary:
+    start_time: "1970-01-01T00:00:00Z"
+    end_time: "1970-01-01T00:00:00Z"
+    package_verification_code: ""
+    licenses:
+    - license: "NONE"
+      location:
+        path: "LICENSE-junit.txt"
+        start_line: -1
+        end_line: -1
+    - license: "NONE"
+      location:
+        path: "META-INF"
+        start_line: -1
+        end_line: -1
+    - license: "NONE"
+      location:
+        path: "junit"
+        start_line: -1
+        end_line: -1
+    - license: "NONE"
+      location:
+        path: "org"
+        start_line: -1
+        end_line: -1
+Maven:org.apache.commons:commons-lang3:3.5:
+- provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0.0"
+    configuration: ""
+  summary:
+    start_time: "1970-01-01T00:00:00Z"
+    end_time: "1970-01-01T00:00:00Z"
+    package_verification_code: ""
+    licenses:
+    - license: "NONE"
+      location:
+        path: "META-INF"
+        start_line: -1
+        end_line: -1
+    - license: "NONE"
+      location:
+        path: "org"
+        start_line: -1
+        end_line: -1
+Maven:org.apache.commons:commons-text:1.1:
+- provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0.0"
+    configuration: ""
+  summary:
+    start_time: "1970-01-01T00:00:00Z"
+    end_time: "1970-01-01T00:00:00Z"
+    package_verification_code: ""
+    licenses:
+    - license: "NONE"
+      location:
+        path: "META-INF"
+        start_line: -1
+        end_line: -1
+    - license: "NONE"
+      location:
+        path: "org"
+        start_line: -1
+        end_line: -1
+Maven:org.hamcrest:hamcrest-core:1.3:
+- provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0.0"
+    configuration: ""
+  summary:
+    start_time: "1970-01-01T00:00:00Z"
+    end_time: "1970-01-01T00:00:00Z"
+    package_verification_code: ""
+    licenses:
+    - license: "NONE"
+      location:
+        path: "META-INF"
+        start_line: -1
+        end_line: -1
+    - license: "NONE"
+      location:
+        path: "org"
+        start_line: -1
+        end_line: -1

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -58,7 +58,7 @@ class ScannerIntegrationFunTest : StringSpec({
         patchActualResult(result.toYaml(), patchStartAndEndTime = true) should matchExpectedResult(expectedResultFile)
     }
 
-    "scan() returns the expected scan results for a given analyzer result".config(invocations = 3) {
+    "scan() returns the expected (merged) scan results for a given analyzer result".config(invocations = 3) {
         val analyzerResultFile = getAssetFile("analyzer-result.yml")
         val expectedResultFile = getAssetFile("dummy-expected-scan-results-for-analyzer-result.yml")
 

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -53,34 +53,36 @@ class ScannerIntegrationFunTest : StringSpec({
         val analyzerResultFile = getAssetFile("analyzer-result.yml")
         val expectedResultFile = getAssetFile("dummy-expected-output-for-analyzer-result.yml")
 
-        val downloaderConfiguration = DownloaderConfiguration()
-        val workingTreeCache = DefaultWorkingTreeCache()
-        val provenanceDownloader = DefaultProvenanceDownloader(downloaderConfiguration, workingTreeCache)
-        val packageProvenanceStorage = DummyProvenanceStorage()
-        val nestedProvenanceStorage = DummyNestedProvenanceStorage()
-        val packageProvenanceResolver = DefaultPackageProvenanceResolver(packageProvenanceStorage, workingTreeCache)
-        val nestedProvenanceResolver = DefaultNestedProvenanceResolver(nestedProvenanceStorage, workingTreeCache)
-        val dummyScanner = DummyScanner()
-
-        val scanner = Scanner(
-            scannerConfig = ScannerConfiguration(),
-            downloaderConfig = downloaderConfiguration,
-            provenanceDownloader = provenanceDownloader,
-            storageReaders = emptyList(),
-            storageWriters = emptyList(),
-            packageProvenanceResolver = packageProvenanceResolver,
-            nestedProvenanceResolver = nestedProvenanceResolver,
-            scannerWrappers = mapOf(
-                PackageType.PROJECT to listOf(dummyScanner),
-                PackageType.PACKAGE to listOf(dummyScanner)
-            )
-        )
-
-        val result = scanner.scan(analyzerResultFile.readValue(), skipExcluded = false, emptyMap())
+        val result = createScanner().scan(analyzerResultFile.readValue(), skipExcluded = false, emptyMap())
 
         patchActualResult(result.toYaml(), patchStartAndEndTime = true) should matchExpectedResult(expectedResultFile)
     }
 })
+
+private fun createScanner(): Scanner {
+    val downloaderConfiguration = DownloaderConfiguration()
+    val workingTreeCache = DefaultWorkingTreeCache()
+    val provenanceDownloader = DefaultProvenanceDownloader(downloaderConfiguration, workingTreeCache)
+    val packageProvenanceStorage = DummyProvenanceStorage()
+    val nestedProvenanceStorage = DummyNestedProvenanceStorage()
+    val packageProvenanceResolver = DefaultPackageProvenanceResolver(packageProvenanceStorage, workingTreeCache)
+    val nestedProvenanceResolver = DefaultNestedProvenanceResolver(nestedProvenanceStorage, workingTreeCache)
+    val dummyScanner = DummyScanner()
+
+    return Scanner(
+        scannerConfig = ScannerConfiguration(),
+        downloaderConfig = downloaderConfiguration,
+        provenanceDownloader = provenanceDownloader,
+        storageReaders = emptyList(),
+        storageWriters = emptyList(),
+        packageProvenanceResolver = packageProvenanceResolver,
+        nestedProvenanceResolver = nestedProvenanceResolver,
+        scannerWrappers = mapOf(
+            PackageType.PROJECT to listOf(dummyScanner),
+            PackageType.PACKAGE to listOf(dummyScanner)
+        )
+    )
+}
 
 private class DummyScanner : PathScannerWrapper {
     override val details = ScannerDetails(name = "Dummy", version = "1.0.0", configuration = "")

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -49,13 +49,27 @@ import org.ossreviewtoolkit.utils.test.matchExpectedResult
 import org.ossreviewtoolkit.utils.test.patchActualResult
 
 class ScannerIntegrationFunTest : StringSpec({
-    "Gradle project scan results for a given analyzer result are correct".config(invocations = 3) {
+    "scan() returns the expected ORT result for a given analyzer result".config(invocations = 3) {
         val analyzerResultFile = getAssetFile("analyzer-result.yml")
         val expectedResultFile = getAssetFile("dummy-expected-output-for-analyzer-result.yml")
 
         val result = createScanner().scan(analyzerResultFile.readValue(), skipExcluded = false, emptyMap())
 
         patchActualResult(result.toYaml(), patchStartAndEndTime = true) should matchExpectedResult(expectedResultFile)
+    }
+
+    "scan() returns the expected scan results for a given analyzer result".config(invocations = 3) {
+        val analyzerResultFile = getAssetFile("analyzer-result.yml")
+        val expectedResultFile = getAssetFile("dummy-expected-scan-results-for-analyzer-result.yml")
+
+        val scanResults = createScanner().scan(
+            analyzerResultFile.readValue(),
+            skipExcluded = false,
+            emptyMap()
+        ).getScanResults().toSortedMap()
+
+        patchActualResult(scanResults.toYaml(), patchStartAndEndTime = true) should
+                matchExpectedResult(expectedResultFile)
     }
 })
 

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -160,6 +160,12 @@ class ScanController(
         nestedProvenances.values.flatMapTo(mutableSetOf()) { it.getProvenances() }
 
     /**
+     * Return all scan results.
+     */
+    fun getAllScanResults(): List<ScanResult> =
+        scanResults.values.flatMap { scanResultsByProvenance -> scanResultsByProvenance.values.flatten() }
+
+    /**
      * Return all provenances including sub-repositories associated with the identifiers of the packages they belong to.
      */
     fun getIdsByProvenance(): Map<KnownProvenance, Set<Identifier>> =
@@ -259,6 +265,8 @@ class ScanController(
      */
     fun getPackagesForProvenanceWithoutVcsPath(provenance: KnownProvenance): Set<Identifier> =
         packageProvenancesWithoutVcsPath.filter { (_, packageProvenance) -> packageProvenance == provenance }.keys
+
+    fun getPackageProvenance(id: Identifier): KnownProvenance? = packageProvenances[id]
 
     /**
      * Return the package provenanceResolutionIssue associated with the given [id].

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -88,15 +88,17 @@ class ScannerTest : WordSpec({
             val packageContext = createContext(type = PackageType.PACKAGE)
             val projectContext = createContext(type = PackageType.PROJECT)
 
-            scanner.scan(setOf(pkgWithArtifact), packageContext)[pkgWithArtifact.id] shouldNotBeNull {
-                this shouldNot beEmpty()
-                forEach { it.scanner.name shouldBe "package scanner" }
-            }
+            scanner.scan(setOf(pkgWithArtifact), packageContext)
+                .getAllScanResults()[pkgWithArtifact.id] shouldNotBeNull {
+                    this shouldNot beEmpty()
+                    forEach { it.scanner.name shouldBe "package scanner" }
+                }
 
-            scanner.scan(setOf(pkgWithArtifact), projectContext)[pkgWithArtifact.id] shouldNotBeNull {
-                this shouldNot beEmpty()
-                forEach { it.scanner.name shouldBe "project scanner" }
-            }
+            scanner.scan(setOf(pkgWithArtifact), projectContext)
+                .getAllScanResults()[pkgWithArtifact.id] shouldNotBeNull {
+                    this shouldNot beEmpty()
+                    forEach { it.scanner.name shouldBe "project scanner" }
+                }
         }
 
         "Not scan projects if no scanner wrapper for projects is configured" {
@@ -106,8 +108,9 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper),
                 projectScannerWrappers = emptyList()
             )
+            val context = createContext(type = PackageType.PROJECT)
 
-            scanner.scan(setOf(pkgWithArtifact), createContext(type = PackageType.PROJECT)) should beEmptyMap()
+            scanner.scan(setOf(pkgWithArtifact), context).getAllScanResults() should beEmptyMap()
         }
 
         "Not scan packages if no scanner wrapper for packages is configured" {
@@ -118,7 +121,7 @@ class ScannerTest : WordSpec({
                 projectScannerWrappers = listOf(scannerWrapper)
             )
 
-            scanner.scan(setOf(pkgWithArtifact), createContext()) should beEmptyMap()
+            scanner.scan(setOf(pkgWithArtifact), createContext()).getAllScanResults() should beEmptyMap()
         }
     }
 
@@ -136,7 +139,7 @@ class ScannerTest : WordSpec({
 
             val scanner = createScanner(packageScannerWrappers = listOf(scannerWrapper))
 
-            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -182,7 +185,7 @@ class ScannerTest : WordSpec({
             val scannerWrapper = spyk(FakeProvenanceScannerWrapper())
             val scanner = createScanner(packageScannerWrappers = listOf(scannerWrapper))
 
-            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -228,7 +231,7 @@ class ScannerTest : WordSpec({
             val scannerWrapper = spyk(FakePathScannerWrapper())
             val scanner = createScanner(packageScannerWrappers = listOf(scannerWrapper))
 
-            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -260,7 +263,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext())
+            scanner.scan(setOf(pkgWithArtifact, pkgWithVcs), createContext()).getAllScanResults()
 
             verify(exactly = 1) {
                 provenanceDownloader.download(pkgWithArtifact.artifactProvenance())
@@ -283,7 +286,7 @@ class ScannerTest : WordSpec({
                 vcsInfo = pkgWithVcsPath.vcsProcessed.copy(path = "")
             )
 
-            scanner.scan(setOf(pkgWithVcsPath), createContext())
+            scanner.scan(setOf(pkgWithVcsPath), createContext()).getAllScanResults()
 
             verify(exactly = 1) {
                 provenanceDownloader.download(provenance)
@@ -307,7 +310,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            scanner.scan(setOf(pkgWithVcsPath1, pkgWithVcsPath2, pkgWithVcsPath3), createContext())
+            scanner.scan(setOf(pkgWithVcsPath1, pkgWithVcsPath2, pkgWithVcsPath3), createContext()).getAllScanResults()
 
             verify(exactly = 1) {
                 provenanceDownloader.download(any())
@@ -331,7 +334,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            val result = scanner.scan(setOf(pkgWithArtifact), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -359,7 +362,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            val result = scanner.scan(setOf(pkgWithArtifact), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -383,11 +386,11 @@ class ScannerTest : WordSpec({
             val scannerWrapper = spyk(FakeProvenanceScannerWrapper())
 
             val scannedSubRepository = RepositoryProvenance(
-                VcsInfo(VcsType.GIT, "https://example.com/scanned", "revision"),
+                VcsInfo(VcsType.GIT, "https://example.com/scanned", "resolvedRevision"),
                 "resolvedRevision"
             )
             val unscannedSubRepository = RepositoryProvenance(
-                VcsInfo(VcsType.GIT, "https://example.com/unscanned", "revision"),
+                VcsInfo(VcsType.GIT, "https://example.com/unscanned", "resolvedRevision"),
                 "resolvedRevision"
             )
 
@@ -438,6 +441,7 @@ class ScannerTest : WordSpec({
             )
 
             val result = scanner.scan(setOf(pkgCompletelyScanned, pkgPartlyScanned), createContext())
+                .getAllScanResults()
 
             result should containExactly(
                 pkgCompletelyScanned.id to nestedScanResultCompletelyScanned.merge(),
@@ -469,7 +473,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            val result = scanner.scan(setOf(pkgWithArtifact), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -498,7 +502,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            val result = scanner.scan(setOf(pkgWithArtifact), createContext())
+            val result = scanner.scan(setOf(pkgWithArtifact), createContext()).getAllScanResults()
 
             result should containExactly(
                 pkgWithArtifact.id to listOf(
@@ -522,11 +526,11 @@ class ScannerTest : WordSpec({
             val scannerWrapper = spyk(FakeProvenanceScannerWrapper())
 
             val scannedSubRepository = RepositoryProvenance(
-                VcsInfo(VcsType.GIT, "https://example.com/scanned", "revision"),
+                VcsInfo(VcsType.GIT, "https://example.com/scanned", "resolvedRevision"),
                 "resolvedRevision"
             )
             val unscannedSubRepository = RepositoryProvenance(
-                VcsInfo(VcsType.GIT, "https://example.com/unscanned", "revision"),
+                VcsInfo(VcsType.GIT, "https://example.com/unscanned", "resolvedRevision"),
                 "resolvedRevision"
             )
 
@@ -578,6 +582,7 @@ class ScannerTest : WordSpec({
             )
 
             val result = scanner.scan(setOf(pkgCompletelyScanned, pkgPartlyScanned), createContext())
+                .getAllScanResults()
 
             result should containExactly(
                 pkgCompletelyScanned.id to nestedScanResultCompletelyScanned.merge(),
@@ -655,7 +660,7 @@ class ScannerTest : WordSpec({
                 packageScannerWrappers = listOf(scannerWrapper)
             )
 
-            val result = scanner.scan(setOf(pkgWithVcsPath), createContext())
+            val result = scanner.scan(setOf(pkgWithVcsPath), createContext()).getAllScanResults()
 
             val filteredScanResult = createScanResult(
                 provenanceWithVcsPath,


### PR DESCRIPTION
This PR changes `OrtResult`s internal representation to store scan results by provenance, which eliminates redundancies in case multiple packages share the same provenance. It keeps `OrtResults` API _as-is_. That is, client code using `OrtResult.getScanResults()` or `OrtResult.getScanResults(id)` remains _as-is_, thereby hiding the complexities of the new internal representation completely. Also, information about the sub-repository structure is now available for all packages in `OrtResult`.

**Breaking change:** 

1. "old" ORT files containing a `ScannerRun` won't de-serialize anymore.
2. The scanner cannot output package verification codes anymore. This will be fixed again, by computing
    these codes on-the-fly from file lists which are not present yet but will be added soon.

Fixes #5950.