### PR TITLE
docs: Add instructions how to take over actual test results on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,6 +786,7 @@ the clipboard and run
 * `wl-paste | cut -d ' ' -f 5- | git apply` (Linux with Wayland)
 * `xsel -b | cut -d ' ' -f 5- | git apply` (Linux with X)
 * `cat /dev/clipboard | dos2unix | cut -d ' ' -f 5- | git apply` (Windows with Git Bash)
+* `pbpaste | cut -d ' ' -f 5- | git apply` (macOS)
 
 to apply the diff to the local Git working tree (this does not create a commit yet). After reviewing the changes, create
 a commit to accept the new expected result.

--- a/utils/test/src/main/kotlin/Matchers.kt
+++ b/utils/test/src/main/kotlin/Matchers.kt
@@ -91,6 +91,7 @@ fun matchExpectedResult(
                     - `wl-paste | cut -d ' ' -f 5- | git apply` (Linux with Wayland)
                     - `xsel -b | cut -d ' ' -f 5- | git apply` (Linux with X)
                     - `cat /dev/clipboard | dos2unix | cut -d ' ' -f 5- | git apply` (Windows with Git Bash)
+                    - `pbpaste | cut -d ' ' -f 5- | git apply` (macOS)
                     Then copy the following lines to the clipboard and run the previously pasted commands.
                 """.trimIndent() + diff.joinToString("\n", "\n")
             },


### PR DESCRIPTION
I tested the command with (the default) BSD `cut` and with GNU `cut`.