### PR TITLE
Missing license info

### DIFF
--- a/website/docs/license.md
+++ b/website/docs/license.md
@@ -6,8 +6,7 @@ sidebar_position: 8
 
 Copyright (C) 2017-2023 [The ORT Project Authors](https://github.com/oss-review-toolkit/ort/blob/main/NOTICE).
 
-See the [LICENSE](https://github.com/oss-review-toolkit/ort/blob/main/LICENSE) file in the root of this project for
-license details.
+Licensed under the [Apache License, Version 2.0](https://github.com/oss-review-toolkit/ort/blob/main/LICENSE).
 
 OSS Review Toolkit (ORT) is a [Linux Foundation project](https://www.linuxfoundation.org) and part of
 [ACT](https://automatecompliance.org/).


### PR DESCRIPTION
License page has only a link but no mention of what license ORT is using