### PR TITLE
package-configuration provider plugin

### DIFF
--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfigurationWrapper
-import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
+import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
 import org.ossreviewtoolkit.model.config.REFERENCE_CONFIG_FILENAME
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.toYaml
@@ -62,7 +62,7 @@ class OrtMainFunTest : StringSpec() {
             OrtConfigurationWrapper(
                 OrtConfiguration(
                     packageCurationProviders = listOf(
-                        PackageCurationProviderConfiguration(
+                        ProviderPluginConfiguration(
                             type = "File",
                             config = mapOf("path" to getAssetFile("gradle-curations.yml").path)
                         )

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -30,6 +30,7 @@ application {
 dependencies {
     implementation(project(":analyzer"))
     implementation(project(":downloader"))
+    implementation(project(":plugins:package-configuration-providers:dir-package-configuration-provider"))
     implementation(project(":plugins:package-curation-providers:file-package-curation-provider"))
     implementation(project(":scanner"))
     implementation(project(":utils:ort-utils"))

--- a/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
@@ -31,10 +31,10 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.OrtConfiguration
-import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.DirectoryPackageConfigurationProvider
 import org.ossreviewtoolkit.scanner.ScanStorages
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME

--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.DirectoryPackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.expandTilde
 
 internal class ListCopyrightsCommand : CliktCommand(

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.DirectoryPackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -85,9 +85,9 @@ data class OrtConfiguration(
      * providers: Providers that appear earlier in the list can overwrite curations for the same package from providers
      * that appear later in the list.
      */
-    val packageCurationProviders: List<PackageCurationProviderConfiguration> = listOf(
-        PackageCurationProviderConfiguration(type = "DefaultDir"),
-        PackageCurationProviderConfiguration(type = "DefaultFile")
+    val packageCurationProviders: List<ProviderPluginConfiguration> = listOf(
+        ProviderPluginConfiguration(type = "DefaultDir"),
+        ProviderPluginConfiguration(type = "DefaultFile")
     ),
 
     /**

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
+import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_FILENAME
 
@@ -78,6 +79,14 @@ data class OrtConfiguration(
      * The license file patterns.
      */
     val licenseFilePatterns: LicenseFilePatterns = LicenseFilePatterns.DEFAULT,
+
+    /**
+     * The package configuration providers to use. Defaults to the provider [ORT_PACKAGE_CONFIGURATIONS_DIRNAME]
+     * configuration location.
+     */
+    val packageConfigurationProviders: List<ProviderPluginConfiguration> = listOf(
+        ProviderPluginConfiguration(type = "DefaultDir")
+    ),
 
     /**
      * The package curation providers to use. Defaults to providers for the default [ORT_PACKAGE_CURATIONS_FILENAME] and

--- a/model/src/main/kotlin/config/ProviderPluginConfiguration.kt
+++ b/model/src/main/kotlin/config/ProviderPluginConfiguration.kt
@@ -23,25 +23,28 @@ import com.sksamuel.hoplite.ConfigAlias
 
 import org.ossreviewtoolkit.utils.common.Plugin
 
-data class PackageCurationProviderConfiguration(
+/**
+ * The configuration of provider plugins.
+ */
+data class ProviderPluginConfiguration(
     /**
-     * The [type][Plugin.type] of the package curation provider.
+     * The [type][Plugin.type] of the provider.
      */
     @ConfigAlias("name")
     val type: String,
 
     /**
-     * A unique identifier for the package curation provider.
+     * A unique identifier for the provider.
      */
     val id: String = type,
 
     /**
-     * Whether this curation provider is enabled.
+     * Whether this provider is enabled.
      */
     val enabled: Boolean = true,
 
     /**
-     * The configuration of the package curation provider. See the specific implementation for available configuration
+     * The configuration of the provider. See the specific implementation for available configuration
      * options.
      */
     val config: Map<String, String> = emptyMap()

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -36,6 +36,16 @@ ort:
     patentFilenames: ['patents']
     rootLicenseFilenames: ['readme*']
 
+  # Package configurations have to be unique by ID and provenance. Ensure that different providers do not provide
+  # configurations for the same package, see https://github.com/oss-review-toolkit/ort/issues/6972 for details.
+  packageConfigurationProviders:
+  - type: DefaultDir
+  - type: Dir
+    id: SomeConfigDir
+    config:
+      path: '/some-path/'
+      mustExist: true
+
   # Providers are listed from highest to lower priority. Technically, they are applied in reverse order: The provider
   # with the highest priority is applied last, so it can override any previously applied curations.
   packageCurationProviders:

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -37,7 +37,7 @@ ort:
     rootLicenseFilenames: ['readme*']
 
   # Providers are listed from highest to lower priority. Technically, they are applied in reverse order: The provider
-  # with the highest priority is applied last, so it can overwrite any previously applied curations.
+  # with the highest priority is applied last, so it can override any previously applied curations.
   packageCurationProviders:
   - type: DefaultFile
   - type: DefaultDir

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -39,33 +39,33 @@ ort:
   # Providers are listed from highest to lower priority. Technically, they are applied in reverse order: The provider
   # with the highest priority is applied last, so it can overwrite any previously applied curations.
   packageCurationProviders:
-    - type: DefaultFile
-    - type: DefaultDir
-    - type: File
-      id: SomeCurationsFile
-      config:
-        path: '/some-path/curations.yml'
-        mustExist: true
-    - type: File
-      id: SomeCurationsDir
-      config:
-        path: '/some-path/curations-dir'
-        mustExist: false
-    - type: OrtConfig
-      enabled: '${USE_ORT_CONFIG_CURATIONS:-true}'
-    - type: ClearlyDefined
-      config:
-        serverUrl: 'https://api.clearlydefined.io'
-        minTotalLicenseScore: 80
-    - type: SW360
-      config:
-        restUrl: 'https://your-sw360-rest-url'
-        authUrl: 'https://your-authentication-url'
-        username: username
-        password: password
-        clientId: clientId
-        clientPassword: clientPassword
-        token: token
+  - type: DefaultFile
+  - type: DefaultDir
+  - type: File
+    id: SomeCurationsFile
+    config:
+      path: '/some-path/curations.yml'
+      mustExist: true
+  - type: File
+    id: SomeCurationsDir
+    config:
+      path: '/some-path/curations-dir'
+      mustExist: false
+  - type: OrtConfig
+    enabled: '${USE_ORT_CONFIG_CURATIONS:-true}'
+  - type: ClearlyDefined
+    config:
+      serverUrl: 'https://api.clearlydefined.io'
+      minTotalLicenseScore: 80
+  - type: SW360
+    config:
+      restUrl: 'https://your-sw360-rest-url'
+      authUrl: 'https://your-authentication-url'
+      username: username
+      password: password
+      clientId: clientId
+      clientPassword: clientPassword
+      token: token
 
   severeIssueThreshold: ERROR
   severeRuleViolationThreshold: ERROR

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -64,24 +64,24 @@ class OrtConfigurationTest : WordSpec({
             }
 
             ortConfig.packageCurationProviders should containExactly(
-                PackageCurationProviderConfiguration(type = "DefaultFile"),
-                PackageCurationProviderConfiguration(type = "DefaultDir"),
-                PackageCurationProviderConfiguration(
+                ProviderPluginConfiguration(type = "DefaultFile"),
+                ProviderPluginConfiguration(type = "DefaultDir"),
+                ProviderPluginConfiguration(
                     type = "File",
                     id = "SomeCurationsFile",
                     config = mapOf("path" to "/some-path/curations.yml", "mustExist" to "true")
                 ),
-                PackageCurationProviderConfiguration(
+                ProviderPluginConfiguration(
                     type = "File",
                     id = "SomeCurationsDir",
                     config = mapOf("path" to "/some-path/curations-dir", "mustExist" to "false")
                 ),
-                PackageCurationProviderConfiguration(type = "OrtConfig", enabled = true),
-                PackageCurationProviderConfiguration(
+                ProviderPluginConfiguration(type = "OrtConfig", enabled = true),
+                ProviderPluginConfiguration(
                     type = "ClearlyDefined",
                     config = mapOf("serverUrl" to "https://api.clearlydefined.io", "minTotalLicenseScore" to "80")
                 ),
-                PackageCurationProviderConfiguration(
+                ProviderPluginConfiguration(
                     type = "SW360",
                     config = mapOf(
                         "restUrl" to "https://your-sw360-rest-url",

--- a/plugins/commands/evaluator/build.gradle.kts
+++ b/plugins/commands/evaluator/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 dependencies {
     api(project(":plugins:commands:command-api"))
 
+    implementation(platform(project(":plugins:package-configuration-providers")))
     implementation(platform(project(":plugins:package-curation-providers")))
 
     implementation(project(":evaluator"))

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -54,8 +54,6 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
-import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.addPackageConfigurations
 import org.ossreviewtoolkit.model.utils.addPackageCurations
 import org.ossreviewtoolkit.model.utils.addResolutions
@@ -67,6 +65,8 @@ import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.plugins.commands.api.utils.writeOrtResult
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.DirectoryPackageConfigurationProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.file.FilePackageCurationProvider
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -53,13 +53,13 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
-import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.DirectoryPackageConfigurationProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.reporter.DefaultLicenseTextProvider
 import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.Reporter

--- a/plugins/package-configuration-providers/api/build.gradle.kts
+++ b/plugins/package-configuration-providers/api/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-library-conventions")
+}
+
+dependencies {
+    api(project(":model"))
+}

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
+
+import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
+import org.ossreviewtoolkit.utils.common.Plugin
+import org.ossreviewtoolkit.utils.common.getDuplicates
+
+/**
+ * The extension point for [PackageConfigurationProvider]s.
+ */
+interface PackageConfigurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageConfigurationProvider> {
+    companion object {
+        val ALL = Plugin.getAll<PackageConfigurationProviderFactory<*>>()
+
+        /**
+         * Create a new (identifier, provider instance) tuple for each
+         * [enabled][ProviderPluginConfiguration.enabled] provider configuration in [configurations] ordered
+         * highest priority first. The given [configurations] must be ordered highest-priority first as well.
+         */
+        fun create(
+            configurations: List<ProviderPluginConfiguration>
+        ): List<Pair<String, PackageConfigurationProvider>> =
+            configurations.filter { it.enabled }
+                .map { it.id to ALL.getValue(it.type).create(it.config) }
+                .apply {
+                    require(none { (id, _) -> id.isBlank() }) {
+                        "The configuration contains a package configuration provider with a blank ID which is not " +
+                                "allowed."
+                    }
+
+                    val duplicateIds = getDuplicates { (id, _) -> id }.keys
+                    require(duplicateIds.isEmpty()) {
+                        "Found multiple package configuration providers for the IDs ${duplicateIds.joinToString()}, " +
+                                "which is not allowed. Please configure a unique ID for each package configuration " +
+                                "provider."
+                    }
+                }
+    }
+
+    override fun create(config: Map<String, String>): PackageConfigurationProvider = create(parseConfig(config))
+
+    /**
+     * Create a new [PackageConfigurationProvider] with [config].
+     */
+    fun create(config: CONFIG): PackageConfigurationProvider
+
+    /**
+     * Parse the [config] map into a [CONFIG] instance.
+     */
+    fun parseConfig(config: Map<String, String>): CONFIG
+}

--- a/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model.utils
+package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
 import java.io.File
 import java.io.IOException
@@ -28,6 +28,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 
 /**
  * A provider for [PackageConfiguration]s providing exactly the packages of the given list.

--- a/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
+++ b/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
@@ -17,14 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model
+package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 
 class SimplePackageConfigurationProviderTest : WordSpec({
     "constructor" should {

--- a/plugins/package-configuration-providers/build.gradle.kts
+++ b/plugins/package-configuration-providers/build.gradle.kts
@@ -25,3 +25,7 @@ plugins {
 javaPlatform {
     allowDependencies()
 }
+
+dependencies {
+    api(project(":plugins:package-configuration-providers:dir-package-configuration-provider"))
+}

--- a/plugins/package-configuration-providers/build.gradle.kts
+++ b/plugins/package-configuration-providers/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply core plugins.
+    `java-platform`
+}
+
+javaPlatform {
+    allowDependencies()
+}

--- a/plugins/package-configuration-providers/dir/build.gradle.kts
+++ b/plugins/package-configuration-providers/dir/build.gradle.kts
@@ -23,17 +23,5 @@ plugins {
 }
 
 dependencies {
-    api(project(":plugins:commands:command-api"))
-
-    implementation(platform(project(":plugins:package-configuration-providers")))
-    implementation(platform(project(":plugins:reporters")))
-
-    implementation(project(":reporter"))
-    implementation(project(":model"))
-    implementation(project(":utils:common-utils"))
-    implementation(project(":utils:ort-utils"))
-
-    implementation(libs.clikt)
-    implementation(libs.kotlinxCoroutines)
-    implementation(libs.log4jApiKotlin)
+    api(project(":plugins:package-configuration-providers:package-configuration-provider-api"))
 }

--- a/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir
+
+import java.io.File
+import java.io.IOException
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.model.FileFormat
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
+import org.ossreviewtoolkit.utils.common.getDuplicates
+import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
+import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
+
+class DirPackageConfigurationProviderConfig(
+    /**
+     * The path of the package configuration directory.
+     */
+    val path: File,
+
+    /**
+     * A flag to denote whether the path is required to exist.
+     */
+    val mustExist: Boolean
+)
+
+open class DirPackageConfigurationProviderFactory :
+    PackageConfigurationProviderFactory<DirPackageConfigurationProviderConfig> {
+    override val type = "Dir"
+
+    override fun create(config: DirPackageConfigurationProviderConfig) =
+        DirPackageConfigurationProvider(config)
+
+    override fun parseConfig(config: Map<String, String>) =
+        DirPackageConfigurationProviderConfig(
+            path = File(config.getValue("path")),
+            mustExist = config["mustExist"]?.toBooleanStrict() ?: true
+        )
+}
+
+class DefaultDirPackageConfigurationProviderFactory : DirPackageConfigurationProviderFactory() {
+    override val type = "DefaultDir"
+
+    override fun parseConfig(config: Map<String, String>) =
+        DirPackageConfigurationProviderConfig(
+            path = ortConfigDirectory.resolve(ORT_PACKAGE_CONFIGURATIONS_DIRNAME),
+            mustExist = false
+        )
+}
+
+/**
+ * A [PackageConfigurationProvider] that loads [PackageConfiguration]s from all given package configuration files.
+ * Supports all file formats specified in [FileFormat].
+ */
+class DirPackageConfigurationProvider(
+    vararg paths: File?
+) : SimplePackageConfigurationProvider(readConfigurationFiles(paths.filterNotNull())) {
+    constructor(config: DirPackageConfigurationProviderConfig) : this(
+        config.path.takeUnless { !it.exists() && !config.mustExist }
+    )
+
+    companion object : Logging {
+        fun readConfigurationFiles(paths: Collection<File>): List<PackageConfiguration> {
+            val allConfigurations = mutableListOf<Pair<PackageConfiguration, File>>()
+
+            val configurationFiles = paths.flatMap {
+                require(it.exists()) {
+                    "The path '$it' does not exist."
+                }
+
+                if (it.isDirectory) FileFormat.findFilesWithKnownExtensions(it) else listOf(it)
+            }.filterNot { it.length() == 0L }
+
+            configurationFiles.map { configurationFile ->
+                val configuration = runCatching {
+                    configurationFile.readValue<PackageConfiguration>()
+                }.getOrElse {
+                    throw IOException(
+                        "Failed parsing package configuration(s) from '${configurationFile.absolutePath}'.",
+                        it
+                    )
+                }
+
+                allConfigurations += configuration to configurationFile
+            }
+
+            val duplicates = allConfigurations.getDuplicates { it.first }
+            if (duplicates.isNotEmpty()) {
+                val duplicatesInfo = buildString {
+                    duplicates.forEach { (packageConfiguration, origins) ->
+                        appendLine("Configurations for '${packageConfiguration.id.toCoordinates()}' found in all of:")
+                        val files = origins.joinToString(separator = "\n") { (_, file) -> file.absolutePath }
+                        appendLine(files.prependIndent())
+                    }
+                }
+                throw DuplicatedConfigurationException(
+                    "Duplicate package configuration found:\n${duplicatesInfo.prependIndent()}"
+                )
+            }
+
+            return allConfigurations.unzip().first
+        }
+    }
+}
+
+private class DuplicatedConfigurationException(message: String?) : Exception(message)

--- a/plugins/package-configuration-providers/dir/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
+++ b/plugins/package-configuration-providers/dir/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
@@ -1,0 +1,2 @@
+org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DefaultDirPackageConfigurationProviderFactory
+org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProviderFactory

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.plugins.packagecurationproviders.api
 
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
-import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
+import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.Plugin
@@ -35,11 +35,11 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
 
         /**
          * Return a new (identifier, provider instance) tuple for each
-         * [enabled][PackageCurationProviderConfiguration.enabled] provider configuration in [configurations] ordered
+         * [enabled][ProviderPluginConfiguration.enabled] provider configuration in [configurations] ordered
          * highest-priority first. The given [configurations] must be ordered highest-priority first as well.
          */
         fun create(
-            configurations: List<PackageCurationProviderConfiguration>
+            configurations: List<ProviderPluginConfiguration>
         ): List<Pair<String, PackageCurationProvider>> =
             configurations.filter {
                 it.enabled


### PR DESCRIPTION
Move the package-configuration provider to a separate plugin.

This allows adding more providers through the plugin API, for instance adding the package-configurations from [ort-config](https://github.com/oss-review-toolkit/ort-config)