### PR TITLE
SpdxDocumentReporter: Adhere to detected licenses when computing extracted license info

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -228,7 +228,7 @@ internal fun SpdxDocument.addExtractedLicenseInfo(licenseTextProvider: LicenseTe
         packages.forEach {
             add(it.licenseConcluded)
             add(it.licenseDeclared)
-            // TODO: Also add detected non-SPDX licenses here.
+            addAll(it.licenseInfoFromFiles)
         }
     }.flatMapTo(mutableSetOf()) { SpdxExpression.parse(it).licenses() }
 

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -224,10 +224,15 @@ private fun ProcessedDeclaredLicense.toSpdxDeclaredLicense(): String =
  * Use [licenseTextProvider] to add the license texts for all packages to the [SpdxDocument].
  */
 internal fun SpdxDocument.addExtractedLicenseInfo(licenseTextProvider: LicenseTextProvider): SpdxDocument {
-    val nonSpdxLicenses = packages.flatMapTo(mutableSetOf()) {
-        // TODO: Also add detected non-SPDX licenses here.
-        SpdxExpression.parse(it.licenseConcluded).licenses() + SpdxExpression.parse(it.licenseDeclared).licenses()
-    }.filter {
+    val allLicenses = buildSet {
+        packages.forEach {
+            add(it.licenseConcluded)
+            add(it.licenseDeclared)
+            // TODO: Also add detected non-SPDX licenses here.
+        }
+    }.flatMapTo(mutableSetOf()) { SpdxExpression.parse(it).licenses() }
+
+    val nonSpdxLicenses = allLicenses.filter {
         SpdxConstants.isPresent(it) && SpdxLicense.forId(it) == null && SpdxLicenseException.forId(it) == null
     }
 

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -47,7 +47,6 @@ import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
-import org.ossreviewtoolkit.utils.spdx.SpdxLicenseException
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.spdx.model.SpdxChecksum
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
@@ -232,9 +231,7 @@ internal fun SpdxDocument.addExtractedLicenseInfo(licenseTextProvider: LicenseTe
         }
     }.flatMapTo(mutableSetOf()) { SpdxExpression.parse(it).licenses() }
 
-    val nonSpdxLicenses = allLicenses.filter {
-        SpdxConstants.isPresent(it) && SpdxLicense.forId(it) == null && SpdxLicenseException.forId(it) == null
-    }
+    val nonSpdxLicenses = allLicenses.filter { SpdxConstants.isPresent(it) && SpdxLicense.forId(it) == null }
 
     val extractedLicenseInfo = nonSpdxLicenses.sorted().mapNotNull { license ->
         licenseTextProvider.getLicenseText(license)?.let { text ->


### PR DESCRIPTION
This eliminates one type of violation of the SPDX spec V 2.2 from produced documents.

See individual commits.
