### PR TITLE
feat(fossid-webapp): Generate ignore rules from path excludes 

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -796,7 +796,8 @@ class FossId internal constructor(
                         }
                     }
 
-                    it to snippets.filterNot { it.matchType == MatchType.IGNORED }.toSet()
+                    val excludedMatchTypes = enumSetOf(MatchType.IGNORED, MatchType.NONE)
+                    it to snippets.filterNotTo(mutableSetOf()) { it.matchType in excludedMatchTypes }
                 }
             }.awaitAll().toMap()
         }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
@@ -135,7 +135,7 @@ internal fun mapSnippetFindings(
             // FossID does not return the hash of the remote artifact. Instead, it returns the MD5 hash of the
             // matched file in the remote artifact as part of the "match_file_id" property.
             val url = checkNotNull(snippet.url) {
-                "The URL of snippet ${snippet.id} must not be null."
+                "The URL of snippet ${snippet.id} for file '$file' must not be null."
             }
             val snippetProvenance = ArtifactProvenance(RemoteArtifact(url, Hash.NONE))
             val purl = snippet.purl

--- a/scanner/src/main/kotlin/scanners/fossid/Utils.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/Utils.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import org.ossreviewtoolkit.clients.fossid.model.rules.IgnoreRule
+import org.ossreviewtoolkit.clients.fossid.model.rules.RuleType
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PathExclude
+
+private val DIRECTORY_REGEX = "(?<directory>(?:\\w+/)*\\w+)/?(?<starstar>\\*\\*)?".toRegex()
+private val EXTENSION_REGEX = "\\*\\.(?<extension>\\w+)".toRegex()
+private val FILE_REGEX = "(?<file>[\\w.]+)".toRegex()
+
+/**
+ * Convert the ORT [path excludes][Excludes.paths] in [excludes] to FossID [IgnoreRule]s.. If an error is encountered
+ * during the mapping, an issue is added to [issues].
+ */
+internal fun convertRules(excludes: Excludes, issues: MutableList<Issue>): List<IgnoreRule> {
+    return excludes.paths.mapNotNull {
+        it.mapToRule().also { mappedRule ->
+            if (mappedRule == null) {
+                issues += Issue(
+                    source = "FossID.convertRules",
+                    message = "Path exclude '${it.pattern}' cannot be converted to an ignore rule.",
+                    severity = Severity.HINT
+                )
+                FossId.logger.warn {
+                    "Path exclude  '${it.pattern}' cannot be converted to an ignore rule."
+                }
+            }
+        }
+    }
+}
+
+private fun PathExclude.mapToRule(): IgnoreRule? {
+    DIRECTORY_REGEX.matchEntire(pattern)?.let { directoryMatch ->
+        val directory = directoryMatch.groups["directory"]!!.value
+        val starStar = directoryMatch.groups["starstar"]?.value
+
+        return if (starStar == null) {
+            IgnoreRule(-1, RuleType.DIRECTORY, directory, -1, "")
+        } else {
+            IgnoreRule(-1, RuleType.DIRECTORY, "$directory/**", -1, "")
+        }
+    }
+
+    EXTENSION_REGEX.matchEntire(pattern)?.let { extensionMatch ->
+        val extension = extensionMatch.groups["extension"]!!.value
+        return IgnoreRule(-1, RuleType.EXTENSION, ".$extension", -1, "")
+    }
+
+    FILE_REGEX.matchEntire(pattern)?.let { fileMatch ->
+        val file = fileMatch.groups["file"]!!.value
+        return IgnoreRule(-1, RuleType.FILE, file, -1, "")
+    }
+
+    return null
+}
+
+/**
+ * Check if some elements of [rulesToTest] are legacy rules i.e. are not present in a reference list (current object).
+ * Create an issue on [issues] for each legacy rule and return a list of the latter.
+ */
+internal fun List<IgnoreRule>.filterLegacyRules(
+    rulesToTest: List<IgnoreRule>,
+    issues: MutableList<Issue>
+): List<IgnoreRule> = rulesToTest.filterNot { ruleToTest ->
+    any { it.value == ruleToTest.value && it.type == ruleToTest.type }
+}.onEach {
+    issues += Issue(
+        source = "FossID.compare",
+        message = "Rule '${it.value}' with type '${it.type}' is not present in the .ort.yml path excludes. " +
+                "Add it to the .ort.yml file or remove it from the FossID scan.",
+        severity = Severity.HINT
+    )
+}

--- a/scanner/src/test/kotlin/scanners/fossid/LegacyRulesTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/LegacyRulesTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.clients.fossid.model.rules.IgnoreRule
+import org.ossreviewtoolkit.clients.fossid.model.rules.RuleType
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+class LegacyRulesTest : WordSpec({
+    "compareRules" should {
+        "create an issue when a legacy rule is present" {
+            val referenceRules = listOf(
+                IgnoreRule(-1, RuleType.DIRECTORY, "directory", -1, ""),
+                IgnoreRule(-1, RuleType.FILE, "file", -1, "")
+            )
+            val rulesToTest = listOf(
+                IgnoreRule(-1, RuleType.EXTENSION, ".pdf", -1, "")
+            )
+            val issues = mutableListOf<Issue>()
+
+            val legacyRules = referenceRules.filterLegacyRules(rulesToTest, issues)
+
+            issues shouldHaveSize 1
+            issues.first().shouldNotBeNull {
+                message shouldBe "Rule '.pdf' with type '${RuleType.EXTENSION}' is not present in the .ort.yml path" +
+                        " excludes. Add it to the .ort.yml file or remove it from the FossID scan."
+                severity shouldBe Severity.HINT
+            }
+            legacyRules shouldHaveSize 1
+            legacyRules shouldBe rulesToTest
+        }
+
+        "not create an issue when no legacy rule is present" {
+            val referenceRules = listOf(
+                IgnoreRule(-1, RuleType.DIRECTORY, "directory", -1, ""),
+                IgnoreRule(-1, RuleType.FILE, "file", -1, "")
+            )
+            val rulesToTest = listOf(
+                IgnoreRule(-1, RuleType.DIRECTORY, "directory", -1, "")
+            )
+            val issues = mutableListOf<Issue>()
+
+            val legacyRules = referenceRules.filterLegacyRules(rulesToTest, issues)
+
+            issues should beEmpty()
+            legacyRules should beEmpty()
+        }
+    }
+})

--- a/scanner/src/test/kotlin/scanners/fossid/MapIgnoreRulesTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/MapIgnoreRulesTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.clients.fossid.model.rules.RuleType
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.PathExcludeReason
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+class MapIgnoreRulesTest : WordSpec({
+    "convertRules" should {
+        "map rule with directory with **" {
+            val exclude = Excludes(listOf(PathExclude("directory/**", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "directory/**"
+                type shouldBe RuleType.DIRECTORY
+            }
+
+            issues should beEmpty()
+        }
+
+        "map rule with directory containing subdirectories with **" {
+            val exclude = Excludes(listOf(PathExclude("directory/sub1/sub2/**", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "directory/sub1/sub2/**"
+                type shouldBe RuleType.DIRECTORY
+            }
+
+            issues should beEmpty()
+        }
+
+        "map rule with directory" {
+            val exclude = Excludes(listOf(PathExclude("directory/", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "directory"
+                type shouldBe RuleType.DIRECTORY
+            }
+
+            issues should beEmpty()
+        }
+
+        "map rule with directory containing subdirectories" {
+            val exclude = Excludes(listOf(PathExclude("directory/sub1/sub2", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "directory/sub1/sub2"
+                type shouldBe RuleType.DIRECTORY
+            }
+
+            issues should beEmpty()
+        }
+
+        "map rule with file extensions" {
+            val exclude = Excludes(listOf(PathExclude("*.pdf", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe ".pdf"
+                type shouldBe RuleType.EXTENSION
+            }
+
+            issues should beEmpty()
+        }
+
+        "map rule with file" {
+            val exclude = Excludes(listOf(PathExclude("file.txt", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "file.txt"
+                type shouldBe RuleType.FILE
+            }
+
+            issues should beEmpty()
+        }
+
+        "map rule with files (with '.' in the names" {
+            val exclude = Excludes(listOf(PathExclude("file.old.txt", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "file.old.txt"
+                type shouldBe RuleType.FILE
+            }
+
+            issues should beEmpty()
+        }
+
+        "add an issue when the pattern cannot be mapped" {
+            val exclude = Excludes(listOf(PathExclude("directory/**/test/*", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules should beEmpty()
+
+            issues shouldHaveSize 1
+            issues.first().shouldNotBeNull {
+                message shouldBe "Path exclude 'directory/**/test/*' cannot be converted to an ignore rule."
+                severity shouldBe Severity.HINT
+            }
+        }
+    }
+})


### PR DESCRIPTION
Currently, the ignore rules are carried over from the last successful delta
scan. Since this process can lead to loss of rules when a new branch is
scanned, and to promote "configuration as code", this commit changes the
logic to create the ignore rules from the path excludes present in the
.ort.yml file.
ORT excludes path patterns is based on [1] and FossID supports only a
subset of it. Hence, this commit adds the mapping of this subset to the
FossID scanner. If a path exclude cannot be mapped to an ignore rule, an
issue is added to the scan summary.

Since it is not expected for the user to have already an .ort.yml
configured with path excludes, the rules of the last successful delta scan
are still carried over but, for each rule not existing as a path exclude,
an issue is also added to the scan summary.

This handling of "legacy ignore rules" will be removed in the future, after
a grace period allowing migration.

[1]: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html

Please have a look at the individual commit messages for the details.