### PR TITLE
refactor(model)!: Make curations a list in `ResolvedPackageCurations`

### DIFF
--- a/cli/src/funTest/assets/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/cli/src/funTest/assets/gradle-all-dependencies-expected-result-with-curations.yml
@@ -463,11 +463,11 @@ resolved_configuration:
   - provider:
       id: "File"
     curations:
-    - id: "Maven:org.hamcrest:hamcrest-core:"
-      curations:
-        comment: "Fix description."
-        description: "Curated description."
     - id: "Maven:org.hamcrest::"
       curations:
         comment: "Use the actual homepage instead of the GitHub page."
         homepage_url: "http://hamcrest.org/JavaHamcrest/"
+    - id: "Maven:org.hamcrest:hamcrest-core:"
+      curations:
+        comment: "Fix description."
+        description: "Curated description."

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -539,7 +539,7 @@ data class OrtResult(
                     if (it.provider.id != REPOSITORY_CONFIGURATION_PROVIDER_ID) {
                         it
                     } else {
-                        it.copy(curations = config.curations.packages.toSet())
+                        it.copy(curations = config.curations.packages)
                     }
                 }
             )

--- a/model/src/main/kotlin/ResolvedConfiguration.kt
+++ b/model/src/main/kotlin/ResolvedConfiguration.kt
@@ -81,7 +81,7 @@ data class ResolvedPackageCurations(
      * All package curations applicable to the packages contained in the enclosing [OrtResult] in the order as they
      * were provided by the package curation provider.
      */
-    val curations: Set<PackageCuration> = emptySet()
+    val curations: List<PackageCuration> = emptyList()
 ) {
     data class Provider(
         /**

--- a/model/src/main/kotlin/utils/ConfigurationResolver.kt
+++ b/model/src/main/kotlin/utils/ConfigurationResolver.kt
@@ -59,7 +59,7 @@ object ConfigurationResolver : Logging {
         packages: Collection<Package>,
         curationProviders: List<Pair<String, PackageCurationProvider>>
     ): List<ResolvedPackageCurations> {
-        val packageCurations = mutableMapOf<String, Set<PackageCuration>>()
+        val packageCurations = mutableMapOf<String, List<PackageCuration>>()
 
         curationProviders.forEach { (id, curationProvider) ->
             val (curations, duration) = measureTimedValue {
@@ -68,7 +68,7 @@ object ConfigurationResolver : Logging {
 
             val (applicableCurations, nonApplicableCurations) = curations.partition { curation ->
                 packages.any { pkg -> curation.isApplicable(pkg.id) }
-            }.let { it.first.toSet() to it.second.toSet() }
+            }.let { it.first to it.second }
 
             if (nonApplicableCurations.isNotEmpty()) {
                 logger.warn {


### PR DESCRIPTION
The `curations` property is supposed to contain the curations in the order they were provided by the package curation provider, therefore change the type from set to list to preserve the order.