### PR TITLE
fix(fossid-webapp): Set severity to HINT when snippet license cannot be mapped

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageProvider
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Snippet as OrtSnippet
 import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
@@ -124,7 +125,8 @@ internal fun mapSnippetFindings(
                     if (expression == null) {
                         issues += FossId.createAndLogIssue(
                             source = "FossId",
-                            message = "Failed to map license '$it' as an SPDX expression."
+                            message = "Failed to map license '$it' as an SPDX expression.",
+                            severity = Severity.HINT
                         )
                     }
                 }

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdLicenseMappingTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdLicenseMappingTest.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.clients.fossid.model.result.LicenseCategory
 import org.ossreviewtoolkit.clients.fossid.model.result.MatchType
 import org.ossreviewtoolkit.clients.fossid.model.result.Snippet
 import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
@@ -91,7 +92,9 @@ class FossIdLicenseMappingTest : WordSpec({
 
             issues should haveSize(1)
             issues.first() shouldNotBeNull {
-                message shouldStartWith "Failed to map license 'invalid license' as an SPDX expression."
+                message shouldStartWith
+                        "Failed to map license 'invalid license' as an SPDX expression."
+                severity shouldBe Severity.HINT
             }
             findings should haveSize(1)
             findings.first() shouldNotBeNull {


### PR DESCRIPTION
With the introduction of snippet findings in the scan results, some
issues are also present in the result because licenses from FossID
snippets cannot always be mapped to SPDX, for instance "RETURNN license"
or "Apache 2-0".
While the usage of the declared license mapping file helped to
alleviate some of these issues, several remained, polluting the webapp
report.

Opening a support ticket at FossID to have them correct the license,
while being the correct solution, does not scale regarding the amount of
licenses to correct.
Therefore, this commit lowers for now the severity of these issues to
`HINT` and map them to `NO_ASSERTION`. This is a temporary solution
until a snippet curation mechanism is introduced to be able to correct
those licenses.


FYI @MarcelBochtler.