### PR TITLE
Fix SPDX expression validation in the CtrlX Automation reporter, again

### DIFF
--- a/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationModel.kt
+++ b/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationModel.kt
@@ -22,7 +22,8 @@ package org.ossreviewtoolkit.plugins.reporters.ctrlx
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression.Strictness
+import org.ossreviewtoolkit.utils.spdx.isSpdxExpression
 
 /**
  * The root element of "fossinfo.json" files, see https://github.com/boschrexroth/json-schema.
@@ -165,7 +166,7 @@ data class License(
             "The '$name' value of the 'name' field must not contain any leading or trailing whitespaces."
         }
 
-        require(spdx == null || SpdxExpression.parse(spdx).isValid()) {
+        require(spdx == null || spdx.isSpdxExpression(Strictness.ALLOW_LICENSEREF_EXCEPTIONS)) {
             "The '$spdx' value of the 'spdx' field must be a valid SPDX identifier."
         }
 

--- a/plugins/reporters/ctrlx/src/test/kotlin/CtrlXAutomationModelTest.kt
+++ b/plugins/reporters/ctrlx/src/test/kotlin/CtrlXAutomationModelTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.reporters.ctrlx
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.StringSpec
+
+class CtrlXAutomationModelTest : StringSpec({
+    "The license model should accept SPDX expressions with custom exceptions" {
+        shouldNotThrow<IllegalArgumentException> {
+            License(
+                name = "License",
+                spdx = "LGPL-3.0-or-later WITH LicenseRef-scancode-openssl-exception-lgpl-3.0-plus",
+                text = ""
+            )
+        }
+
+        shouldNotThrow<IllegalArgumentException> {
+            License(
+                name = "License",
+                spdx = "GPL-2.0-or-later WITH LicenseRef-scancode-autoconf-simple-exception-2.0",
+                text = ""
+            )
+        }
+    }
+})

--- a/utils/spdx/src/main/kotlin/Extensions.kt
+++ b/utils/spdx/src/main/kotlin/Extensions.kt
@@ -81,8 +81,8 @@ fun String.isSpdxExpressionOrNotPresent(): Boolean =
     SpdxConstants.isNotPresent(this) || isSpdxExpression()
 
 /**
- * Parses the string as an [SpdxExpression] and returns the result.
- * @throws SpdxException if the string is not a valid representation of an SPDX expression.
+ * Parses the string as an [SpdxExpression] of the given [strictness] and returns the result on success, or throws an
+ * [SpdxException] if the string cannot be parsed.
  */
 fun String.toSpdx(strictness: Strictness = Strictness.ALLOW_ANY): SpdxExpression =
     SpdxExpression.parse(this, strictness)

--- a/utils/spdx/src/main/kotlin/Extensions.kt
+++ b/utils/spdx/src/main/kotlin/Extensions.kt
@@ -68,10 +68,10 @@ fun SpdxLicense.toExpression(): SpdxLicenseIdExpression {
 }
 
 /**
- * Return true if and only if this String can be successfully parsed to a [SpdxExpression].
+ * Return true if and only if this string can be successfully parsed to a [SpdxExpression] of the given [strictness].
  */
-fun String.isSpdxExpression(): Boolean =
-    runCatching { SpdxExpression.parse(this, Strictness.ALLOW_DEPRECATED) }.isSuccess
+fun String.isSpdxExpression(strictness: Strictness = Strictness.ALLOW_DEPRECATED): Boolean =
+    runCatching { SpdxExpression.parse(this, strictness) }.isSuccess
 
 /**
  * Return true if and only if this String can be successfully parsed to an [SpdxExpression] or if it equals


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 