### PR TITLE
React over documentation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,9 +4,15 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - docusaurus/**
+      - examples/**
   push:
     branches:
       - main
+    paths-ignore:
+      - docusaurus/**
+      - examples/**
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false

--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - docusaurus/**
+      - examples/**
 
 jobs:
   build:

--- a/.github/workflows/docusaurus-test.yml
+++ b/.github/workflows/docusaurus-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - docusaurus/**
+      - examples/**
 
 jobs:
   test:


### PR DESCRIPTION
For documentation change only, build-and-test pipeline can be ignored. For docusaurus-test, it only needed if effective changes happened in the docusaurus folder.

