### PR TITLE
fix(FossId): Allow directories with dots to be added as ignore rules

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/Utils.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/Utils.kt
@@ -31,7 +31,7 @@ private val EXTENSION_REGEX = "\\*\\.(?<extension>\\w+)".toRegex()
 private val FILE_REGEX = "(?<file>[^/]+)".toRegex()
 
 /**
- * Convert the ORT [path excludes][Excludes.paths] in [excludes] to FossID [IgnoreRule]s.. If an error is encountered
+ * Convert the ORT [path excludes][Excludes.paths] in [excludes] to FossID [IgnoreRule]s. If an error is encountered
  * during the mapping, an issue is added to [issues].
  */
 internal fun convertRules(excludes: Excludes, issues: MutableList<Issue>): List<IgnoreRule> {

--- a/plugins/scanners/fossid/src/test/kotlin/MapIgnoreRulesTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/MapIgnoreRulesTest.kt
@@ -65,6 +65,34 @@ class MapIgnoreRulesTest : WordSpec({
             issues should beEmpty()
         }
 
+        "map rule with directory containing a dot" {
+            val exclude = Excludes(listOf(PathExclude(".git/", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe ".git"
+                type shouldBe RuleType.DIRECTORY
+            }
+        }
+
+        "map rule with directory containing subdirectories with a dot" {
+            val exclude = Excludes(listOf(PathExclude("src/example.test/templates/", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "src/example.test/templates"
+                type shouldBe RuleType.DIRECTORY
+            }
+
+            issues should beEmpty()
+        }
+
         "map rule with directory" {
             val exclude = Excludes(listOf(PathExclude("directory/", PathExcludeReason.OTHER)))
             val issues = mutableListOf<Issue>()


### PR DESCRIPTION
Fix the FossID ignore rule creation for directories using a dot in the
name. While the regex is far from perfect [1], this fixes the very common
use case of ignoring `.git/` and `.idea/` directories.

[1]: For instance, `**/example/` is not added as directory ignore rule.
