### PR TITLE
refactor(model): Change the type of unmatched copyrights

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -125,7 +125,7 @@ class LicenseInfoResolver(
         val filteredDetectedLicenseInfo =
             licenseInfo.detectedLicenseInfo.filterCopyrightGarbage(copyrightGarbageFindings)
 
-        val unmatchedCopyrights = mutableMapOf<Provenance, MutableSet<CopyrightFinding>>()
+        val unmatchedCopyrights = mutableMapOf<Provenance, MutableSet<ResolvedCopyrightFinding>>()
         val resolvedLocations = resolveLocations(filteredDetectedLicenseInfo, unmatchedCopyrights)
         val detectedLicenses = licenseInfo.detectedLicenseInfo.findings.flatMapTo(mutableSetOf()) { findings ->
             FindingCurationMatcher().applyAll(
@@ -179,7 +179,7 @@ class LicenseInfoResolver(
 
     private fun resolveLocations(
         detectedLicenseInfo: DetectedLicenseInfo,
-        unmatchedCopyrights: MutableMap<Provenance, MutableSet<CopyrightFinding>>
+        unmatchedCopyrights: MutableMap<Provenance, MutableSet<ResolvedCopyrightFinding>>
     ): Map<SpdxSingleLicenseExpression, Set<ResolvedLicenseLocation>> {
         val resolvedLocations = mutableMapOf<SpdxSingleLicenseExpression, MutableSet<ResolvedLicenseLocation>>()
         val curationMatcher = FindingCurationMatcher()
@@ -225,8 +225,12 @@ class LicenseInfoResolver(
                 }
             }
 
-            unmatchedCopyrights.getOrPut(findings.provenance) { mutableSetOf() } += matchResult.unmatchedCopyrights
-        }
+            unmatchedCopyrights.getOrPut(findings.provenance) { mutableSetOf() } += resolveCopyrights(
+                copyrightFindings = matchResult.unmatchedCopyrights,
+                pathExcludes = findings.pathExcludes,
+                relativeFindingsPath = findings.relativeFindingsPath
+            )
+         }
 
         return resolvedLocations
     }

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -59,7 +59,7 @@ data class ResolvedLicenseInfo(
      * All copyright findings that could not be matched to a license finding, mapped to the [Provenance] where they were
      * detected.
      */
-    val unmatchedCopyrights: Map<Provenance, Set<CopyrightFinding>>
+    val unmatchedCopyrights: Map<Provenance, Set<ResolvedCopyrightFinding>>
 ) : Iterable<ResolvedLicense> by licenses {
     operator fun get(license: SpdxSingleLicenseExpression): ResolvedLicense? = find { it.license == license }
 


### PR DESCRIPTION
Use `ResolvedCopyrightFinding` instead of just `CopyrightFinding` as type, to prepare for an upcoming change which needs to know for each of the entries whether it is excluded by any path exclude.

Part of #6947.