### PR TITLE
Scan summary drop package verification code

### DIFF
--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -376,7 +376,7 @@ advisor:
       - advisor:
           name: "NexusIQ"
           capabilities:
-            - "VULNERABILITIES"
+          - "VULNERABILITIES"
         summary:
           start_time: "2021-04-29T14:54:17.322191Z"
           end_time: "2021-04-29T14:54:18.966672Z"

--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -217,7 +217,6 @@ scanner:
     summary:
       start_time: "2020-09-30T09:28:32.817956Z"
       end_time: "2020-09-30T09:29:02.889213Z"
-      package_verification_code: ""
       licenses:
       - license: "Apache-2.0"
         location:
@@ -290,7 +289,6 @@ scanner:
     summary:
       start_time: "2020-09-30T09:27:12.023451Z"
       end_time: "2020-09-30T09:28:20.525647Z"
-      package_verification_code: ""
       licenses:
       - license: "BSD-3-Clause"
         location:

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -225,8 +225,7 @@ private fun createOrtResult(
                     provenance = RepositoryProvenance(vcsInfo, vcsInfo.revision),
                     scanner = ScannerDetails.EMPTY,
                     summary = ScanSummary.EMPTY.copy(
-                        licenseFindings = licenseFindings,
-                        packageVerificationCode = "0000000000000000000000000000000000000000"
+                        licenseFindings = licenseFindings
                     )
                 )
             )

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 /**
  * A short summary of the scan results.
  */
-@JsonIgnoreProperties("file_count")
+@JsonIgnoreProperties("file_count", "package_verification_code")
 data class ScanSummary(
     /**
      * The time when the scan started.
@@ -49,13 +49,6 @@ data class ScanSummary(
      * The time when the scan finished.
      */
     val endTime: Instant,
-
-    /**
-     * The [SPDX package verification code](https://spdx.dev/spdx_specification_2_0_html#h.2p2csry), calculated from all
-     * files in the package. Note that if the scanner is configured to ignore certain files they will still be included
-     * in the calculation of this code.
-     */
-    val packageVerificationCode: String,
 
     /**
      * The detected license findings.
@@ -96,8 +89,7 @@ data class ScanSummary(
         @JvmField
         val EMPTY = ScanSummary(
             startTime = Instant.EPOCH,
-            endTime = Instant.EPOCH,
-            packageVerificationCode = ""
+            endTime = Instant.EPOCH
         )
     }
 

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -109,10 +109,6 @@ data class ScannerRun(
                     "The revision and resolved revision of a scan result are not equal, which is not allowed."
                 }
             }
-
-            require(scanResult.summary.packageVerificationCode.isEmpty()) {
-                "Found a scan result with a non-empty package verification code, which is not allowed."
-            }
         }
 
         provenances.getDuplicates { it.id }.keys.let { idsForDuplicateProvenanceResolutionResults ->
@@ -211,8 +207,6 @@ data class ScannerRun(
                 provenance = packageProvenance,
                 summary = scanResult.summary.addIssue(resolutionResult.nestedProvenanceResolutionIssue)
             )
-
-            // TODO: Compute and set the package verification code of the scan summary.
         }
 
         return scanResults.takeIf { it.isNotEmpty() }

--- a/model/src/main/kotlin/utils/ScanResultUtils.kt
+++ b/model/src/main/kotlin/utils/ScanResultUtils.kt
@@ -34,8 +34,7 @@ import org.ossreviewtoolkit.model.SnippetFinding
  * for the result. All other entries in [scanResultsByPath] hold the scan results for each respective (recursive)
  * sub-repository of the main repository. This maps the given [scanResultsByPath] to the format currently used by
  * [OrtResult]. When merging multiple [ScanSummary]s for a particular scanner the earliest start time and lasted end
- * time will be used as the new values for the respective scanner. Because the [ScanSummary] does not contain the
- * checksums of the individual files, no package verification code can be calculated.
+ * time will be used as the new values for the respective scanner.
  */
 fun mergeScanResultsByScanner(scanResultsByPath: Map<String, List<ScanResult>>): List<ScanResult> {
     val rootProvenance = scanResultsByPath.getValue("").map { it.provenance }.distinct().also {
@@ -65,7 +64,6 @@ fun mergeScanResultsByScanner(scanResultsByPath: Map<String, List<ScanResult>>):
             summary = ScanSummary(
                 startTime = startTime,
                 endTime = endTime,
-                packageVerificationCode = "",
                 licenseFindings = licenseFindings,
                 copyrightFindings = copyrightFindings,
                 snippetFindings = snippetFindings,

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -14,7 +14,6 @@ results:
   summary:
     start_time: "1970-01-02T00:01:00Z"
     end_time: "1970-01-02T00:02:00Z"
-    package_verification_code: "packageVerificationCode"
     licenses:
     - license: "license-1.1"
       location:
@@ -60,7 +59,6 @@ results:
   summary:
     start_time: "1970-01-03T00:01:00Z"
     end_time: "1970-01-03T00:02:00Z"
-    package_verification_code: "packageVerificationCode"
     licenses:
     - license: "license-2.1"
       location:

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -447,7 +447,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "Apache-2.0"
         location:
@@ -494,7 +493,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
           \ MIT"
@@ -544,7 +542,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
@@ -558,7 +555,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
@@ -572,7 +568,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
@@ -586,7 +581,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
@@ -600,7 +594,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -434,76 +434,6 @@ scanner:
           algorithm: "SHA-1"
   scan_results:
   - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
-        hash:
-          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-        hash:
-          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-        hash:
-          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-        hash:
-          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-        hash:
-          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
       vcs_info:
         type: "Git"
         url: "https://example.com/git"
@@ -601,6 +531,76 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
   files:
   - provenance:
       vcs_info:
@@ -689,7 +689,7 @@ advisor:
       - advisor:
           name: "VulnerableCode"
           capabilities:
-            - "VULNERABILITIES"
+          - "VULNERABILITIES"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -443,7 +443,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "Apache-2.0"
         location:
@@ -490,7 +489,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
           \ MIT"
@@ -540,7 +538,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
@@ -554,7 +551,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
@@ -568,7 +564,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
@@ -582,7 +577,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
@@ -596,7 +590,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -430,76 +430,6 @@ scanner:
           algorithm: "SHA-1"
   scan_results:
   - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
-        hash:
-          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-        hash:
-          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-        hash:
-          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-        hash:
-          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-        hash:
-          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
       vcs_info:
         type: "Git"
         url: "https://example.com/git"
@@ -597,6 +527,76 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
   files:
   - provenance:
       vcs_info:
@@ -685,7 +685,7 @@ advisor:
       - advisor:
           name: "VulnerableCode"
           capabilities:
-            - "VULNERABILITIES"
+          - "VULNERABILITIES"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"

--- a/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
+++ b/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
@@ -456,7 +456,6 @@ private fun createOrtResult(): OrtResult {
                         configuration = "configuration"
                     ),
                     summary = ScanSummary.EMPTY.copy(
-                        packageVerificationCode = "0000000000000000000000000000000000000000",
                         licenseFindings = setOf(
                             LicenseFinding(
                                 license = "Apache-2.0",
@@ -493,7 +492,6 @@ private fun createOrtResult(): OrtResult {
                     summary = ScanSummary.EMPTY.copy(
                         startTime = Instant.EPOCH,
                         endTime = Instant.EPOCH,
-                        packageVerificationCode = "0000000000000000000000000000000000000000",
                         licenseFindings = setOf(
                             LicenseFinding(
                                 license = "BSD-2-Clause",

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -299,7 +299,6 @@ private val ortResult = OrtResult(
                 ),
                 scanner = ScannerDetails.EMPTY.copy(name = "scanner1"),
                 summary = ScanSummary.EMPTY.copy(
-                    packageVerificationCode = "0000000000000000000000000000000000000000",
                     licenseFindings = setOf(
                         LicenseFinding(
                             license = "Apache-2.0",
@@ -330,7 +329,6 @@ private val ortResult = OrtResult(
                 ),
                 scanner = ScannerDetails.EMPTY.copy(name = "scanner2"),
                 summary = ScanSummary.EMPTY.copy(
-                    packageVerificationCode = "0000000000000000000000000000000000000000",
                     licenseFindings = setOf(
                         LicenseFinding(
                             license = "BSD-2-Clause",

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -443,7 +443,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "Apache-2.0"
         location:
@@ -490,7 +489,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR\
           \ MIT"
@@ -540,7 +538,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
@@ -554,7 +551,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
@@ -568,7 +564,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
@@ -582,7 +577,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   - provenance:
       source_artifact:
         url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
@@ -596,7 +590,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -430,76 +430,6 @@ scanner:
           algorithm: "SHA-1"
   scan_results:
   - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
-        hash:
-          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-        hash:
-          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-        hash:
-          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-        hash:
-          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
-      source_artifact:
-        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-        hash:
-          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          algorithm: "SHA-1"
-    scanner:
-      name: "Dummy"
-      version: "1.0"
-      configuration: ""
-    summary:
-      start_time: "1970-01-01T00:00:00Z"
-      end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
-  - provenance:
       vcs_info:
         type: "Git"
         url: "https://example.com/git"
@@ -597,6 +527,76 @@ scanner:
           \ Please make sure the published POM file includes the SCM connection, see:\
           \ https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
         severity: "ERROR"
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+        hash:
+          value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+        hash:
+          value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+        hash:
+          value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+        hash:
+          value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
+  - provenance:
+      source_artifact:
+        url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+        hash:
+          value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+          algorithm: "SHA-1"
+    scanner:
+      name: "Dummy"
+      version: "1.0"
+      configuration: ""
+    summary:
+      start_time: "1970-01-01T00:00:00Z"
+      end_time: "1970-01-01T00:00:00Z"
+      package_verification_code: ""
   files:
   - provenance:
       vcs_info:
@@ -685,7 +685,7 @@ advisor:
       - advisor:
           name: "VulnerableCode"
           capabilities:
-            - "VULNERABILITIES"
+          - "VULNERABILITIES"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"

--- a/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
@@ -274,7 +274,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:
@@ -309,7 +308,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:
@@ -334,7 +332,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:
@@ -359,7 +356,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
 class Askalono internal constructor(
     private val name: String,
@@ -104,7 +103,6 @@ class Askalono internal constructor(
         return ScanSummary(
             startTime = startTime,
             endTime = endTime,
-            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             issues = listOf(
                 Issue(

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -41,7 +41,6 @@ import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
 class BoyterLc internal constructor(
     private val name: String,
@@ -114,7 +113,6 @@ class BoyterLc internal constructor(
         return ScanSummary(
             startTime = startTime,
             endTime = endTime,
-            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             issues = listOf(
                 Issue(

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -862,7 +862,6 @@ class FossId internal constructor(
         val summary = ScanSummary(
             startTime = startTime,
             endTime = Instant.now(),
-            packageVerificationCode = "",
             licenseFindings = licenseFindings,
             copyrightFindings = copyrightFindings,
             snippetFindings = snippetFindings,

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
 class Licensee internal constructor(
     private val name: String,
@@ -77,11 +76,11 @@ class Licensee internal constructor(
             if (stderr.isNotBlank()) logger.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
-            generateSummary(startTime, endTime, path, stdout)
+            generateSummary(startTime, endTime, stdout)
         }
     }
 
-    private fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: String): ScanSummary {
+    private fun generateSummary(startTime: Instant, endTime: Instant, result: String): ScanSummary {
         val licenseFindings = mutableSetOf<LicenseFinding>()
 
         val json = jsonMapper.readTree(result)
@@ -103,7 +102,6 @@ class Licensee internal constructor(
         return ScanSummary(
             startTime = startTime,
             endTime = endTime,
-            packageVerificationCode = calculatePackageVerificationCode(scanPath),
             licenseFindings = licenseFindings,
             issues = listOf(
                 Issue(

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -122,7 +122,6 @@ class ScanOss internal constructor(
         return generateSummary(
             startTime,
             endTime,
-            path,
             resolvedResponse,
             scannerConfig.detectedLicenseMapping
         )

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
-import java.io.File
 import java.time.Instant
 
 import org.ossreviewtoolkit.clients.scanoss.FullScanResponse
@@ -37,35 +36,14 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
-import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
 /**
- * Generate a summary from the given SCANOSS [result], using [startTime] and [endTime] metadata. From the [scanPath]
- * the package verification code is generated.
+ * Generate a summary from the given SCANOSS [result], using [startTime], [endTime] as metadata. This variant can be
+ * used if the result is not read from a local file.
  */
 internal fun generateSummary(
     startTime: Instant,
     endTime: Instant,
-    scanPath: File,
-    result: FullScanResponse,
-    detectedLicenseMapping: Map<String, String>
-) =
-    generateSummary(
-        startTime,
-        endTime,
-        calculatePackageVerificationCode(scanPath),
-        result,
-        detectedLicenseMapping
-    )
-
-/**
- * Generate a summary from the given SCANOSS [result], using [startTime], [endTime], and [verificationCode]
- * metadata. This variant can be used if the result is not read from a local file.
- */
-internal fun generateSummary(
-    startTime: Instant,
-    endTime: Instant,
-    verificationCode: String,
     result: FullScanResponse,
     detectedLicenseMapping: Map<String, String>
 ): ScanSummary {
@@ -96,7 +74,6 @@ internal fun generateSummary(
     return ScanSummary(
         startTime = startTime,
         endTime = endTime,
-        packageVerificationCode = verificationCode,
         licenseFindings = licenseFindings,
         copyrightFindings = copyrightFindings,
         snippetFindings = snippetFindings

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -42,7 +42,6 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 class ScanOssResultParserTest : WordSpec({
@@ -53,7 +52,7 @@ class ScanOssResultParserTest : WordSpec({
             }
 
             val time = Instant.now()
-            val summary = generateSummary(time, time, SpdxConstants.NONE, result, emptyMap())
+            val summary = generateSummary(time, time, result, emptyMap())
 
             summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
                 "Apache-2.0",
@@ -91,7 +90,7 @@ class ScanOssResultParserTest : WordSpec({
             }
 
             val time = Instant.now()
-            val summary = generateSummary(time, time, SpdxConstants.NONE, result, emptyMap())
+            val summary = generateSummary(time, time, result, emptyMap())
 
             summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
                 "Apache-2.0",

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -307,7 +307,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:
@@ -338,7 +337,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:
@@ -369,7 +367,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:

--- a/scanner/src/funTest/assets/scanner-integration-expected-scan-results.yml
+++ b/scanner/src/funTest/assets/scanner-integration-expected-scan-results.yml
@@ -14,7 +14,6 @@ Dummy::pkg0:1.0.0:
   summary:
     start_time: "1970-01-01T00:00:00Z"
     end_time: "1970-01-01T00:00:00Z"
-    package_verification_code: ""
     licenses:
     - license: "NONE"
       location:
@@ -96,7 +95,6 @@ Dummy::pkg1:1.0.0:
   summary:
     start_time: "1970-01-01T00:00:00Z"
     end_time: "1970-01-01T00:00:00Z"
-    package_verification_code: ""
     licenses:
     - license: "NONE"
       location:
@@ -123,7 +121,6 @@ Dummy::pkg2:1.0.0:
   summary:
     start_time: "1970-01-01T00:00:00Z"
     end_time: "1970-01-01T00:00:00Z"
-    package_verification_code: ""
     licenses:
     - license: "NONE"
       location:
@@ -150,7 +147,6 @@ Dummy::pkg3:1.0.0:
   summary:
     start_time: "1970-01-01T00:00:00Z"
     end_time: "1970-01-01T00:00:00Z"
-    package_verification_code: ""
     licenses:
     - license: "NONE"
       location:
@@ -192,7 +188,6 @@ Dummy::pkg4:1.0.0:
   summary:
     start_time: "1970-01-01T00:00:00Z"
     end_time: "1970-01-01T00:00:00Z"
-    package_verification_code: ""
     licenses:
     - license: "NONE"
       location:
@@ -228,7 +223,6 @@ Dummy::project:1.0.0:
   summary:
     start_time: "1970-01-01T00:00:00Z"
     end_time: "1970-01-01T00:00:00Z"
-    package_verification_code: ""
     issues:
     - timestamp: "1970-01-01T00:00:00Z"
       source: "scanner"

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -185,7 +185,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:
@@ -216,7 +215,6 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
-      package_verification_code: ""
       licenses:
       - license: "NONE"
         location:

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -102,7 +102,6 @@ abstract class AbstractStorageFunTest(vararg listeners: TestListener) : WordSpec
     private val scanSummaryWithFiles = ScanSummary.EMPTY.copy(
         startTime = Instant.EPOCH + Duration.ofMinutes(1),
         endTime = Instant.EPOCH + Duration.ofMinutes(2),
-        packageVerificationCode = "packageVerificationCode",
         licenseFindings = setOf(
             LicenseFinding("license-1.1", DUMMY_TEXT_LOCATION),
             LicenseFinding("license-1.2", DUMMY_TEXT_LOCATION)
@@ -155,7 +154,9 @@ abstract class AbstractStorageFunTest(vararg listeners: TestListener) : WordSpec
 
             "not store a result for the same scanner and provenance twice" {
                 val summary1 = scanSummaryWithFiles
-                val summary2 = scanSummaryWithFiles.copy(packageVerificationCode = "anotherPackageVerificationCode")
+                val summary2 = scanSummaryWithFiles.copy(
+                    startTime = scanSummaryWithFiles.startTime.plusSeconds(10)
+                )
 
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, summary1)
                 val scanResult2 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, summary2)

--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -40,7 +40,6 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
-import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 
 class ClearlyDefinedStorageFunTest : StringSpec({
     val storage = ClearlyDefinedStorage(ClearlyDefinedStorageConfiguration(Server.PRODUCTION.apiUrl))
@@ -73,7 +72,6 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                 summary = ScanSummary.EMPTY.copy(
                     startTime = Instant.parse("2020-02-14T00:36:14.000335513Z"),
                     endTime = Instant.parse("2020-02-14T00:36:37.000492119Z"),
-                    packageVerificationCode = SpdxConstants.NONE,
                     licenseFindings = setOf(
                         LicenseFinding(
                             license = "MIT",
@@ -115,8 +113,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                 ),
                 summary = ScanSummary.EMPTY.copy(
                     startTime = Instant.parse("2022-05-02T07:34:28.000784295Z"),
-                    endTime = Instant.parse("2022-05-02T07:34:59.000958218Z"),
-                    packageVerificationCode = SpdxConstants.NONE
+                    endTime = Instant.parse("2022-05-02T07:34:59.000958218Z")
                 )
             )
         }

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
@@ -64,8 +64,7 @@ data class NestedProvenanceScanResult(
      * Merge the nested [ScanResult]s into one [ScanResult] per used scanner, using the root of the [nestedProvenance]
      * as provenance. This is used to transform this class into the format currently used by [OrtResult].
      * When merging multiple [ScanSummary]s for a particular scanner the earliest start time and lasted end time will
-     * be used as the new values for the respective scanner. Because the [ScanSummary] does not contain the checksums
-     * of the individual files, no package verification code can be calculated.
+     * be used as the new values for the respective scanner.
      */
     fun merge(): List<ScanResult> {
         val scanResultsByPath = scanResults.mapKeys { (provenance, _) -> getPath(provenance) }

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -148,7 +148,6 @@ class ScanCode internal constructor(
 
         val parseLicenseExpressions = scanCodeConfiguration["parseLicenseExpressions"].isTrue()
         val summary = generateSummary(
-            path,
             result,
             scannerConfig.detectedLicenseMapping,
             parseLicenseExpressions

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -23,7 +23,6 @@ package org.ossreviewtoolkit.scanner.scanners.scancode
 
 import com.fasterxml.jackson.databind.JsonNode
 
-import java.io.File
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -40,7 +39,6 @@ import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.model.utils.associateLicensesWithExceptions
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants.LICENSE_REF_PREFIX
-import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.spdx.toSpdxId
 
 import org.semver4j.Semver
@@ -77,29 +75,11 @@ private val TIMEOUT_ERROR_REGEX = Regex(
 )
 
 /**
- * Generate a summary from the given raw ScanCode [result]. From the [scanPath] the package verification code is
- * generated. If [parseExpressions] is true, license findings are preferably parsed as license expressions.
- */
-internal fun generateSummary(
-    scanPath: File,
-    result: JsonNode,
-    detectedLicenseMapping: Map<String, String> = emptyMap(),
-    parseExpressions: Boolean = true
-) =
-    generateSummary(
-        calculatePackageVerificationCode(scanPath),
-        result,
-        detectedLicenseMapping,
-        parseExpressions
-    )
-
-/**
  * Generate a summary from the given raw ScanCode [result] using [verificationCode] metadata. This variant can be used
  * if the result is not read from a local file. If [parseExpressions] is true, license findings are preferably parsed as
  * license expressions.
  */
 internal fun generateSummary(
-    verificationCode: String,
     result: JsonNode,
     detectedLicenseMapping: Map<String, String> = emptyMap(),
     parseExpressions: Boolean = true
@@ -130,7 +110,6 @@ internal fun generateSummary(
     return ScanSummary(
         startTime = startTime,
         endTime = endTime,
-        packageVerificationCode = verificationCode,
         licenseFindings = getLicenseFindings(result, detectedLicenseMapping, parseExpressions),
         copyrightFindings = getCopyrightFindings(result),
         issues = issues + getIssues(result)

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -57,7 +57,6 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.showStackTrace
-import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 
 import retrofit2.HttpException
 
@@ -121,7 +120,7 @@ class ClearlyDefinedStorage(
                 when (name) {
                     "scancode" -> {
                         loadToolData(coordinates, name, versions.last())?.let { result ->
-                            val summary = generateSummary(SpdxConstants.NONE, result)
+                            val summary = generateSummary(result)
                             val details = generateScannerDetails(result)
 
                             val provenance = getProvenance(coordinates)

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
@@ -44,7 +44,6 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.readTree
-import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.test.transformingCollectionMatcher
 
 class ScanCodeResultParserTest : FreeSpec({
@@ -54,7 +53,7 @@ class ScanCodeResultParserTest : FreeSpec({
                 val resultFile = File("src/test/assets/scancode-3.0.2_mime-types-2.1.18.json")
                 val result = resultFile.readTree()
 
-                val summary = generateSummary(SpdxConstants.NONE, result)
+                val summary = generateSummary(result)
 
                 summary.licenseFindings.size shouldBe 4
                 summary.copyrightFindings.size shouldBe 4
@@ -67,7 +66,7 @@ class ScanCodeResultParserTest : FreeSpec({
                 val resultFile = File("src/test/assets/scancode-3.2.1rc2_h2database-1.4.200.json")
                 val result = resultFile.readTree()
 
-                val summary = generateSummary(SpdxConstants.NONE, result)
+                val summary = generateSummary(result)
 
                 summary.licenseFindings should containExactlyInAnyOrder(
                     LicenseFinding(
@@ -87,7 +86,7 @@ class ScanCodeResultParserTest : FreeSpec({
                 val resultFile = File("src/test/assets/scancode-3.2.1rc2_spring-javaformat-checkstyle-0.0.15.json")
                 val result = resultFile.readTree()
 
-                val summary = generateSummary(SpdxConstants.NONE, result)
+                val summary = generateSummary(result)
                 val fileExtensions = listOf("html", "java", "txt")
 
                 summary.licenseFindings.forAll {
@@ -111,7 +110,7 @@ class ScanCodeResultParserTest : FreeSpec({
                     val resultFile = File("src/test/assets/$filename")
                     val result = resultFile.readTree()
 
-                    val summary = generateSummary(SpdxConstants.NONE, result)
+                    val summary = generateSummary(result)
 
                     summary.licenseFindings.size shouldBe 5
                     summary.copyrightFindings.size shouldBe 4
@@ -122,7 +121,7 @@ class ScanCodeResultParserTest : FreeSpec({
                     val resultFile = File("src/test/assets/scancode-output-format-$version.0.0_mime-types-2.1.18.json")
                     val result = resultFile.readTree()
 
-                    val summary = generateSummary(SpdxConstants.NONE, result)
+                    val summary = generateSummary(result)
 
                     summary should containLicensesExactly("MIT")
 
@@ -140,7 +139,7 @@ class ScanCodeResultParserTest : FreeSpec({
                     val resultFile = File("src/test/assets/scancode-output-format-$version.0.0_mime-types-2.1.18.json")
                     val result = resultFile.readTree()
 
-                    val summary = generateSummary(SpdxConstants.NONE, result)
+                    val summary = generateSummary(result)
 
                     summary should containCopyrightsExactly(
                         "Copyright (c) 2014 Jonathan Ong" to
@@ -186,7 +185,7 @@ class ScanCodeResultParserTest : FreeSpec({
 
                 val result = jsonMapper.readTree(headers)
 
-                val summary = generateSummary(SpdxConstants.NONE, result)
+                val summary = generateSummary(result)
 
                 summary.issues.map { it.copy(timestamp = Instant.EPOCH) } shouldHaveSingleElement Issue(
                     timestamp = Instant.EPOCH,

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -164,8 +164,7 @@ fun scannerRunOf(vararg pkgScanResults: Pair<Identifier, List<ScanResult>>): Sca
     val scanResults = pkgScanResultsWithKnownProvenance.values.flatten().mapTo(mutableSetOf()) { scanResult ->
         scanResult.copy(
             provenance = (scanResult.provenance as? RepositoryProvenance)?.clearVcsPath()?.alignRevisions()
-                ?: scanResult.provenance,
-            summary = scanResult.summary.copy(packageVerificationCode = "")
+                ?: scanResult.provenance
         )
     }
 


### PR DESCRIPTION
The SPDX package verification codes have started to turn obsolete once `ScanSummary` started to correspond (also) to a `Provenance`, as of the re-write of the scanner to scan "by provenance". However, scan summaries are still used to describe results of a package, e.g. as `OrtResult.getScanResult()` does. Recently reporters have been updated to compute these verification codes solely based on the file lists contained in `OrtResult` turning `ScanSummary.packageVerificationCode` fully obsolete. This PR removes that property.

Follow-up for #6948.

