### PR TITLE
feat(scanner): Expose the Excludes to the scanner 

### DIFF
--- a/scanner/src/main/kotlin/ScanContext.kt
+++ b/scanner/src/main/kotlin/ScanContext.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.scanner
 
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.PackageType
+import org.ossreviewtoolkit.model.config.Excludes
 
 /**
  * Additional context information that can be used by a [ScannerWrapper] to alter its behavior.
@@ -34,5 +35,10 @@ data class ScanContext(
     /**
      * The [type][PackageType] of the packages to scan.
      */
-    val packageType: PackageType
+    val packageType: PackageType,
+
+    /**
+     * The [Excludes] of the project to scan.
+     */
+    val excludes: Excludes? = null
 )

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -99,6 +99,7 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.scanners.fossid.FossId.Companion.SCAN_CODE_KEY
@@ -562,7 +563,11 @@ class FossIdTest : WordSpec({
                     launch {
                         fossId.scanPackage(
                             createPackage(createIdentifier(index = 1), vcsInfo),
-                            ScanContext(labels = emptyMap(), packageType = PackageType.PACKAGE)
+                            ScanContext(
+                                labels = emptyMap(),
+                                packageType = PackageType.PACKAGE,
+                                Excludes()
+                            )
                         )
                     }
                 }
@@ -1513,4 +1518,4 @@ private fun FossIdServiceWithVersion.mockFiles(
  * Trigger a FossID scan of the given [package][pkg].
  */
 private fun FossId.scan(pkg: Package, labels: Map<String, String> = emptyMap()): ScanResult =
-scanPackage(pkg, ScanContext(labels = labels, packageType = PackageType.PACKAGE))
+scanPackage(pkg, ScanContext(labels = labels, packageType = PackageType.PACKAGE, Excludes()))


### PR DESCRIPTION
In a future commit, the FossID scanner will use the `Excludes` contained in the configuration to generate ignore rules for the scan.