### PR TITLE
build(Gradle): Add more POM metadata required for publishing

### DIFF
--- a/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
@@ -43,6 +43,18 @@ configure<PublishingExtension> {
             artifact(tasks["docsJavadocJar"])
 
             pom {
+                name = project.name
+                description = "Part of the OSS Review Toolkit (ORT), a suite to automate software compliance checks."
+                url = "https://oss-review-toolkit.org/"
+
+                developers {
+                    developer {
+                        name = "The ORT Project Authors"
+                        email = "ort@ossreviewtoolkit.org"
+                        url = "https://github.com/oss-review-toolkit/ort/blob/main/NOTICE"
+                    }
+                }
+
                 licenses {
                     license {
                         name = "Apache-2.0"


### PR DESCRIPTION
Without these, the check performed by Sonatype Nexus when closing a staging repository for releasing fails.