### PR TITLE
fix(Downloader): Prefer license category of concluded license

### DIFF
--- a/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
+++ b/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
@@ -371,7 +371,7 @@ class DownloaderCommand : OrtCommand(
     ): Set<String> {
         val resolvedLicenseInfo = licenseInfoResolver.resolveLicenseInfo(pkg.id)
         val effectiveLicenses = resolvedLicenseInfo.effectiveLicense(
-            LicenseView.ALL,
+            LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
             *licenseChoices
         )?.decompose().orEmpty()
 


### PR DESCRIPTION
The downloader can be configured to just download the sources of specified license categories.
Prefer the concluded license if one exists, when deciding if a package should be downloaded.
