### PR TITLE
ci(GitHub): Clean up the Gradle user home before caching

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Build all classes
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: --scan classes -x :plugins:reporters:web-app-template:yarnBuild
   build-web-app-reporter:
     needs: build
@@ -44,6 +45,7 @@ jobs:
     - name: Build the web-app-reporter
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: --scan :plugins:reporters:web-app-template:yarnBuild
   codeql-analysis:
     needs: build
@@ -66,6 +68,7 @@ jobs:
     - name: Build all classes
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: -Dorg.gradle.jvmargs=-Xmx1g classes -x :plugins:reporters:web-app-template:yarnBuild
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
@@ -83,6 +86,7 @@ jobs:
     - name: Run unit tests
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: --scan test jacocoTestReport -x :plugins:reporters:web-app-template:yarnBuild
     - name: Upload code coverage data
       uses: codecov/codecov-action@v3
@@ -129,6 +133,7 @@ jobs:
     - name: Run functional tests that do not require external tools
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: --scan -Ptests.exclude=org.ossreviewtoolkit.cli.*,org.ossreviewtoolkit.analyzer.*,org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
     - name: Upload code coverage data
       uses: codecov/codecov-action@v3

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Check copyright and license information
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: checkCopyrightsInNoticeFile checkLicenseHeaders
   detekt-issues:
     runs-on: ubuntu-22.04
@@ -49,6 +50,7 @@ jobs:
     - name: Check for Detekt Issues
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: detekt detektTest detektFunTest
     - name: Upload SARIF File
       uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
See [1]. At a later point, this will become the default [2], and then this could be reverted.

[1]: https://github.com/gradle/gradle-build-action#removing-unused-files-from-gradle-user-home-before-saving-to-cache
[2]: https://github.com/gradle/gradle-build-action/issues/630