### PR TITLE
Migrate the Scancode result parser to kotlinx-serialization

### DIFF
--- a/plugins/scanners/scancode/build.gradle.kts
+++ b/plugins/scanners/scancode/build.gradle.kts
@@ -17,9 +17,14 @@
  * License-Filename: LICENSE
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     // Apply precompiled plugins.
     id("ort-library-conventions")
+
+    // Apply third-party plugins.
+    alias(libs.plugins.kotlinSerialization)
 }
 
 dependencies {
@@ -34,9 +39,19 @@ dependencies {
     implementation(project(":utils:ort-utils"))
     implementation(project(":utils:spdx-utils"))
 
-    implementation(libs.jacksonDatabind)
+    implementation(libs.bundles.kotlinxSerialization)
 
     funTestApi(testFixtures(project(":scanner")))
 
     testImplementation(libs.mockk)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    val customCompilerArgs = listOf(
+        "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
+    )
+
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + customCompilerArgs
+    }
 }

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -173,7 +173,7 @@ class ScanCode internal constructor(
 
         val issues = summary.issues.toMutableList()
 
-        mapUnknownIssues(issues)
+        mapUnknownErrors(issues)
         mapTimeoutErrors(issues)
 
         return summary.copy(issues = issues)

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -30,7 +30,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -167,9 +166,8 @@ class ScanCode internal constructor(
     }
 
     override fun createSummary(result: String, startTime: Instant, endTime: Instant): ScanSummary {
-        val json = jsonMapper.readTree(result)
         val parseLicenseExpressions = scanCodeConfiguration["parseLicenseExpressions"].isTrue()
-        val summary = generateSummary(json, parseLicenseExpressions)
+        val summary = parseResult(result).toScanSummary(parseLicenseExpressions)
 
         val issues = summary.issues.toMutableList()
 

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeErrorMappers.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeErrorMappers.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2017 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.scanners.scancode
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import org.ossreviewtoolkit.model.Issue
+
+// Note: The "(File: ...)" part in the patterns below is actually added by our own getRawResult() function.
+private val UNKNOWN_ERROR_REGEX = Regex(
+    "(ERROR: for scanner: (?<scanner>\\w+):\n)?" +
+            "ERROR: Unknown error:\n.+\n(?<error>\\w+Error)(:|\n)(?<message>.*) \\(File: (?<file>.+)\\)",
+    RegexOption.DOT_MATCHES_ALL
+)
+
+private val TIMEOUT_ERROR_REGEX = Regex(
+    "(ERROR: for scanner: (?<scanner>\\w+):\n)?" +
+            "ERROR: Processing interrupted: timeout after (?<timeout>\\d+) seconds. \\(File: (?<file>.+)\\)"
+)
+
+private fun getInputPath(result: JsonNode): String {
+    val header = result["headers"].single()
+    val input = header["options"]["input"]
+    val path = input.takeUnless { it.isArray } ?: input.single()
+    return path.textValue().let { "$it/" }
+}
+
+/**
+ * Map scan errors for all files using messages that contain the relative file path.
+ */
+internal fun mapScanErrors(result: JsonNode): List<Issue> {
+    val input = getInputPath(result)
+    return result["files"]?.flatMap { file ->
+        val path = file["path"].textValue().removePrefix(input)
+        file["scan_errors"].map {
+            Issue(
+                source = ScanCode.SCANNER_NAME,
+                message = "${it.textValue()} (File: $path)"
+            )
+        }
+    }.orEmpty()
+}
+
+/**
+ * Map messages about timeout errors to a more compact form. Return true if solely timeout errors occurred, return false
+ * otherwise.
+ */
+internal fun mapTimeoutErrors(issues: MutableList<Issue>): Boolean {
+    if (issues.isEmpty()) return false
+
+    var onlyTimeoutErrors = true
+
+    val mappedIssues = issues.map { fullError ->
+        val match = TIMEOUT_ERROR_REGEX.matchEntire(fullError.message)
+        if (match?.groups?.get("timeout")?.value == ScanCode.TIMEOUT.toString()) {
+            val file = match.groups["file"]!!.value
+            fullError.copy(
+                message = "ERROR: Timeout after ${ScanCode.TIMEOUT} seconds while scanning file '$file'."
+            )
+        } else {
+            onlyTimeoutErrors = false
+            fullError
+        }
+    }
+
+    issues.clear()
+    issues += mappedIssues.distinctBy { it.message }
+
+    return onlyTimeoutErrors
+}
+
+/**
+ * Map messages about unknown errors to a more compact form. Return true if solely memory errors occurred, return false
+ * otherwise.
+ */
+internal fun mapUnknownErrors(issues: MutableList<Issue>): Boolean {
+    if (issues.isEmpty()) return false
+
+    var onlyMemoryErrors = true
+
+    val mappedIssues = issues.map { fullError ->
+        UNKNOWN_ERROR_REGEX.matchEntire(fullError.message)?.let { match ->
+            val file = match.groups["file"]!!.value
+            val error = match.groups["error"]!!.value
+            if (error == "MemoryError") {
+                fullError.copy(message = "ERROR: MemoryError while scanning file '$file'.")
+            } else {
+                onlyMemoryErrors = false
+                val message = match.groups["message"]!!.value.trim()
+                fullError.copy(message = "ERROR: $error while scanning file '$file' ($message).")
+            }
+        } ?: run {
+            onlyMemoryErrors = false
+            fullError
+        }
+    }
+
+    issues.clear()
+    issues += mappedIssues.distinctBy { it.message }
+
+    return onlyMemoryErrors
+}

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModel.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModel.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.scanners.scancode
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonTransformingSerializer
+
+@Serializable
+data class ScanCodeResult(
+    val headers: List<HeaderEntry>,
+    val files: List<FileEntry>
+)
+
+@Serializable
+data class HeaderEntry(
+    val toolName: String,
+    val toolVersion: String,
+    val options: Options,
+    val startTimestamp: String,
+    val endTimestamp: String,
+    val outputFormatVersion: String? = null // This might be missing in JSON.
+)
+
+@Serializable
+data class Options(
+    @Serializable(InputListSerializer::class)
+    val input: List<String>
+)
+
+@Serializable
+data class FileEntry(
+    val path: String,
+    val type: String,
+    val licenses: List<LicenseEntry>,
+    val copyrights: List<CopyrightEntry>,
+    val scanErrors: List<String>
+)
+
+@Serializable
+data class LicenseEntry(
+    val key: String,
+    val score: Float,
+    val spdxLicenseKey: String? = null, // This might be explicitly set to null in JSON.
+    val startLine: Int,
+    val endLine: Int,
+    val matchedRule: LicenseRule
+)
+
+@Serializable
+data class LicenseRule(
+    val licenseExpression: String
+)
+
+sealed interface CopyrightEntry {
+    val statement: String
+    val startLine: Int
+    val endLine: Int
+
+    @Serializable
+    data class Version1(
+        val value: String,
+        override val startLine: Int,
+        override val endLine: Int
+    ) : CopyrightEntry {
+        override val statement = value
+    }
+
+    @Serializable
+    data class Version2(
+        val copyright: String,
+        override val startLine: Int,
+        override val endLine: Int
+    ) : CopyrightEntry {
+        override val statement = copyright
+    }
+}
+
+/**
+ * A serializer that wraps an old primitive input option from ScanCode 3 into an array like it is for recent ScanCode
+ * versions. Note that the input option format changed before the output format version property was introduced.
+ */
+private object InputListSerializer : JsonTransformingSerializer<List<String>>(ListSerializer(String.serializer())) {
+    override fun transformDeserialize(element: JsonElement): JsonElement =
+        if (element !is JsonArray) JsonArray(listOf(element)) else element
+}

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultParser.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultParser.kt
@@ -100,7 +100,7 @@ internal fun generateSummary(result: JsonNode, parseExpressions: Boolean = true)
         endTime = endTime,
         licenseFindings = getLicenseFindings(result, parseExpressions),
         copyrightFindings = getCopyrightFindings(result),
-        issues = issues + getIssues(result)
+        issues = issues + mapScanErrors(result)
     )
 }
 
@@ -207,9 +207,9 @@ private fun getCopyrightFindings(result: JsonNode): Set<CopyrightFinding> {
 }
 
 /**
- * Get the list of [Issue]s for scanned files.
+ * Map scan errors for all files using messages that contain the relative file path.
  */
-private fun getIssues(result: JsonNode): List<Issue> {
+private fun mapScanErrors(result: JsonNode): List<Issue> {
     val input = getInputPath(result)
     return result["files"]?.flatMap { file ->
         val path = file["path"].textValue().removePrefix(input)
@@ -251,10 +251,10 @@ internal fun mapTimeoutErrors(issues: MutableList<Issue>): Boolean {
 }
 
 /**
- * Map messages about unknown issues to a more compact form. Return true if solely memory errors occurred, return false
+ * Map messages about unknown errors to a more compact form. Return true if solely memory errors occurred, return false
  * otherwise.
  */
-internal fun mapUnknownIssues(issues: MutableList<Issue>): Boolean {
+internal fun mapUnknownErrors(issues: MutableList<Issue>): Boolean {
     if (issues.isEmpty()) return false
 
     var onlyMemoryErrors = true

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeResultParserTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeResultParserTest.kt
@@ -35,8 +35,6 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.jsonMapper
-import org.ossreviewtoolkit.model.readTree
 import org.ossreviewtoolkit.utils.test.transformingCollectionMatcher
 
 class ScanCodeResultParserTest : FreeSpec({
@@ -44,9 +42,8 @@ class ScanCodeResultParserTest : FreeSpec({
         "for ScanCode 3.0.2 should" - {
             "get correct counts" {
                 val resultFile = File("src/test/assets/scancode-3.0.2_mime-types-2.1.18.json")
-                val result = resultFile.readTree()
 
-                val summary = generateSummary(result)
+                val summary = parseResult(resultFile).toScanSummary()
 
                 summary.licenseFindings.size shouldBe 4
                 summary.copyrightFindings.size shouldBe 4
@@ -57,9 +54,8 @@ class ScanCodeResultParserTest : FreeSpec({
         "for ScanCode 3.2.1rc2 should" - {
             "properly parse license expressions" {
                 val resultFile = File("src/test/assets/scancode-3.2.1rc2_h2database-1.4.200.json")
-                val result = resultFile.readTree()
 
-                val summary = generateSummary(result)
+                val summary = parseResult(resultFile).toScanSummary()
 
                 summary.licenseFindings should containExactlyInAnyOrder(
                     LicenseFinding(
@@ -81,9 +77,8 @@ class ScanCodeResultParserTest : FreeSpec({
                 "get correct counts" {
                     val filename = "scancode-output-format-$version.0.0_mime-types-2.1.18.json"
                     val resultFile = File("src/test/assets/$filename")
-                    val result = resultFile.readTree()
 
-                    val summary = generateSummary(result)
+                    val summary = parseResult(resultFile).toScanSummary()
 
                     summary.licenseFindings.size shouldBe 5
                     summary.copyrightFindings.size shouldBe 4
@@ -92,12 +87,10 @@ class ScanCodeResultParserTest : FreeSpec({
 
                 "properly summarize license findings" {
                     val resultFile = File("src/test/assets/scancode-output-format-$version.0.0_mime-types-2.1.18.json")
-                    val result = resultFile.readTree()
 
-                    val summary = generateSummary(result)
+                    val summary = parseResult(resultFile).toScanSummary()
 
                     summary should containLicensesExactly("MIT")
-
                     summary should containLocationsForLicenseExactly(
                         "MIT",
                         TextLocation("LICENSE", 1),
@@ -110,9 +103,8 @@ class ScanCodeResultParserTest : FreeSpec({
 
                 "properly summarize copyright findings" {
                     val resultFile = File("src/test/assets/scancode-output-format-$version.0.0_mime-types-2.1.18.json")
-                    val result = resultFile.readTree()
 
-                    val summary = generateSummary(result)
+                    val summary = parseResult(resultFile).toScanSummary()
 
                     summary should containCopyrightsExactly(
                         "Copyright (c) 2014 Jonathan Ong" to
@@ -152,13 +144,13 @@ class ScanCodeResultParserTest : FreeSpec({
                           "end_timestamp": "2022-12-12T065637.770792",
                           "output_format_version": "3.0.0"
                         }
+                      ],
+                      "files": [
                       ]
                     }
                 """.trimIndent()
 
-                val result = jsonMapper.readTree(headers)
-
-                val summary = generateSummary(result)
+                val summary = parseResult(headers).toScanSummary()
 
                 summary.issues.map { it.copy(timestamp = Instant.EPOCH) } shouldHaveSingleElement Issue(
                     timestamp = Instant.EPOCH,


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 