### PR TITLE
OrtResult: Include file lists for all known provenances in `ScannerRun`

### DIFF
--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -318,6 +318,7 @@ scanner:
           path: "LICENSE.md"
           start_line: 3
           end_line: 3
+  files: []
 advisor:
   start_time: "2021-04-29T14:54:16.562951Z"
   end_time: "2021-04-29T14:54:18.969210Z"

--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -318,7 +318,39 @@ scanner:
           path: "LICENSE.md"
           start_line: 3
           end_line: 3
-  files: []
+  files:
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/junit-team/junit.git"
+        revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+        path: ""
+      resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+    files:
+    - path: "LICENSE-junit.txt"
+      sha1: "1dc94a80dbba8262f732e0b0d7235149861a1b57"
+    - path: "epl-v10.html"
+      sha1: "49f3f46520878abad864392fddf0da834c041bf8"
+    - path: "pom.xml"
+      sha1: "442292b8a7efeabbe4cc176709b833b1792140ec"
+    - path: "src/site/fml/faq.fml"
+      sha1: "220d7662a1fd7597e320e6e61589127349f9e5b0"
+    - path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+      sha1: "ac230b8be930f5ee9b30a59562eda4cd27452b7e"
+    - path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+      sha1: "8d68f8ccf1ae22b306e7cc0890df978e6c8a9abb"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/vdurmont/semver4j.git"
+        revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+        path: ""
+      resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    files:
+    - path: "LICENSE.md"
+      sha1: "4a8486805915245bbbe2e3c8c1a9d680c6843a82"
+    - path: "pom.xml"
+      sha1: "442292b8a7efeabbe4cc176709b833b1792140ec"
 advisor:
   start_time: "2021-04-29T14:54:16.562951Z"
   end_time: "2021-04-29T14:54:18.969210Z"

--- a/model/src/main/kotlin/FileList.kt
+++ b/model/src/main/kotlin/FileList.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+
+import org.ossreviewtoolkit.model.utils.FileListEntrySortedSetConverter
+import org.ossreviewtoolkit.utils.common.getDuplicates
+
+/**
+ * The file info for files contained in [provenance].
+ */
+data class FileList(
+    /**
+     * The provenance this file list corresponds to.
+     */
+    val provenance: KnownProvenance,
+
+    /**
+     * The files contained in [provenance], excluding directories which are certainly irrelevant, like e.g. the `.git`
+     * directory.
+     */
+    @JsonSerialize(converter = FileListEntrySortedSetConverter::class)
+    val files: Set<Entry>
+) {
+    data class Entry(
+        /**
+         * The path of the file relative to the root of the provenance corresponding to the enclosing [FileList].
+         */
+        val path: String,
+
+        /**
+         * The sha1 checksum of the file, consisting of 40 lowercase hexadecimal digits.
+         */
+        val sha1: String
+    ) {
+        init {
+            require(path.isNotBlank()) { "The path must not be blank." }
+            require(sha1.isNotBlank()) { "The sha1 must not be blank." }
+        }
+    }
+
+    init {
+        files.getDuplicates { it.path }.keys.let { duplicateFilePaths ->
+            require(duplicateFilePaths.isEmpty()) {
+                "Found duplicate file paths which is not allowed: ${duplicateFilePaths.joinToString()}."
+            }
+        }
+    }
+}

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -412,6 +412,17 @@ data class OrtResult(
     fun getScanResults(): Map<Identifier, List<ScanResult>> = scanner?.getAllScanResults().orEmpty()
 
     /**
+     * Return the [FileList] for the given [id].
+     */
+    fun getFileListForId(id: Identifier): FileList? = scanner?.getFileList(id)
+
+    /**
+     * Return the [FileList] associated with the respective identifier.
+     */
+    @JsonIgnore
+    fun getFileLists(): Map<Identifier, FileList> = scanner?.getAllFileLists().orEmpty()
+
+    /**
      * Return an uncurated [Package] which represents either a [Package] if the given [id] corresponds to a [Package],
      * a [Project] if the given [id] corresponds to a [Project] or `null` otherwise.
      */

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.FileList
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
@@ -40,6 +41,16 @@ import org.ossreviewtoolkit.model.SnippetFinding
 
 class CopyrightFindingSortedSetConverter : StdConverter<Set<CopyrightFinding>, SortedSet<CopyrightFinding>>() {
     override fun convert(value: Set<CopyrightFinding>) = value.toSortedSet(CopyrightFinding.COMPARATOR)
+}
+
+/** Do not convert to SortedSet in order to not require a comparator consistent with equals */
+class FileListSortedSetConverter : StdConverter<Set<FileList>, Set<FileList>>() {
+    override fun convert(value: Set<FileList>) = value.sortedBy { it.provenance.getSortKey() }.toSet()
+}
+
+/** Do not convert to SortedSet in order to not require a comparator consistent with equals */
+class FileListEntrySortedSetConverter : StdConverter<Set<FileList.Entry>, Set<FileList.Entry>>() {
+    override fun convert(value: Set<FileList.Entry>) = value.sortedBy { it.path }.toSet()
 }
 
 class LicenseFindingSortedSetConverter : StdConverter<Set<LicenseFinding>, SortedSet<LicenseFinding>>() {

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+import org.ossreviewtoolkit.model.FileList.Entry
+import org.ossreviewtoolkit.model.utils.alignRevisions
+import org.ossreviewtoolkit.model.utils.clearVcsPath
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+class ScannerRunTest : WordSpec({
+    "getFileList()" should {
+        "filter by VCS path and merge sub-repository lists as expected" {
+            val id = Identifier("a:b:c:1.0.0")
+
+            val packageProvenance = RepositoryProvenance(
+                vcsInfo = VcsInfo(
+                    type = VcsType.GIT,
+                    url = "https://example.org/some/project.git",
+                    revision = "master",
+                    path = "vcs/path"
+                ),
+                resolvedRevision = "000000000000000000000000000000000000"
+            )
+
+            val subRepositoryVcsInfo = VcsInfo(
+                type = VcsType.GIT,
+                url = "https://example.org/some/subrepository.git",
+                revision = "1111111111111111111111111111111111111111"
+            )
+
+            val run = ScannerRun.EMPTY.copy(
+                provenances = setOf(
+                    ProvenanceResolutionResult(
+                        id = id,
+                        packageProvenance = packageProvenance,
+                        subRepositories = mapOf("vcs/path/sub/repository" to subRepositoryVcsInfo)
+                    )
+                ),
+                files = setOf(
+                    FileList(
+                        provenance = packageProvenance.clearVcsPath().alignRevisions(),
+                        files = setOf(
+                            Entry(
+                                path = "vcs/path/file1.txt",
+                                sha1 = "1111111111111111111111111111111111111111"
+                            ),
+                            Entry(
+                                path = "other/path/file2.txt",
+                                sha1 = "2222222222222222222222222222222222222222"
+                            ),
+                            Entry(
+                                path = "file3.txt",
+                                sha1 = "3333333333333333333333333333333333333333"
+                            )
+                        )
+                    ),
+                    FileList(
+                        provenance = RepositoryProvenance(
+                            vcsInfo = subRepositoryVcsInfo,
+                            resolvedRevision = subRepositoryVcsInfo.revision
+                        ),
+                        files = setOf(
+                            Entry(
+                                path = "some/dir/file4.txt",
+                                sha1 = "4444444444444444444444444444444444444444"
+                            )
+                        )
+                    )
+                )
+            )
+
+            run.getFileList(id).shouldNotBeNull {
+                files shouldContainExactlyInAnyOrder listOf(
+                    Entry("vcs/path/file1.txt", "1111111111111111111111111111111111111111"),
+                    Entry("vcs/path/sub/repository/some/dir/file4.txt", "4444444444444444444444444444444444444444")
+                )
+            }
+        }
+    }
+})

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -601,7 +601,70 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
-  files: []
+  files:
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "0000000000000000000000000000000000000000"
+        path: ""
+      resolved_revision: "0000000000000000000000000000000000000000"
+    files:
+    - path: "project/file.java"
+      sha1: "6cc74f4207b821c70b74b14abe774dcda5d2a9b2"
+    - path: "project/file.kt"
+      sha1: "63db5ac00c29f8ee2085e1a24686171bb8a206b8"
+    - path: "project/file1.java"
+      sha1: "bb833fb533893ed2d12ce9e96a7f8285a542159e"
+    - path: "project/file2.java"
+      sha1: "bc38db3681c82d12994a9e1e8e90c58d2fb35e76"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        path: ""
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+    files:
+    - path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+      sha1: "8fd2d8bd263e5990aebb7994502b6a435ae255a2"
+    - path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+      sha1: "dffa81d449bc8acef4ea7be963171834057cefe3"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    files: []
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -601,6 +601,7 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
+  files: []
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -597,7 +597,70 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
-  files: []
+  files:
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "0000000000000000000000000000000000000000"
+        path: ""
+      resolved_revision: "0000000000000000000000000000000000000000"
+    files:
+    - path: "project/file.java"
+      sha1: "6cc74f4207b821c70b74b14abe774dcda5d2a9b2"
+    - path: "project/file.kt"
+      sha1: "63db5ac00c29f8ee2085e1a24686171bb8a206b8"
+    - path: "project/file1.java"
+      sha1: "bb833fb533893ed2d12ce9e96a7f8285a542159e"
+    - path: "project/file2.java"
+      sha1: "bc38db3681c82d12994a9e1e8e90c58d2fb35e76"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        path: ""
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+    files:
+    - path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+      sha1: "8fd2d8bd263e5990aebb7994502b6a435ae255a2"
+    - path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+      sha1: "dffa81d449bc8acef4ea7be963171834057cefe3"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    files: []
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -597,6 +597,7 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
+  files: []
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -597,7 +597,70 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
-  files: []
+  files:
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "0000000000000000000000000000000000000000"
+        path: ""
+      resolved_revision: "0000000000000000000000000000000000000000"
+    files:
+    - path: "project/file.java"
+      sha1: "6cc74f4207b821c70b74b14abe774dcda5d2a9b2"
+    - path: "project/file.kt"
+      sha1: "63db5ac00c29f8ee2085e1a24686171bb8a206b8"
+    - path: "project/file1.java"
+      sha1: "bb833fb533893ed2d12ce9e96a7f8285a542159e"
+    - path: "project/file2.java"
+      sha1: "bc38db3681c82d12994a9e1e8e90c58d2fb35e76"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        path: ""
+      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+    files:
+    - path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+      sha1: "8fd2d8bd263e5990aebb7994502b6a435ae255a2"
+    - path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+      sha1: "dffa81d449bc8acef4ea7be963171834057cefe3"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    files: []
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    files: []
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -597,6 +597,7 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
+  files: []
 advisor:
   start_time: "1970-01-01T01:01:00Z"
   end_time: "1970-01-01T01:08:00Z"

--- a/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -371,7 +371,55 @@ scanner:
           path: "org"
           start_line: -1
           end_line: -1
-  files: []
+  files:
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    files:
+    - path: "LICENSE-junit.txt"
+      sha1: "1dc94a80dbba8262f732e0b0d7235149861a1b57"
+    - path: "META-INF"
+      sha1: "7aa592f161c21d3edcc778ff76f6f30c8b707962"
+    - path: "junit"
+      sha1: "fdda4a4a842bd2bb90c6bd3c8076c777264fc204"
+    - path: "org"
+      sha1: "d23b5987504c1b3de484bf2e47c76f75abb794d3"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    files:
+    - path: "META-INF"
+      sha1: "7aa592f161c21d3edcc778ff76f6f30c8b707962"
+    - path: "org"
+      sha1: "d23b5987504c1b3de484bf2e47c76f75abb794d3"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    files:
+    - path: "META-INF"
+      sha1: "7aa592f161c21d3edcc778ff76f6f30c8b707962"
+    - path: "org"
+      sha1: "d23b5987504c1b3de484bf2e47c76f75abb794d3"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    files:
+    - path: "META-INF"
+      sha1: "7aa592f161c21d3edcc778ff76f6f30c8b707962"
+    - path: "org"
+      sha1: "d23b5987504c1b3de484bf2e47c76f75abb794d3"
 advisor: null
 evaluator: null
 resolved_configuration:

--- a/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -371,6 +371,7 @@ scanner:
           path: "org"
           start_line: -1
           end_line: -1
+  files: []
 advisor: null
 evaluator: null
 resolved_configuration:

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -406,7 +406,57 @@ scanner:
           path: "pkg4/pkg4.txt"
           start_line: -1
           end_line: -1
-  files: []
+  files:
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort-test-data-scanner-subrepo.git"
+        revision: "a732695e03efcbd74539208af98c297ee86e49d5"
+        path: ""
+      resolved_revision: "a732695e03efcbd74539208af98c297ee86e49d5"
+    files:
+    - path: "LICENSE"
+      sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+    - path: "README"
+      sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+    - path: "pkg-s1/pkg-s1.txt"
+      sha1: "e5fb17f8f4f4ef0748bb5ba137fd0e091dd5a1f6"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort-test-data-scanner-subrepo2.git"
+        revision: "6431fd85188db22b942deb66c7a8c1a53921fc35"
+        path: ""
+      resolved_revision: "6431fd85188db22b942deb66c7a8c1a53921fc35"
+    files:
+    - path: "LICENSE"
+      sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+    - path: "README"
+      sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+    - path: "pkg-s2/pkg-s2.txt"
+      sha1: "37996d13eceb6b29db43a381ce8df375b5eee8e9"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+        revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+        path: ""
+      resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+    files:
+    - path: ".gitmodules"
+      sha1: "d7f070ddbe0b6dd8a173714d565a1240dd96eacd"
+    - path: "LICENSE"
+      sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+    - path: "README"
+      sha1: "82cfc115138054ce5b5e6839f38687c9d7186710"
+    - path: "pkg1/pkg1.txt"
+      sha1: "22eb73bd30d47540a4e05781f0f6e07640857cae"
+    - path: "pkg2/pkg2.txt"
+      sha1: "cc8f97cebe1dc0ed889a31f504bcf491d5241aaa"
+    - path: "pkg3/pkg3.txt"
+      sha1: "859d66be2d153968cdaa8ec7265270c241eea024"
+    - path: "pkg4/pkg4.txt"
+      sha1: "3cba29011be2b9d59f6204d6fa0a386b1b2dbd90"
 advisor: null
 evaluator: null
 resolved_configuration: {}

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -406,6 +406,7 @@ scanner:
           path: "pkg4/pkg4.txt"
           start_line: -1
           end_line: -1
+  files: []
 advisor: null
 evaluator: null
 resolved_configuration: {}

--- a/scanner/src/funTest/assets/scanner-integration-expected-file-lists.yml
+++ b/scanner/src/funTest/assets/scanner-integration-expected-file-lists.yml
@@ -1,0 +1,92 @@
+---
+Dummy::pkg0:1.0.0:
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+      revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+      path: ""
+    resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+  files:
+  - path: ".gitmodules"
+    sha1: "d7f070ddbe0b6dd8a173714d565a1240dd96eacd"
+  - path: "LICENSE"
+    sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+  - path: "README"
+    sha1: "82cfc115138054ce5b5e6839f38687c9d7186710"
+  - path: "pkg1/pkg1.txt"
+    sha1: "22eb73bd30d47540a4e05781f0f6e07640857cae"
+  - path: "pkg2/pkg2.txt"
+    sha1: "cc8f97cebe1dc0ed889a31f504bcf491d5241aaa"
+  - path: "pkg3/pkg3.txt"
+    sha1: "859d66be2d153968cdaa8ec7265270c241eea024"
+  - path: "pkg3/subrepo/LICENSE"
+    sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+  - path: "pkg3/subrepo/README"
+    sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+  - path: "pkg3/subrepo/pkg-s1/pkg-s1.txt"
+    sha1: "e5fb17f8f4f4ef0748bb5ba137fd0e091dd5a1f6"
+  - path: "pkg4/pkg4.txt"
+    sha1: "3cba29011be2b9d59f6204d6fa0a386b1b2dbd90"
+  - path: "pkg4/subrepo/LICENSE"
+    sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+  - path: "pkg4/subrepo/README"
+    sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+  - path: "pkg4/subrepo/pkg-s2/pkg-s2.txt"
+    sha1: "37996d13eceb6b29db43a381ce8df375b5eee8e9"
+Dummy::pkg1:1.0.0:
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+      revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+      path: "pkg1"
+    resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+  files:
+  - path: "pkg1/pkg1.txt"
+    sha1: "22eb73bd30d47540a4e05781f0f6e07640857cae"
+Dummy::pkg2:1.0.0:
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+      revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+      path: "pkg2"
+    resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+  files:
+  - path: "pkg2/pkg2.txt"
+    sha1: "cc8f97cebe1dc0ed889a31f504bcf491d5241aaa"
+Dummy::pkg3:1.0.0:
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+      revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+      path: "pkg3"
+    resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+  files:
+  - path: "pkg3/pkg3.txt"
+    sha1: "859d66be2d153968cdaa8ec7265270c241eea024"
+  - path: "pkg3/subrepo/LICENSE"
+    sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+  - path: "pkg3/subrepo/README"
+    sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+  - path: "pkg3/subrepo/pkg-s1/pkg-s1.txt"
+    sha1: "e5fb17f8f4f4ef0748bb5ba137fd0e091dd5a1f6"
+Dummy::pkg4:1.0.0:
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+      revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+      path: "pkg4"
+    resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+  files:
+  - path: "pkg4/pkg4.txt"
+    sha1: "3cba29011be2b9d59f6204d6fa0a386b1b2dbd90"
+  - path: "pkg4/subrepo/LICENSE"
+    sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+  - path: "pkg4/subrepo/README"
+    sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+  - path: "pkg4/subrepo/pkg-s2/pkg-s2.txt"
+    sha1: "37996d13eceb6b29db43a381ce8df375b5eee8e9"

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -233,7 +233,33 @@ scanner:
           path: "pkg3/pkg3.txt"
           start_line: -1
           end_line: -1
-  files: []
+  files:
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort-test-data-scanner-subrepo.git"
+        revision: "a732695e03efcbd74539208af98c297ee86e49d5"
+        path: ""
+      resolved_revision: "a732695e03efcbd74539208af98c297ee86e49d5"
+    files:
+    - path: "LICENSE"
+      sha1: "7df059597099bb7dcf25d2a9aedfaf4465f72d8d"
+    - path: "README"
+      sha1: "ae8044f7fce7ee914a853c30c3085895e9be8b9c"
+    - path: "pkg-s1/pkg-s1.txt"
+      sha1: "e5fb17f8f4f4ef0748bb5ba137fd0e091dd5a1f6"
+  - provenance:
+      vcs_info:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+        revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+        path: ""
+      resolved_revision: "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
+    files:
+    - path: "pkg1/pkg1.txt"
+      sha1: "22eb73bd30d47540a4e05781f0f6e07640857cae"
+    - path: "pkg3/pkg3.txt"
+      sha1: "859d66be2d153968cdaa8ec7265270c241eea024"
 advisor: null
 evaluator: null
 resolved_configuration: {}

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -233,6 +233,7 @@ scanner:
           path: "pkg3/pkg3.txt"
           start_line: -1
           end_line: -1
+  files: []
 advisor: null
 evaluator: null
 resolved_configuration: {}

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -78,6 +78,14 @@ class ScannerIntegrationFunTest : WordSpec({
             patchActualResult(scanResults.toYaml(), patchStartAndEndTime = true) should
                     matchExpectedResult(expectedResultFile)
         }
+
+        "return the expected (merged) file lists" {
+            val expectedResultFile = getAssetFile("scanner-integration-expected-file-lists.yml")
+
+            val fileLists = ortResult.getFileLists().toSortedMap()
+
+            fileLists.toYaml() should matchExpectedResult(expectedResultFile)
+        }
     }
 
     "Scanning a subset of the packages corresponding to a single VCS" should {

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -93,6 +93,11 @@ internal class ScanController(
     private val scanResults = mutableMapOf<ScannerWrapper, MutableMap<KnownProvenance, MutableList<ScanResult>>>()
 
     /**
+     * The [FileList] for each [KnownProvenance].
+     */
+    private val fileLists = mutableMapOf<KnownProvenance, FileList>()
+
+    /**
      * Set the [issue] which failed package provenance resolution for the package denoted by [id].
      */
     fun putPackageProvenanceResolutionIssue(id: Identifier, issue: Issue) {
@@ -105,6 +110,18 @@ internal class ScanController(
     fun putNestedProvenanceResolutionIssue(id: Identifier, issue: Issue) {
         nestedProvenanceResolutionIssues[id] = issue
     }
+
+    /**
+     * Set the [fileList] corresponding to [provenance], overwriting any existing value.
+     */
+    fun putFileList(provenance: KnownProvenance, fileList: FileList) {
+        fileLists[provenance] = fileList
+    }
+
+    /**
+     * Return all [FileList] by their corresponding [provenance].
+     */
+    fun getAllFileLists(): Map<KnownProvenance, FileList> = fileLists
 
     fun addIssue(id: Identifier, issue: Issue) {
         issues.getOrPut(id) { mutableListOf() } += issue

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -167,7 +167,8 @@ class Scanner(
             provenances = projectResults.provenances + packageResults.provenances,
             scanResults = (projectResults.scanResults + packageResults.scanResults).mapTo(mutableSetOf()) {
                 it.clearPackageVerificationCode()
-            }
+            },
+            files = projectResults.files + packageResults.files
         )
 
         return ortResult.copy(scanner = scannerRun)
@@ -229,7 +230,9 @@ class Scanner(
         return ScannerRun.EMPTY.copy(
             config = scannerConfig,
             provenances = provenances,
-            scanResults = scanResults
+            scanResults = scanResults,
+            // TODO: Set the file lists.
+            files = emptySet()
         )
     }
 


### PR DESCRIPTION
The file lists are an enabler for

1. Computing SPDX package verification codes on-the-fly.
2. Adding file findings to SPDX reports
3. Several `helper-cli` automation opportunities like e.g. `PathExcludeGenerator`
 
Fixes: #6944.

**Breaking change:** `OrtResult` de-serialization is not backwards compatible.