### PR TITLE
test(ort-config-package-curation-provider): Update NuGet identifiers

### DIFF
--- a/plugins/package-curation-providers/ort-config/src/funTest/kotlin/OrtConfigPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/ort-config/src/funTest/kotlin/OrtConfigPackageCurationProviderFunTest.kt
@@ -29,8 +29,8 @@ import org.ossreviewtoolkit.model.Package
 
 class OrtConfigPackageCurationProviderFunTest : StringSpec({
     "provider can load curations from the ort-config repository" {
-        val azureCore = Identifier("NuGet::Azure.Core:1.22.0")
-        val azureCoreAmqp = Identifier("NuGet::Azure.Core.Amqp:1.2.0")
+        val azureCore = Identifier("NuGet:Azure:Core:1.22.0")
+        val azureCoreAmqp = Identifier("NuGet:Azure.Core:Amqp:1.2.0")
         val packages = createPackagesFromIds(azureCore, azureCoreAmqp)
 
         val curations = OrtConfigPackageCurationProvider().getCurationsFor(packages)


### PR DESCRIPTION
Update the NuGet identifiers used in the
`OrtConfigPackageCurationProviderFunTest` as they were updated in the ort-config repository [1].

[1]: https://github.com/oss-review-toolkit/ort-config/pull/136