### PR TITLE
Map 'GPL-2.0-only WITH Universal-FOSS-exception-1.0' 

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -444,6 +444,7 @@
 "The GNU General Public License (GPL), Version 2, With Classpath Exception": GPL-2.0-only WITH Classpath-exception-2.0
 "The GNU General Public License, Version 2": GPL-2.0-only
 "The GNU General Public License, v2 with FOSS exception": GPL-2.0-only WITH Universal-FOSS-exception-1.0
+"The GNU General Public License, v2 with Universal FOSS Exception, v1.0": GPL-2.0-only WITH Universal-FOSS-exception-1.0
 "The GNU Lesser General Public License, Version 2.1": LGPL-2.1-only
 "The GNU Lesser General Public License, Version 3.0": LGPL-3.0-only
 "The Go license": BSD-3-Clause


### PR DESCRIPTION
Found in [1].

[1]: https://repo.maven.apache.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.pom
