### PR TITLE
fix(model): Use the correct PURL type for CocoaPods

### DIFF
--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -207,6 +207,7 @@ fun Identifier.getPurlType() =
         "maven" -> PurlType.MAVEN
         "npm" -> PurlType.NPM
         "nuget" -> PurlType.NUGET
+        "pod" -> PurlType.COCOAPODS
         "pypi" -> PurlType.PYPI
         else -> lowerType
     }.toString()

--- a/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/dep-tree-expected-output.yml
+++ b/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/dep-tree-expected-output.yml
@@ -115,7 +115,7 @@ project:
     - id: "Pod::base64url:1.1.0"
 packages:
 - id: "Pod::Alamofire:5.4.3"
-  purl: "pkg:pod/Alamofire@5.4.3"
+  purl: "pkg:cocoapods/Alamofire@5.4.3"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -143,7 +143,7 @@ packages:
     revision: "5.4.3"
     path: ""
 - id: "Pod::CryptoSwift:1.4.0"
-  purl: "pkg:pod/CryptoSwift@1.4.0"
+  purl: "pkg:cocoapods/CryptoSwift@1.4.0"
   declared_licenses:
   - "Attribution"
   declared_licenses_processed:
@@ -173,7 +173,7 @@ packages:
     revision: "1.4.0"
     path: ""
 - id: "Pod::DeviceKit:3.2.0"
-  purl: "pkg:pod/DeviceKit@3.2.0"
+  purl: "pkg:cocoapods/DeviceKit@3.2.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -202,7 +202,7 @@ packages:
     revision: "3.2.0"
     path: ""
 - id: "Pod::IQKeyboardManagerSwift:3.3.7"
-  purl: "pkg:pod/IQKeyboardManagerSwift@3.3.7"
+  purl: "pkg:cocoapods/IQKeyboardManagerSwift@3.3.7"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -231,7 +231,7 @@ packages:
     revision: "v3.3.7"
     path: ""
 - id: "Pod::JGProgressHUD:2.2"
-  purl: "pkg:pod/JGProgressHUD@2.2"
+  purl: "pkg:cocoapods/JGProgressHUD@2.2"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -259,7 +259,7 @@ packages:
     revision: "v2.2"
     path: ""
 - id: "Pod::LicensesViewController:0.9.0"
-  purl: "pkg:pod/LicensesViewController@0.9.0"
+  purl: "pkg:cocoapods/LicensesViewController@0.9.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -287,7 +287,7 @@ packages:
     revision: "0.9.0"
     path: ""
 - id: "Pod::MDFInternationalization:3.0.0"
-  purl: "pkg:pod/MDFInternationalization@3.0.0"
+  purl: "pkg:cocoapods/MDFInternationalization@3.0.0"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -317,7 +317,7 @@ packages:
     revision: "v3.0.0"
     path: ""
 - id: "Pod::MDFTextAccessibility:2.0.1"
-  purl: "pkg:pod/MDFTextAccessibility@2.0.1"
+  purl: "pkg:cocoapods/MDFTextAccessibility@2.0.1"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -348,7 +348,7 @@ packages:
     revision: "v2.0.1"
     path: ""
 - id: "Pod::MaterialComponents/AnimationTiming:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FAnimationTiming@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FAnimationTiming@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -379,7 +379,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Availability:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FAvailability@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FAvailability@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -410,7 +410,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Buttons:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FButtons@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FButtons@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -441,7 +441,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Elevation:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FElevation@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FElevation@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -472,7 +472,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Ink:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FInk@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FInk@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -503,7 +503,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Palettes:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FPalettes@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FPalettes@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -534,7 +534,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Ripple:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FRipple@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FRipple@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -565,7 +565,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Shadow:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FShadow@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FShadow@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -596,7 +596,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/ShadowElevations:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FShadowElevations@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FShadowElevations@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -627,7 +627,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/ShadowLayer:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FShadowLayer@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FShadowLayer@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -658,7 +658,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/ShapeLibrary:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FShapeLibrary@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FShapeLibrary@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -689,7 +689,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Shapes:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FShapes@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FShapes@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -720,7 +720,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/TextFields:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FTextFields@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FTextFields@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -751,7 +751,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/Typography:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2FTypography@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2FTypography@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -782,7 +782,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/private/Application:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2Fprivate%2FApplication@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2Fprivate%2FApplication@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -813,7 +813,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/private/Color:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2Fprivate%2FColor@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2Fprivate%2FColor@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -844,7 +844,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::MaterialComponents/private/Math:124.2.0"
-  purl: "pkg:pod/MaterialComponents%2Fprivate%2FMath@124.2.0"
+  purl: "pkg:cocoapods/MaterialComponents%2Fprivate%2FMath@124.2.0"
   declared_licenses:
   - "Apache 2.0"
   declared_licenses_processed:
@@ -875,7 +875,7 @@ packages:
     revision: "v124.2.0"
     path: ""
 - id: "Pod::Mocker:2.2.0"
-  purl: "pkg:pod/Mocker@2.2.0"
+  purl: "pkg:cocoapods/Mocker@2.2.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -903,7 +903,7 @@ packages:
     revision: "2.2.0"
     path: ""
 - id: "Pod::PhoneNumberKit:3.3.3"
-  purl: "pkg:pod/PhoneNumberKit@3.3.3"
+  purl: "pkg:cocoapods/PhoneNumberKit@3.3.3"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -931,7 +931,7 @@ packages:
     revision: "3.3.3"
     path: ""
 - id: "Pod::PhoneNumberKit/PhoneNumberKitCore:3.3.3"
-  purl: "pkg:pod/PhoneNumberKit%2FPhoneNumberKitCore@3.3.3"
+  purl: "pkg:cocoapods/PhoneNumberKit%2FPhoneNumberKitCore@3.3.3"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -959,7 +959,7 @@ packages:
     revision: "3.3.3"
     path: ""
 - id: "Pod::PhoneNumberKit/UIKit:3.3.3"
-  purl: "pkg:pod/PhoneNumberKit%2FUIKit@3.3.3"
+  purl: "pkg:cocoapods/PhoneNumberKit%2FUIKit@3.3.3"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -987,7 +987,7 @@ packages:
     revision: "3.3.3"
     path: ""
 - id: "Pod::SimpleCheckbox:2.1.0"
-  purl: "pkg:pod/SimpleCheckbox@2.1.0"
+  purl: "pkg:cocoapods/SimpleCheckbox@2.1.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1015,7 +1015,7 @@ packages:
     revision: "2.1.0"
     path: ""
 - id: "Pod::TTTAttributedLabel:2.0.0"
-  purl: "pkg:pod/TTTAttributedLabel@2.0.0"
+  purl: "pkg:cocoapods/TTTAttributedLabel@2.0.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1044,7 +1044,7 @@ packages:
     revision: "2.0.0"
     path: ""
 - id: "Pod::Validator:3.2.1"
-  purl: "pkg:pod/Validator@3.2.1"
+  purl: "pkg:cocoapods/Validator@3.2.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1072,7 +1072,7 @@ packages:
     revision: "v3.2.1"
     path: ""
 - id: "Pod::base64url:1.1.0"
-  purl: "pkg:pod/base64url@1.1.0"
+  purl: "pkg:cocoapods/base64url@1.1.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/regular-expected-output.yml
+++ b/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/regular-expected-output.yml
@@ -59,7 +59,7 @@ project:
             - id: "Pod::TransitionKit:2.2.1"
 packages:
 - id: "Pod::ISO8601DateFormatterValueTransformer:0.6.1"
-  purl: "pkg:pod/ISO8601DateFormatterValueTransformer@0.6.1"
+  purl: "pkg:cocoapods/ISO8601DateFormatterValueTransformer@0.6.1"
   declared_licenses:
   - "Apache2"
   declared_licenses_processed:
@@ -89,7 +89,7 @@ packages:
     revision: "v0.6.1"
     path: ""
 - id: "Pod::RKValueTransformers:1.1.3"
-  purl: "pkg:pod/RKValueTransformers@1.1.3"
+  purl: "pkg:cocoapods/RKValueTransformers@1.1.3"
   declared_licenses:
   - "Apache2"
   declared_licenses_processed:
@@ -119,7 +119,7 @@ packages:
     revision: "v1.1.3"
     path: ""
 - id: "Pod::RestKit:0.27.3"
-  purl: "pkg:pod/RestKit@0.27.3"
+  purl: "pkg:cocoapods/RestKit@0.27.3"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -150,7 +150,7 @@ packages:
     revision: "v0.27.3"
     path: ""
 - id: "Pod::RestKit/Core:0.27.3"
-  purl: "pkg:pod/RestKit%2FCore@0.27.3"
+  purl: "pkg:cocoapods/RestKit%2FCore@0.27.3"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -181,7 +181,7 @@ packages:
     revision: "v0.27.3"
     path: ""
 - id: "Pod::RestKit/CoreData:0.27.3"
-  purl: "pkg:pod/RestKit%2FCoreData@0.27.3"
+  purl: "pkg:cocoapods/RestKit%2FCoreData@0.27.3"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -212,7 +212,7 @@ packages:
     revision: "v0.27.3"
     path: ""
 - id: "Pod::RestKit/Network:0.27.3"
-  purl: "pkg:pod/RestKit%2FNetwork@0.27.3"
+  purl: "pkg:cocoapods/RestKit%2FNetwork@0.27.3"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -243,7 +243,7 @@ packages:
     revision: "v0.27.3"
     path: ""
 - id: "Pod::RestKit/ObjectMapping:0.27.3"
-  purl: "pkg:pod/RestKit%2FObjectMapping@0.27.3"
+  purl: "pkg:cocoapods/RestKit%2FObjectMapping@0.27.3"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -274,7 +274,7 @@ packages:
     revision: "v0.27.3"
     path: ""
 - id: "Pod::RestKit/Support:0.27.3"
-  purl: "pkg:pod/RestKit%2FSupport@0.27.3"
+  purl: "pkg:cocoapods/RestKit%2FSupport@0.27.3"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -305,7 +305,7 @@ packages:
     revision: "v0.27.3"
     path: ""
 - id: "Pod::SOCKit:1.1"
-  purl: "pkg:pod/SOCKit@1.1"
+  purl: "pkg:cocoapods/SOCKit@1.1"
   declared_licenses:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
@@ -335,7 +335,7 @@ packages:
     revision: "1.1"
     path: ""
 - id: "Pod::TransitionKit:2.2.1"
-  purl: "pkg:pod/TransitionKit@2.2.1"
+  purl: "pkg:cocoapods/TransitionKit@2.2.1"
   declared_licenses:
   - "Apache2"
   declared_licenses_processed:


### PR DESCRIPTION
According to the purl-spec and ossindex, the name of CocoaPods is "CocoaPods" not "Pod".

[1] https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#cocoapods
[2] https://ossindex.sonatype.org/ecosystem/cocoapods
