### PR TITLE
fix(scanner): Consistently filter file findings in `ScanSummary`

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -121,7 +121,8 @@ data class ScanSummary(
 
         return copy(
             licenseFindings = licenseFindings.filterTo(mutableSetOf()) { it.location.matchesPath() },
-            copyrightFindings = copyrightFindings.filterTo(mutableSetOf()) { it.location.matchesPath() }
+            copyrightFindings = copyrightFindings.filterTo(mutableSetOf()) { it.location.matchesPath() },
+            snippetFindings = snippetFindings.filterTo(mutableSetOf()) { it.sourceLocation.matchesPath() }
         )
     }
 
@@ -134,7 +135,8 @@ data class ScanSummary(
 
         return copy(
             licenseFindings = licenseFindings.filterTo(mutableSetOf()) { !matcher.matches(it.location.path) },
-            copyrightFindings = copyrightFindings.filterTo(mutableSetOf()) { !matcher.matches(it.location.path) }
+            copyrightFindings = copyrightFindings.filterTo(mutableSetOf()) { !matcher.matches(it.location.path) },
+            snippetFindings = snippetFindings.filterTo(mutableSetOf()) { !matcher.matches(it.sourceLocation.path) }
         )
     }
 }


### PR DESCRIPTION
Snipped findings have recently been added to `ScanSummary`, but the `filter*()` functions have not been updated to also filter snippet findings. There seems to be no good reason why snippet findings shouldn't be filtered, so add the missing implementation.

Part of #7206.