### PR TITLE
docs(test): Use `patch` instead of `git apply` to update expected results

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,10 +783,10 @@ any failing tests will show the deviation from the expected result in a unified 
 `git apply`. If the actual result should be taken as the new expected result, simply copy the diff from the console to
 the clipboard and run
 
-* `wl-paste | cut -d ' ' -f 5- | git apply` (Linux with Wayland)
-* `xsel -b | cut -d ' ' -f 5- | git apply` (Linux with X)
-* `cat /dev/clipboard | dos2unix | cut -d ' ' -f 5- | git apply` (Windows with Git Bash)
-* `pbpaste | cut -d ' ' -f 5- | git apply` (macOS)
+* `wl-paste | patch -p1` (Linux with Wayland)
+* `xsel -b | patch -p1` (Linux with X)
+* `cat /dev/clipboard | patch -p1` (Windows with Git Bash)
+* `pbpaste | patch -p1` (macOS)
 
 to apply the diff to the local Git working tree (this does not create a commit yet). After reviewing the changes, create
 a commit to accept the new expected result.

--- a/utils/test/src/main/kotlin/Matchers.kt
+++ b/utils/test/src/main/kotlin/Matchers.kt
@@ -88,10 +88,10 @@ fun matchExpectedResult(
                     Expected and actual results differ. To use the actual results as the new expected results, first
                     copy one of the following commands to the clipboard and paste it to a terminal without running it
                     yet:
-                    - `wl-paste | cut -d ' ' -f 5- | git apply` (Linux with Wayland)
-                    - `xsel -b | cut -d ' ' -f 5- | git apply` (Linux with X)
-                    - `cat /dev/clipboard | dos2unix | cut -d ' ' -f 5- | git apply` (Windows with Git Bash)
-                    - `pbpaste | cut -d ' ' -f 5- | git apply` (macOS)
+                    - `wl-paste | patch -p1` (Linux with Wayland)
+                    - `xsel -b | patch -p1` (Linux with X)
+                    - `cat /dev/clipboard | patch -p1` (Windows with Git Bash)
+                    - `pbpaste | patch -p1` (macOS)
                     Then copy the following lines to the clipboard and run the previously pasted commands.
                 """.trimIndent() + diff.joinToString("\n", "\n")
             },


### PR DESCRIPTION
The `patch`command is more powerful as it can apply patch "fuzzily" (see e.g. [1]). This enables applying patches whose diff context contains `<REPLACE_*` placeholders in the old expected result, but not in the actual / new expected result.

[1]: https://stackoverflow.com/q/6336440/1127485