### PR TITLE
chore(package-configuration-providers): Remove superfluous declarations

### DIFF
--- a/plugins/package-configuration-providers/build.gradle.kts
+++ b/plugins/package-configuration-providers/build.gradle.kts
@@ -21,11 +21,3 @@ plugins {
     // Apply precompiled plugins.
     id("ort-plugins-conventions")
 }
-
-javaPlatform {
-    allowDependencies()
-}
-
-dependencies {
-    api(project(":plugins:package-configuration-providers:dir-package-configuration-provider"))
-}


### PR DESCRIPTION
These are set via the `ort-plugins-conventions` plugin already. This
fixes the `ort-config` plugin to be part of the platform.