### PR TITLE
fix(scanner): Ignore any symbolic links when creating file lists

### DIFF
--- a/scanner/src/main/kotlin/utils/FileListResolver.kt
+++ b/scanner/src/main/kotlin/utils/FileListResolver.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.scanner.FileList.FileEntry
 import org.ossreviewtoolkit.scanner.provenance.ProvenanceDownloader
 import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
+import org.ossreviewtoolkit.utils.common.isSymbolicLink
 
 internal class FileListResolver(
     private val storage: ProvenanceFileStorage,
@@ -64,9 +65,9 @@ private val IGNORED_DIRECTORY_MATCHER by lazy {
 
 private fun createFileList(dir: File): FileList {
     val files = dir.walk().onEnter {
-        !IGNORED_DIRECTORY_MATCHER.matches(it.relativeTo(dir).invariantSeparatorsPath)
+        !IGNORED_DIRECTORY_MATCHER.matches(it.relativeTo(dir).invariantSeparatorsPath) && !it.isSymbolicLink()
     }.filter {
-        it.isFile
+        it.isFile && !it.isSymbolicLink()
     }.mapTo(mutableSetOf()) {
         FileEntry(path = it.relativeTo(dir).invariantSeparatorsPath, sha1 = HashAlgorithm.SHA1.calculate(it))
     }


### PR DESCRIPTION
Do not follow symbolic links to directories, because that leads to
undesired entries resulting from undesired duplicate traversal. Also,
ignore symbolic links to files, because the file it points to is
included already anyway if it is within the VCS or it is to be ignored
if it is not within.

Note: Programatically creating a symbolic link fails with [1] Operation
      not permitted, which is why this commit does not have unit test
      coverage.

[1] `Path.createSymbolicLinkPointingTo()`

Fixes: #7225.

**Important note:** Please delete existing file lists from your storage to make this change have effect also for
           previously created file list.
