### PR TITLE
fix(ResolvedLicenseInfo): Eliminate unneeded DNF computations

### DIFF
--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -72,13 +72,17 @@ data class ResolvedLicenseInfo(
     fun effectiveLicense(licenseView: LicenseView, vararg licenseChoices: List<SpdxLicenseChoice>): SpdxExpression? {
         val resolvedLicenseInfo = filter(licenseView, filterSources = true)
 
-        return resolvedLicenseInfo.licenses.flatMap { resolvedLicense ->
+        val resolvedLicenses = resolvedLicenseInfo.licenses.flatMap { resolvedLicense ->
             resolvedLicense.originalExpressions.map { it.expression }
-        }.toSet()
-            .reduceOrNull(SpdxExpression::and)
-            ?.applyChoices(licenseChoices.asList().flatten())
-            ?.validChoices()
-            ?.reduceOrNull(SpdxExpression::or)
+        }.toSet().reduceOrNull(SpdxExpression::and)
+
+        val choices = licenseChoices.asList().flatten()
+
+        return if (choices.isEmpty()) {
+            resolvedLicenses
+        } else {
+            resolvedLicenses?.applyChoices(choices)?.validChoices()?.reduceOrNull(SpdxExpression::or)
+        }
     }
 
     /**


### PR DESCRIPTION
Applying license choices is a slow operation, in particular `validChoices()` and `validChoicesForDnf()`. So, not executing the logic for applying the license choice in case the given flattened `licenseChoices` improves the performance quite a bit.

Furthermore, given some large SPDX expression the logic has been observed to execute for minutes at maximum CPU load eventually ending with a crash, for yet unknown reason. This change fixes that issue in case no license choice is given for the particular package.


