### PR TITLE
fix(nuget-inspector): Do not use empty PURLs

### DIFF
--- a/plugins/package-managers/nuget/src/funTest/assets/nuget-expected-output.yml
+++ b/plugins/package-managers/nuget/src/funTest/assets/nuget-expected-output.yml
@@ -409,7 +409,7 @@ packages:
     revision: ""
     path: ""
 - id: "NuGet::foobar:1.2.3"
-  purl: ""
+  purl: "pkg:nuget/foobar@1.2.3"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspector.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspector.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.fromYaml
+import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -235,7 +236,7 @@ internal fun Collection<NuGetInspector.PackageData>.toOrtPackages(): Set<Package
 
         Package(
             id = id,
-            purl = pkg.purl,
+            purl = pkg.purl.takeUnless { it.isEmpty() } ?: id.toPurl(),
             authors = pkg.parties.toAuthors(),
             declaredLicenses = declaredLicenses,
             declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses),


### PR DESCRIPTION
If `nuget-inspector` returns an empty PURL, fall back to creating one using ORT's usual mechanism.