### PR TITLE
test: Fix an inconsistency in the synthetic `reporter-test-input.yml`

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -346,7 +346,7 @@ packages:
   findings:
   - type: "COPYRIGHT"
     copyright: 0
-    path: "file.java"
+    path: "project/file.java"
     start_line: 1
     end_line: 1
     scan_result: 1
@@ -354,7 +354,7 @@ packages:
     - 1
   - type: "LICENSE"
     license: 3
-    path: "file.java"
+    path: "project/file.java"
     start_line: 1
     end_line: 2
     scan_result: 1
@@ -362,13 +362,13 @@ packages:
     - 1
   - type: "LICENSE"
     license: 3
-    path: "file.kt"
+    path: "project/file.kt"
     start_line: 1
     end_line: 2
     scan_result: 1
   - type: "COPYRIGHT"
     copyright: 0
-    path: "file1.java"
+    path: "project/file1.java"
     start_line: 1
     end_line: 1
     scan_result: 1
@@ -376,7 +376,7 @@ packages:
     - 1
   - type: "LICENSE"
     license: 4
-    path: "file1.java"
+    path: "project/file1.java"
     start_line: 1
     end_line: 2
     scan_result: 1
@@ -384,7 +384,7 @@ packages:
     - 1
   - type: "LICENSE"
     license: 4
-    path: "file2.java"
+    path: "project/file2.java"
     start_line: 1
     end_line: 2
     scan_result: 1

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -405,7 +405,7 @@
     "findings" : [ {
       "type" : "COPYRIGHT",
       "copyright" : 0,
-      "path" : "file.java",
+      "path" : "project/file.java",
       "start_line" : 1,
       "end_line" : 1,
       "scan_result" : 1,
@@ -413,7 +413,7 @@
     }, {
       "type" : "LICENSE",
       "license" : 3,
-      "path" : "file.java",
+      "path" : "project/file.java",
       "start_line" : 1,
       "end_line" : 2,
       "scan_result" : 1,
@@ -421,14 +421,14 @@
     }, {
       "type" : "LICENSE",
       "license" : 3,
-      "path" : "file.kt",
+      "path" : "project/file.kt",
       "start_line" : 1,
       "end_line" : 2,
       "scan_result" : 1
     }, {
       "type" : "COPYRIGHT",
       "copyright" : 0,
-      "path" : "file1.java",
+      "path" : "project/file1.java",
       "start_line" : 1,
       "end_line" : 1,
       "scan_result" : 1,
@@ -436,7 +436,7 @@
     }, {
       "type" : "LICENSE",
       "license" : 4,
-      "path" : "file1.java",
+      "path" : "project/file1.java",
       "start_line" : 1,
       "end_line" : 2,
       "scan_result" : 1,
@@ -444,7 +444,7 @@
     }, {
       "type" : "LICENSE",
       "license" : 4,
-      "path" : "file2.java",
+      "path" : "project/file2.java",
       "start_line" : 1,
       "end_line" : 2,
       "scan_result" : 1,

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -346,7 +346,7 @@ packages:
   findings:
   - type: "COPYRIGHT"
     copyright: 0
-    path: "file.java"
+    path: "project/file.java"
     start_line: 1
     end_line: 1
     scan_result: 1
@@ -354,7 +354,7 @@ packages:
     - 1
   - type: "LICENSE"
     license: 3
-    path: "file.java"
+    path: "project/file.java"
     start_line: 1
     end_line: 2
     scan_result: 1
@@ -362,13 +362,13 @@ packages:
     - 1
   - type: "LICENSE"
     license: 3
-    path: "file.kt"
+    path: "project/file.kt"
     start_line: 1
     end_line: 2
     scan_result: 1
   - type: "COPYRIGHT"
     copyright: 0
-    path: "file1.java"
+    path: "project/file1.java"
     start_line: 1
     end_line: 1
     scan_result: 1
@@ -376,7 +376,7 @@ packages:
     - 1
   - type: "LICENSE"
     license: 4
-    path: "file1.java"
+    path: "project/file1.java"
     start_line: 1
     end_line: 2
     scan_result: 1
@@ -384,7 +384,7 @@ packages:
     - 1
   - type: "LICENSE"
     license: 4
-    path: "file2.java"
+    path: "project/file2.java"
     start_line: 1
     end_line: 2
     scan_result: 1

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -411,33 +411,33 @@ scanner:
         licenses:
         - license: "Apache-2.0"
           location:
-            path: "file.java"
+            path: "project/file.java"
             start_line: 1
             end_line: 2
         - license: "Apache-2.0"
           location:
-            path: "file.kt"
+            path: "project/file.kt"
             start_line: 1
             end_line: 2
         - license: "MIT"
           location:
-            path: "file1.java"
+            path: "project/file1.java"
             start_line: 1
             end_line: 2
         - license: "MIT"
           location:
-            path: "file2.java"
+            path: "project/file2.java"
             start_line: 1
             end_line: 2
         copyrights:
         - statement: "Copyright (c) example authors."
           location:
-            path: "file.java"
+            path: "project/file.java"
             start_line: 1
             end_line: 1
         - statement: "Copyright (c) example authors."
           location:
-            path: "file1.java"
+            path: "project/file1.java"
             start_line: 1
             end_line: 1
     Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -411,33 +411,33 @@ scanner:
         licenses:
         - license: "Apache-2.0"
           location:
-            path: "file.java"
+            path: "project/file.java"
             start_line: 1
             end_line: 2
         - license: "Apache-2.0"
           location:
-            path: "file.kt"
+            path: "project/file.kt"
             start_line: 1
             end_line: 2
         - license: "MIT"
           location:
-            path: "file1.java"
+            path: "project/file1.java"
             start_line: 1
             end_line: 2
         - license: "MIT"
           location:
-            path: "file2.java"
+            path: "project/file2.java"
             start_line: 1
             end_line: 2
         copyrights:
         - statement: "Copyright (c) example authors."
           location:
-            path: "file.java"
+            path: "project/file.java"
             start_line: 1
             end_line: 1
         - statement: "Copyright (c) example authors."
           location:
-            path: "file1.java"
+            path: "project/file1.java"
             start_line: 1
             end_line: 1
     Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -411,33 +411,33 @@ scanner:
         licenses:
         - license: "Apache-2.0"
           location:
-            path: "file.java"
+            path: "project/file.java"
             start_line: 1
             end_line: 2
         - license: "Apache-2.0"
           location:
-            path: "file.kt"
+            path: "project/file.kt"
             start_line: 1
             end_line: 2
         - license: "MIT"
           location:
-            path: "file1.java"
+            path: "project/file1.java"
             start_line: 1
             end_line: 2
         - license: "MIT"
           location:
-            path: "file2.java"
+            path: "project/file2.java"
             start_line: 1
             end_line: 2
         copyrights:
         - statement: "Copyright (c) example authors."
           location:
-            path: "file.java"
+            path: "project/file.java"
             start_line: 1
             end_line: 1
         - statement: "Copyright (c) example authors."
           location:
-            path: "file1.java"
+            path: "project/file1.java"
             start_line: 1
             end_line: 1
     Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:


### PR DESCRIPTION
The scan results in the ORT file are filtered by the respective VCS path. So, move the paths of several files under the VCS path, because the previously used paths would have been filtered out.

Part of #5950.