### PR TITLE
fix(scanner): Filter scan results by scanner name

### DIFF
--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -201,6 +201,15 @@ scanner:
         revision: "r4.12"
         path: ""
       resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+  scanners:
+    "Maven:com.vdurmont:semver4j:3.1.0":
+    - "ScanCode"
+    "Maven:junit:junit:4.12":
+    - "ScanCode"
+    "Maven:org.hamcrest:hamcrest-core:1.3":
+    - "ScanCode"
+    "Maven:org.mockito:mockito-all:1.10.19":
+    - "ScanCode"
   scan_results:
   - provenance:
       vcs_info:

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -28,6 +28,7 @@ import java.util.SortedSet
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.FileList
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
@@ -72,6 +73,11 @@ class ProjectSortedSetConverter : StdConverter<Set<Project>, SortedSet<Project>>
 class ProvenanceResolutionResultSortedSetConverter :
     StdConverter<Set<ProvenanceResolutionResult>, SortedSet<ProvenanceResolutionResult>>() {
     override fun convert(value: Set<ProvenanceResolutionResult>) = value.toSortedSet(compareBy { it.id })
+}
+
+class ScannersMapConverter : StdConverter<Map<Identifier, Set<String>>, Map<Identifier, Set<String>>>() {
+    override fun convert(value: Map<Identifier, Set<String>>) =
+        value.mapValues { it.value.toSortedSet() }.toSortedMap()
 }
 
 /** Do not convert to SortedSet in order to not require a comparator consistent with equals */

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -594,6 +594,25 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
+  scanners:
+    "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0":
+    - "FakeScanner"
+    "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0":
+    - "FakeScanner"
+    "Ant:junit:junit:4.12":
+    - "Dummy"
+    "Maven:com.foobar:foobar:1.0":
+    - "Dummy"
+    "Maven:com.h2database:h2:1.4.200":
+    - "Dummy"
+    "Maven:org.apache.commons:commons-lang3:3.5":
+    - "Dummy"
+    "Maven:org.apache.commons:commons-text:1.1":
+    - "Dummy"
+    "Maven:org.example.test:example-component:1.11":
+    - "Dummy"
+    "Maven:org.hamcrest:hamcrest-core:1.3":
+    - "Dummy"
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -590,6 +590,25 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
+  scanners:
+    "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0":
+    - "FakeScanner"
+    "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0":
+    - "FakeScanner"
+    "Ant:junit:junit:4.12":
+    - "Dummy"
+    "Maven:com.foobar:foobar:1.0":
+    - "Dummy"
+    "Maven:com.h2database:h2:1.4.200":
+    - "Dummy"
+    "Maven:org.apache.commons:commons-lang3:3.5":
+    - "Dummy"
+    "Maven:org.apache.commons:commons-text:1.1":
+    - "Dummy"
+    "Maven:org.example.test:example-component:1.11":
+    - "Dummy"
+    "Maven:org.hamcrest:hamcrest-core:1.3":
+    - "Dummy"
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -590,6 +590,25 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
+  scanners:
+    "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0":
+      - "FakeScanner"
+    "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0":
+      - "FakeScanner"
+    "Ant:junit:junit:4.12":
+      - "Dummy"
+    "Maven:com.foobar:foobar:1.0":
+      - "Dummy"
+    "Maven:com.h2database:h2:1.4.200":
+      - "Dummy"
+    "Maven:org.apache.commons:commons-lang3:3.5":
+      - "Dummy"
+    "Maven:org.apache.commons:commons-text:1.1":
+      - "Dummy"
+    "Maven:org.example.test:example-component:1.11":
+      - "Dummy"
+    "Maven:org.hamcrest:hamcrest-core:1.3":
+      - "Dummy"
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
@@ -367,6 +367,25 @@ scanner:
           path: "org"
           start_line: -1
           end_line: -1
+  scanners:
+    "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0":
+      - "FakeScanner"
+    "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0":
+      - "FakeScanner"
+    "Ant:junit:junit:4.12":
+      - "Dummy"
+    "Maven:com.foobar:foobar:1.0":
+      - "Dummy"
+    "Maven:com.h2database:h2:1.4.200":
+      - "Dummy"
+    "Maven:org.apache.commons:commons-lang3:3.5":
+      - "Dummy"
+    "Maven:org.apache.commons:commons-text:1.1":
+      - "Dummy"
+    "Maven:org.example.test:example-component:1.11":
+      - "Dummy"
+    "Maven:org.hamcrest:hamcrest-core:1.3":
+      - "Dummy"
   files:
   - provenance:
       source_artifact:

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -403,6 +403,19 @@ scanner:
           path: "pkg4/pkg4.txt"
           start_line: -1
           end_line: -1
+  scanners:
+    Dummy::pkg0:1.0.0:
+    - "Dummy"
+    Dummy::pkg1:1.0.0:
+    - "Dummy"
+    Dummy::pkg2:1.0.0:
+    - "Dummy"
+    Dummy::pkg3:1.0.0:
+    - "Dummy"
+    Dummy::pkg4:1.0.0:
+    - "Dummy"
+    Dummy::project:1.0.0:
+    - "Dummy"
   files:
   - provenance:
       vcs_info:

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -231,6 +231,13 @@ scanner:
           path: "pkg3/pkg3.txt"
           start_line: -1
           end_line: -1
+  scanners:
+    Dummy::pkg1:1.0.0:
+    - "Dummy"
+    Dummy::pkg3:1.0.0:
+    - "Dummy"
+    Dummy::project:1.0.0:
+    - "Dummy"
   files:
   - provenance:
       vcs_info:

--- a/scanner/src/funTest/kotlin/scanners/MultipleScannersTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/MultipleScannersTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.AnalyzerRun
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageType
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+private val PROJECT_ID = Identifier("Dummy", "", "project", "1.0.0")
+private val PACKAGE_ID = Identifier("Dummy", "", "pkg1", "1.0.0")
+
+class MultipleScannersTest : WordSpec({
+    "Scanning a project and a package with overlapping provenance and non overlapping scanners" should {
+        val analyzerResult = createAnalyzerResult()
+
+        val scannerWrappers = mapOf(
+            PackageType.PROJECT to listOf(DummyScanner("Dummy2")),
+            PackageType.PACKAGE to listOf(DummyScanner("Dummy1"))
+        )
+        val ortResult = createScanner(scannerWrappers).scan(analyzerResult, skipExcluded = false, emptyMap())
+
+        "return scan results with non-overlapping scanners" {
+            ortResult.scanner.shouldNotBeNull {
+                val results = getScanResults(PROJECT_ID)
+                results.map { it.scanner.name }.toSet() should containExactly("Dummy2")
+                val results2 = getScanResults(PACKAGE_ID)
+                results2.map { it.scanner.name }.toSet() should containExactly("Dummy1")
+            }
+        }
+    }
+})
+
+private fun createAnalyzerResult(): OrtResult {
+    val vcs = VcsInfo(
+        type = VcsType.GIT,
+        url = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git",
+        revision = "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec",
+        path = ""
+    )
+
+    val pkg = Package.EMPTY.copy(
+        id = PACKAGE_ID,
+        vcs = vcs,
+        vcsProcessed = vcs.normalize()
+    )
+
+    val project = Project.EMPTY.copy(
+        id = PROJECT_ID,
+        vcs = vcs,
+        vcsProcessed = vcs.normalize()
+    )
+
+    val analyzerRun = AnalyzerRun.EMPTY.copy(
+        result = AnalyzerResult.EMPTY.copy(
+            projects = setOf(project),
+            packages = setOf(pkg)
+        )
+    )
+
+    return OrtResult.EMPTY.copy(analyzer = analyzerRun)
+}

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -45,6 +45,7 @@ import org.ossreviewtoolkit.scanner.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.Scanner
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapper
 import org.ossreviewtoolkit.scanner.provenance.DefaultNestedProvenanceResolver
 import org.ossreviewtoolkit.scanner.provenance.DefaultPackageProvenanceResolver
 import org.ossreviewtoolkit.scanner.provenance.DefaultProvenanceDownloader
@@ -100,7 +101,7 @@ class ScannerIntegrationFunTest : WordSpec({
     }
 })
 
-private fun createScanner(): Scanner {
+internal fun createScanner(scannerWrappers: Map<PackageType, List<ScannerWrapper>>? = null): Scanner {
     val downloaderConfiguration = DownloaderConfiguration()
     val workingTreeCache = DefaultWorkingTreeCache()
     val provenanceDownloader = DefaultProvenanceDownloader(downloaderConfiguration, workingTreeCache)
@@ -118,7 +119,7 @@ private fun createScanner(): Scanner {
         storageWriters = emptyList(),
         packageProvenanceResolver = packageProvenanceResolver,
         nestedProvenanceResolver = nestedProvenanceResolver,
-        scannerWrappers = mapOf(
+        scannerWrappers = scannerWrappers ?: mapOf(
             PackageType.PROJECT to listOf(dummyScanner),
             PackageType.PACKAGE to listOf(dummyScanner)
         )
@@ -210,8 +211,7 @@ private val pkg4 = createPackage(
     )
 )
 
-private class DummyScanner : PathScannerWrapper {
-    override val name = "Dummy"
+internal class DummyScanner(override val name: String = "Dummy") : PathScannerWrapper {
     override val version = "1.0.0"
     override val configuration = ""
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -169,7 +169,8 @@ class Scanner(
             config = filteredScannerConfig,
             provenances = projectResults.provenances + packageResults.provenances,
             scanResults = projectResults.scanResults + packageResults.scanResults,
-            files = projectResults.files + packageResults.files
+            files = projectResults.files + packageResults.files,
+            scanners = projectResults.scanners + packageResults.scanners
         )
 
         return ortResult.copy(scanner = scannerRun)
@@ -238,11 +239,15 @@ class Scanner(
             }
         }
 
+        val scannerNames = scanners.mapTo(mutableSetOf()) { it.name }
+        val scannerNamesByPackageId = packages.associateBy({ it.id }) { scannerNames }
+
         return ScannerRun.EMPTY.copy(
             config = scannerConfig,
             provenances = provenances,
             scanResults = scanResults,
-            files = files
+            files = files,
+            scanners = scannerNamesByPackageId
         )
     }
 

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -188,6 +188,9 @@ fun scannerRunOf(vararg pkgScanResults: Pair<Identifier, List<ScanResult>>): Sca
             }
         )
     }
+    val scanners = pkgScanResults.associate { (id, scanResultsForId) ->
+        id to scanResultsForId.mapTo(mutableSetOf()) { it.scanner.name }
+    }
 
     return ScannerRun.EMPTY.copy(
         provenances = pkgScanResultsWithKnownProvenance.mapTo(mutableSetOf()) { (id, scanResultsForId) ->
@@ -202,6 +205,7 @@ fun scannerRunOf(vararg pkgScanResults: Pair<Identifier, List<ScanResult>>): Sca
             )
         },
         scanResults = scanResults,
-        files = files
+        files = files,
+        scanners = scanners
     )
 }


### PR DESCRIPTION
When a project scanner is configured alongside a package scanner, the scan results could be duplicated if the provenances of those packages are overlapping (e.g. in the case of repositories with Git submodules). This commit addresses the bug by constructing a map of packages with their scanners and filtering the scan results using this map.

Fixes #7231.

**Breaking change: OrtResult deserialization is not backwards compatible.**
