### PR TITLE
SpdxDocumentReporter: Compute SPDX verification codes on-the-fly

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -100,6 +100,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "be26ae6e9285a5d349d037deeb5eff2015635739"
   issues:
   - 0
 - _id: 1
@@ -116,6 +117,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "bab81eca7b6fae7b64d4c7343a2f5c43c4caa171"
 - _id: 2
   provenance:
     source_artifact:
@@ -129,6 +131,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 3
   provenance:
     source_artifact:
@@ -142,6 +145,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 4
   provenance:
     source_artifact:
@@ -155,6 +159,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 5
   provenance:
     source_artifact:
@@ -168,6 +173,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 6
   provenance:
     source_artifact:
@@ -181,6 +187,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 packages:
 - _id: 0
   id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -125,6 +125,7 @@
     },
     "start_time" : "1970-01-01T00:00:00Z",
     "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "be26ae6e9285a5d349d037deeb5eff2015635739",
     "issues" : [ 0 ]
   }, {
     "_id" : 1,
@@ -143,7 +144,8 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z"
+    "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "bab81eca7b6fae7b64d4c7343a2f5c43c4caa171"
   }, {
     "_id" : 2,
     "provenance" : {
@@ -161,7 +163,8 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z"
+    "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "da39a3ee5e6b4b0d3255bfef95601890afd80709"
   }, {
     "_id" : 3,
     "provenance" : {
@@ -179,7 +182,8 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z"
+    "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "da39a3ee5e6b4b0d3255bfef95601890afd80709"
   }, {
     "_id" : 4,
     "provenance" : {
@@ -197,7 +201,8 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z"
+    "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "da39a3ee5e6b4b0d3255bfef95601890afd80709"
   }, {
     "_id" : 5,
     "provenance" : {
@@ -215,7 +220,8 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z"
+    "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "da39a3ee5e6b4b0d3255bfef95601890afd80709"
   }, {
     "_id" : 6,
     "provenance" : {
@@ -233,7 +239,8 @@
       "configuration" : ""
     },
     "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z"
+    "end_time" : "1970-01-01T00:00:00Z",
+    "package_verification_code" : "da39a3ee5e6b4b0d3255bfef95601890afd80709"
   } ],
   "packages" : [ {
     "_id" : 0,

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -100,6 +100,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "be26ae6e9285a5d349d037deeb5eff2015635739"
   issues:
   - 0
 - _id: 1
@@ -116,6 +117,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "bab81eca7b6fae7b64d4c7343a2f5c43c4caa171"
 - _id: 2
   provenance:
     source_artifact:
@@ -129,6 +131,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 3
   provenance:
     source_artifact:
@@ -142,6 +145,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 4
   provenance:
     source_artifact:
@@ -155,6 +159,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 5
   provenance:
     source_artifact:
@@ -168,6 +173,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 - _id: 6
   provenance:
     source_artifact:
@@ -181,6 +187,7 @@ scan_results:
     configuration: ""
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 packages:
 - _id: 0
   id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
+import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
 /**
  * Maps the [reporter input][input] to an [EvaluatedModel].
@@ -426,7 +427,9 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             scanner = result.scanner,
             startTime = result.summary.startTime,
             endTime = result.summary.endTime,
-            packageVerificationCode = result.summary.packageVerificationCode,
+            packageVerificationCode = input.ortResult.getFileListForId(pkg.id)?.let { fileList ->
+                calculatePackageVerificationCode(fileList.files.map { it.sha1 }.asSequence())
+            }.orEmpty(),
             issues = issues
         )
 

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedScanResult.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedScanResult.kt
@@ -36,6 +36,7 @@ data class EvaluatedScanResult(
     val scanner: ScannerDetails,
     val startTime: Instant,
     val endTime: Instant,
+    // TODO: Consider moving the package verification code to EvaluatedPackage.
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val packageVerificationCode: String,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -60,12 +60,15 @@
       "referenceType" : "purl",
       "referenceLocator" : "pkg:maven/first-package-group/first-package@0.0.1"
     } ],
-    "filesAnalyzed" : false,
+    "filesAnalyzed" : true,
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
     "licenseInfoFromFiles" : [ "Apache-2.0", "BSD-2-Clause" ],
     "name" : "first-package",
+    "packageVerificationCode" : {
+      "packageVerificationCodeValue" : "3700a1e8575c082653af662ac024337faf78990f"
+    },
     "summary" : "A package with all supported attributes set, with a VCS URL containing a user name, and with two scan results for the VCS containing copyright findings matched to a license finding.",
     "versionInfo" : "0.0.1"
   }, {

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -154,12 +154,15 @@
       "referenceType" : "purl",
       "referenceLocator" : "pkg:maven/seventh-package-group/seventh-package@0.0.1"
     } ],
-    "filesAnalyzed" : false,
+    "filesAnalyzed" : true,
     "homepage" : "NONE",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "NOASSERTION",
     "licenseInfoFromFiles" : [ "GPL-3.0-only" ],
     "name" : "seventh-package",
+    "packageVerificationCode" : {
+      "packageVerificationCodeValue" : "e14acc46fad3a38a1ef2830067619812b51cb4bc"
+    },
     "summary" : "A package with a source artifact scan result.",
     "versionInfo" : "0.0.1"
   }, {

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -73,7 +73,7 @@ packages:
   - referenceCategory: "PACKAGE_MANAGER"
     referenceType: "purl"
     referenceLocator: "pkg:maven/first-package-group/first-package@0.0.1"
-  filesAnalyzed: false
+  filesAnalyzed: true
   homepage: "first package's homepage URL"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
@@ -81,6 +81,8 @@ packages:
   - "Apache-2.0"
   - "BSD-2-Clause"
   name: "first-package"
+  packageVerificationCode:
+    packageVerificationCodeValue: "3700a1e8575c082653af662ac024337faf78990f"
   summary: "A package with all supported attributes set, with a VCS URL containing\
     \ a user name, and with two scan results for the VCS containing copyright findings\
     \ matched to a license finding."

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -165,13 +165,15 @@ packages:
   - referenceCategory: "PACKAGE_MANAGER"
     referenceType: "purl"
     referenceLocator: "pkg:maven/seventh-package-group/seventh-package@0.0.1"
-  filesAnalyzed: false
+  filesAnalyzed: true
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "NOASSERTION"
   licenseInfoFromFiles:
   - "GPL-3.0-only"
   name: "seventh-package"
+  packageVerificationCode:
+    packageVerificationCodeValue: "e14acc46fad3a38a1ef2830067619812b51cb4bc"
   summary: "A package with a source artifact scan result."
   versionInfo: "0.0.1"
 - SPDXID: "SPDXRef-Package-Maven-sixth-package-group-sixth-package-0.0.1"

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -119,7 +119,7 @@ internal enum class SpdxPackageType(val infix: String, val suffix: String = "") 
 
 /**
  * Convert this ORT package to an SPDX package. As an ORT package can hold more metadata about its associated artifacts
- * and origin than an SPDX package, the [type] is used to specify which kind of SPDX package should be created from
+ * and origin than an SPDX package, the [type] is used to specify which kind of SPDX package should be created from the
  * respective ORT package metadata. [licenseInfoResolver] is used for license and copyright information, and the
  * optional [scanResult] and [provenance] are used for [type]-specific information.
  */

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -38,6 +38,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseException
+import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.spdx.model.SpdxChecksum
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
 import org.ossreviewtoolkit.utils.spdx.model.SpdxExternalReference
@@ -182,10 +183,10 @@ private fun OrtResult.getResolvedRevision(id: Identifier): String? =
 
 private fun OrtResult.getPackageVerificationCode(id: Identifier, type: SpdxPackageType): String? =
     when (type) {
-        SpdxPackageType.VCS_PACKAGE -> getVcsScanResult(id)?.summary?.packageVerificationCode?.takeUnless {
-            it.isEmpty()
-        }
+        SpdxPackageType.VCS_PACKAGE -> getFileListForId(id).takeIf { it?.provenance is RepositoryProvenance }
         else -> null
+    }?.let { fileList ->
+        calculatePackageVerificationCode(fileList.files.map { it.sha1 }.asSequence())
     }
 
 /**

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -21,6 +21,7 @@
 
 package org.ossreviewtoolkit.plugins.reporters.spdx
 
+import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
@@ -184,6 +185,7 @@ private fun OrtResult.getResolvedRevision(id: Identifier): String? =
 private fun OrtResult.getPackageVerificationCode(id: Identifier, type: SpdxPackageType): String? =
     when (type) {
         SpdxPackageType.VCS_PACKAGE -> getFileListForId(id).takeIf { it?.provenance is RepositoryProvenance }
+        SpdxPackageType.SOURCE_PACKAGE -> getFileListForId(id).takeIf { it?.provenance is ArtifactProvenance }
         else -> null
     }?.let { fileList ->
         calculatePackageVerificationCode(fileList.files.map { it.sha1 }.asSequence())


### PR DESCRIPTION
Compute the SPDX package verification code based on the file lists which have been added to `OrtResult` recently.

See individual commits.

Fixes: #6948.