### PR TITLE
fix(osv): Align `Reference.Type` with spec version 1.6.0

### DIFF
--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -164,7 +164,12 @@ data class Reference(
     enum class Type {
         ADVISORY,
         ARTICLE,
+        DETECTION,
+        DISCUSSION,
+        EVIDENCE,
         FIX,
+        GIT,
+        INTRODUCED,
         PACKAGE,
         REPORT,
         WEB


### PR DESCRIPTION
The `Osv` backend returns JSON data compliant with spec version 1.6.0, while ORT's handling hasn't been updated to that (latest) version.

For example, the root cause of [2] is that `Reference.Type` is lacking the value `EVIDENCE`.

Align only the values of `Reference.Type` with version 1.6.0 in order to fix [2] quickly. In a future change, remaining alignments, if any, should be made.

[1] https://github.com/ossf/osv-schema/blob/v1.6.0/validation/schema.json
[2] https://github.com/oss-review-toolkit/ort/issues/7531

Fixes #7531.

---

Follow-up work: #7534.
