### PR TITLE
ci(GitHub): Use `npm ci` instead of `npm install`

### DIFF
--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           cache: npm
           cache-dependency-path: docusaurus/package-lock.json
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: docusaurus
       - name: Build website
         run: npm run build

--- a/.github/workflows/docusaurus-test.yml
+++ b/.github/workflows/docusaurus-test.yml
@@ -17,7 +17,7 @@ jobs:
           cache: npm
           cache-dependency-path: docusaurus/package-lock.json
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: docusaurus
       - name: Test build
         run: npm run build


### PR DESCRIPTION
Use `npm ci` [1] instead of `npm install` to install the dependencies of the Docusaurus project to ensure that exactly the versions from the lockfile are used.

[1]: https://docs.npmjs.com/cli/v9/commands/npm-ci