### PR TITLE
test(Gradle): Fix expected results for disabled tests

### DIFF
--- a/plugins/package-managers/gradle-inspector/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/plugins/package-managers/gradle-inspector/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -18,5 +18,8 @@ project:
   scopes: []
 packages: []
 issues:
-- "This project uses the unsupported Gradle version 3.2.1. At least Gradle 3.3 is\
-  \ required."
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "Gradle"
+  message: "This project uses the unsupported Gradle version 3.2.1. At least Gradle 3.3 is\
+    \ required."
+  severity: "ERROR"

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -18,5 +18,8 @@ project:
   scopes: []
 packages: []
 issues:
-- "This project uses the unsupported Gradle version 3.2.1. At least Gradle 3.3 is\
-  \ required."
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "Gradle"
+  message: "This project uses the unsupported Gradle version 3.2.1. At least Gradle 3.3 is\
+    \ required."
+  severity: "ERROR"


### PR DESCRIPTION
The tests that use these files have been disabled for a while, and they were not deserializable anymore due to changes in the issues section. Fix these to make the files deserializable again.