### PR TITLE
build(GitHub): Give a job a better name

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: wagoid/commitlint-github-action@v5
         with:
           configFile: .commitlintrc.yml
-  copyright-license:
+  code-base-checks:
     runs-on: ubuntu-22.04
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false


### PR DESCRIPTION
Since 32ee335 this is not limited to copyright and license header checks anymore.