### PR TITLE
chore(CocoaPods): Do not use a regex for package name matching

### DIFF
--- a/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
@@ -197,7 +197,6 @@ class CocoaPods(
                 "spec", "which", podspecName,
                 "--version=${id.version}",
                 "--allow-root",
-                "--regex",
                 workingDir = workingDir
             )
         }.getOrElse {


### PR DESCRIPTION
ORT exclusively runs `pod spec which` with an `Identifier`'s `name` which can never be a regex, so do not allow to interpret it as one.