### PR TITLE
SpdxDocumentReporter: Include file information for dependencies

### DIFF
--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.utils.common.percentEncode
 fun String.prependPath(prefix: String): String =
     if (prefix.isBlank()) this else "${prefix.removeSuffix("/")}/$this"
 
-internal fun TextLocation.prependedPath(prefix: String): String =
+fun TextLocation.prependedPath(prefix: String): String =
     path.prependPath(prefix)
 
 fun TextLocation.prependPath(prefix: String): TextLocation =

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -198,6 +198,37 @@
     "summary" : "A package with only unmapped declared license.",
     "versionInfo" : "0.0.1"
   } ],
+  "files" : [ {
+    "SPDXID" : "SPDXRef-File-1",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "8c38f605503f2a48ef7b6220ad06aa0f3387484b"
+    } ],
+    "copyrightText" : "Copyright 2020 Some copyright holder in VCS\nCopyright 2020 Some copyright holder in source artifact\nCopyright 2020 Some other copyright holder in source artifact",
+    "fileName" : "project-path/some/file",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseInfoInFiles" : [ "NONE" ]
+  }, {
+    "SPDXID" : "SPDXRef-File-2",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "0398ccd0f49298b10a3d76a47800d2ebecd49859"
+    } ],
+    "copyrightText" : "NONE",
+    "fileName" : "LICENSE",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseInfoInFiles" : [ "GPL-3.0-only" ]
+  }, {
+    "SPDXID" : "SPDXRef-File-3",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "4552f707bdf537911c9943cec56a0bf11bd8468d"
+    } ],
+    "copyrightText" : "Copyright 2020 Some copyright holder in source artifact",
+    "fileName" : "some/file",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseInfoInFiles" : [ "NONE" ]
+  } ],
   "relationships" : [ {
     "spdxElementId" : "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1",
     "relationshipType" : "GENERATED_FROM",
@@ -207,9 +238,21 @@
     "relationshipType" : "GENERATED_FROM",
     "relatedSpdxElement" : "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs"
   }, {
+    "spdxElementId" : "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs",
+    "relationshipType" : "CONTAINS",
+    "relatedSpdxElement" : "SPDXRef-File-1"
+  }, {
     "spdxElementId" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1",
     "relationshipType" : "GENERATED_FROM",
     "relatedSpdxElement" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
+  }, {
+    "spdxElementId" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact",
+    "relationshipType" : "CONTAINS",
+    "relatedSpdxElement" : "SPDXRef-File-2"
+  }, {
+    "spdxElementId" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact",
+    "relationshipType" : "CONTAINS",
+    "relatedSpdxElement" : "SPDXRef-File-3"
   }, {
     "spdxElementId" : "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1",
     "relationshipType" : "DEPENDS_ON",

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -204,6 +204,36 @@ packages:
   name: "third-package"
   summary: "A package with only unmapped declared license."
   versionInfo: "0.0.1"
+files:
+- SPDXID: "SPDXRef-File-1"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "8c38f605503f2a48ef7b6220ad06aa0f3387484b"
+  copyrightText: "Copyright 2020 Some copyright holder in VCS\nCopyright 2020 Some\
+    \ copyright holder in source artifact\nCopyright 2020 Some other copyright holder\
+    \ in source artifact"
+  fileName: "project-path/some/file"
+  licenseConcluded: "NOASSERTION"
+  licenseInfoInFiles:
+  - "NONE"
+- SPDXID: "SPDXRef-File-2"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "0398ccd0f49298b10a3d76a47800d2ebecd49859"
+  copyrightText: "NONE"
+  fileName: "LICENSE"
+  licenseConcluded: "NOASSERTION"
+  licenseInfoInFiles:
+  - "GPL-3.0-only"
+- SPDXID: "SPDXRef-File-3"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "4552f707bdf537911c9943cec56a0bf11bd8468d"
+  copyrightText: "Copyright 2020 Some copyright holder in source artifact"
+  fileName: "some/file"
+  licenseConcluded: "NOASSERTION"
+  licenseInfoInFiles:
+  - "NONE"
 relationships:
 - spdxElementId: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1"
   relationshipType: "GENERATED_FROM"
@@ -211,9 +241,18 @@ relationships:
 - spdxElementId: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1"
   relationshipType: "GENERATED_FROM"
   relatedSpdxElement: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs"
+- spdxElementId: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs"
+  relationshipType: "CONTAINS"
+  relatedSpdxElement: "SPDXRef-File-1"
 - spdxElementId: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1"
   relationshipType: "GENERATED_FROM"
   relatedSpdxElement: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
+- spdxElementId: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
+  relationshipType: "CONTAINS"
+  relatedSpdxElement: "SPDXRef-File-2"
+- spdxElementId: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
+  relationshipType: "CONTAINS"
+  relatedSpdxElement: "SPDXRef-File-3"
 - spdxElementId: "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1"
   relationshipType: "DEPENDS_ON"
   relatedSpdxElement: "SPDXRef-Package-Maven-fifth-package-group-fifth-package-0.0.1"

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -48,7 +48,8 @@ internal object SpdxDocumentModelMapper : Logging {
     data class SpdxDocumentParams(
         val documentName: String,
         val documentComment: String,
-        val creationInfoComment: String
+        val creationInfoComment: String,
+        val fileInformationEnabled: Boolean
     )
 
     fun map(
@@ -108,9 +109,11 @@ internal object SpdxDocumentModelMapper : Logging {
                     ortResult
                 )
 
-                ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, VCS, nextFileIndex).let {
-                    files += it
-                    relationships += it.createFileRelationships(vcsPackage)
+                if (params.fileInformationEnabled) {
+                    ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, VCS, nextFileIndex).let {
+                        files += it
+                        relationships += it.createFileRelationships(vcsPackage)
+                    }
                 }
 
                 val vcsPackageRelationShip = SpdxRelationship(
@@ -131,9 +134,11 @@ internal object SpdxDocumentModelMapper : Logging {
                     ortResult
                 )
 
-                ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, ARTIFACT, nextFileIndex).let {
-                    files += it
-                    relationships += it.createFileRelationships(sourceArtifactPackage)
+                if (params.fileInformationEnabled) {
+                    ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, ARTIFACT, nextFileIndex).let {
+                        files += it
+                        relationships += it.createFileRelationships(sourceArtifactPackage)
+                    }
                 }
 
                 val sourceArtifactPackageRelationship = SpdxRelationship(

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -38,6 +38,8 @@ import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
  * - *document.comment*: Add the corresponding value as metadata to the [SpdxDocument].
  * - *document.name*: The name of the generated [SpdxDocument], defaults to "Unnamed document".
  * - *output.file.formats*: The list of [FileFormat]s to generate, defaults to [FileFormat.YAML].
+ * - *file.information.enabled*: Toggle whether the output document should contain information on file granularity
+ *                               about files containing findings.
  */
 class SpdxDocumentReporter : Reporter {
     companion object {
@@ -47,6 +49,7 @@ class SpdxDocumentReporter : Reporter {
         const val OPTION_DOCUMENT_COMMENT = "document.comment"
         const val OPTION_DOCUMENT_NAME = "document.name"
         const val OPTION_OUTPUT_FILE_FORMATS = "output.file.formats"
+        const val OPTION_FILE_INFORMATION_ENABLED = "file.information.enabled"
 
         private const val DOCUMENT_NAME_DEFAULT_VALUE = "Unnamed document"
     }
@@ -66,7 +69,8 @@ class SpdxDocumentReporter : Reporter {
         val params = SpdxDocumentModelMapper.SpdxDocumentParams(
             documentName = options.getOrDefault(OPTION_DOCUMENT_NAME, DOCUMENT_NAME_DEFAULT_VALUE),
             documentComment = options.getOrDefault(OPTION_DOCUMENT_COMMENT, ""),
-            creationInfoComment = options.getOrDefault(OPTION_CREATION_INFO_COMMENT, "")
+            creationInfoComment = options.getOrDefault(OPTION_CREATION_INFO_COMMENT, ""),
+            fileInformationEnabled = options.getOrDefault(OPTION_FILE_INFORMATION_ENABLED, "true").toBoolean()
         )
 
         val spdxDocument = SpdxDocumentModelMapper.map(

--- a/utils/spdx/src/main/kotlin/model/SpdxFile.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxFile.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.spdx.isSpdxExpressionOrNotPresent
 @JsonIgnoreProperties("ranges") // TODO: Implement ranges which is broken in the specification examples.
 data class SpdxFile(
     /**
-     * A unique identifies this [SpdxFile] within a SPDX document.
+     * A unique identifies this [SpdxFile] within a [SpdxDocument].
      */
     @JsonProperty("SPDXID")
     val spdxId: String,


### PR DESCRIPTION
Extend the SPDX document reporter to include file information for
dependencies for all files which have at least one license or copyright
finding. Make the file information include the detected licenses,
copyright statements as well as the mandatory sha1 checksums.

Also an option to disable this feature, as it may not always be desired to include file information.

Fixes #6947.
