### PR TITLE
build(downloader): Exclude `sshd-{core,common}` dependencies

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -29,7 +29,12 @@ dependencies {
 
     implementation(libs.jgit)
     implementation(libs.jgitSshApacheAgent)
-    implementation(libs.svnkit)
+    implementation(libs.svnkit) {
+        exclude(group = "org.apache.sshd", module = "sshd-core")
+            .because("it is included in JGit's sshd-osgi dependency")
+        exclude(group = "org.apache.sshd", module = "sshd-common")
+            .because("it is included in JGit's sshd-osgi dependency")
+    }
 
     testImplementation(libs.mockk)
 }


### PR DESCRIPTION
The JGit upgrade in 115f241 excludes the `sshd-{core,common}` dependencies [1] in favor of keeping only the dependency on `sshd-osgi`. As svnkit also depends on `sshd-{core,common}`, this "sometimes" seems to cause JGit to use the wrong `sshd-common` dependency, namely svnkit's instead of its own [2]. Avoid that by aligning on the (newer) `sshd-common` that is included in JGit's `sshd-osgi` dependency.

Fixes #7177.

[1]: https://git.eclipse.org/r/c/jgit/jgit/+/201879/3/org.eclipse.jgit.ssh.apache/pom.xml
[2]: https://bugs.eclipse.org/bugs/show_bug.cgi?id=582109