### PR TITLE
feat(web-app-reporter): Add 1000 and 5000 as page size options

### DIFF
--- a/plugins/reporters/web-app-template/src/components/IssuesTable.js
+++ b/plugins/reporters/web-app-template/src/components/IssuesTable.js
@@ -312,7 +312,7 @@ class IssuesTable extends React.Component {
                     {
                         defaultPageSize: 25,
                         hideOnSinglePage: true,
-                        pageSizeOptions: ['50', '100', '250', '500'],
+                        pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                         position: 'bottom',
                         showQuickJumper: true,
                         showSizeChanger: true,

--- a/plugins/reporters/web-app-template/src/components/PackageFindingsTable.js
+++ b/plugins/reporters/web-app-template/src/components/PackageFindingsTable.js
@@ -233,7 +233,7 @@ const PackageFindingsTable = (props) => {
                 {
                     defaultPageSize: 250,
                     hideOnSinglePage: true,
-                    pageSizeOptions: ['50', '100', '250', '500'],
+                    pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                     position: 'bottom',
                     showQuickJumper: true,
                     showSizeChanger: true,

--- a/plugins/reporters/web-app-template/src/components/PathExcludesTable.js
+++ b/plugins/reporters/web-app-template/src/components/PathExcludesTable.js
@@ -55,7 +55,7 @@ const PathExcludesTable = (props) => {
                 {
                     defaultPageSize: 50,
                     hideOnSinglePage: true,
-                    pageSizeOptions: ['50', '100', '250', '500'],
+                    pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                     position: 'bottom',
                     showQuickJumper: true,
                     showSizeChanger: true,

--- a/plugins/reporters/web-app-template/src/components/ResolutionTable.js
+++ b/plugins/reporters/web-app-template/src/components/ResolutionTable.js
@@ -55,7 +55,7 @@ const ResolutionTable = (props) => {
                 {
                     defaultPageSize: 50,
                     hideOnSinglePage: true,
-                    pageSizeOptions: ['50', '100', '250', '500'],
+                    pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                     position: 'bottom',
                     showQuickJumper: true,
                     showSizeChanger: true,

--- a/plugins/reporters/web-app-template/src/components/RuleViolationsTable.js
+++ b/plugins/reporters/web-app-template/src/components/RuleViolationsTable.js
@@ -335,7 +335,7 @@ class RuleViolationsTable extends React.Component {
                     {
                         defaultPageSize: 25,
                         hideOnSinglePage: true,
-                        pageSizeOptions: ['50', '100', '250', '500'],
+                        pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                         position: 'bottom',
                         showQuickJumper: true,
                         showSizeChanger: true,

--- a/plugins/reporters/web-app-template/src/components/ScopeExcludesTable.js
+++ b/plugins/reporters/web-app-template/src/components/ScopeExcludesTable.js
@@ -55,7 +55,7 @@ const ScopeExcludesTable = (props) => {
                 {
                     defaultPageSize: 50,
                     hideOnSinglePage: true,
-                    pageSizeOptions: ['50', '100', '250', '500'],
+                    pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                     position: 'bottom',
                     showQuickJumper: true,
                     showSizeChanger: true,

--- a/plugins/reporters/web-app-template/src/components/TableView.js
+++ b/plugins/reporters/web-app-template/src/components/TableView.js
@@ -501,7 +501,7 @@ class TableView extends React.Component {
                         {
                             defaultPageSize: 100,
                             hideOnSinglePage: true,
-                            pageSizeOptions: ['50', '100', '250', '500'],
+                            pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                             position: 'both',
                             showSizeChanger: true
                         }

--- a/plugins/reporters/web-app-template/src/components/VulnerabilitiesTable.js
+++ b/plugins/reporters/web-app-template/src/components/VulnerabilitiesTable.js
@@ -355,7 +355,7 @@ class VulnerabilitiesTable extends React.Component {
                     {
                         defaultPageSize: 25,
                         hideOnSinglePage: true,
-                        pageSizeOptions: ['50', '100', '250', '500'],
+                        pageSizeOptions: ['50', '100', '250', '500', '1000', '5000'],
                         position: 'bottom',
                         showQuickJumper: true,
                         showSizeChanger: true,


### PR DESCRIPTION
While these page sizes usually are too large for browsers to handle, there seem to be use-cases where trying it out makes sense. So let users chose these at their own risk.

Resolves #6980.