### PR TITLE
chore(osv-client): Revert unnecessary changes from 5f8f378c

### DIFF
--- a/clients/osv/src/funTest/assets/vulnerabilities-by-commit-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerabilities-by-commit-expected-result.json
@@ -19,12 +19,10 @@
                         "repo": "https://github.com/harfbuzz/harfbuzz.git",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "4009a05ca7de21fff2176621597cd0cd01e9d80e"
+                                "introduced": "4009a05ca7de21fff2176621597cd0cd01e9d80e"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "cc8e9a436fa408a1c63f4b9afb7643cea76a079c"
+                                "fixed": "cc8e9a436fa408a1c63f4b9afb7643cea76a079c"
                             }
                         ]
                     }

--- a/clients/osv/src/funTest/assets/vulnerabilities-by-name-and-version-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerabilities-by-name-and-version-expected-result.json
@@ -27,12 +27,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.10.1"
+                                "fixed": "2.10.1"
                             }
                         ]
                     }
@@ -178,7 +176,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-8r7q-cvjq-x353",
-        "modified": "2023-04-11T01:29:39.253214Z",
+        "modified": "2023-03-28T05:34:47.958777Z",
         "published": "2022-05-14T04:04:14Z",
         "aliases": [
             "CVE-2014-1402"
@@ -197,12 +195,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.7.2"
+                                "fixed": "2.7.2"
                             }
                         ]
                     }
@@ -328,7 +324,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-fqh9-2qgg-h84h",
-        "modified": "2023-04-11T01:29:34.742416Z",
+        "modified": "2023-03-28T05:32:13.513552Z",
         "published": "2022-05-17T04:01:00Z",
         "aliases": [
             "CVE-2014-0012"
@@ -347,12 +343,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.7.2"
+                                "fixed": "2.7.2"
                             }
                         ]
                     }
@@ -430,7 +424,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-g3rq-g295-4j3m",
-        "modified": "2023-04-11T01:27:03.685024Z",
+        "modified": "2023-04-03T19:04:42.225806Z",
         "published": "2021-03-19T21:28:05Z",
         "aliases": [
             "CVE-2020-28493"
@@ -455,12 +449,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.11.3"
+                                "fixed": "2.11.3"
                             }
                         ]
                     }
@@ -561,7 +553,7 @@
     {
         "schema_version": "1.4.0",
         "id": "GHSA-hj2j-77xm-mc5v",
-        "modified": "2023-04-11T01:41:57.013215Z",
+        "modified": "2023-03-28T05:27:00.632427Z",
         "published": "2019-04-10T14:30:13Z",
         "aliases": [
             "CVE-2016-10745"
@@ -586,12 +578,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.8.1"
+                                "fixed": "2.8.1"
                             }
                         ]
                     }
@@ -715,12 +705,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.7.2"
+                                "fixed": "2.7.2"
                             }
                         ]
                     }
@@ -848,12 +836,10 @@
                         "repo": "https://github.com/mitsuhiko/jinja2",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "acb672b6a179567632e032f547582f30fa2f4aa7"
+                                "fixed": "acb672b6a179567632e032f547582f30fa2f4aa7"
                             }
                         ]
                     },
@@ -861,12 +847,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.7.3"
+                                "fixed": "2.7.3"
                             }
                         ]
                     }
@@ -955,12 +939,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.10.1"
+                                "fixed": "2.10.1"
                             }
                         ]
                     }
@@ -1109,12 +1091,10 @@
                         "repo": "https://github.com/pallets/jinja",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "9b53045c34e61013dc8f09b7e52a555fa16bed16"
+                                "fixed": "9b53045c34e61013dc8f09b7e52a555fa16bed16"
                             }
                         ]
                     },
@@ -1122,12 +1102,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.8.1"
+                                "fixed": "2.8.1"
                             }
                         ]
                     }
@@ -1235,12 +1213,10 @@
                         "type": "ECOSYSTEM",
                         "events": [
                             {
-                                "type": "INTRODUCED",
-                                "value": "0"
+                                "introduced": "0"
                             },
                             {
-                                "type": "FIXED",
-                                "value": "2.11.3"
+                                "fixed": "2.11.3"
                             }
                         ]
                     }

--- a/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
@@ -26,12 +26,10 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "1.0.0"
+                            "introduced": "1.0.0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "1.2.6"
+                            "fixed": "1.2.6"
                         }
                     ]
                 }
@@ -51,12 +49,10 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "0"
+                            "introduced": "0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "0.2.4"
+                            "fixed": "0.2.4"
                         }
                     ]
                 }
@@ -125,12 +121,12 @@
         }
     ],
     "database_specific": {
-        "github_reviewed_at": "2022-03-18T23:13:40Z",
-        "github_reviewed": true,
-        "severity": "CRITICAL",
         "cwe_ids": [
             "CWE-1321"
         ],
+        "severity": "CRITICAL",
+        "github_reviewed": true,
+        "github_reviewed_at": "2022-03-18T23:13:40Z",
         "nvd_published_at": "2022-03-17T16:15:00Z"
     }
 }

--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -111,7 +111,7 @@ object Ecosystem {
     const val RUBY_GEMS = "RubyGems"
 }
 
-@Serializable
+@Serializable(EventSerializer::class)
 data class Event(
     val type: Type,
     val value: String
@@ -136,7 +136,6 @@ data class Package(
 data class Range(
     val type: Type,
     val repo: String? = null,
-    @Serializable(EventListSerializer::class)
     val events: List<Event>,
     val databaseSpecific: JsonObject? = null
 ) {

--- a/clients/osv/src/main/kotlin/Serializers.kt
+++ b/clients/osv/src/main/kotlin/Serializers.kt
@@ -23,35 +23,46 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonTransformingSerializer
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Use a custom serializer to transform the legacy single-field events into newer typed events.
+ * Use a custom serializer in order to map the original data structure to a more strict and simple, enum based, model.
  */
-internal object EventListSerializer : JsonTransformingSerializer<List<Event>>(ListSerializer(Event.serializer())) {
-    override fun transformDeserialize(element: JsonElement): JsonElement =
-        element.jsonArray.map {
-            val event = it.jsonObject
-            when (event.entries.size) {
-                1 -> {
-                    val (type, value) = event.entries.first()
-                    JsonObject(mapOf("type" to JsonPrimitive(type.uppercase()), "value" to value))
-                }
-                else -> event
-            }
-        }.let { JsonArray(it) }
+@Serializer(Event::class)
+internal object EventSerializer : KSerializer<Event> {
+    override fun deserialize(decoder: Decoder): Event {
+        val input = decoder as? JsonDecoder
+            ?: throw SerializationException("This serializer only works with the JSON format.")
+
+        val element = input.decodeJsonElement()
+        require(element is JsonObject)
+
+        require(element.entries.size == 1)
+        val (key, value) = element.entries.first()
+        val type = enumValueOf<Event.Type>(key.uppercase())
+
+        return Event(type, value.jsonPrimitive.content)
+    }
+
+    override fun serialize(encoder: Encoder, value: Event) {
+        val output = encoder as? JsonEncoder
+            ?: throw SerializationException("This serializer only works with the JSON format.")
+
+        val tree = JsonObject(mapOf(value.type.name.lowercase() to JsonPrimitive(value.value)))
+
+        output.encodeJsonElement(tree)
+    }
 }
 
 /**

--- a/clients/osv/src/test/assets/vulnerability/examples/1.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/1.json
@@ -29,20 +29,16 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "1.0.0"
+                            "introduced": "1.0.0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "1.14.14"
+                            "fixed": "1.14.14"
                         },
                         {
-                            "type": "INTRODUCED",
-                            "value": "1.15.0"
+                            "introduced": "1.15.0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "1.15.17"
+                            "fixed": "1.15.17"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/2.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/2.json
@@ -25,20 +25,16 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "1.0.0"
+                            "introduced": "1.0.0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "1.14.14"
+                            "fixed": "1.14.14"
                         },
                         {
-                            "type": "INTRODUCED",
-                            "value": "1.15.10"
+                            "introduced": "1.15.10"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "1.15.17"
+                            "fixed": "1.15.17"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/3.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/3.json
@@ -25,12 +25,10 @@
                     "type": "ECOSYSTEM",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "0"
+                            "introduced": "0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "6.5.4"
+                            "fixed": "6.5.4"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/4.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/4.json
@@ -23,12 +23,10 @@
                     "repo": "https://github.com/unicode-org/icu.git",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "6e5755a2a833bc64852eae12967d0a54d7adf629"
+                            "introduced": "6e5755a2a833bc64852eae12967d0a54d7adf629"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "c43455749b914feef56b178b256f29b3016146eb"
+                            "fixed": "c43455749b914feef56b178b256f29b3016146eb"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/5.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/5.json
@@ -30,12 +30,10 @@
                     "type": "SEMVER",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "0"
+                            "introduced": "0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "0.1.20"
+                            "fixed": "0.1.20"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/6.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/6.json
@@ -26,12 +26,10 @@
                     "repo": "https://github.com/pikepdf/pikepdf",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "0"
+                            "introduced": "0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "3f38f73218e5e782fe411ccbb3b44a793c0b343a"
+                            "fixed": "3f38f73218e5e782fe411ccbb3b44a793c0b343a"
                         }
                     ]
                 },
@@ -39,12 +37,10 @@
                     "type": "ECOSYSTEM",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "2.8.0"
+                            "introduced": "2.8.0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "2.10.0"
+                            "fixed": "2.10.0"
                         }
                     ]
                 }

--- a/clients/osv/src/test/assets/vulnerability/examples/7.json
+++ b/clients/osv/src/test/assets/vulnerability/examples/7.json
@@ -16,12 +16,10 @@
                     "type": "ECOSYSTEM",
                     "events": [
                         {
-                            "type": "INTRODUCED",
-                            "value": "1.14.0"
+                            "introduced": "1.14.0"
                         },
                         {
-                            "type": "FIXED",
-                            "value": "2.1.0"
+                            "fixed": "2.1.0"
                         }
                     ]
                 }


### PR DESCRIPTION
The mix of single-field and typed event serializations that was seen was caused by creating the new expected results with the wrong serializer. Reverting those parts of the expected results shows that the actual results do not require the serializer changes.

To see how the diff of 5f8f378c should have looked like, run

    git diff 5f8f378c^ HEAD -- clients/osv/src

on this commit.