### PR TITLE
feat(spdx): Allow LicenseRef exceptions for licenseInfoInFiles 

### DIFF
--- a/utils/spdx/src/main/kotlin/Extensions.kt
+++ b/utils/spdx/src/main/kotlin/Extensions.kt
@@ -74,11 +74,11 @@ fun String.isSpdxExpression(strictness: Strictness = Strictness.ALLOW_DEPRECATED
     runCatching { SpdxExpression.parse(this, strictness) }.isSuccess
 
 /**
- * Return true if and only if this String can be successfully parsed to an [SpdxExpression] or if it equals
- * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION].
+ * Return true if and only if this String can be successfully parsed to an [SpdxExpression] with the given [strictness]
+ * or if it equals [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION].
  */
-fun String.isSpdxExpressionOrNotPresent(): Boolean =
-    SpdxConstants.isNotPresent(this) || isSpdxExpression()
+fun String.isSpdxExpressionOrNotPresent(strictness: Strictness = Strictness.ALLOW_DEPRECATED): Boolean =
+    SpdxConstants.isNotPresent(this) || isSpdxExpression(strictness)
 
 /**
  * Parses the string as an [SpdxExpression] of the given [strictness] and returns the result on success, or throws an

--- a/utils/spdx/src/main/kotlin/model/SpdxFile.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxFile.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants.REF_PREFIX
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.isSpdxExpressionOrNotPresent
 
 /**
@@ -187,7 +188,9 @@ data class SpdxFile(
 
         // TODO: The check for [licenseInfoInFiles] can be made more strict, but the SPDX specification is not exact
         //       enough yet to do this safely.
-        licenseInfoInFiles.filterNot { it.isSpdxExpressionOrNotPresent() }.let {
+        licenseInfoInFiles.filterNot {
+            it.isSpdxExpressionOrNotPresent(SpdxExpression.Strictness.ALLOW_LICENSEREF_EXCEPTIONS)
+        }.let {
             require(it.isEmpty()) {
                 "The entries in licenseInfoInFiles must each be either an SpdxExpression, 'NONE' or 'NOASSERTION', " +
                     "but found ${it.joinToString()}."


### PR DESCRIPTION
While the [SPDX specification](https://spdx.github.io/spdx-spec/v2-draft/file-information/#861-description) doesn't explicitly allow exceptions for `licenseInfoInFiles` it also doesn't disallow them.
IMO ORT should allow SPDX expressions in it's created SpdxDocument.
Or am I misinterpreting the SPDX specifications @oss-review-toolkit/core-devs?

This fixes an issue in a project where scancode detected `GPL-2.0-or-later WITH LicenseRef-scancode-autoconf-simple-exception-2.0`, causing the `SpdxDocument` reporter break:
https://github.com/java-native-access/jna/blob/c32053e3137d7af5764ed4148e866d28eb8fd398/native/libffi/.ci/ar-lib#L10-L30