### PR TITLE
refactor(scanner)!: Always parse ScanCode license expressions

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -211,8 +211,6 @@ ort:
         # Command line options that do not affect the ScanCode output.
         commandLineNonConfig: '--processes 4'
 
-        parseLicenseExpressions: true
-
         # Criteria for matching stored scan results. These can be configured for any scanner that uses semantic
         # versioning. Note that the 'maxVersion' is exclusive and not part of the range of accepted versions.
         minVersion: '3.2.1-rc2'

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -229,7 +229,6 @@ class OrtConfigurationTest : WordSpec({
                         this shouldContainExactly mapOf(
                             "commandLine" to "--copyright --license --info --strip-root --timeout 300",
                             "commandLineNonConfig" to "--processes 4",
-                            "parseLicenseExpressions" to "true",
                             "minVersion" to "3.2.1-rc2",
                             "maxVersion" to "32.0.0"
                         )

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -37,7 +37,6 @@ import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
-import org.ossreviewtoolkit.utils.common.isTrue
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.withoutPrefix
@@ -56,9 +55,6 @@ import org.semver4j.RangesListFactory
  *   looking up results from the [ScanResultsStorage]. Defaults to [DEFAULT_CONFIGURATION_OPTIONS].
  * * **"commandLineNonConfig":** Command line options that do not modify the result and should therefore not be
  *   considered in [configuration], like "--processes". Defaults to [DEFAULT_NON_CONFIGURATION_OPTIONS].
- * * **"parseLicenseExpressions":** By default the license `key`, which can contain a single license id, is used for the
- *   detected licenses. If this option is set to "true", the detected `license_expression` is used instead, which can
- *   contain an SPDX expression.
  */
 class ScanCode internal constructor(
     name: String,
@@ -166,8 +162,7 @@ class ScanCode internal constructor(
     }
 
     override fun createSummary(result: String, startTime: Instant, endTime: Instant): ScanSummary {
-        val parseLicenseExpressions = scanCodeConfiguration["parseLicenseExpressions"].isTrue()
-        val summary = parseResult(result).toScanSummary(parseLicenseExpressions)
+        val summary = parseResult(result).toScanSummary()
 
         val issues = summary.issues.toMutableList()
 

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultParser.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultParser.kt
@@ -99,7 +99,7 @@ private fun LicenseEntry.getSpdxId(): String {
     return "$LICENSE_REF_PREFIX_SCAN_CODE${key.toSpdxId(allowPlusSuffix = true)}"
 }
 
-fun ScanCodeResult.toScanSummary(parseExpressions: Boolean = true): ScanSummary {
+fun ScanCodeResult.toScanSummary(): ScanSummary {
     val licenseFindings = mutableSetOf<LicenseFinding>()
     val copyrightFindings = mutableSetOf<CopyrightFinding>()
     val issues = mutableListOf<Issue>()
@@ -129,9 +129,8 @@ fun ScanCodeResult.toScanSummary(parseExpressions: Boolean = true): ScanSummary 
 
     filesOfTypeFile.forEach { file ->
         // ScanCode creates separate license entries for each license in an expression. Deduplicate these by grouping by
-        // the same expression if expression parsing is enabled.
-        val licenses = file.licenses.takeUnless { parseExpressions }
-            ?: file.licenses.groupBy {
+        // the same expression.
+        val licenses = file.licenses.groupBy {
                 LicenseMatch(it.matchedRule.licenseExpression, it.startLine, it.endLine, it.score)
             }.map {
                 // Arbitrarily take the first of the duplicate license entries.
@@ -140,10 +139,7 @@ fun ScanCodeResult.toScanSummary(parseExpressions: Boolean = true): ScanSummary 
 
         licenses.mapTo(licenseFindings) { license ->
             // ScanCode uses its own license keys as identifiers in license expressions.
-            val scanCodeLicenseExpression = license.key.takeUnless { parseExpressions }
-                ?: license.matchedRule.licenseExpression
-
-            val spdxLicenseExpression = scanCodeLicenseExpression.mapLicense(scanCodeKeyToSpdxIdMappings)
+            val spdxLicenseExpression = license.matchedRule.licenseExpression.mapLicense(scanCodeKeyToSpdxIdMappings)
 
             LicenseFinding(
                 license = spdxLicenseExpression,


### PR DESCRIPTION
Remove the feature to toggle parsing of ScanCode license expressions. Starting with ScanCode output format version 3, license expressions are first class citizens in ScanCode results, making this feature cumbersome to maintain.

Note that the web-app report still would not show license expressions anyway (see issue #5017).

> **Note**
> This is a breaking change for the configuration as the `parseLicenseExpressions` option for ScanCode is being removed. Users that rely on `parseLicenseExpressions = false` for historic reasons might need to update license curations to properly use expressions.