### PR TITLE
fix(ScanSummary): Turn `licenses` into a `lazy` initialized property

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -94,7 +94,7 @@ data class ScanSummary(
     }
 
     @get:JsonIgnore
-    val licenses: Set<SpdxExpression> = licenseFindings.mapTo(mutableSetOf()) { it.license }
+    val licenses: Set<SpdxExpression> by lazy { licenseFindings.mapTo(mutableSetOf()) { it.license } }
 
     /**
      * Filter all detected licenses and copyrights from this [ScanSummary] which are underneath [path]. Findings which


### PR DESCRIPTION
When the SPDX expressions are mapped into a `MutableSet`, then `equals` gets called on each added SPDX expression instance. Equals in turn calls `validChoicesForDnf()` which is quite slow.

Turn the property into a lazy one, to remove the performance penalty from code paths which do not access that `licenses` property.

