### PR TITLE
refactor: Move the `PackageManagerFunTest` to the `analyzer` module

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
         }
     }
 
+    funTestImplementation(platform(project(":plugins:package-managers")))
+
     // Only the Java plugin's built-in "test" source set automatically depends on the test fixtures.
     funTestImplementation(testFixtures(project))
 

--- a/analyzer/src/funTest/kotlin/PackageManagerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/PackageManagerFunTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.cli
+package org.ossreviewtoolkit.analyzer
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
@@ -32,8 +32,6 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
-import org.ossreviewtoolkit.analyzer.ManagedProjectFiles
-import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason


### PR DESCRIPTION
This is a better fit than the `cli` module as no dependency on the CLI is required. The needed dependency on all package manager plugins can be added as a `funTestImplementation` only.