### PR TITLE
fix(spdx-utils): Make `copyrightText` default to `NOASSERTION`

### DIFF
--- a/utils/spdx/src/main/kotlin/model/SpdxFile.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxFile.kt
@@ -59,7 +59,7 @@ data class SpdxFile(
      * A text relating to a copyright notice, even if not complete. To represent a not present value
      * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
      */
-    val copyrightText: String,
+    val copyrightText: String = SpdxConstants.NOASSERTION,
 
     /**
      * The list of contributors which contributed to the file. Contributors could include names of copyright holders

--- a/utils/spdx/src/main/kotlin/model/SpdxPackage.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxPackage.kt
@@ -66,7 +66,7 @@ data class SpdxPackage(
      * A text relating to a copyright notice, even if not complete. To represent a not present value
      * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
      */
-    val copyrightText: String,
+    val copyrightText: String = SpdxConstants.NOASSERTION,
 
     /**
      * A more detailed description of the package as opposed to [summary], which may be an extract from the package.

--- a/utils/spdx/src/main/kotlin/model/SpdxSnippet.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxSnippet.kt
@@ -55,7 +55,7 @@ data class SpdxSnippet(
      * respectively. Ideally this text is extracted from the actual snippet. To represent a not present value
      * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
      */
-    val copyrightText: String,
+    val copyrightText: String = SpdxConstants.NOASSERTION,
 
     /**
      * Any relevant background references or analysis that went in to arriving at the concluded License for the file.


### PR DESCRIPTION
As clarified in the 2.3 specs (see [1] vs. [2]), an absent `copyrightText` should be interpreted as `NOASSERTION`.

[1]: https://spdx.github.io/spdx-spec/v2.2.2/package-information/#717-copyright-text-field
[2]: https://github.com/spdx/spdx-spec/blob/development/v2.2/schemas/spdx-schema.json#L311