### PR TITLE
fix(osv): Account for typed events being introduced in the model

### DIFF
--- a/advisor/src/funTest/assets/retrieve-package-findings-expected-result.json
+++ b/advisor/src/funTest/assets/retrieve-package-findings-expected-result.json
@@ -73,14 +73,18 @@
     "defects" : [ ],
     "vulnerabilities" : [ {
       "id" : "GHSA-3qr5-h7w4-3gx3",
-      "summary" : "Donfig Command Execution",
-      "description" : "An issue was discovered in Donfig 0.3.0. There is a vulnerability in the collect_yaml method in config_obj.py. It can execute arbitrary Python commands, resulting in command execution.",
+      "summary" : "Donfig Command Injection in collect_yaml method",
+      "description" : "An issue was discovered in Donfig 0.3.0. There is a vulnerability in the `collect_yaml` method in `config_obj.py`. It can execute arbitrary Python commands, resulting in command execution.",
       "references" : [ {
         "url" : "https://nvd.nist.gov/vuln/detail/CVE-2019-7537",
         "scoring_system" : "CVSS:3.0",
         "severity" : "9.8"
       }, {
         "url" : "https://github.com/pytroll/donfig/issues/5",
+        "scoring_system" : "CVSS:3.0",
+        "severity" : "9.8"
+      }, {
+        "url" : "https://github.com/pytroll/donfig",
         "scoring_system" : "CVSS:3.0",
         "severity" : "9.8"
       } ]

--- a/clients/osv/src/funTest/assets/vulnerabilities-by-commit-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerabilities-by-commit-expected-result.json
@@ -19,10 +19,12 @@
                         "repo": "https://github.com/harfbuzz/harfbuzz.git",
                         "events": [
                             {
-                                "introduced": "4009a05ca7de21fff2176621597cd0cd01e9d80e"
+                                "type": "INTRODUCED",
+                                "value": "4009a05ca7de21fff2176621597cd0cd01e9d80e"
                             },
                             {
-                                "fixed": "cc8e9a436fa408a1c63f4b9afb7643cea76a079c"
+                                "type": "FIXED",
+                                "value": "cc8e9a436fa408a1c63f4b9afb7643cea76a079c"
                             }
                         ]
                     }

--- a/clients/osv/src/funTest/assets/vulnerabilities-by-name-and-version-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerabilities-by-name-and-version-expected-result.json
@@ -2,13 +2,13 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-462w-v97r-4m45",
-        "modified": "2023-03-28T05:38:46.649127Z",
+        "modified": "2023-08-30T21:16:22.456465Z",
         "published": "2019-04-10T14:30:24Z",
         "aliases": [
             "CVE-2019-10906"
         ],
-        "summary": "High severity vulnerability that affects Jinja2",
-        "details": "In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.",
+        "summary": "Jinja2 sandbox escape via string formatting",
+        "details": "In Pallets Jinja before 2.10.1, `str.format_map` allows a sandbox escape.\n\nThe sandbox is used to restrict what code can be evaluated when rendering untrusted, user-provided templates. Due to the way string formatting works in Python, the `str.format_map` method could be used to escape the sandbox.\n\nThis issue was previously addressed for the `str.format` method in Jinja 2.8.1, which discusses the issue in detail. However, the less-common `str.format_map` method was overlooked. This release applies the same sandboxing to both methods.\n\nIf you cannot upgrade Jinja, you can override the `is_safe_attribute` method on the sandbox and explicitly disallow the `format_map` method on string objects.",
         "severity": [
             {
                 "type": "CVSS_V3",
@@ -27,10 +27,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.10.1"
+                                "type": "FIXED",
+                                "value": "2.10.1"
                             }
                         ]
                     }
@@ -68,6 +70,11 @@
                     "2.9.5",
                     "2.9.6"
                 ],
+                "ecosystem_specific": {
+                    "affected_functions": [
+                        ""
+                    ]
+                },
                 "database_specific": {
                     "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2019/04/GHSA-462w-v97r-4m45/GHSA-462w-v97r-4m45.json"
                 }
@@ -171,7 +178,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-8r7q-cvjq-x353",
-        "modified": "2023-03-28T05:34:47.958777Z",
+        "modified": "2023-04-11T01:29:39.253214Z",
         "published": "2022-05-14T04:04:14Z",
         "aliases": [
             "CVE-2014-1402"
@@ -190,10 +197,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.7.2"
+                                "type": "FIXED",
+                                "value": "2.7.2"
                             }
                         ]
                     }
@@ -319,7 +328,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-fqh9-2qgg-h84h",
-        "modified": "2023-03-28T05:32:13.513552Z",
+        "modified": "2023-04-11T01:29:34.742416Z",
         "published": "2022-05-17T04:01:00Z",
         "aliases": [
             "CVE-2014-0012"
@@ -338,10 +347,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.7.2"
+                                "type": "FIXED",
+                                "value": "2.7.2"
                             }
                         ]
                     }
@@ -419,7 +430,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-g3rq-g295-4j3m",
-        "modified": "2023-04-03T19:04:42.225806Z",
+        "modified": "2023-04-11T01:27:03.685024Z",
         "published": "2021-03-19T21:28:05Z",
         "aliases": [
             "CVE-2020-28493"
@@ -444,10 +455,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.11.3"
+                                "type": "FIXED",
+                                "value": "2.11.3"
                             }
                         ]
                     }
@@ -548,7 +561,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-hj2j-77xm-mc5v",
-        "modified": "2023-03-28T05:27:00.632427Z",
+        "modified": "2023-04-11T01:41:57.013215Z",
         "published": "2019-04-10T14:30:13Z",
         "aliases": [
             "CVE-2016-10745"
@@ -573,10 +586,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.8.1"
+                                "type": "FIXED",
+                                "value": "2.8.1"
                             }
                         ]
                     }
@@ -700,10 +715,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.7.2"
+                                "type": "FIXED",
+                                "value": "2.7.2"
                             }
                         ]
                     }
@@ -831,10 +848,12 @@
                         "repo": "https://github.com/mitsuhiko/jinja2",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "acb672b6a179567632e032f547582f30fa2f4aa7"
+                                "type": "FIXED",
+                                "value": "acb672b6a179567632e032f547582f30fa2f4aa7"
                             }
                         ]
                     },
@@ -842,10 +861,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.7.3"
+                                "type": "FIXED",
+                                "value": "2.7.3"
                             }
                         ]
                     }
@@ -934,10 +955,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.10.1"
+                                "type": "FIXED",
+                                "value": "2.10.1"
                             }
                         ]
                     }
@@ -1086,10 +1109,12 @@
                         "repo": "https://github.com/pallets/jinja",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "9b53045c34e61013dc8f09b7e52a555fa16bed16"
+                                "type": "FIXED",
+                                "value": "9b53045c34e61013dc8f09b7e52a555fa16bed16"
                             }
                         ]
                     },
@@ -1097,10 +1122,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.8.1"
+                                "type": "FIXED",
+                                "value": "2.8.1"
                             }
                         ]
                     }
@@ -1208,10 +1235,12 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "introduced": "0"
+                                "type": "INTRODUCED",
+                                "value": "0"
                             },
                             {
-                                "fixed": "2.11.3"
+                                "type": "FIXED",
+                                "value": "2.11.3"
                             }
                         ]
                     }

--- a/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
@@ -26,20 +26,16 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "introduced": "1.0.0"
+                            "type": "INTRODUCED",
+                            "value": "1.0.0"
                         },
                         {
-                            "fixed": "1.2.6"
+                            "type": "FIXED",
+                            "value": "1.2.6"
                         }
                     ]
                 }
             ],
-            "ecosystem_specific": {
-                "affected_functions": [
-                    "minimist.isConstructorOrProto",
-                    "minimist.setKey"
-                ]
-            },
             "database_specific": {
                 "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2022/03/GHSA-xvch-5gv4-984h/GHSA-xvch-5gv4-984h.json"
             }
@@ -55,20 +51,16 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "introduced": "0"
+                            "type": "INTRODUCED",
+                            "value": "0"
                         },
                         {
-                            "fixed": "0.2.4"
+                            "type": "FIXED",
+                            "value": "0.2.4"
                         }
                     ]
                 }
             ],
-            "ecosystem_specific": {
-                "affected_functions": [
-                    "minimist.isConstructorOrProto",
-                    "minimist.setKey"
-                ]
-            },
             "database_specific": {
                 "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2022/03/GHSA-xvch-5gv4-984h/GHSA-xvch-5gv4-984h.json"
             }
@@ -133,12 +125,12 @@
         }
     ],
     "database_specific": {
+        "github_reviewed_at": "2022-03-18T23:13:40Z",
+        "github_reviewed": true,
+        "severity": "CRITICAL",
         "cwe_ids": [
             "CWE-1321"
         ],
-        "severity": "CRITICAL",
-        "github_reviewed": true,
-        "github_reviewed_at": "2022-03-18T23:13:40Z",
         "nvd_published_at": "2022-03-17T16:15:00Z"
     }
 }

--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -111,7 +111,7 @@ object Ecosystem {
     const val RUBY_GEMS = "RubyGems"
 }
 
-@Serializable(EventSerializer::class)
+@Serializable
 data class Event(
     val type: Type,
     val value: String
@@ -136,6 +136,7 @@ data class Package(
 data class Range(
     val type: Type,
     val repo: String? = null,
+    @Serializable(EventListSerializer::class)
     val events: List<Event>,
     val databaseSpecific: JsonObject? = null
 ) {

--- a/clients/osv/src/test/assets/vulnerability/examples/1.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/1.json
@@ -29,16 +29,20 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "introduced": "1.0.0"
+                            "type": "INTRODUCED",
+                            "value": "1.0.0"
                         },
                         {
-                            "fixed": "1.14.14"
+                            "type": "FIXED",
+                            "value": "1.14.14"
                         },
                         {
-                            "introduced": "1.15.0"
+                            "type": "INTRODUCED",
+                            "value": "1.15.0"
                         },
                         {
-                            "fixed": "1.15.17"
+                            "type": "FIXED",
+                            "value": "1.15.17"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/2.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/2.json
@@ -25,16 +25,20 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "introduced": "1.0.0"
+                            "type": "INTRODUCED",
+                            "value": "1.0.0"
                         },
                         {
-                            "fixed": "1.14.14"
+                            "type": "FIXED",
+                            "value": "1.14.14"
                         },
                         {
-                            "introduced": "1.15.10"
+                            "type": "INTRODUCED",
+                            "value": "1.15.10"
                         },
                         {
-                            "fixed": "1.15.17"
+                            "type": "FIXED",
+                            "value": "1.15.17"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/3.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/3.json
@@ -25,10 +25,12 @@
                     "type": "ECOSYSTEM",
                     "events": [
                         {
-                            "introduced": "0"
+                            "type": "INTRODUCED",
+                            "value": "0"
                         },
                         {
-                            "fixed": "6.5.4"
+                            "type": "FIXED",
+                            "value": "6.5.4"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/4.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/4.json
@@ -23,10 +23,12 @@
                     "repo": "https://github.com/unicode-org/icu.git",
                     "events": [
                         {
-                            "introduced": "6e5755a2a833bc64852eae12967d0a54d7adf629"
+                            "type": "INTRODUCED",
+                            "value": "6e5755a2a833bc64852eae12967d0a54d7adf629"
                         },
                         {
-                            "fixed": "c43455749b914feef56b178b256f29b3016146eb"
+                            "type": "FIXED",
+                            "value": "c43455749b914feef56b178b256f29b3016146eb"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/5.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/5.json
@@ -30,10 +30,12 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "introduced": "0"
+                            "type": "INTRODUCED",
+                            "value": "0"
                         },
                         {
-                            "fixed": "0.1.20"
+                            "type": "FIXED",
+                            "value": "0.1.20"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/6.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/6.json
@@ -26,10 +26,12 @@
                     "repo": "https://github.com/pikepdf/pikepdf",
                     "events": [
                         {
-                            "introduced": "0"
+                            "type": "INTRODUCED",
+                            "value": "0"
                         },
                         {
-                            "fixed": "3f38f73218e5e782fe411ccbb3b44a793c0b343a"
+                            "type": "FIXED",
+                            "value": "3f38f73218e5e782fe411ccbb3b44a793c0b343a"
                         }
                     ]
                 },
@@ -37,10 +39,12 @@
                     "type": "ECOSYSTEM",
                     "events": [
                         {
-                            "introduced": "2.8.0"
+                            "type": "INTRODUCED",
+                            "value": "2.8.0"
                         },
                         {
-                            "fixed": "2.10.0"
+                            "type": "FIXED",
+                            "value": "2.10.0"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/7.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/7.json
@@ -16,10 +16,12 @@
                     "type": "ECOSYSTEM",
                     "events": [
                         {
-                            "introduced": "1.14.0"
+                            "type": "INTRODUCED",
+                            "value": "1.14.0"
                         },
                         {
-                            "fixed": "2.1.0"
+                            "type": "FIXED",
+                            "value": "2.1.0"
                         }
                     ]
                 }


### PR DESCRIPTION
Some, but not all, OSV requests now return "typed" events where the
event type and value are serialized to separate fields. This is the
natural serialization format that kotlinx-serialization would use for
the `Event` class via the auto-generated deserializer.

However, some queries still return the single-line format for events.
This means the auto-generated deserializer should be used by default, and
a custom deserializer that understands the single-line format should be
used as a fallback. The current approach of a low-level `KSerializer`
is not very suitable to handle this case, as trying to decode one format
would advance in the input, leaving incomplete input to the fallback
deserializer if the first deserializer fails.

To solve this, a `JsonTransformingSerializer` is used instead that
transforms the single-line format to the typed format on a
`JsonElement` level before the auto-generated deserializer does its work.
As this serializer needs to be based on the auto-generated serializer,
another trick needs to be applied in order to not run into a recursion
problem: The `JsonTransformingSerializer` works on a list of events
instead of a single event. This way, it can refer to the auto-generated
serializer for a single event (instead of referring to itself) and
transform each events of a list instead of a single even.