### PR TITLE
fix(CocoaPods): Restrict package name matching to full matches

### DIFF
--- a/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
@@ -194,7 +194,7 @@ class CocoaPods(
 
         val podspecCommand = runCatching {
             run(
-                "spec", "which", podspecName,
+                "spec", "which", "^$podspecName$",
                 "--version=${id.version}",
                 "--allow-root",
                 "--regex",


### PR DESCRIPTION
Both the default and the regex query string matching logic actually match substrings case-insensitively. So if a package name is a substring of another package name, invalid matches could occur. To circumvent that, force the regex to be a full match.