### PR TITLE
Add an AWS S3 scan result storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,35 @@ ort:
     storageWriters: ["artifactoryStorage"]
 ```
 
+### AWS S3 Storage
+
+An [AWS S3 Bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) can be used to store scan
+results. You must provide a previously created Bucket, an optional AWS region (if not present, the
+[default](https://docs.aws.amazon.com/sdk-for-kotlin/latest/developer-guide/region-selection.html) will be used),
+credentials (if not provided, system
+[default](https://docs.aws.amazon.com/sdk-for-kotlin/latest/developer-guide/credential-providers.html) values will be
+used), and an optional [custom endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) to
+support local endpoints, VPC endpoints, and third-party local AWS development environments. Also, you can optionally
+set the data to be compressed before stored.
+
+```yaml
+ort:
+  scanner:
+    storages:
+      awsS3Storage:
+        backend:
+          s3FileStorage:
+            accessKeyId: "aws-access-key (optional)"
+            awsRegion: "us-east-1 (optional)"
+            bucketName: "ort-scan-results"
+            compression: true (optional),
+            customEndpoint: "https://192.145.16.241/aws (optional)",
+            secretAccessKey: "aws-access-key-secret (optional)"
+
+    storageReaders: ["awsS3Storage"]
+    storageWriters: ["awsS3Storage"]
+```
+
 ### PostgreSQL Storage
 
 To use PostgreSQL for storing scan results you need at least version 9.4, create a database with the `client_encoding`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ postgresEmbedded = "1.0.2"
 reflections = "0.10.2"
 retrofit = "2.9.0"
 retrofitConverterKotlinxSerialization = "1.0.0"
+s3 = "2.20.162"
 saxonHe = "12.3"
 scanoss = "1.1.6"
 semver4j = "5.2.2"
@@ -74,6 +75,7 @@ versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin
 antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
 asciidoctorjPdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = "asciidoctorjPdf" }
+awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 cvssCalculator = { module = "us.springett:cvss-calculator", version.ref = "cvssCalculator" }

--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -263,6 +263,9 @@
                 },
                 "httpFileStorage": {
                     "§ref": "#/definitions/HttpFileStorage"
+                },
+                "s3FileStorage": {
+                    "§ref": "#/definitions/S3FileStorage"
                 }
             },
             "required": [
@@ -301,6 +304,33 @@
             },
             "required": [
                 "url"
+            ]
+        },
+        "S3FileStorage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "awsRegion": {
+                    "type": "string"
+                },
+                "bucketName": {
+                    "type": "string"
+                },
+                "compression": {
+                    "type": "boolean"
+                },
+                "customEndpoint": {
+                    "type": "string"
+                },
+                "secretAccessKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "bucketName"
             ]
         },
         "PostgresConfig": {
@@ -397,6 +427,7 @@
         },
         "StorageTypes": {
             "enum": [
+                "aws",
                 "clearlyDefined",
                 "http",
                 "local",

--- a/model/src/main/kotlin/config/S3FileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/S3FileStorageConfiguration.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+/**
+ * A class to hold the configuration for using an AWS S3 bucket as a storage.
+ */
+data class S3FileStorageConfiguration(
+    /** The AWS access key */
+    val accessKeyId: String? = null,
+
+    /** The AWS region to be used. */
+    val awsRegion: String? = null,
+
+    /** The name of the S3 bucket used to store files in. */
+    val bucketName: String,
+
+    /** Whether to use compression for storing files or not. Defaults to true. */
+    val compression: Boolean = false,
+
+    /** Custom endpoint to perform AWS API Requests */
+    val customEndpoint: String? = null,
+
+    /** The AWS secret for the access key. */
+    val secretAccessKey: String? = null
+)

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -273,6 +273,16 @@ ort:
               key1: value1
               key2: value2
 
+      aws:
+        backend:
+          s3FileStorage:
+            accessKeyId: "accessKey"
+            awsRegion: "us-east-1"
+            bucketName: "ort-scan-results"
+            compression: false
+            customEndpoint: "http://localhost:4567"
+            secretAccessKey: "secret"
+
       clearlyDefined:
         serverUrl: 'https://api.clearlydefined.io'
 
@@ -298,7 +308,7 @@ ort:
         token: token
 
     # Storage readers are listed from highest to lower priority, i.e. the first match wins.
-    storageReaders: [local, postgres, http, clearlyDefined]
+    storageReaders: [local, postgres, http, aws, clearlyDefined]
 
     # For storage writers no priority is implied by the order; scan results are stored for all writers.
     storageWriters: [postgres]

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -193,6 +193,7 @@ class OrtConfigurationTest : WordSpec({
                     enabled shouldBe true
 
                     fileStorage shouldNotBeNull {
+                        s3FileStorage should beNull()
                         httpFileStorage should beNull()
                         localFileStorage shouldNotBeNull {
                             directory shouldBe File("~/.ort/scanner/archive")
@@ -224,6 +225,7 @@ class OrtConfigurationTest : WordSpec({
 
                 fileListStorage shouldNotBeNull {
                     fileStorage shouldNotBeNull {
+                        s3FileStorage should beNull()
                         httpFileStorage should beNull()
                         localFileStorage shouldNotBeNull {
                             directory shouldBe File("~/.ort/scanner/file-lists")
@@ -291,7 +293,7 @@ class OrtConfigurationTest : WordSpec({
 
                 storages shouldNotBeNull {
                     keys shouldContainExactlyInAnyOrder setOf(
-                        "local", "http", "clearlyDefined", "postgres", "sw360Configuration"
+                        "local", "http", "aws", "clearlyDefined", "postgres", "sw360Configuration"
                     )
 
                     val localStorage = this["local"]
@@ -307,6 +309,16 @@ class OrtConfigurationTest : WordSpec({
                         url shouldBe "https://your-http-server"
                         query shouldBe "?username=user&password=123"
                         headers should containExactlyEntries("key1" to "value1", "key2" to "value2")
+                    }
+
+                    val s3Storage = this["aws"]
+                    s3Storage.shouldBeInstanceOf<FileBasedStorageConfiguration>()
+                    s3Storage.backend.s3FileStorage shouldNotBeNull {
+                        bucketName shouldBe "ort-scan-results"
+                        awsRegion shouldBe "us-east-1"
+                        accessKeyId shouldBe "accessKey"
+                        secretAccessKey shouldBe "secret"
+                        compression shouldBe false
                     }
 
                     val cdStorage = this["clearlyDefined"]
@@ -338,7 +350,7 @@ class OrtConfigurationTest : WordSpec({
                     sw360Storage.token shouldBe "token"
                 }
 
-                storageReaders shouldContainExactly listOf("local", "postgres", "http", "clearlyDefined")
+                storageReaders shouldContainExactly listOf("local", "postgres", "http", "aws", "clearlyDefined")
                 storageWriters shouldContainExactly listOf("postgres")
 
                 ignorePatterns shouldContainExactly listOf("**/META-INF/DEPENDENCIES")
@@ -346,6 +358,7 @@ class OrtConfigurationTest : WordSpec({
                 provenanceStorage shouldNotBeNull {
                     fileStorage shouldNotBeNull {
                         httpFileStorage should beNull()
+                        s3FileStorage should beNull()
                         localFileStorage shouldNotBeNull {
                             directory shouldBe File("~/.ort/scanner/provenance")
                             compression shouldBe false

--- a/model/src/test/kotlin/config/ScannerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ScannerConfigurationTest.kt
@@ -51,6 +51,7 @@ class ScannerConfigurationTest : WordSpec({
             actualScannerConfig.storageReaders shouldBe expectedScannerConfig.storageReaders
             actualScannerConfig.storageWriters shouldBe expectedScannerConfig.storageWriters
             actualScannerConfig.archive?.fileStorage?.httpFileStorage should beNull()
+            actualScannerConfig.archive?.fileStorage?.s3FileStorage should beNull()
 
             actualStorages.keys shouldContainExactly expectedStorages.keys
             actualStorages.entries.forAll { (storageKey, storage) ->

--- a/utils/ort/build.gradle.kts
+++ b/utils/ort/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     api(libs.okhttp)
 
+    implementation(libs.awsS3)
     implementation(libs.commonsCompress)
     implementation(libs.kotlinxCoroutines)
 

--- a/utils/ort/src/funTest/kotlin/storage/S3FileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/S3FileStorageFunTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.ort.storage
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.shouldBe
+
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.InetSocketAddress
+
+import kotlin.random.Random
+
+import org.apache.logging.log4j.kotlin.logger
+
+class S3FileStorageFunTest : WordSpec() {
+    private val loopback = InetAddress.getLoopbackAddress()
+    private val protocol = "http"
+    private val port = Random.nextInt(1024, 49152) // See https://en.wikipedia.org/wiki/Registered_port.
+        .also { logger.debug { "Using port $it for S3 Mock server." } }
+
+    private val bucket = "ort-scan-results"
+
+    private val handler = object : HttpHandler {
+        val requests = mutableMapOf<String, String>()
+
+        override fun handle(exchange: HttpExchange) {
+            when (exchange.requestMethod) {
+                "HEAD" -> {
+                    val status = if (requests.containsKey(exchange.requestURI.toString())) {
+                        HttpURLConnection.HTTP_OK
+                    } else {
+                        HttpURLConnection.HTTP_NOT_FOUND
+                    }
+                    exchange.sendResponseHeaders(status, -1)
+                }
+                "PUT" -> {
+                    val key = exchange.requestURI.toString().removePrefix("/$bucket/")
+                    requests[key] = exchange.requestBody.reader().use { it.readText() }.split("\n")[1].trimEnd()
+                    exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0)
+                }
+                "GET" -> {
+                    val key = exchange.requestURI.toString().removePrefix("/$bucket/")
+                    val data = requests[key]
+
+                    if (data != null) {
+                        exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0)
+                        exchange.responseBody.writer().use { it.write(data) }
+                    } else {
+                        exchange.sendResponseHeaders(HttpURLConnection.HTTP_NOT_FOUND, 0)
+                        exchange.responseBody.bufferedWriter().use {
+                            it.write(
+                                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                    "<Error>\n" +
+                                    "  <Code>NoSuchKey</Code>\n" +
+                                    "  <Message>The resource you requested does not exist</Message>\n" +
+                                    "  <Resource>${exchange.requestURI}</Resource> \n" +
+                                    "  <RequestId>4442587FB7D0A2F9</RequestId>\n" +
+                                    "</Error>"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Start a local HTTP server to mock S3 with the system default value for queued incoming connections.
+    private val server = HttpServer.create(InetSocketAddress(loopback, port), 0).apply {
+        createContext("/", handler)
+        start()
+    }
+
+    private val storage = S3FileStorage(
+        accessKeyId = "key",
+        awsRegion = "us-east-1",
+        bucketName = bucket,
+        compression = false,
+        customEndpoint = "$protocol://${loopback.hostAddress}:$port",
+        secretAccessKey = "secret"
+    )
+
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        handler.requests.clear()
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        // Ensure the server is properly stopped even in case of exceptions, but wait at most 5 seconds.
+        server.stop(5)
+    }
+
+    init {
+        "Querying for a file" should {
+            "succeed if the file does not exist" {
+                storage.exists("target/file") shouldBe false
+            }
+        }
+
+        "Writing a file" should {
+            "succeed if the file does not exist" {
+                shouldNotThrowAny {
+                    storage.write("target/file", "content".byteInputStream())
+                }
+                handler.requests["target/file"] shouldBe "content"
+            }
+        }
+
+        "Reading a file" should {
+            "succeed if the file exists" {
+                handler.requests["target/file"] = "content"
+                storage.read("target/file").use { input ->
+                    val content = input.bufferedReader().readText()
+                    content shouldBe "content"
+                }
+            }
+
+            "fail if the file does not exist" {
+                shouldThrow<NoSuchFileException> {
+                    storage.read("file-does-not-exist")
+                }
+            }
+        }
+    }
+}

--- a/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.ort.storage
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.net.URI
+
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
+import org.apache.logging.log4j.kotlin.logger
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.S3Exception
+
+/**
+ * A [FileStorage] that stores files in an AWS S3 bucket [bucketName]. The [read] and [exists] operations are
+ * blocking, but the [write] operation is asynchronous unless a [customEndpoint] is provided. Contents are compressed
+ * before store if the [compression] flag is set to true.
+ */
+@Suppress("SwallowedException")
+class S3FileStorage(
+    /** The AWS access key */
+    private val accessKeyId: String? = null,
+
+    /** The AWS region to be used. */
+    private val awsRegion: String? = null,
+
+    /** The name of the S3 bucket used to store files in. */
+    private val bucketName: String,
+
+    /** Whether to use compression for storing files or not. Defaults to true. */
+    private val compression: Boolean = false,
+
+    /** Custom endpoint to perform AWS API Requests */
+    private val customEndpoint: String? = null,
+
+    /** The AWS secret for the access key. */
+    private val secretAccessKey: String? = null
+) : FileStorage {
+    private val s3Client: S3Client by lazy {
+        val provider = if (accessKeyId != null && secretAccessKey != null) {
+            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey))
+        } else {
+            null
+        }
+
+        if (awsRegion != null && provider != null) {
+            S3Client.builder().apply {
+                region(Region.of(awsRegion))
+                credentialsProvider(provider)
+                endpointOverride(if (customEndpoint != null) URI.create(customEndpoint) else null)
+            }.build()
+        } else {
+            if (awsRegion != null) {
+                S3Client.builder().region(Region.of(awsRegion)).build()
+            } else {
+                S3Client.create()
+            }
+        }
+    }
+
+    override fun exists(path: String): Boolean {
+        val request = HeadObjectRequest.builder().apply {
+            key(path)
+            bucket(bucketName)
+        }.build()
+
+        return runCatching { s3Client.headObject(request) }.onFailure { exception ->
+            if (exception !is NoSuchKeyException) {
+                logger.warn { "Unable to retrieve status for S3 key $path. Error: ${exception.message}" }
+            }
+        }.isSuccess
+    }
+
+    override fun read(path: String): InputStream {
+        val request = GetObjectRequest.builder().apply {
+            key(path)
+            bucket(bucketName)
+        }.build()
+
+        return try {
+            s3Client.getObjectAsBytes(request).let { resp ->
+                val stream = ByteArrayInputStream(resp?.asByteArray())
+                if (compression) XZCompressorInputStream(stream) else stream
+            }
+        } catch (e: NoSuchKeyException) {
+            throw NoSuchFileException(File(path))
+        }
+    }
+
+    override fun write(path: String, inputStream: InputStream) {
+        val request = PutObjectRequest.builder().apply {
+            key(path)
+            bucket(bucketName)
+        }.build()
+
+        inputStream.use {
+            if (compression) {
+                val stream = ByteArrayOutputStream()
+                XZCompressorOutputStream(stream).write(it.readBytes())
+                RequestBody.fromBytes(stream.toByteArray())
+            } else {
+                RequestBody.fromBytes(it.readBytes())
+            }
+        }.let {
+            try {
+                s3Client.putObject(request, it)
+            } catch (e: S3Exception) {
+                logger.warn { "Can not write $path to S3 bucket $bucketName" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for using AWS S3 as online cache for scan results.

Provides a S3FileStorage class which extends [FileStorage](https://github.com/oss-review-toolkit/ort/blob/main/utils/ort/src/main/kotlin/storage/FileStorage.kt) and uses official Amazon's  [AWS Java SDK](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/examples-s3.html) to store scan results.

Issue oss-review-toolkit/ort#730