### PR TITLE
fix(spdx): Fix-up representing the relationship of files and packages

### DIFF
--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -61,6 +61,7 @@
       "referenceLocator" : "pkg:maven/first-package-group/first-package@0.0.1"
     } ],
     "filesAnalyzed" : true,
+    "hasFiles" : [ "SPDXRef-File-1" ],
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
@@ -155,6 +156,7 @@
       "referenceLocator" : "pkg:maven/seventh-package-group/seventh-package@0.0.1"
     } ],
     "filesAnalyzed" : true,
+    "hasFiles" : [ "SPDXRef-File-2", "SPDXRef-File-3" ],
     "homepage" : "NONE",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "NOASSERTION",
@@ -238,21 +240,9 @@
     "relationshipType" : "GENERATED_FROM",
     "relatedSpdxElement" : "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs"
   }, {
-    "spdxElementId" : "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs",
-    "relationshipType" : "CONTAINS",
-    "relatedSpdxElement" : "SPDXRef-File-1"
-  }, {
     "spdxElementId" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1",
     "relationshipType" : "GENERATED_FROM",
     "relatedSpdxElement" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
-  }, {
-    "spdxElementId" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact",
-    "relationshipType" : "CONTAINS",
-    "relatedSpdxElement" : "SPDXRef-File-2"
-  }, {
-    "spdxElementId" : "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact",
-    "relationshipType" : "CONTAINS",
-    "relatedSpdxElement" : "SPDXRef-File-3"
   }, {
     "spdxElementId" : "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1",
     "relationshipType" : "DEPENDS_ON",

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -74,6 +74,8 @@ packages:
     referenceType: "purl"
     referenceLocator: "pkg:maven/first-package-group/first-package@0.0.1"
   filesAnalyzed: true
+  hasFiles:
+  - "SPDXRef-File-1"
   homepage: "first package's homepage URL"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
@@ -166,6 +168,9 @@ packages:
     referenceType: "purl"
     referenceLocator: "pkg:maven/seventh-package-group/seventh-package@0.0.1"
   filesAnalyzed: true
+  hasFiles:
+  - "SPDXRef-File-2"
+  - "SPDXRef-File-3"
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "NOASSERTION"
@@ -241,18 +246,9 @@ relationships:
 - spdxElementId: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1"
   relationshipType: "GENERATED_FROM"
   relatedSpdxElement: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs"
-- spdxElementId: "SPDXRef-Package-Maven-first-package-group-first-package-0.0.1-vcs"
-  relationshipType: "CONTAINS"
-  relatedSpdxElement: "SPDXRef-File-1"
 - spdxElementId: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1"
   relationshipType: "GENERATED_FROM"
   relatedSpdxElement: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
-- spdxElementId: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
-  relationshipType: "CONTAINS"
-  relatedSpdxElement: "SPDXRef-File-2"
-- spdxElementId: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
-  relationshipType: "CONTAINS"
-  relatedSpdxElement: "SPDXRef-File-3"
 - spdxElementId: "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1"
   relationshipType: "DEPENDS_ON"
   relatedSpdxElement: "SPDXRef-Package-Maven-fifth-package-group-fifth-package-0.0.1"

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -102,19 +102,18 @@ internal object SpdxDocumentModelMapper : Logging {
             packages += binaryPackage
 
             if (pkg.vcsProcessed.url.isNotBlank()) {
+                val filesForPackage = if (params.fileInformationEnabled) {
+                    ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, VCS, nextFileIndex)
+                } else {
+                    emptyList()
+                }
+
                 // TODO: The copyright text contains copyrights from all scan results.
                 val vcsPackage = pkg.toSpdxPackage(
                     SpdxPackageType.VCS_PACKAGE,
                     licenseInfoResolver,
                     ortResult
-                )
-
-                if (params.fileInformationEnabled) {
-                    ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, VCS, nextFileIndex).let {
-                        files += it
-                        relationships += it.createFileRelationships(vcsPackage)
-                    }
-                }
+                ).copy(hasFiles = filesForPackage.map { it.spdxId })
 
                 val vcsPackageRelationShip = SpdxRelationship(
                     spdxElementId = binaryPackage.spdxId,
@@ -122,24 +121,24 @@ internal object SpdxDocumentModelMapper : Logging {
                     relatedSpdxElement = vcsPackage.spdxId
                 )
 
+                files += filesForPackage
                 packages += vcsPackage
                 relationships += vcsPackageRelationShip
             }
 
             if (pkg.sourceArtifact.url.isNotBlank()) {
+                val filesForPackage = if (params.fileInformationEnabled) {
+                    ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, ARTIFACT, nextFileIndex)
+                } else {
+                    emptyList()
+                }
+
                 // TODO: The copyright text contains copyrights from all scan results.
                 val sourceArtifactPackage = pkg.toSpdxPackage(
                     SpdxPackageType.SOURCE_PACKAGE,
                     licenseInfoResolver,
                     ortResult
-                )
-
-                if (params.fileInformationEnabled) {
-                    ortResult.getSpdxFiles(pkg.id, licenseInfoResolver, ARTIFACT, nextFileIndex).let {
-                        files += it
-                        relationships += it.createFileRelationships(sourceArtifactPackage)
-                    }
-                }
+                ).copy(hasFiles = filesForPackage.map { it.spdxId })
 
                 val sourceArtifactPackageRelationship = SpdxRelationship(
                     spdxElementId = binaryPackage.spdxId,
@@ -147,6 +146,7 @@ internal object SpdxDocumentModelMapper : Logging {
                     relatedSpdxElement = sourceArtifactPackage.spdxId
                 )
 
+                files += filesForPackage
                 packages += sourceArtifactPackage
                 relationships += sourceArtifactPackageRelationship
             }


### PR DESCRIPTION
Use the dedicated field for representing that a file corresponds to a package, instead of the more verbose generic relationship (in the SPDX Document report).

This fix-up corresponds to #6947.