### PR TITLE
fix(fossid-webapp)!: Simplify the pattern for directories in ignore rules

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/Utils.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/Utils.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.PathExclude
 
-private val DIRECTORY_REGEX = "(?<directory>(?:[\\w.]+/)*[\\w.]+)/?(?<starstar>\\*\\*)?".toRegex()
+private val DIRECTORY_REGEX = "(?<directory>.+)/(?<starstar>\\*\\*)?".toRegex()
 private val EXTENSION_REGEX = "\\*\\.(?<extension>\\w+)".toRegex()
 private val FILE_REGEX = "(?<file>[^/]+)".toRegex()
 

--- a/plugins/scanners/fossid/src/test/kotlin/MapIgnoreRulesTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/MapIgnoreRulesTest.kt
@@ -93,6 +93,34 @@ class MapIgnoreRulesTest : WordSpec({
             issues should beEmpty()
         }
 
+        "map rule with directory containing a dash" {
+            val exclude = Excludes(listOf(PathExclude("test-prod/", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "test-prod"
+                type shouldBe RuleType.DIRECTORY
+            }
+        }
+
+        "map rule with directory containing subdirectories with a dash" {
+            val exclude = Excludes(listOf(PathExclude("src/test-prod/templates/", PathExcludeReason.OTHER)))
+            val issues = mutableListOf<Issue>()
+
+            val ignoreRules = convertRules(exclude, issues)
+
+            ignoreRules shouldHaveSize 1
+            ignoreRules.first().shouldNotBeNull {
+                value shouldBe "src/test-prod/templates"
+                type shouldBe RuleType.DIRECTORY
+            }
+
+            issues should beEmpty()
+        }
+
         "map rule with directory" {
             val exclude = Excludes(listOf(PathExclude("directory/", PathExcludeReason.OTHER)))
             val issues = mutableListOf<Issue>()
@@ -109,7 +137,7 @@ class MapIgnoreRulesTest : WordSpec({
         }
 
         "map rule with directory containing subdirectories" {
-            val exclude = Excludes(listOf(PathExclude("directory/sub1/sub2", PathExcludeReason.OTHER)))
+            val exclude = Excludes(listOf(PathExclude("directory/sub1/sub2/", PathExcludeReason.OTHER)))
             val issues = mutableListOf<Issue>()
 
             val ignoreRules = convertRules(exclude, issues)


### PR DESCRIPTION
The commit b194cf37 added a change for supporting '.' in directory names. Currently, the dash symbol is also no supported. Therefore, the current commit simplifies the logic to allow all special characters in the directory name, by simplifying the regular expression.

This is a breaking change as the directory name "directory/sub1/sub2" is not accepted anymore and won't be mapped to a directory ignore rule. The directory name must now always end with '/', i.e. "directory/sub1/sub2/".

