### PR TITLE
fix(fossid-webapp): Group snippets by source file matching lines 

### DIFF
--- a/model/src/main/kotlin/SnippetFinding.kt
+++ b/model/src/main/kotlin/SnippetFinding.kt
@@ -20,8 +20,8 @@
 package org.ossreviewtoolkit.model
 
 /**
- * A class representing a snippet finding for a source file. A snippet finding is a code snippet from another origin,
- * matching the code being scanned.
+ * A class representing the snippet findings for a source file location. A snippet finding is a code snippet from
+ * another origin, matching the code being scanned.
  * It is meant to be reviewed by an operator as it could be a false positive.
  */
 data class SnippetFinding(
@@ -31,7 +31,7 @@ data class SnippetFinding(
     val sourceLocation: TextLocation,
 
     /**
-     * The corresponding snippet.
+     * The corresponding snippets.
      */
-    val snippet: Snippet
+    val snippets: Set<Snippet>
 )

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -90,7 +90,7 @@ class ScopeSortedSetConverter : StdConverter<Set<Scope>, SortedSet<Scope>>() {
 
 class SnippetFindingSortedSetConverter : StdConverter<Set<SnippetFinding>, SortedSet<SnippetFinding>>() {
     override fun convert(value: Set<SnippetFinding>) =
-        value.toSortedSet(compareBy<SnippetFinding> { it.sourceLocation.path }.thenByDescending { it.snippet.purl })
+        value.toSortedSet(compareBy<SnippetFinding> { it.sourceLocation }.thenByDescending { it.snippet.purl })
 }
 
 private fun Provenance.getSortKey(): String =

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -89,8 +89,7 @@ class ScopeSortedSetConverter : StdConverter<Set<Scope>, SortedSet<Scope>>() {
 }
 
 class SnippetFindingSortedSetConverter : StdConverter<Set<SnippetFinding>, SortedSet<SnippetFinding>>() {
-    override fun convert(value: Set<SnippetFinding>) =
-        value.toSortedSet(compareBy<SnippetFinding> { it.sourceLocation }.thenByDescending { it.snippet.purl })
+    override fun convert(value: Set<SnippetFinding>) = value.toSortedSet(compareBy { it.sourceLocation })
 }
 
 private fun Provenance.getSortKey(): String =

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.SnippetFinding
+import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.RuleViolationResolution
@@ -319,11 +320,27 @@ class FreemarkerTemplateProcessor(
             snippetFindings.groupBy { it.sourceLocation.path }
 
         /**
+         * Return a list of [SnippetFinding]s grouped by the source file location ( line ranges) being matched by those
+         * snippets.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun groupSnippetsBySourceLines(snippetFindings: Collection<SnippetFinding>): Map<TextLocation, SnippetFinding> =
+            snippetFindings.associateBy { it.sourceLocation }
+
+        /**
+         * Return a flag if the given [sourceLocation] refers to the full source file.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun isFullFileLocation(sourceLocation: TextLocation) =
+            sourceLocation.startLine == TextLocation.UNKNOWN_LINE && sourceLocation.endLine == TextLocation.UNKNOWN_LINE
+
+        /**
          * Collect all the licenses present in a collection of [SnippetFinding]s.
          */
         @Suppress("UNUSED") // This function is used in the templates.
-        fun collectLicenses(snippetFindings: Collection<SnippetFinding>): Set<String> =
-            snippetFindings.flatMapTo(mutableSetOf()) { it.snippets.map { snippet -> snippet.licenses.toString() } }
+        fun collectLicenses(snippetsFindings: Collection<SnippetFinding>): Set<String> =
+            snippetsFindings.flatMap { findings -> findings.snippets }.map { snippet -> snippet.licenses.toString() }
+                .toSet()
 
         /**
          * Return a flag indicating that issues have been encountered during the run of an advisor with the given

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -323,7 +323,7 @@ class FreemarkerTemplateProcessor(
          */
         @Suppress("UNUSED") // This function is used in the templates.
         fun collectLicenses(snippetFindings: Collection<SnippetFinding>): Set<String> =
-            snippetFindings.mapTo(mutableSetOf()) { it.snippet.licenses.toString() }
+            snippetFindings.flatMapTo(mutableSetOf()) { it.snippets.map { snippet -> snippet.licenses.toString() } }
 
         /**
          * Return a flag indicating that issues have been encountered during the run of an advisor with the given

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -185,7 +185,7 @@ internal fun mapSnippetFindings(rawResults: RawResults, issues: MutableList<Issu
             }
         }
 
-        findings.flatMap { finding -> finding.value.map { SnippetFinding(finding.key, it) } }
+        findings.map { SnippetFinding(it.key, it.value) }
     }.toSet()
 }
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
@@ -67,7 +67,9 @@ class FossIdLicenseMappingTest : WordSpec({
             issues should beEmpty()
             findings should haveSize(1)
             findings.first() shouldNotBeNull {
-                snippet.licenses.toString() shouldBe "Apache-2.0"
+                snippets.first() shouldNotBeNull {
+                    licenses.toString() shouldBe "Apache-2.0"
+                }
             }
         }
 
@@ -80,7 +82,9 @@ class FossIdLicenseMappingTest : WordSpec({
             issues should beEmpty()
             findings should haveSize(1)
             findings.first() shouldNotBeNull {
-                snippet.licenses.toString() shouldBe "Apache-2.0"
+                snippets.first() shouldNotBeNull {
+                    licenses.toString() shouldBe "Apache-2.0"
+                }
             }
         }
 
@@ -98,7 +102,9 @@ class FossIdLicenseMappingTest : WordSpec({
             }
             findings should haveSize(1)
             findings.first() shouldNotBeNull {
-                snippet.licenses shouldBe SpdxConstants.NOASSERTION.toSpdx()
+                snippets.first() shouldNotBeNull {
+                    licenses shouldBe SpdxConstants.NOASSERTION.toSpdx()
+                }
             }
         }
     }

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.scanners.fossid
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.clients.fossid.PolymorphicList
+import org.ossreviewtoolkit.clients.fossid.model.result.MatchType
+import org.ossreviewtoolkit.clients.fossid.model.result.MatchedLines
+import org.ossreviewtoolkit.clients.fossid.model.result.Snippet
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+class FossIdSnippetMappingTest : WordSpec({
+    "mapSnippetFindings" should {
+        "group snippets by source file location" {
+            val issues = mutableListOf<Issue>()
+            val listSnippets = mapOf(
+                "src/main/java/Tokenizer.java" to setOf(
+                    createSnippet(
+                        1,
+                        MatchType.FULL,
+                        "pkg:github/vdurmont/semver4j@3.1.0",
+                        "MIT",
+                        "src/main/java/com/vdurmont/semver4j/Tokenizer.java"
+                    ),
+                    createSnippet(
+                        2,
+                        MatchType.FULL,
+                        "pkg:maven/com.vdurmont/semver4j@3.1.0",
+                        "MIT",
+                        "com/vdurmont/semver4j/Tokenizer.java"
+                    )
+                ),
+                "src/main/java/com/vdurmont/semver4j/Requirement.java" to setOf(
+                    createSnippet(
+                        3,
+                        MatchType.PARTIAL,
+                        "pkg:github/vdurmont/semver4j@3.1.0",
+                        "MIT",
+                        "com/vdurmont/semver4j/Requirement.java"
+                    )
+                )
+            )
+            val localFile = ((1..24) + (45..675)).toPolymorphicList()
+            val remoteFile = (1..655).toPolymorphicList()
+            // There is no matched line information for full match snippets.
+            val snippetMatchedLines = mapOf(3 to MatchedLines(localFile, remoteFile))
+            val rawResults = RawResults(
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                listSnippets,
+                snippetMatchedLines
+            )
+
+            val mappedSnippets = mapSnippetFindings(rawResults, issues)
+
+            issues should beEmpty()
+            mappedSnippets shouldHaveSize 3
+            mappedSnippets.first().apply {
+                sourceLocation shouldBe TextLocation("src/main/java/Tokenizer.java", TextLocation.UNKNOWN_LINE)
+                snippets shouldHaveSize 2
+                snippets.map { it.purl } should containExactly(
+                    "pkg:github/vdurmont/semver4j@3.1.0",
+                    "pkg:maven/com.vdurmont/semver4j@3.1.0"
+                )
+            }
+            mappedSnippets.elementAtOrNull(1) shouldNotBeNull {
+                sourceLocation shouldBe TextLocation("src/main/java/com/vdurmont/semver4j/Requirement.java", 1, 24)
+                snippets.map { it.purl } should containExactly("pkg:github/vdurmont/semver4j@3.1.0")
+            }
+            mappedSnippets.elementAtOrNull(2) shouldNotBeNull {
+                sourceLocation shouldBe TextLocation("src/main/java/com/vdurmont/semver4j/Requirement.java", 45, 675)
+                snippets.map { it.purl } should containExactly("pkg:github/vdurmont/semver4j@3.1.0")
+            }
+        }
+    }
+})
+
+private fun createSnippet(id: Int, matchType: MatchType, purl: String, license: String, file: String) =
+    Snippet(
+        id = id,
+        created = "",
+        scanId = 1,
+        scanFileId = 1,
+        fileId = 1,
+        matchType = matchType,
+        reason = null,
+        author = null,
+        artifact = null,
+        version = null,
+        purl = purl,
+        artifactLicense = license,
+        artifactLicenseCategory = null,
+        releaseDate = null,
+        mirror = null,
+        file = file,
+        fileLicense = null,
+        url = "",
+        hits = null,
+        size = null,
+        updated = null,
+        cpe = null,
+        score = "1.0",
+        matchFileId = null,
+        classification = null,
+        highlighting = null
+    )
+
+private fun IntRange.toPolymorphicList() = toList().toPolymorphicList()
+private fun List<Int>.toPolymorphicList() = PolymorphicList(this)

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -59,7 +59,8 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, result: FullS
                 val snippets = getSnippets(scanResponse)
 
                 snippets.forEach {
-                    snippetFindings += SnippetFinding(sourceLocation, it)
+                    // TODO: Aggregate the snippet by source file location.
+                    snippetFindings += SnippetFinding(sourceLocation, setOf(it))
                 }
             }
         }

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -115,19 +115,21 @@ class ScanOssResultParserTest : WordSpec({
             summary.snippetFindings.shouldContainExactly(
                 SnippetFinding(
                     TextLocation("src/main/java/com/vdurmont/semver4j/Requirement.java", 1, 710),
-                    Snippet(
-                        98.0f,
-                        TextLocation(
-                            "https://osskb.org/api/file_contents/6ff2427335b985212c9b79dfa795799f",
-                            1,
-                            710
-                        ),
-                        RepositoryProvenance(
-                            VcsInfo(VcsType.UNKNOWN, "https://github.com/vdurmont/semver4j", ""),
-                            "."
-                        ),
-                        "pkg:github/vdurmont/semver4j",
-                        SpdxExpression.parse("CC-BY-SA-2.0")
+                    setOf(
+                        Snippet(
+                            98.0f,
+                            TextLocation(
+                                "https://osskb.org/api/file_contents/6ff2427335b985212c9b79dfa795799f",
+                                1,
+                                710
+                            ),
+                            RepositoryProvenance(
+                                VcsInfo(VcsType.UNKNOWN, "https://github.com/vdurmont/semver4j", ""),
+                                "."
+                            ),
+                            "pkg:github/vdurmont/semver4j",
+                            SpdxExpression.parse("CC-BY-SA-2.0")
+                        )
                     )
                 )
             )

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -111,18 +111,20 @@ class ScanOssScannerDirectoryTest : StringSpec({
             snippetFindings.shouldContainExactly(
                 SnippetFinding(
                     TextLocation("utils/src/main/kotlin/ArchiveUtils.kt", 1, 240),
-                    Snippet(
-                        99.0f,
-                        TextLocation(
-                            "https://osskb.org/api/file_contents/871fb0c5188c2f620d9b997e225b0095",
-                            128,
-                            367
-                        ),
-                        RepositoryProvenance(
-                            VcsInfo(VcsType.UNKNOWN, "https://github.com/scanoss/ort", ""), "."
-                        ),
-                        "pkg:github/scanoss/ort",
-                        SpdxExpression.parse("Apache-2.0")
+                    setOf(
+                        Snippet(
+                            99.0f,
+                            TextLocation(
+                                "https://osskb.org/api/file_contents/871fb0c5188c2f620d9b997e225b0095",
+                                128,
+                                367
+                            ),
+                            RepositoryProvenance(
+                                VcsInfo(VcsType.UNKNOWN, "https://github.com/scanoss/ort", ""), "."
+                            ),
+                            "pkg:github/scanoss/ort",
+                            SpdxExpression.parse("Apache-2.0")
+                        )
                     )
                 )
             )


### PR DESCRIPTION
Following the [17.07 Kotlin Developer meeting](https://github.com/oss-review-toolkit/ort/wiki/Kotlin-Developer-Meeting#2023-07-17), it was agreed that, _before the Snippet Choice feature is implemented in ORT_, the snippet model has to be changed to group the snippets by the source file location including the line ranges.

Please have a look at the individual commit messages for the details.