### PR TITLE
fix(helper-cli): Stop failing with an `IllegalStateException`

### DIFF
--- a/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
@@ -25,7 +25,6 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.optionalValue
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
@@ -50,10 +49,11 @@ internal class ImportCommand : CliktCommand(
                 "${enumValues<LicenseClassificationProvider>().map { it.name }}."
     ).enum<LicenseClassificationProvider>()
 
+    // TODO: Make this default to the provider name with clikt 4, see https://github.com/ajalt/clikt/issues/381.
     private val prefix by option(
         "--prefix", "-p",
         help = "A prefix to use for all category names declared by the provider's classifications."
-    ).optionalValue(provider.name)
+    )
 
     private val licenseClassificationsFile by option(
         "--output", "-o",


### PR DESCRIPTION
The code introduced for the default value of `prefix` introduced by [1] is executed before the command line is parsed. So, the `provider` property is accessed before it is initialized. This cause an `InvalidStateException` each time `orthw` is executed. No matter which (sub-)command is run.

Revert [1] to fix this.

[1] ee63c878aa6cc6964d77eb862a723247f5002fe3.
