### PR TITLE
build(Gradle): Remove the `buildCacheRetentionDays` logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,6 @@ org.gradle.caching = true
 org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.parallel = true
 
-buildCacheRetentionDays = 7
-
 kotlin.code.style = official
 
 # The version of the SPDX license list which is used to import license texts and generate SPDX enums. Must be a valid

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -82,14 +82,6 @@ file("plugins").walk().maxDepth(3).filter {
     }
 }
 
-val buildCacheRetentionDays: String by settings
-
-buildCache {
-    local {
-        removeUnusedEntriesAfterDays = buildCacheRetentionDays.toInt()
-    }
-}
-
 pluginManagement {
     repositories {
         mavenCentral()


### PR DESCRIPTION
The property was introduced in ba8c2f1 to be able to configure a shorter cache retention time on CI. But with the switch to GitHub actions and 4fbcd31, caching is now anyway limited to a single build, also see [1].

[1]: https://github.com/gradle/gradle-build-action/issues/406#issuecomment-1612078906