### PR TITLE
build(Gradle): Extend the ANTLR work-around to all source sets

### DIFF
--- a/utils/spdx/build.gradle.kts
+++ b/utils/spdx/build.gradle.kts
@@ -61,8 +61,10 @@ tasks.withType<AntlrTask>().configureEach {
     }
 }
 
-private val generateGrammarSource by tasks.existing
-sourceSets.main.get().java.srcDir(generateGrammarSource.map { files() })
+sourceSets.configureEach {
+    val generateGrammarSource by tasks.existing
+    sourceSets.main.get().java.srcDir(generateGrammarSource.map { files() })
+}
 
 dependencies {
     antlr(libs.antlr)


### PR DESCRIPTION
This fixup for 6a73769 addresses the error [1]:

    Reason: Task ':utils:spdx-utils:compileTestKotlin' uses this output of
    task ':utils:spdx-utils:generateTestGrammarSource' without declaring
    an explicit or implicit dependency. This can lead to incorrect results
    being produced, depending on what order the tasks are executed.

[1]: https://github.com/oss-review-toolkit/ort/actions/runs/5288598268/jobs/9570557290#step:4:5223