### PR TITLE
test(downloader): Update `GitWorkingTreeFunTest` results

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -69,8 +69,6 @@ class GitWorkingTreeFunTest : StringSpec({
 
         // Ignore auto-created branches by Dependabot to avoid regular updates to this list.
         workingTree.listRemoteBranches().filterNot { it.startsWith("dependabot/") } should containAll(
-            "all-repos_autofix_bump",
-            "all-repos_autofix_bump-2023-02-05",
             "main"
         )
     }

--- a/plugins/package-managers/pub/src/funTest/assets/projects/external/dart-http-expected-output.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/external/dart-http-expected-output.yml
@@ -187,7 +187,7 @@ project:
         - id: "Pub:stack_trace:stack_trace:1.11.1"
           dependencies:
           - id: "Pub:path:path:1.8.3"
-        - id: "Pub:vm_service:vm_service:11.7.2"
+        - id: "Pub:vm_service:vm_service:11.8.0"
       - id: "Pub:http_multi_server:http_multi_server:3.2.1"
         dependencies:
         - id: "Pub:async:async:2.11.0"
@@ -704,7 +704,7 @@ project:
           - id: "Pub:stack_trace:stack_trace:1.11.1"
             dependencies:
             - id: "Pub:path:path:1.8.3"
-          - id: "Pub:vm_service:vm_service:11.7.2"
+          - id: "Pub:vm_service:vm_service:11.8.0"
         - id: "Pub:frontend_server_client:frontend_server_client:3.2.0"
           dependencies:
           - id: "Pub:async:async:2.11.0"
@@ -834,7 +834,7 @@ project:
               - id: "Pub:path:path:1.8.3"
               - id: "Pub:term_glyph:term_glyph:1.2.1"
           - id: "Pub:term_glyph:term_glyph:1.2.1"
-        - id: "Pub:vm_service:vm_service:11.7.2"
+        - id: "Pub:vm_service:vm_service:11.8.0"
         - id: "Pub:yaml:yaml:3.1.2"
           dependencies:
           - id: "Pub:collection:collection:1.17.2"
@@ -2005,8 +2005,8 @@ packages:
     url: "https://github.com/dart-lang/typed_data.git"
     revision: ""
     path: ""
-- id: "Pub:vm_service:vm_service:11.7.2"
-  purl: "pkg:pub/vm_service/vm_service@11.7.2"
+- id: "Pub:vm_service:vm_service:11.8.0"
+  purl: "pkg:pub/vm_service/vm_service@11.8.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library to communicate with a service implementing the Dart VM service\


### PR DESCRIPTION
The test now is not very meaningful anymore as only `main` is expected, but this is just a quick fix to make the test pass again as a more sophisticated test requires larger refactoring (probably by using a dedicated new repository).