### PR TITLE
build(Gradle): Make task configuration compatible with the cache

### DIFF
--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -19,7 +19,6 @@
 
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
-import org.gradle.kotlin.dsl.support.serviceOf
 
 plugins {
     // Apply precompiled plugins.
@@ -41,9 +40,18 @@ configurations.all {
     }
 }
 
+// A provider to get a StyledTextOutputFactory via dependency injection.
+interface StyledTextOutputProvider {
+    @get:Inject
+    val out: StyledTextOutputFactory
+}
+
 tasks.named<Jar>("jar") {
+    // Resolve objects at configuration time to be compatible with the configuration cache.
+    val objects = objects
+
     doLast {
-        val out = serviceOf<StyledTextOutputFactory>().create("detekt-rules")
+        val out = objects.newInstance<StyledTextOutputProvider>().out.create("detekt-rules")
         val message = "The detekt-rules have changed. You need to stop the Gradle daemon to allow the detekt plugin " +
                 "to reload for the rule changes to take effect."
         out.withStyle(StyledTextOutput.Style.Info).println(message)


### PR DESCRIPTION
Make the configuration refinement of the "jar" task compatible with Gradle's new configuration cache [1] by getting `StyledTextOutputFactory` via dependency injection.

[1]: https://docs.gradle.org/current/userguide/configuration_cache.html