### PR TITLE
fix(reporter): Align setting `licenseInfoInFiles` with the spec v2.2

### DIFF
--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -47,7 +47,6 @@
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "BSD-2-Clause AND BSD-3-Clause AND MIT",
     "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
-    "licenseInfoFromFiles" : [ "Apache-2.0", "BSD-2-Clause" ],
     "name" : "first-package",
     "summary" : "A package with all supported attributes set, with a VCS URL containing a user name, and with two scan results for the VCS containing copyright findings matched to a license finding.",
     "versionInfo" : "0.0.1"
@@ -89,7 +88,6 @@
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
-    "licenseInfoFromFiles" : [ "Apache-2.0", "BSD-2-Clause" ],
     "name" : "first-package",
     "summary" : "A package with all supported attributes set, with a VCS URL containing a user name, and with two scan results for the VCS containing copyright findings matched to a license finding.",
     "versionInfo" : "0.0.1"
@@ -138,7 +136,6 @@
     "homepage" : "NONE",
     "licenseConcluded" : "NOASSERTION",
     "licenseDeclared" : "NOASSERTION",
-    "licenseInfoFromFiles" : [ "GPL-3.0-only" ],
     "name" : "seventh-package",
     "summary" : "A package with a source artifact scan result.",
     "versionInfo" : "0.0.1"

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -56,9 +56,6 @@ packages:
   homepage: "first package's homepage URL"
   licenseConcluded: "BSD-2-Clause AND BSD-3-Clause AND MIT"
   licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
-  licenseInfoFromFiles:
-  - "Apache-2.0"
-  - "BSD-2-Clause"
   name: "first-package"
   summary: "A package with all supported attributes set, with a VCS URL containing\
     \ a user name, and with two scan results for the VCS containing copyright findings\
@@ -105,9 +102,6 @@ packages:
   homepage: "first package's homepage URL"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
-  licenseInfoFromFiles:
-  - "Apache-2.0"
-  - "BSD-2-Clause"
   name: "first-package"
   summary: "A package with all supported attributes set, with a VCS URL containing\
     \ a user name, and with two scan results for the VCS containing copyright findings\
@@ -152,8 +146,6 @@ packages:
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "NOASSERTION"
-  licenseInfoFromFiles:
-  - "GPL-3.0-only"
   name: "seventh-package"
   summary: "A package with a source artifact scan result."
   versionInfo: "0.0.1"

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -169,15 +169,19 @@ internal fun Package.toSpdxPackage(
             else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
         },
         licenseDeclared = declaredLicensesProcessed.toSpdxDeclaredLicense(),
-        licenseInfoFromFiles = licenseInfoResolver.resolveLicenseInfo(id)
-            .filterExcluded()
-            .filter(LicenseView.ONLY_DETECTED)
-            .map { resolvedLicense ->
-                resolvedLicense.license.takeIf { it.isValid(SpdxExpression.Strictness.ALLOW_DEPRECATED) }
-                    .nullOrBlankToSpdxNoassertionOrNone()
-            }
-            .distinct()
-            .sorted(),
+        licenseInfoFromFiles = if (packageVerificationCode == null) {
+            emptyList()
+        } else {
+            licenseInfoResolver.resolveLicenseInfo(id)
+                .filterExcluded()
+                .filter(LicenseView.ONLY_DETECTED)
+                .map { resolvedLicense ->
+                    resolvedLicense.license.takeIf { it.isValid(SpdxExpression.Strictness.ALLOW_DEPRECATED) }
+                        .nullOrBlankToSpdxNoassertionOrNone()
+                }
+                .distinct()
+                .sorted()
+        },
         packageVerificationCode = packageVerificationCode,
         name = id.name,
         summary = description.nullOrBlankToSpdxNone(),


### PR DESCRIPTION
The description for the `filesAnalyzed` attribute says that "If false, the package shall not contain any files.", see [1]. This in turn implies that `licenseInfoInFiles` must be empty in that case.

Running [2] against an SPDX document which has a package with `filesAnalyzed=false` and a non-empty value for `licenseInfoInFiles` yields an error saying that the document is not valid for mentioned reason.

Fix that issue by reporting non-empty `licenseInfoInFiles` only for VCS and source artifact packages.

[1] https://github.com/spdx/spdx-spec/blob/development/v2.2.1/chapters/package-information.md#78-files-analyzed-field-
[2] https://github.com/spdx/tools-python

