### PR TITLE
refactor(scanner): Apply the detected license mapping globally

### DIFF
--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
-import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -87,7 +86,7 @@ class Askalono internal constructor(
             val root = jsonMapper.readTree(line)
             root["result"]?.let { result ->
                 val licenseFinding = LicenseFinding(
-                    license = result["license"]["name"].textValue().mapLicense(scannerConfig.detectedLicenseMapping),
+                    license = result["license"]["name"].textValue(),
                     location = TextLocation(
                         // Turn absolute paths in the native result into relative paths to not expose any information.
                         relativizePath(scanPath, File(root["path"].textValue())),

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -31,7 +31,6 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.model.readTree
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
@@ -99,7 +98,7 @@ class BoyterLc internal constructor(
             val filePath = File(file["Directory"].textValue(), file["Filename"].textValue())
             file["LicenseGuesses"].map {
                 LicenseFinding(
-                    license = it["LicenseId"].textValue().mapLicense(scannerConfig.detectedLicenseMapping),
+                    license = it["LicenseId"].textValue(),
                     location = TextLocation(
                         // Turn absolute paths in the native result into relative paths to not expose any information.
                         relativizePath(scanPath, filePath),

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -857,7 +857,7 @@ class FossId internal constructor(
 
         val (licenseFindings, copyrightFindings) = rawResults.markedAsIdentifiedFiles.ifEmpty {
             rawResults.identifiedFiles
-        }.mapSummary(ignoredFiles, issues, scannerConfig.detectedLicenseMapping)
+        }.mapSummary(ignoredFiles, issues)
 
         val summary = ScanSummary(
             startTime = startTime,

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -38,7 +38,6 @@ import org.ossreviewtoolkit.model.Snippet as OrtSnippet
 import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.model.utils.PurlType
 import org.ossreviewtoolkit.utils.common.collapseToRanges
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -72,8 +71,7 @@ internal data class FindingsContainer(
  */
 internal fun <T : Summarizable> List<T>.mapSummary(
     ignoredFiles: Map<String, IgnoredFile>,
-    issues: MutableList<Issue>,
-    detectedLicenseMapping: Map<String, String>
+    issues: MutableList<Issue>
 ): FindingsContainer {
     val licenseFindings = mutableSetOf<LicenseFinding>()
     val copyrightFindings = mutableSetOf<CopyrightFinding>()
@@ -85,7 +83,7 @@ internal fun <T : Summarizable> List<T>.mapSummary(
 
         summary.licences.forEach {
             runCatching {
-                LicenseFinding(it.identifier.mapLicense(detectedLicenseMapping), location)
+                LicenseFinding(it.identifier, location)
             }.onSuccess { licenseFinding ->
                 licenseFindings += licenseFinding.copy(license = licenseFinding.license.normalize())
             }.onFailure { spdxException ->

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
@@ -49,7 +49,7 @@ class FossIdLicenseMappingTest : WordSpec({
             val sampleFile = createMarkAsIdentifiedFile("invalid license")
             val issues = mutableListOf<Issue>()
 
-            val findings = listOf(sampleFile).mapSummary(emptyMap(), issues, emptyMap())
+            val findings = listOf(sampleFile).mapSummary(emptyMap(), issues)
 
             issues should haveSize(1)
             issues.first() shouldNotBeNull {

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
-import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -89,7 +88,7 @@ class Licensee internal constructor(
         matchedFiles.mapTo(licenseFindings) {
             val filePath = File(it["filename"].textValue())
             LicenseFinding(
-                license = it["matched_license"].textValue().mapLicense(scannerConfig.detectedLicenseMapping),
+                license = it["matched_license"].textValue(),
                 location = TextLocation(
                     // The path is already relative.
                     filePath.path,

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -119,12 +119,7 @@ class ScanOss internal constructor(
         }.toMap()
 
         val endTime = Instant.now()
-        return generateSummary(
-            startTime,
-            endTime,
-            resolvedResponse,
-            scannerConfig.detectedLicenseMapping
-        )
+        return generateSummary(startTime, endTime, resolvedResponse)
     }
 
     internal fun generateRandomUUID() = UUID.randomUUID()

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -33,7 +33,6 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
@@ -44,8 +43,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 internal fun generateSummary(
     startTime: Instant,
     endTime: Instant,
-    result: FullScanResponse,
-    detectedLicenseMapping: Map<String, String>
+    result: FullScanResponse
 ): ScanSummary {
     val licenseFindings = mutableSetOf<LicenseFinding>()
     val copyrightFindings = mutableSetOf<CopyrightFinding>()
@@ -54,7 +52,7 @@ internal fun generateSummary(
     result.forEach { (_, scanResponses) ->
         scanResponses.forEach { scanResponse ->
             if (scanResponse.id == IdentificationType.FILE) {
-                licenseFindings += getLicenseFindings(scanResponse, detectedLicenseMapping)
+                licenseFindings += getLicenseFindings(scanResponse)
                 copyrightFindings += getCopyrightFindings(scanResponse)
             }
 
@@ -83,10 +81,7 @@ internal fun generateSummary(
 /**
  * Get the license findings from the given [scanResponse].
  */
-private fun getLicenseFindings(
-    scanResponse: ScanResponse,
-    detectedLicenseMappings: Map<String, String>
-): List<LicenseFinding> {
+private fun getLicenseFindings(scanResponse: ScanResponse): List<LicenseFinding> {
     val path = scanResponse.file ?: return emptyList()
     val score = scanResponse.matched?.removeSuffix("%")?.toFloatOrNull()
 
@@ -100,7 +95,7 @@ private fun getLicenseFindings(
         }
 
         LicenseFinding(
-            license = validatedLicense.mapLicense(detectedLicenseMappings),
+            license = validatedLicense,
             location = TextLocation(
                 path = path,
                 startLine = TextLocation.UNKNOWN_LINE,

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -52,7 +52,7 @@ class ScanOssResultParserTest : WordSpec({
             }
 
             val time = Instant.now()
-            val summary = generateSummary(time, time, result, emptyMap())
+            val summary = generateSummary(time, time, result)
 
             summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
                 "Apache-2.0",
@@ -90,7 +90,7 @@ class ScanOssResultParserTest : WordSpec({
             }
 
             val time = Instant.now()
-            val summary = generateSummary(time, time, result, emptyMap())
+            val summary = generateSummary(time, time, result)
 
             summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
                 "Apache-2.0",

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -147,11 +147,7 @@ class ScanCode internal constructor(
         resultFile.parentFile.safeDeleteRecursively(force = true)
 
         val parseLicenseExpressions = scanCodeConfiguration["parseLicenseExpressions"].isTrue()
-        val summary = generateSummary(
-            result,
-            scannerConfig.detectedLicenseMapping,
-            parseLicenseExpressions
-        )
+        val summary = generateSummary(result, parseLicenseExpressions)
 
         val issues = summary.issues.toMutableList()
 

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -35,7 +35,6 @@ import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.model.mapLicense
 import org.ossreviewtoolkit.model.utils.associateLicensesWithExceptions
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants.LICENSE_REF_PREFIX
@@ -79,11 +78,7 @@ private val TIMEOUT_ERROR_REGEX = Regex(
  * if the result is not read from a local file. If [parseExpressions] is true, license findings are preferably parsed as
  * license expressions.
  */
-internal fun generateSummary(
-    result: JsonNode,
-    detectedLicenseMapping: Map<String, String> = emptyMap(),
-    parseExpressions: Boolean = true
-): ScanSummary {
+internal fun generateSummary(result: JsonNode, parseExpressions: Boolean = true): ScanSummary {
     val header = result["headers"].single()
 
     val issues = mutableListOf<Issue>()
@@ -110,7 +105,7 @@ internal fun generateSummary(
     return ScanSummary(
         startTime = startTime,
         endTime = endTime,
-        licenseFindings = getLicenseFindings(result, detectedLicenseMapping, parseExpressions),
+        licenseFindings = getLicenseFindings(result, parseExpressions),
         copyrightFindings = getCopyrightFindings(result),
         issues = issues + getIssues(result)
     )
@@ -166,11 +161,7 @@ private fun getInputPath(result: JsonNode): String {
  * in the result, these are preferred over separate license findings. Otherwise, only separate license findings are
  * parsed.
  */
-private fun getLicenseFindings(
-    result: JsonNode,
-    detectedLicenseMapping: Map<String, String>,
-    parseExpressions: Boolean
-): Set<LicenseFinding> {
+private fun getLicenseFindings(result: JsonNode, parseExpressions: Boolean): Set<LicenseFinding> {
     val licenseFindings = mutableListOf<LicenseFinding>()
 
     val input = getInputPath(result)
@@ -195,7 +186,7 @@ private fun getLicenseFindings(
             val spdxLicenseExpression = replaceLicenseKeys(licenseMatch.expression, replacements)
 
             LicenseFinding(
-                license = spdxLicenseExpression.mapLicense(detectedLicenseMapping),
+                license = spdxLicenseExpression,
                 location = TextLocation(
                     path = file["path"].textValue().removePrefix(input),
                     startLine = licenseMatch.startLine,


### PR DESCRIPTION
The `detectedLicenseMapping` is part of the global `ScannerConfiguration`, so also apply it globally on the `ScanSummary` returned by the scanners instead of leaving it to each scanner implementation to apply the mapping.