### PR TITLE
Move ClearlyDefined and PURL coordinate mapping code to separate files

### DIFF
--- a/model/src/main/kotlin/utils/ClearlyDefinedUtils.kt
+++ b/model/src/main/kotlin/utils/ClearlyDefinedUtils.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import org.ossreviewtoolkit.clients.clearlydefined.ComponentType
+import org.ossreviewtoolkit.clients.clearlydefined.Coordinates
+import org.ossreviewtoolkit.clients.clearlydefined.Provider
+import org.ossreviewtoolkit.clients.clearlydefined.SourceLocation
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageProvider
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+
+/**
+ * Map an [Identifier's type][Identifier.type] to a ClearlyDefined [ComponentType], or return null if a mapping is not
+ * possible.
+ */
+fun Identifier.toClearlyDefinedType(): ComponentType? =
+    when (type) {
+        "Bower" -> ComponentType.GIT
+        "CocoaPods" -> ComponentType.POD
+        "Composer" -> ComponentType.COMPOSER
+        "Crate" -> ComponentType.CRATE
+        "Gem" -> ComponentType.GEM
+        "Go" -> ComponentType.GO
+        "Maven" -> ComponentType.MAVEN
+        "NPM" -> ComponentType.NPM
+        "NuGet" -> ComponentType.NUGET
+        "Pub" -> ComponentType.GIT
+        "PyPI" -> ComponentType.PYPI
+        else -> null
+    }
+
+/**
+ * Determine the ClearlyDefined [Provider] based on a [Package]'s location as defined by the [RemoteArtifact] URLs or
+ * the [VcsInfo] URL. Return null if a mapping is not possible.
+ */
+fun Package.toClearlyDefinedProvider(): Provider? =
+    sequenceOf(
+        binaryArtifact.url,
+        sourceArtifact.url,
+        vcsProcessed.url
+    ).firstNotNullOfOrNull { url ->
+        PackageProvider.get(url)?.let { provider ->
+            Provider.entries.find { it.name == provider.name }
+        }
+    }
+
+/**
+ * Map an ORT [Package] to ClearlyDefined [Coordinates], or to null if a mapping is not possible.
+ */
+fun Package.toClearlyDefinedCoordinates(): Coordinates? {
+    val type = id.toClearlyDefinedType() ?: return null
+    val provider = toClearlyDefinedProvider() ?: type.defaultProvider ?: return null
+
+    return Coordinates(
+        type = type,
+        provider = provider,
+        namespace = id.namespace.takeUnless { it.isEmpty() },
+        name = id.name,
+        revision = id.version.takeUnless { it.isEmpty() }
+    )
+}
+
+/**
+ * Create a ClearlyDefined [SourceLocation] from a [Package]. Prefer [VcsInfo], but eventually fall back to the
+ * [RemoteArtifact] for the source code, or return null if not enough information is available.
+ */
+fun Package.toClearlyDefinedSourceLocation(): SourceLocation? {
+    val coordinates = toClearlyDefinedCoordinates() ?: return null
+
+    return when {
+        // TODO: Find out how to handle VCS curations without a revision.
+        vcsProcessed != VcsInfo.EMPTY -> {
+            SourceLocation(
+                type = ComponentType.GIT,
+                provider = coordinates.provider,
+                namespace = coordinates.namespace,
+                name = coordinates.name,
+
+                revision = vcsProcessed.revision,
+
+                path = vcsProcessed.path,
+                url = vcsProcessed.url
+            )
+        }
+
+        sourceArtifact != RemoteArtifact.EMPTY -> {
+            SourceLocation(
+                type = ComponentType.SOURCE_ARCHIVE,
+                provider = coordinates.provider,
+                namespace = coordinates.namespace,
+                name = coordinates.name,
+
+                revision = id.version,
+
+                url = sourceArtifact.url
+            )
+        }
+
+        else -> null
+    }
+}

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -17,28 +17,17 @@
  * License-Filename: LICENSE
  */
 
-@file:Suppress("TooManyFunctions")
-
 package org.ossreviewtoolkit.model.utils
 
 import java.net.URI
 
-import org.ossreviewtoolkit.clients.clearlydefined.ComponentType
-import org.ossreviewtoolkit.clients.clearlydefined.Coordinates
-import org.ossreviewtoolkit.clients.clearlydefined.Provider
-import org.ossreviewtoolkit.clients.clearlydefined.SourceLocation
 import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
-import org.ossreviewtoolkit.model.Package
-import org.ossreviewtoolkit.model.PackageProvider
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
-import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.utils.common.percentEncode
 
 fun String.prependPath(prefix: String): String =
     if (prefix.isBlank()) this else "${prefix.removeSuffix("/")}/$this"
@@ -48,97 +37,6 @@ fun TextLocation.prependedPath(prefix: String): String =
 
 fun TextLocation.prependPath(prefix: String): TextLocation =
     if (prefix.isEmpty()) this else copy(path = path.prependPath(prefix))
-
-/**
- * Map an [Identifier's type][Identifier.type] to a ClearlyDefined [ComponentType], or return null if a mapping is not
- * possible.
- */
-fun Identifier.toClearlyDefinedType(): ComponentType? =
-    when (type) {
-        "Bower" -> ComponentType.GIT
-        "CocoaPods" -> ComponentType.POD
-        "Composer" -> ComponentType.COMPOSER
-        "Crate" -> ComponentType.CRATE
-        "Gem" -> ComponentType.GEM
-        "Go" -> ComponentType.GO
-        "Maven" -> ComponentType.MAVEN
-        "NPM" -> ComponentType.NPM
-        "NuGet" -> ComponentType.NUGET
-        "Pub" -> ComponentType.GIT
-        "PyPI" -> ComponentType.PYPI
-        else -> null
-    }
-
-/**
- * Determine the ClearlyDefined [Provider] based on a [Package]'s location as defined by the [RemoteArtifact] URLs or
- * the [VcsInfo] URL. Return null if a mapping is not possible.
- */
-fun Package.toClearlyDefinedProvider(): Provider? =
-    sequenceOf(
-        binaryArtifact.url,
-        sourceArtifact.url,
-        vcsProcessed.url
-    ).firstNotNullOfOrNull { url ->
-        PackageProvider.get(url)?.let { provider ->
-            Provider.entries.find { it.name == provider.name }
-        }
-    }
-
-/**
- * Map an ORT [Package] to ClearlyDefined [Coordinates], or to null if a mapping is not possible.
- */
-fun Package.toClearlyDefinedCoordinates(): Coordinates? {
-    val type = id.toClearlyDefinedType() ?: return null
-    val provider = toClearlyDefinedProvider() ?: type.defaultProvider ?: return null
-
-    return Coordinates(
-        type = type,
-        provider = provider,
-        namespace = id.namespace.takeUnless { it.isEmpty() },
-        name = id.name,
-        revision = id.version.takeUnless { it.isEmpty() }
-    )
-}
-
-/**
- * Create a ClearlyDefined [SourceLocation] from a [Package]. Prefer [VcsInfo], but eventually fall back to the
- * [RemoteArtifact] for the source code, or return null if not enough information is available.
- */
-fun Package.toClearlyDefinedSourceLocation(): SourceLocation? {
-    val coordinates = toClearlyDefinedCoordinates() ?: return null
-
-    return when {
-        // TODO: Find out how to handle VCS curations without a revision.
-        vcsProcessed != VcsInfo.EMPTY -> {
-            SourceLocation(
-                type = ComponentType.GIT,
-                provider = coordinates.provider,
-                namespace = coordinates.namespace,
-                name = coordinates.name,
-
-                revision = vcsProcessed.revision,
-
-                path = vcsProcessed.path,
-                url = vcsProcessed.url
-            )
-        }
-
-        sourceArtifact != RemoteArtifact.EMPTY -> {
-            SourceLocation(
-                type = ComponentType.SOURCE_ARCHIVE,
-                provider = coordinates.provider,
-                namespace = coordinates.namespace,
-                name = coordinates.name,
-
-                revision = id.version,
-
-                url = sourceArtifact.url
-            )
-        }
-
-        else -> null
-    }
-}
 
 /**
  * Return the VCS path if this is a [RepositoryProvenance] or else an empty string.
@@ -162,118 +60,6 @@ fun ProvenanceResolutionResult.getKnownProvenancesWithoutVcsPath(): Map<String, 
             RepositoryProvenance(vcsInfo = vcsInfo, resolvedRevision = vcsInfo.revision)
         }
     }
-
-/**
- * A subset of the Package URL types defined at https://github.com/package-url/purl-spec/blob/ad8a673/PURL-TYPES.rst.
- */
-enum class PurlType(private val value: String) {
-    ALPINE("alpine"),
-    A_NAME("a-name"),
-    BOWER("bower"),
-    CARGO("cargo"),
-    CARTHAGE("carthage"),
-    COCOAPODS("cocoapods"),
-    COMPOSER("composer"),
-    CONAN("conan"),
-    CONDA("conda"),
-    CRAN("cran"),
-    DEBIAN("deb"),
-    DRUPAL("drupal"),
-    GEM("gem"),
-    GENERIC("generic"),
-    GITHUB("github"),
-    GITLAB("gitlab"),
-    GOLANG("golang"),
-    HACKAGE("hackage"),
-    MAVEN("maven"),
-    NPM("npm"),
-    NUGET("nuget"),
-    PUB("pub"),
-    PYPI("pypi"),
-    RPM("rpm"),
-    SWIFT("swift");
-
-    override fun toString() = value
-}
-
-/**
- * Map a [Package]'s type to the string representation of the respective [PurlType], or fall back to [PurlType.GENERIC]
- * if the [Package]'s type has no direct equivalent.
- */
-fun Identifier.getPurlType() =
-    when (type.lowercase()) {
-        "bower" -> PurlType.BOWER
-        "carthage" -> PurlType.CARTHAGE
-        "composer" -> PurlType.COMPOSER
-        "conan" -> PurlType.CONAN
-        "crate" -> PurlType.CARGO
-        "go" -> PurlType.GOLANG
-        "gem" -> PurlType.GEM
-        "hackage" -> PurlType.HACKAGE
-        "maven" -> PurlType.MAVEN
-        "npm" -> PurlType.NPM
-        "nuget" -> PurlType.NUGET
-        "pod" -> PurlType.COCOAPODS
-        "pub" -> PurlType.PUB
-        "pypi" -> PurlType.PYPI
-        "spm" -> PurlType.SWIFT
-        else -> PurlType.GENERIC
-    }.toString()
-
-/**
- * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on the properties of
- * the [Identifier]. Some issues remain with this specification
- * (see e.g. https://github.com/package-url/purl-spec/issues/33).
- *
- * This implementation uses the package type as 'type' purl element as it is used
- * [in the documentation](https://github.com/package-url/purl-spec/blob/master/README.rst#purl).
- * E.g. 'maven' for Gradle projects.
- */
-fun Identifier.toPurl() = if (this == Identifier.EMPTY) "" else createPurl(getPurlType(), namespace, name, version)
-
-/**
- * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on given properties:
- * [type] (which must be a String representation of a [PurlType] instance, [namespace], [name] and [version].
- * Optional [qualifiers] may be given and will be appended to the purl as query parameters e.g.
- * pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
- * Optional [subpath] may be given and will be appended to the purl e.g.
- * pkg:golang/google.golang.org/genproto#googleapis/api/annotations
- *
- */
-fun createPurl(
-    type: String,
-    namespace: String,
-    name: String,
-    version: String,
-    qualifiers: Map<String, String> = emptyMap(),
-    subpath: String = ""
-): String = buildString {
-    append("pkg:")
-    append(type)
-
-    if (namespace.isNotEmpty()) {
-        append('/')
-        append(namespace.percentEncode())
-    }
-
-    append('/')
-    append(name.percentEncode())
-
-    append('@')
-    append(version.percentEncode())
-
-    qualifiers.onEachIndexed { index, entry ->
-        if (index == 0) append("?") else append("&")
-        append(entry.key.percentEncode())
-        append("=")
-        append(entry.value.percentEncode())
-    }
-
-    if (subpath.isNotEmpty()) {
-        val value = subpath.split('/').joinToString("/", prefix = "#") { it.percentEncode() }
-        append(value)
-    }
-}
 
 /**
  * Return a copy of this [RepositoryProvenance] with an empty VCS path.

--- a/model/src/main/kotlin/utils/PurlUtils.kt
+++ b/model/src/main/kotlin/utils/PurlUtils.kt
@@ -102,7 +102,7 @@ fun Identifier.toPurl() = if (this == Identifier.EMPTY) "" else createPurl(getPu
  * pkg:golang/google.golang.org/genproto#googleapis/api/annotations
  *
  */
-fun createPurl(
+internal fun createPurl(
     type: String,
     namespace: String,
     name: String,

--- a/model/src/main/kotlin/utils/PurlUtils.kt
+++ b/model/src/main/kotlin/utils/PurlUtils.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+@file:Suppress("MatchingDeclarationName")
+
+package org.ossreviewtoolkit.model.utils
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.utils.common.percentEncode
+
+/**
+ * A subset of the Package URL types defined at https://github.com/package-url/purl-spec/blob/ad8a673/PURL-TYPES.rst.
+ */
+enum class PurlType(private val value: String) {
+    ALPINE("alpine"),
+    A_NAME("a-name"),
+    BOWER("bower"),
+    CARGO("cargo"),
+    CARTHAGE("carthage"),
+    COCOAPODS("cocoapods"),
+    COMPOSER("composer"),
+    CONAN("conan"),
+    CONDA("conda"),
+    CRAN("cran"),
+    DEBIAN("deb"),
+    DRUPAL("drupal"),
+    GEM("gem"),
+    GENERIC("generic"),
+    GITHUB("github"),
+    GITLAB("gitlab"),
+    GOLANG("golang"),
+    HACKAGE("hackage"),
+    MAVEN("maven"),
+    NPM("npm"),
+    NUGET("nuget"),
+    PUB("pub"),
+    PYPI("pypi"),
+    RPM("rpm"),
+    SWIFT("swift");
+
+    override fun toString() = value
+}
+
+/**
+ * Map a [Package]'s type to the string representation of the respective [PurlType], or fall back to [PurlType.GENERIC]
+ * if the [Package]'s type has no direct equivalent.
+ */
+fun Identifier.getPurlType() =
+    when (type.lowercase()) {
+        "bower" -> PurlType.BOWER
+        "carthage" -> PurlType.CARTHAGE
+        "composer" -> PurlType.COMPOSER
+        "conan" -> PurlType.CONAN
+        "crate" -> PurlType.CARGO
+        "go" -> PurlType.GOLANG
+        "gem" -> PurlType.GEM
+        "hackage" -> PurlType.HACKAGE
+        "maven" -> PurlType.MAVEN
+        "npm" -> PurlType.NPM
+        "nuget" -> PurlType.NUGET
+        "pod" -> PurlType.COCOAPODS
+        "pub" -> PurlType.PUB
+        "pypi" -> PurlType.PYPI
+        "spm" -> PurlType.SWIFT
+        else -> PurlType.GENERIC
+    }.toString()
+
+/**
+ * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on the properties of
+ * the [Identifier]. Some issues remain with this specification
+ * (see e.g. https://github.com/package-url/purl-spec/issues/33).
+ *
+ * This implementation uses the package type as 'type' purl element as it is used
+ * [in the documentation](https://github.com/package-url/purl-spec/blob/master/README.rst#purl).
+ * E.g. 'maven' for Gradle projects.
+ */
+fun Identifier.toPurl() = if (this == Identifier.EMPTY) "" else createPurl(getPurlType(), namespace, name, version)
+
+/**
+ * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on given properties:
+ * [type] (which must be a String representation of a [PurlType] instance, [namespace], [name] and [version].
+ * Optional [qualifiers] may be given and will be appended to the purl as query parameters e.g.
+ * pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
+ * Optional [subpath] may be given and will be appended to the purl e.g.
+ * pkg:golang/google.golang.org/genproto#googleapis/api/annotations
+ *
+ */
+fun createPurl(
+    type: String,
+    namespace: String,
+    name: String,
+    version: String,
+    qualifiers: Map<String, String> = emptyMap(),
+    subpath: String = ""
+): String = buildString {
+    append("pkg:")
+    append(type)
+
+    if (namespace.isNotEmpty()) {
+        append('/')
+        append(namespace.percentEncode())
+    }
+
+    append('/')
+    append(name.percentEncode())
+
+    append('@')
+    append(version.percentEncode())
+
+    qualifiers.onEachIndexed { index, entry ->
+        if (index == 0) append("?") else append("&")
+        append(entry.key.percentEncode())
+        append("=")
+        append(entry.value.percentEncode())
+    }
+
+    if (subpath.isNotEmpty()) {
+        val value = subpath.split('/').joinToString("/", prefix = "#") { it.percentEncode() }
+        append(value)
+    }
+}

--- a/plugins/reporters/asciidoc/src/main/resources/templates/asciidoc/defect_report.ftl
+++ b/plugins/reporters/asciidoc/src/main/resources/templates/asciidoc/defect_report.ftl
@@ -17,7 +17,7 @@
     License-Filename: LICENSE
 --]
 
-[#assign ModelExtensions = statics['org.ossreviewtoolkit.model.utils.ExtensionsKt']]
+[#assign PurlUtils = statics['org.ossreviewtoolkit.model.utils.PurlUtilsKt']]
 
 :title-page:
 :sectnums:
@@ -45,7 +45,7 @@ section.
 [#list advisorResults as id, results]
 === ${id.name}
 
-Package URL: _${ModelExtensions.toPurl(id)}_
+Package URL: _${PurlUtils.toPurl(id)}_
 
 [#list results as result]
 
@@ -94,7 +94,7 @@ information for the single packages.
 [#list advisorResultsWithErrors as id, results]
 === ${id.name}
 
-${ModelExtensions.toPurl(id)}
+${PurlUtils.toPurl(id)}
 
 [#list results as result]
 

--- a/plugins/reporters/asciidoc/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/plugins/reporters/asciidoc/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -27,7 +27,7 @@
     Excluded projects and packages are ignored.
 --]
 
-[#assign ModelExtensions = statics['org.ossreviewtoolkit.model.utils.ExtensionsKt']]
+[#assign PurlUtils = statics['org.ossreviewtoolkit.model.utils.PurlUtilsKt']]
 
 [#-- Add the licenses of the projects. --]
 :title-page:
@@ -88,12 +88,12 @@ The applicable license information is listed below:
 [#if !package.excluded]
 *Dependency*
 
-Package URL: _${ModelExtensions.toPurl(package.id)}_
+Package URL: _${PurlUtils.toPurl(package.id)}_
 
 [#-- List the content of archived license files and associated copyrights. --]
 [#list package.licenseFiles.files as licenseFile]
 
-License File: <<${ModelExtensions.toPurl(package.id)} ${licenseFile.path}, ${licenseFile.path}>>
+License File: <<${PurlUtils.toPurl(package.id)} ${licenseFile.path}, ${licenseFile.path}>>
 
 [#assign copyrights = licenseFile.getCopyrights()]
 [#list copyrights as copyright]
@@ -174,7 +174,7 @@ ${exceptionText}
 [#if !package.excluded]
 
 [#list package.licenseFiles.files as licenseFile]
-=== ${ModelExtensions.toPurl(package.id)} ${licenseFile.path}
+=== ${PurlUtils.toPurl(package.id)} ${licenseFile.path}
 
 ++++
 [#assign copyrights = licenseFile.getCopyrights()]

--- a/plugins/reporters/asciidoc/src/main/resources/templates/asciidoc/vulnerability_report.ftl
+++ b/plugins/reporters/asciidoc/src/main/resources/templates/asciidoc/vulnerability_report.ftl
@@ -17,7 +17,7 @@
     License-Filename: LICENSE
 --]
 
-[#assign ModelExtensions = statics['org.ossreviewtoolkit.model.utils.ExtensionsKt']]
+[#assign PurlUtils = statics['org.ossreviewtoolkit.model.utils.PurlUtilsKt']]
 
 :publisher: OSS Review Toolkit
 [#assign now = .now]
@@ -46,7 +46,7 @@ lack relevant vulnerabilities. Further details about the issues that occurred ca
 == Packages
 [#assign advisorResults = helper.advisorResultsWithVulnerabilities()]
 [#list advisorResults as id, results]
-=== ${ModelExtensions.toPurl(id)}
+=== ${PurlUtils.toPurl(id)}
 
 [#list results as result]
 
@@ -85,7 +85,7 @@ occurred when requesting vulnerability information for the single packages.
 [#list advisorResultsWithErrors as id, results]
 === ${id.name}
 
-${ModelExtensions.toPurl(id)}
+${PurlUtils.toPurl(id)}
 
 [#list results as result]
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 

> **Note**
> This is a breaking API change as FreeMarker templates may need to be adjusted as indicate din this PR if the `toPurl()` extension function is used.