### PR TITLE
test(clearly-defined): Increase the test delay exponentially

### DIFF
--- a/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -130,8 +130,9 @@ private fun createPackagesFromIds(vararg ids: String) =
 
 private suspend fun <T> withRetry(f: suspend () -> T): T =
     retry(
-        maxRetry = 3,
-        timeout = 9.seconds,
-        delay = 3.seconds,
+        maxRetry = 5,
+        timeout = (10 + 20 + 40 + 80 + 160).seconds,
+        delay = 10.seconds,
+        multiplier = 2,
         f = f
     )


### PR DESCRIPTION
As still timeouts happen [1], give the ClearlyDefined service more time to recover. As the "test" tasks still are way faster than "funTest-docker", the increase in timeout does not matter regarding total test runtime.

[1]: https://github.com/oss-review-toolkit/ort/actions/runs/5308587525/jobs/9608290182#step:5:825