### PR TITLE
fix(fossid-webapp): Remove issues for each pending file

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -846,10 +846,13 @@ class FossId internal constructor(
     ): ScanResult {
         // TODO: Maybe get issues from FossID (see has_failed_scan_files, get_failed_files and maybe get_scan_log).
 
-        // TODO: Deprecation: Remove the pending files in issues. This is a breaking change.
-        val issues = rawResults.listPendingFiles.mapTo(mutableListOf()) {
-            Issue(source = name, message = "Pending identification for '$it'.", severity = Severity.HINT)
-        }
+        val issues = mutableListOf(
+            Issue(
+                source = name,
+                message = "This scan has ${rawResults.listPendingFiles.size} file(s) pending identification in FossID.",
+                severity = Severity.HINT
+            )
+        )
 
         val snippetFindings = mapSnippetFindings(rawResults, issues)
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -329,8 +329,7 @@ class FossIdTest : WordSpec({
             summary.licenseFindings shouldContainExactlyInAnyOrder expectedLicenseFindings
         }
 
-        // TODO: Deprecation: Remove the pending files in issues. This is a breaking change.
-        "report pending files as issues" {
+        "create an issue if there are files pending identification" {
             val projectCode = projectCode(PROJECT)
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
@@ -350,9 +349,14 @@ class FossIdTest : WordSpec({
 
             val summary = fossId.scan(createPackage(pkgId, vcsInfo)).summary
 
-            val expectedIssues = listOf(createPendingFile(4), createPendingFile(5)).map {
-                Issue(Instant.EPOCH, "FossId", "Pending identification for '$it'.", Severity.HINT)
-            }
+            val expectedIssues = listOf(
+                Issue(
+                    timestamp = Instant.EPOCH,
+                    source = "FossId",
+                    message = "This scan has 2 file(s) pending identification in FossID.",
+                    severity = Severity.HINT
+                )
+            )
 
             summary.issues.map { it.copy(timestamp = Instant.EPOCH) } shouldBe expectedIssues
         }


### PR DESCRIPTION
The FossId pending files were present in the scan result as issues with severity `HINT`. Now, the scan result contains the pending file's snippets.
However, counting the unique pending files having snippets is not an option since some pending files could have no snippet at all. Therefore, add a single issue with severity `HINT` with the count of pending files.

This is a breaking change.