### PR TITLE
build(clients): Add OkHttp as an explicit API dependency

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -84,9 +84,6 @@ kotlin.target.compilations.apply {
 
 configurations.all {
     resolutionStrategy {
-        // Ensure all OkHttp versions match our version >= 4 to avoid Kotlin vs. Java issues with OkHttp 3.
-        force(libs.okhttp)
-
         // Ensure all JRuby versions match our version to avoid Psych YAML library issues.
         force(libs.jruby)
 

--- a/clients/fossid-webapp/build.gradle.kts
+++ b/clients/fossid-webapp/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 
 dependencies {
     api(libs.log4jApiKotlin)
+    api(libs.okhttp)
     api(libs.retrofit)
 
     implementation(libs.jacksonModuleKotlin)

--- a/clients/nexus-iq/build.gradle.kts
+++ b/clients/nexus-iq/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 }
 
 dependencies {
+    api(libs.okhttp)
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)

--- a/clients/oss-index/build.gradle.kts
+++ b/clients/oss-index/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
 }
 
 dependencies {
+    api(libs.okhttp)
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)

--- a/clients/osv/build.gradle.kts
+++ b/clients/osv/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 }
 
 dependencies {
+    api(libs.okhttp)
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)

--- a/clients/scanoss/build.gradle.kts
+++ b/clients/scanoss/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 }
 
 dependencies {
+    api(libs.okhttp)
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)

--- a/clients/vulnerable-code/build.gradle.kts
+++ b/clients/vulnerable-code/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 }
 
 dependencies {
+    api(libs.okhttp)
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)


### PR DESCRIPTION
These clients all have `create()` functions that take an `OkHttpClient`, so OkHttp should be an API dependency and not just a transitive dependency of Retrofit.

As a positive side-effect this bumps the OkHttp version from 3.14.9 (as used by Retrofit) to the current version used by ORT, getting rid of some reported vulnerabilities. See [1] for why Retrofit is stuck on OkHttp version 3 although version 4 is binary compatible [2].

[1]: https://github.com/square/retrofit/pull/3767#issuecomment-1720031134
[2]: https://github.com/square/retrofit/issues/3384#issuecomment-1645583665