### PR TITLE
deps(Dockerfile-legacy): Upgrade node to the current LTS release 18

### DIFF
--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -99,7 +99,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     apt-get install -y --no-install-recommends ca-certificates gnupg software-properties-common && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Node.js 16 will reach the end of the maintenance period in early September [1] so upgrade to Node.js 18.

[1]: https://nodejs.dev/en/about/releases/