### PR TITLE
refactor(PythonInspector): Remove default arguments

### DIFF
--- a/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
@@ -37,7 +37,8 @@ class PythonInspectorFunTest : StringSpec({
             PythonInspector.inspect(
                 workingDir = workingDir,
                 definitionFile = definitionFile,
-                pythonVersion = "27"
+                pythonVersion = "27",
+                operatingSystem = "linux"
             )
         } finally {
             workingDir.resolve(".cache").safeDeleteRecursively(force = true)

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
@@ -64,12 +64,7 @@ internal object PythonInspector : CommandLineTool, Logging {
 
     override fun getVersionRequirement(): RangesList = RangesListFactory.create("[0.9.2,)")
 
-    fun inspect(
-        workingDir: File,
-        definitionFile: File,
-        pythonVersion: String = "38",
-        operatingSystem: String = "linux"
-    ): Result {
+    fun inspect(workingDir: File, definitionFile: File, pythonVersion: String, operatingSystem: String): Result {
         val outputFile = createOrtTempFile(prefix = "python-inspector", suffix = ".json")
 
         val commandLineOptions = buildList {


### PR DESCRIPTION
Remove the default function arguments for the Python version and OS from `inspect()` as they are too easily being confused with the configured package manager options and their default values.