### PR TITLE
Show how to route output to current directory

### DIFF
--- a/docs/hints-for-use-with-docker.md
+++ b/docs/hints-for-use-with-docker.md
@@ -9,7 +9,9 @@ docker run \
   -v $PWD/:/project \ # Mount current working directory into /project to use as input.
   ort --info \
   -c /project/ort/config.yml \ # Use file from "<workingdirectory>/ort" as config.
-  analyze -i /project [...] # Insert further arguments for the command.
+  analyze -i /project \ # Analyze the current working directory using the alias (set earlier in the -v option).
+  -o /project \ # Output goes into the current working directory.
+  [...] # Insert further arguments for the command.
 ```
 
 If only a subproject shall be analyzed, change the input path `-i /project` to `-i /project/subproject`. Note that still the projects root directory needs to be mounted to Docker for ORT to detect VCS information.


### PR DESCRIPTION
By default the output is written inside the container.
See our [Slack conversation](https://ort-talk.slack.com/archives/C9NNJ54B1/p1686238330683709?thread_ts=1686195720.781609&cid=C9NNJ54B1).
