### PR TITLE
docs(model): Add ScanCode `commandLineNonConfig` to reference.yml

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -193,7 +193,13 @@ ort:
     options:
       # A map of maps from scanner class names to scanner-specific key-value pairs.
       ScanCode:
+        # Command line options that affect the ScanCode output. If changed, stored scan results that were created with
+        # different options are not reused.
         commandLine: '--copyright --license --info --strip-root --timeout 300'
+
+        # Command line options that do not affect the ScanCode output.
+        commandLineNonConfig: '--processes 4'
+
         parseLicenseExpressions: true
 
         # Criteria for matching stored scan results. These can be configured for any scanner that uses semantic

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -228,6 +228,7 @@ class OrtConfigurationTest : WordSpec({
                     get("ScanCode") shouldNotBeNull {
                         this shouldContainExactly mapOf(
                             "commandLine" to "--copyright --license --info --strip-root --timeout 300",
+                            "commandLineNonConfig" to "--processes 4",
                             "parseLicenseExpressions" to "true",
                             "minVersion" to "3.2.1-rc2",
                             "maxVersion" to "32.0.0"


### PR DESCRIPTION
Add the missing `commandLineNonConfig` option for ScanCode to the reference.yml and explain the difference to the `commandLine` option.