### PR TITLE
 Change to grep/sed solution due Mac grep difference

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -20,7 +20,7 @@
 DOCKER_ARGS=$@
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-GIT_REVISION=$($GIT_ROOT/gradlew -q properties --property version | grep -oP "version: \K.+")
+GIT_REVISION=$($GIT_ROOT/gradlew -q properties --property version | sed -nr "s/version: (.+)/\1/p")
 
 echo "Setting ORT_VERSION to $GIT_REVISION."
 docker buildx build \


### PR DESCRIPTION
Mac BSD based grep tool has different options and behaviour than Linux GNU based, so a solution with basic sed and grep was needed.
