### PR TITLE
refactor(scanner): Store scanner details in separate properties

### DIFF
--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -187,14 +187,14 @@ class ScannerCommand : OrtCommand(
 
         if (projectScannerWrappers.isNotEmpty()) {
             println("Scanning projects with:")
-            println(projectScannerWrappers.joinToString { "\t${it.details.name} (version ${it.details.version})" })
+            println(projectScannerWrappers.joinToString { "\t${it.name} (version ${it.version})" })
         } else {
             println("Projects will not be scanned.")
         }
 
         if (packageScannerWrappers.isNotEmpty()) {
             println("Scanning packages with:")
-            println(packageScannerWrappers.joinToString { "\t${it.details.name} (version ${it.details.version})" })
+            println(packageScannerWrappers.joinToString { "\t${it.name} (version ${it.version})" })
         } else {
             println("Packages will not be scanned.")
         }

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.common.Os
 
 class Askalono internal constructor(
-    private val name: String,
+    name: String,
     private val scannerConfig: ScannerConfiguration
 ) : CommandLinePathScannerWrapper(name) {
     private companion object : Logging

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -50,8 +50,9 @@ class Askalono internal constructor(
             Askalono(type, scannerConfig)
     }
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val configuration = ""
+
+    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -57,8 +57,9 @@ class BoyterLc internal constructor(
             BoyterLc(type, scannerConfig)
     }
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
+
+    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 class BoyterLc internal constructor(
-    private val name: String,
+    name: String,
     private val scannerConfig: ScannerConfiguration
 ) : CommandLinePathScannerWrapper(name) {
     companion object : Logging {

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -69,7 +69,6 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsType
@@ -97,7 +96,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
  * gets a Git repository URL as input and would be a good match for [ProvenanceScannerWrapper].
  */
 class FossId internal constructor(
-    private val name: String,
+    override val name: String,
     private val scannerConfig: ScannerConfiguration,
     private val config: FossIdConfig
 ) : PackageScannerWrapper {
@@ -203,8 +202,10 @@ class FossId internal constructor(
 
     private val service = FossIdRestService.create(config.serverUrl)
 
+    override val version = service.version
+    override val configuration = ""
+
     override val criteria: ScannerCriteria? = null
-    override val details = ScannerDetails(name, service.version, "")
 
     override fun filterSecretOptions(options: Options) =
         options.mapValues { (k, v) ->
@@ -671,7 +672,7 @@ class FossId internal constructor(
             // Scans that were added to the queue are interpreted as an error by FossID before version 2021.2.
             // For older versions, `waitScanComplete()` is able to deal with queued scans. Therefore, not checking the
             // response of queued scans.
-            if (details.version >= "2021.2" || scanResult.error != "Scan was added to queue.") {
+            if (version >= "2021.2" || scanResult.error != "Scan was added to queue.") {
                 scanResult.checkResponse("trigger scan", false)
             }
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -136,7 +136,7 @@ class FossIdTest : WordSpec({
         "return the version reported by FossIdServiceWithVersion" {
             val fossId = createFossId(createConfig())
 
-            fossId.details.version shouldBe FOSSID_VERSION
+            fossId.version shouldBe FOSSID_VERSION
         }
     }
 

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.common.Os
 
 class Licensee internal constructor(
-    private val name: String,
+    name: String,
     private val scannerConfig: ScannerConfiguration
 ) : CommandLinePathScannerWrapper(name) {
     companion object : Logging {

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -52,8 +52,9 @@ class Licensee internal constructor(
             Licensee(type, scannerConfig)
     }
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
+
+    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -34,7 +34,6 @@ import io.mockk.spyk
 import java.io.File
 
 import org.ossreviewtoolkit.model.PackageType
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.common.ProcessCapture
@@ -114,7 +113,9 @@ class ScanCodeTest : WordSpec({
             every { process.errorMessage } returns "some error message"
 
             val scannerSpy = spyk(scanner)
-            every { scannerSpy.details } returns ScannerDetails("ScanCode", "30.1.0", "")
+            every { scannerSpy.name } returns "ScanCode"
+            every { scannerSpy.version } returns "30.1.0"
+            every { scannerSpy.configuration } returns ""
             every { scannerSpy.runScanCode(any(), any()) } answers {
                 val resultFile = File("src/test/assets/scancode-with-issues.json")
                 val targetFile = secondArg<File>()

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
@@ -51,7 +50,7 @@ import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 private const val FAKE_WFP_FILE_NAME = "fake.wfp"
 
 class ScanOss internal constructor(
-    private val name: String,
+    override val name: String,
     private val scannerConfig: ScannerConfiguration
 ) : PathScannerWrapper {
     private companion object : Logging
@@ -67,14 +66,16 @@ class ScanOss internal constructor(
 
     private val service = ScanOssService.create(config.apiUrl)
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
-
-    override val details by lazy {
+    override val version by lazy {
         // TODO: Find out the best / cheapest way to query the SCANOSS server for its version.
         val pomProperties = "/META-INF/maven/com.scanoss/scanner/pom.properties"
         val properties = Scanner::class.java.getResourceAsStream(pomProperties).use { Properties().apply { load(it) } }
-        ScannerDetails(name, properties.getProperty("version"), "")
+        properties.getProperty("version")
     }
+
+    override val configuration = ""
+
+    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
 
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -34,7 +34,6 @@ import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
@@ -212,7 +211,10 @@ private val pkg4 = createPackage(
 )
 
 private class DummyScanner : PathScannerWrapper {
-    override val details = ScannerDetails(name = "Dummy", version = "1.0.0", configuration = "")
+    override val name = "Dummy"
+    override val version = "1.0.0"
+    override val configuration = ""
+
     override val criteria = ScannerCriteria.forDetails(details)
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {

--- a/scanner/src/main/kotlin/CommandLinePathScannerWrapper.kt
+++ b/scanner/src/main/kotlin/CommandLinePathScannerWrapper.kt
@@ -25,21 +25,15 @@ import java.time.Instant
 import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 
 /**
  * A [PathScannerWrapper] that is executed as a [CommandLineTool] on the local machine.
  */
-abstract class CommandLinePathScannerWrapper(name: String) : PathScannerWrapper, CommandLineTool {
+abstract class CommandLinePathScannerWrapper(override val name: String) : PathScannerWrapper, CommandLineTool {
     private companion object : Logging
 
-    /**
-     * The configuration used by the scanner, should contain command line options that influence the scan result.
-     */
-    abstract val configuration: String
-
-    override val details by lazy { ScannerDetails(name, getVersion(), configuration) }
+    override val version by lazy { getVersion() }
 
     final override fun scanPath(path: File, context: ScanContext): ScanSummary {
         val startTime = Instant.now()

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -149,14 +149,14 @@ class Scanner(
         val filteredScannerOptions = mutableMapOf<String, Options>()
 
         projectScannerWrappers.forEach { scannerWrapper ->
-            scannerConfig.options?.get(scannerWrapper.details.name)?.let { options ->
-                filteredScannerOptions[scannerWrapper.details.name] = scannerWrapper.filterSecretOptions(options)
+            scannerConfig.options?.get(scannerWrapper.name)?.let { options ->
+                filteredScannerOptions[scannerWrapper.name] = scannerWrapper.filterSecretOptions(options)
             }
         }
 
         packageScannerWrappers.forEach { scannerWrapper ->
-            scannerConfig.options?.get(scannerWrapper.details.name)?.let { options ->
-                filteredScannerOptions[scannerWrapper.details.name] = scannerWrapper.filterSecretOptions(options)
+            scannerConfig.options?.get(scannerWrapper.name)?.let { options ->
+                filteredScannerOptions[scannerWrapper.name] = scannerWrapper.filterSecretOptions(options)
             }
         }
 
@@ -320,17 +320,16 @@ class Scanner(
                     val hasNestedProvenance = controller.getNestedProvenance(pkg.id) != null
                     if (!hasNestedProvenance) {
                         logger.debug {
-                            "Skipping scan of '${pkg.id.toCoordinates()}' with package scanner " +
-                                    "'${scanner.details.name}' as no nested provenance for the package could be " +
-                                    "resolved."
+                            "Skipping scan of '${pkg.id.toCoordinates()}' with package scanner '${scanner.name}' as " +
+                                    "no nested provenance for the package could be resolved."
                         }
                     }
 
                     val hasCompleteScanResult = controller.hasCompleteScanResult(scanner, pkg)
                     if (hasCompleteScanResult) {
                         logger.debug {
-                            "Skipping scan of '${pkg.id.toCoordinates()}' with package scanner " +
-                                    "'${scanner.details.name}' as stored results are available."
+                            "Skipping scan of '${pkg.id.toCoordinates()}' with package scanner '${scanner.name}' as " +
+                                    "stored results are available."
                         }
                     }
 
@@ -339,7 +338,7 @@ class Scanner(
 
                 if (packagesWithIncompleteScanResult.isEmpty()) {
                     logger.info {
-                        "Skipping scan with package scanner '${scanner.details.name}' as all packages have results."
+                        "Skipping scan with package scanner '${scanner.name}' as all packages have results."
                     }
 
                     return@scanner
@@ -364,8 +363,7 @@ class Scanner(
                 }
 
                 logger.info {
-                    "Scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.details.name} " +
-                            "started."
+                    "Scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.name} started."
                 }
 
                 // Filter the scan context to hide the excludes from scanner with scan criteria.
@@ -373,8 +371,7 @@ class Scanner(
                 val scanResult = scanner.scanPackage(referencePackage, filteredContext)
 
                 logger.info {
-                    "Scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.details.name}' " +
-                            "finished."
+                    "Scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.name}' finished."
                 }
 
                 packagesWithIncompleteScanResult.forEach processResults@{ pkg ->
@@ -403,7 +400,7 @@ class Scanner(
                 if (controller.hasScanResult(scanner, provenance)) {
                     logger.debug {
                         "Skipping $provenance scan (${index + 1} of ${provenances.size}) with provenance scanner " +
-                                "'${scanner.details.name}' as a result is already available."
+                                "'${scanner.name}' as a result is already available."
                     }
 
                     return@scanner
@@ -411,7 +408,7 @@ class Scanner(
 
                 logger.info {
                     "Scanning $provenance (${index + 1} of ${provenances.size}) with provenance scanner " +
-                            "'${scanner.details.name}'."
+                            "'${scanner.name}'."
                 }
 
                 // Filter the scan context to hide the excludes from scanner with scan criteria.
@@ -508,7 +505,7 @@ class Scanner(
         controller.scanners.forEach { scanner ->
             val results = controller.getScanResults(scanner)
             logger.info {
-                "\t${scanner.details.name}: Result(s) for ${results.size} of ${allKnownProvenances.size} provenance(s)."
+                "\t${scanner.name}: Result(s) for ${results.size} of ${allKnownProvenances.size} provenance(s)."
             }
         }
     }
@@ -596,13 +593,13 @@ class Scanner(
 
         return try {
             scanners.associateWith { scanner ->
-                logger.info { "Scan of $provenance with path scanner '${scanner.details.name}' started." }
+                logger.info { "Scan of $provenance with path scanner '${scanner.name}' started." }
 
                 // Filter the scan context to hide the excludes from scanner with scan criteria.
                 val filteredContext = if (scanner.criteria == null) context else context.copy(excludes = null)
                 val summary = scanner.scanPath(downloadDir, filteredContext)
 
-                logger.info { "Scan of $provenance with path scanner '${scanner.details.name}' finished." }
+                logger.info { "Scan of $provenance with path scanner '${scanner.name}' finished." }
 
                 val summaryWithMappedLicenses = summary.copy(
                     licenseFindings = summary.licenseFindings.mapTo(mutableSetOf()) {

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -43,9 +43,25 @@ sealed interface ScannerWrapper {
     }
 
     /**
+     * The name of the scanner.
+     */
+    val name: String
+
+    /**
+     * The version of the scanner.
+     */
+    val version: String
+
+    /**
+     * The configuration of the scanner.
+     */
+    val configuration: String
+
+    /**
      * The details of the scanner.
      */
     val details: ScannerDetails
+        get() = ScannerDetails(name, version, configuration)
 
     /**
      * The [ScannerCriteria] object to be used when looking up existing scan results from a scan storage. By default,

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -805,6 +805,8 @@ private class FakePackageScannerWrapper(
     name: String = "fake"
 ) : PackageScannerWrapper {
     override val details = ScannerDetails(name, "1.0.0", "config")
+
+    // Explicit nullability is required here for a mock response.
     override val criteria: ScannerCriteria? = ScannerCriteria.forDetails(details)
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -802,9 +802,10 @@ class ScannerTest : WordSpec({
 private class FakePackageScannerWrapper(
     val packageProvenanceResolver: PackageProvenanceResolver = FakePackageProvenanceResolver(),
     val sourceCodeOriginPriority: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT),
-    name: String = "fake"
+    override val name: String = "fake"
 ) : PackageScannerWrapper {
-    override val details = ScannerDetails(name, "1.0.0", "config")
+    override val version = "1.0.0"
+    override val configuration = "config"
 
     // Explicit nullability is required here for a mock response.
     override val criteria: ScannerCriteria? = ScannerCriteria.forDetails(details)
@@ -817,7 +818,10 @@ private class FakePackageScannerWrapper(
  * An implementation of [ProvenanceScannerWrapper] that creates empty scan results.
  */
 private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
-    override val details = ScannerDetails("fake", "1.0.0", "config")
+    override val name = "fake"
+    override val version = "1.0.0"
+    override val configuration = "config"
+
     override val criteria = ScannerCriteria.forDetails(details)
 
     override fun scanProvenance(provenance: KnownProvenance, context: ScanContext): ScanResult =
@@ -828,7 +832,10 @@ private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
  * An implementation of [PathScannerWrapper] that creates scan results with one license finding for each file.
  */
 private class FakePathScannerWrapper : PathScannerWrapper {
-    override val details = ScannerDetails("fake", "1.0.0", "config")
+    override val name = "fake"
+    override val version = "1.0.0"
+    override val configuration = "config"
+
     override val criteria = ScannerCriteria.forDetails(details)
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {


### PR DESCRIPTION
E.g. scan storages may need to access a CLI scanner's name without getting the version, which triggers running the local tool. This was not possible before as getting `ScannerDetails` contains the version. Solve that by storing the detail properties individually and constructing `ScannerDetails` only where needed.