### PR TITLE
ci(GitHub): Enforce version 1.1.2 of the reuse tool

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -94,5 +94,5 @@ jobs:
         cache: pip
     - name: Check REUSE Compliance
       run: |
-        pip install --user reuse
+        pip install --user reuse==1.1.2
         ~/.local/bin/reuse lint


### PR DESCRIPTION
The recently published version 2.0.0 of the reuse tool [1] reports several issues which require updating the configuration. As it is not clear yet how much effort this requires, fix the version to the previous release 1.1.2. Note that other projects are having issues with the new release as well [2], so it might make sense to wait a bit before upgrading.

[1]: https://github.com/fsfe/reuse-tool/releases/tag/v2.0.0
[2]: https://github.com/fsfe/reuse-tool/issues/773