### PR TITLE
Several scanner and plugin related refactorings

### DIFF
--- a/advisor/src/main/kotlin/AdviceProviderFactory.kt
+++ b/advisor/src/main/kotlin/AdviceProviderFactory.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.advisor
 import java.util.ServiceLoader
 
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
-import org.ossreviewtoolkit.model.config.Options
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -43,10 +43,10 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.common.collectMessages

--- a/model/src/main/kotlin/config/AdvisorConfiguration.kt
+++ b/model/src/main/kotlin/config/AdvisorConfiguration.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import org.ossreviewtoolkit.utils.common.Options
+
 /**
  * The base configuration model of the advisor.
  */

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -194,11 +194,6 @@ data class OrtConfigurationWrapper(
 )
 
 /**
- * A typealias for key-value pairs, used in several configuration classes.
- */
-typealias Options = Map<String, String>
-
-/**
  * The filename of the reference configuration file.
  */
 const val REFERENCE_CONFIG_FILENAME = "reference.yml"

--- a/model/src/main/kotlin/config/PackageManagerConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageManagerConfiguration.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import org.ossreviewtoolkit.utils.common.Options
+
 /**
  * The configuration for a package manager.
  */

--- a/model/src/main/kotlin/config/ReporterConfiguration.kt
+++ b/model/src/main/kotlin/config/ReporterConfiguration.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import org.ossreviewtoolkit.utils.common.Options
+
 /**
  * The base configuration model of the reporter.
  */

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.utils.FileArchiver
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -179,10 +179,10 @@ class ScannerCommand : OrtCommand(
     ): OrtResult {
         val packageScannerWrappers = scannerWrapperFactories
             .takeIf { PackageType.PACKAGE in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner, ortConfig.downloader) }
+            .map { it.create(ortConfig.scanner) }
         val projectScannerWrappers = projectScannerWrapperFactories
             .takeIf { PackageType.PROJECT in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner, ortConfig.downloader) }
+            .map { it.create(ortConfig.scanner) }
 
         if (projectScannerWrappers.isNotEmpty()) {
             echo("Scanning projects with:")

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -173,8 +173,8 @@ class ScannerCommand : OrtCommand(
     }
 
     private fun runScanners(
-        scannerWrapperFactories: List<ScannerWrapperFactory>,
-        projectScannerWrapperFactories: List<ScannerWrapperFactory>,
+        scannerWrapperFactories: List<ScannerWrapperFactory<*>>,
+        projectScannerWrapperFactories: List<ScannerWrapperFactory<*>>,
         ortConfig: OrtConfiguration
     ): OrtResult {
         val packageScannerWrappers = scannerWrapperFactories

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -179,10 +179,10 @@ class ScannerCommand : OrtCommand(
     ): OrtResult {
         val packageScannerWrappers = scannerWrapperFactories
             .takeIf { PackageType.PACKAGE in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner) }
+            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty()) }
         val projectScannerWrappers = projectScannerWrapperFactories
             .takeIf { PackageType.PROJECT in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner) }
+            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty()) }
 
         if (projectScannerWrappers.isNotEmpty()) {
             echo("Scanning projects with:")

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
@@ -21,14 +21,15 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
 import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.Plugin
+import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.getDuplicates
 
 /**
  * The extension point for [PackageConfigurationProvider]s.
  */
-interface PackageConfigurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageConfigurationProvider> {
+interface PackageConfigurationProviderFactory<CONFIG> :
+    TypedConfigurablePluginFactory<CONFIG, PackageConfigurationProvider> {
     companion object {
         val ALL = Plugin.getAll<PackageConfigurationProviderFactory<*>>()
 
@@ -56,16 +57,4 @@ interface PackageConfigurationProviderFactory<CONFIG> : ConfigurablePluginFactor
                     }
                 }
     }
-
-    override fun create(config: Map<String, String>): PackageConfigurationProvider = create(parseConfig(config))
-
-    /**
-     * Create a new [PackageConfigurationProvider] with [config].
-     */
-    fun create(config: CONFIG): PackageConfigurationProvider
-
-    /**
-     * Parse the [config] map into a [CONFIG] instance.
-     */
-    fun parseConfig(config: Map<String, String>): CONFIG
 }

--- a/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
@@ -52,17 +53,17 @@ open class DirPackageConfigurationProviderFactory :
 
     override fun create(config: DirPackageConfigurationProviderConfig) = DirPackageConfigurationProvider(config)
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         DirPackageConfigurationProviderConfig(
-            path = File(config.getValue("path")),
-            mustExist = config["mustExist"]?.toBooleanStrict() ?: true
+            path = File(options.getValue("path")),
+            mustExist = options["mustExist"]?.toBooleanStrict() ?: true
         )
 }
 
 class DefaultDirPackageConfigurationProviderFactory : DirPackageConfigurationProviderFactory() {
     override val type = "DefaultDir"
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         DirPackageConfigurationProviderConfig(
             path = ortConfigDirectory.resolve(ORT_PACKAGE_CONFIGURATIONS_DIRNAME),
             mustExist = false

--- a/plugins/package-configuration-providers/ort-config/src/main/kotlin/OrtConfigPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/ort-config/src/main/kotlin/OrtConfigPackageConfigurationProvider.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 
@@ -44,7 +45,7 @@ class OrtConfigPackageConfigurationProviderFactory : PackageConfigurationProvide
 
     override fun create(config: Unit): PackageConfigurationProvider = OrtConfigPackageConfigurationProvider()
 
-    override fun parseConfig(config: Map<String, String>) = Unit
+    override fun parseOptions(options: Options) = Unit
 }
 
 /**

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -22,14 +22,14 @@ package org.ossreviewtoolkit.plugins.packagecurationproviders.api
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
-import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.Plugin
+import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.getDuplicates
 
 /**
  * The extension point for [PackageCurationProvider]s.
  */
-interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
+interface PackageCurationProviderFactory<CONFIG> : TypedConfigurablePluginFactory<CONFIG, PackageCurationProvider> {
     companion object {
         val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
 
@@ -60,16 +60,4 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
                 }
             }
     }
-
-    override fun create(config: Map<String, String>): PackageCurationProvider = create(parseConfig(config))
-
-    /**
-     * Create a new [PackageCurationProvider] with [config].
-     */
-    fun create(config: CONFIG): PackageCurationProvider
-
-    /**
-     * Parse the [config] map into an object.
-     */
-    fun parseConfig(config: Map<String, String>): CONFIG
 }

--- a/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.showStackTrace
@@ -70,10 +71,10 @@ class ClearlyDefinedPackageCurationProviderFactory :
     override fun create(config: ClearlyDefinedPackageCurationProviderConfig) =
         ClearlyDefinedPackageCurationProvider(config)
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         ClearlyDefinedPackageCurationProviderConfig(
-            serverUrl = config["serverUrl"] ?: Server.PRODUCTION.apiUrl,
-            minTotalLicenseScore = config["minTotalLicenseScore"]?.toInt() ?: 0
+            serverUrl = options["serverUrl"] ?: Server.PRODUCTION.apiUrl,
+            minTotalLicenseScore = options["minTotalLicenseScore"]?.toInt() ?: 0
         )
 }
 

--- a/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
+++ b/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCurationProvider
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_FILENAME
@@ -52,17 +53,17 @@ open class FilePackageCurationProviderFactory : PackageCurationProviderFactory<F
 
     override fun create(config: FilePackageCurationProviderConfig) = FilePackageCurationProvider(config)
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         FilePackageCurationProviderConfig(
-            path = File(config.getValue("path")),
-            mustExist = config["mustExist"]?.toBooleanStrict() ?: true
+            path = File(options.getValue("path")),
+            mustExist = options["mustExist"]?.toBooleanStrict() ?: true
         )
 }
 
 class DefaultFilePackageCurationProviderFactory : FilePackageCurationProviderFactory() {
     override val type = "DefaultFile"
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         FilePackageCurationProviderConfig(
             path = ortConfigDirectory.resolve(ORT_PACKAGE_CURATIONS_FILENAME),
             mustExist = false
@@ -72,7 +73,7 @@ class DefaultFilePackageCurationProviderFactory : FilePackageCurationProviderFac
 class DefaultDirPackageCurationProviderFactory : FilePackageCurationProviderFactory() {
     override val type = "DefaultDir"
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         FilePackageCurationProviderConfig(
             path = ortConfigDirectory.resolve(ORT_PACKAGE_CURATIONS_DIRNAME),
             mustExist = false

--- a/plugins/package-curation-providers/ort-config/src/main/kotlin/OrtConfigPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/ort-config/src/main/kotlin/OrtConfigPackageCurationProvider.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.encodeOr
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
@@ -45,7 +46,7 @@ class OrtConfigPackageCurationProviderFactory : PackageCurationProviderFactory<U
 
     override fun create(config: Unit) = OrtConfigPackageCurationProvider()
 
-    override fun parseConfig(config: Map<String, String>) = Unit
+    override fun parseOptions(options: Options) = Unit
 }
 
 /**

--- a/plugins/package-curation-providers/sw360/src/main/kotlin/Sw360PackageCurationProvider.kt
+++ b/plugins/package-curation-providers/sw360/src/main/kotlin/Sw360PackageCurationProvider.kt
@@ -44,6 +44,7 @@ import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
@@ -52,15 +53,15 @@ class Sw360PackageCurationProviderFactory : PackageCurationProviderFactory<Sw360
 
     override fun create(config: Sw360StorageConfiguration) = Sw360PackageCurationProvider(config)
 
-    override fun parseConfig(config: Map<String, String>) =
+    override fun parseOptions(options: Options) =
         Sw360StorageConfiguration(
-            restUrl = config.getValue("restUrl"),
-            authUrl = config.getValue("authUrl"),
-            username = config.getValue("username"),
-            password = config["password"].orEmpty(),
-            clientId = config.getValue("clientId"),
-            clientPassword = config["clientPassword"].orEmpty(),
-            token = config["token"].orEmpty()
+            restUrl = options.getValue("restUrl"),
+            authUrl = options.getValue("authUrl"),
+            username = options.getValue("username"),
+            password = options["password"].orEmpty(),
+            clientId = options.getValue("clientId"),
+            clientPassword = options["clientPassword"].orEmpty(),
+            token = options["token"].orEmpty()
         )
 }
 

--- a/plugins/scanners/askalono/src/funTest/kotlin/AskalonoFunTest.kt
+++ b/plugins/scanners/askalono/src/funTest/kotlin/AskalonoFunTest.kt
@@ -24,7 +24,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 
 class AskalonoFunTest : AbstractPathScannerWrapperFunTest() {
-    override val scanner = Askalono("Askalono", scannerConfig)
+    override val scanner = Askalono("Askalono", emptyMap())
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 1.0f)

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -33,11 +33,11 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.Options
-import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Os
 
 private const val CONFIDENCE_NOTICE = "Confidence threshold not high enough for any known license"
@@ -47,7 +47,7 @@ private val JSON = Json { ignoreUnknownKeys = true }
 class Askalono internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
     private companion object : Logging
 
-    class Factory : AbstractScannerWrapperFactory<Askalono>("Askalono") {
+    class Factory : ScannerWrapperFactory<Askalono>("Askalono") {
         override fun create(options: Options) = Askalono(type, options)
     }
 

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -32,12 +32,12 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
 
 private const val CONFIDENCE_NOTICE = "Confidence threshold not high enough for any known license"

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -56,7 +56,7 @@ class Askalono internal constructor(
 
     override val configuration = ""
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
+    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
@@ -52,8 +51,7 @@ class Askalono internal constructor(
     private companion object : Logging
 
     class Factory : AbstractScannerWrapperFactory<Askalono>("Askalono") {
-        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            Askalono(type, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration) = Askalono(type, scannerConfig)
     }
 
     override val configuration = ""

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -56,7 +56,9 @@ class Askalono internal constructor(
 
     override val configuration = ""
 
-    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
+    override val criteria by lazy {
+        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
+    }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -44,21 +44,16 @@ private const val CONFIDENCE_NOTICE = "Confidence threshold not high enough for 
 
 private val JSON = Json { ignoreUnknownKeys = true }
 
-class Askalono internal constructor(
-    name: String,
-    private val scannerConfig: ScannerConfiguration
-) : CommandLinePathScannerWrapper(name) {
+class Askalono internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
     private companion object : Logging
 
     class Factory : AbstractScannerWrapperFactory<Askalono>("Askalono") {
-        override fun create(scannerConfig: ScannerConfiguration) = Askalono(type, scannerConfig)
+        override fun create(options: Options) = Askalono(type, options)
     }
 
     override val configuration = ""
 
-    override val criteria by lazy {
-        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
-    }
+    override val criteria by lazy { ScannerCriteria.create(details, options) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/funTest/kotlin/BoyterLcFunTest.kt
+++ b/plugins/scanners/boyterlc/src/funTest/kotlin/BoyterLcFunTest.kt
@@ -24,7 +24,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 
 class BoyterLcFunTest : AbstractPathScannerWrapperFunTest() {
-    override val scanner = BoyterLc("BoyterLc", scannerConfig)
+    override val scanner = BoyterLc("BoyterLc", emptyMap())
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 0.98388565f),

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -31,7 +31,6 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
@@ -56,8 +55,7 @@ class BoyterLc internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<BoyterLc>("BoyterLc") {
-        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            BoyterLc(type, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration) = BoyterLc(type, scannerConfig)
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -32,11 +32,11 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.Options
-import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -51,7 +51,7 @@ class BoyterLc internal constructor(name: String, private val options: Options) 
         )
     }
 
-    class Factory : AbstractScannerWrapperFactory<BoyterLc>("BoyterLc") {
+    class Factory : ScannerWrapperFactory<BoyterLc>("BoyterLc") {
         override fun create(options: Options) = BoyterLc(type, options)
     }
 

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -60,7 +60,9 @@ class BoyterLc internal constructor(
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
+    override val criteria by lazy {
+        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
+    }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -31,12 +31,12 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -43,10 +43,7 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 private val JSON = Json { ignoreUnknownKeys = true }
 
-class BoyterLc internal constructor(
-    name: String,
-    private val scannerConfig: ScannerConfiguration
-) : CommandLinePathScannerWrapper(name) {
+class BoyterLc internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
     companion object : Logging {
         val CONFIGURATION_OPTIONS = listOf(
             "--confidence", "0.95", // Cut-off value to only get most relevant matches.
@@ -55,14 +52,12 @@ class BoyterLc internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<BoyterLc>("BoyterLc") {
-        override fun create(scannerConfig: ScannerConfiguration) = BoyterLc(type, scannerConfig)
+        override fun create(options: Options) = BoyterLc(type, options)
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val criteria by lazy {
-        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
-    }
+    override val criteria by lazy { ScannerCriteria.create(details, options) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -60,7 +60,7 @@ class BoyterLc internal constructor(
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
+    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -96,7 +96,6 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
  */
 class FossId internal constructor(
     override val name: String,
-    private val options: Options,
     private val config: FossIdConfig
 ) : PackageScannerWrapper {
     companion object : Logging {
@@ -170,7 +169,7 @@ class FossId internal constructor(
     }
 
     class Factory : ScannerWrapperFactory<FossId>("FossId") {
-        override fun create(options: Options) = FossId(type, options, FossIdConfig.create(options))
+        override fun create(options: Options) = FossId(type, FossIdConfig.create(options))
     }
 
     /**

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -72,7 +72,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.scanner.PackageScannerWrapper
@@ -80,6 +79,7 @@ import org.ossreviewtoolkit.scanner.ProvenanceScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.showStackTrace

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -96,7 +96,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
  */
 class FossId internal constructor(
     override val name: String,
-    private val scannerConfig: ScannerConfiguration,
+    private val options: Options,
     private val config: FossIdConfig
 ) : PackageScannerWrapper {
     companion object : Logging {
@@ -170,8 +170,7 @@ class FossId internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<FossId>("FossId") {
-        override fun create(scannerConfig: ScannerConfiguration) =
-            FossId(type, scannerConfig, FossIdConfig.create(scannerConfig))
+        override fun create(options: Options) = FossId(type, options, FossIdConfig.create(options))
     }
 
     /**

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -72,7 +72,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
@@ -171,7 +170,7 @@ class FossId internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<FossId>("FossId") {
-        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+        override fun create(scannerConfig: ScannerConfiguration) =
             FossId(type, scannerConfig, FossIdConfig.create(scannerConfig))
     }
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -75,11 +75,11 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.PackageScannerWrapper
 import org.ossreviewtoolkit.scanner.ProvenanceScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.showStackTrace
@@ -169,7 +169,7 @@ class FossId internal constructor(
             )
     }
 
-    class Factory : AbstractScannerWrapperFactory<FossId>("FossId") {
+    class Factory : ScannerWrapperFactory<FossId>("FossId") {
         override fun create(options: Options) = FossId(type, options, FossIdConfig.create(options))
     }
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -310,7 +310,15 @@ class FossId internal constructor(
 
                     if (config.waitForResult) {
                         val rawResults = getRawResults(scanCode)
-                        createResultSummary(startTime, provenance, rawResults, scanCode, scanId, issues)
+                        createResultSummary(
+                            startTime,
+                            provenance,
+                            rawResults,
+                            scanCode,
+                            scanId,
+                            issues,
+                            context.detectedLicenseMapping
+                        )
                     } else {
                         val issue = createAndLogIssue(
                             source = name,
@@ -857,7 +865,8 @@ class FossId internal constructor(
         rawResults: RawResults,
         scanCode: String,
         scanId: String,
-        additionalIssues: MutableList<Issue>
+        additionalIssues: MutableList<Issue>,
+        detectedLicenseMapping: Map<String, String>
     ): ScanResult {
         // TODO: Maybe get issues from FossID (see has_failed_scan_files, get_failed_files and maybe get_scan_log).
 
@@ -875,7 +884,7 @@ class FossId internal constructor(
 
         val (licenseFindings, copyrightFindings) = rawResults.markedAsIdentifiedFiles.ifEmpty {
             rawResults.identifiedFiles
-        }.mapSummary(ignoredFiles, issues, scannerConfig.detectedLicenseMapping)
+        }.mapSummary(ignoredFiles, issues, detectedLicenseMapping)
 
         val summary = ScanSummary(
             startTime = startTime,

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -21,11 +21,12 @@ package org.ossreviewtoolkit.plugins.scanners.fossid
 
 import org.apache.logging.log4j.kotlin.Logging
 
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 /**
  * A data class that holds the configuration options supported by the [FossId] scanner. An instance of this class is
- * created from the options contained in a [ScannerConfiguration] object under the key _FossId_. It offers the
+ * created from the [Options] contained in a [ScannerConfiguration] object under the key _FossId_. It offers the
  * following configuration options:
  *
  * * **"serverUrl":** The URL of the FossID server.
@@ -160,32 +161,28 @@ internal data class FossIdConfig(
         @JvmStatic
         private val DEFAULT_TIMEOUT = 60
 
-        fun create(scannerConfig: ScannerConfiguration): FossIdConfig {
-            val fossIdScannerOptions = scannerConfig.options?.get("FossId")
+        fun create(options: Options): FossIdConfig {
+            require(options.isNotEmpty()) { "No FossID Scanner configuration found." }
 
-            requireNotNull(fossIdScannerOptions) { "No FossID Scanner configuration found." }
-
-            val serverUrl = fossIdScannerOptions[SERVER_URL_PROPERTY]
+            val serverUrl = options[SERVER_URL_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID server URL configuration found.")
-            val user = fossIdScannerOptions[USER_PROPERTY]
+            val user = options[USER_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID User configuration found.")
-            val apiKey = fossIdScannerOptions[API_KEY_PROPERTY]
+            val apiKey = options[API_KEY_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID API Key configuration found.")
 
-            val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
+            val waitForResult = options[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
 
-            val keepFailedScans = fossIdScannerOptions[KEEP_FAILED_SCANS_PROPERTY]?.toBoolean() ?: false
-            val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
-            val deltaScanLimit = fossIdScannerOptions[DELTA_SCAN_LIMIT_PROPERTY]?.toInt() ?: Int.MAX_VALUE
+            val keepFailedScans = options[KEEP_FAILED_SCANS_PROPERTY]?.toBoolean() ?: false
+            val deltaScans = options[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
+            val deltaScanLimit = options[DELTA_SCAN_LIMIT_PROPERTY]?.toInt() ?: Int.MAX_VALUE
 
-            val detectLicenseDeclarations =
-                fossIdScannerOptions[DETECT_LICENSE_DECLARATIONS_PROPERTY]?.toBoolean() ?: false
-            val detectCopyrightStatements =
-                fossIdScannerOptions[DETECT_COPYRIGHT_STATEMENTS_PROPERTY]?.toBoolean() ?: false
+            val detectLicenseDeclarations = options[DETECT_LICENSE_DECLARATIONS_PROPERTY]?.toBoolean() ?: false
+            val detectCopyrightStatements = options[DETECT_COPYRIGHT_STATEMENTS_PROPERTY]?.toBoolean() ?: false
 
-            val timeout = fossIdScannerOptions[TIMEOUT]?.toInt() ?: DEFAULT_TIMEOUT
+            val timeout = options[TIMEOUT]?.toInt() ?: DEFAULT_TIMEOUT
 
-            val fetchSnippetMatchedLines = fossIdScannerOptions[FETCH_SNIPPET_MATCHED_LINES]?.toBoolean() ?: false
+            val fetchSnippetMatchedLines = options[FETCH_SNIPPET_MATCHED_LINES]?.toBoolean() ?: false
 
             require(deltaScanLimit > 0) {
                 "deltaScanLimit must be > 0, current value is $deltaScanLimit."
@@ -205,7 +202,7 @@ internal data class FossIdConfig(
                 detectCopyrightStatements = detectCopyrightStatements,
                 timeout = timeout,
                 fetchSnippetMatchedLines = fetchSnippetMatchedLines,
-                options = fossIdScannerOptions
+                options = options
             )
         }
     }

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.plugins.scanners.fossid
 
 import org.apache.logging.log4j.kotlin.Logging
 
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.common.Options
 
 /**
  * A data class that holds the configuration options supported by the [FossId] scanner. An instance of this class is

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -85,7 +85,9 @@ internal fun <T : Summarizable> List<T>.mapSummary(
 
         summary.licences.forEach {
             runCatching {
-                // TODO: The license mapping should be moved to a central place.
+                // TODO: The detected license mapping must be applied here, because FossID can return license strings
+                //       which cannot be parsed to an SpdxExpression. A better solution could be to automatically
+                //       convert the strings into a form that can be parsed, then the mapping could be applied globally.
                 LicenseFinding(it.identifier.mapLicense(detectedLicenseMapping), location)
             }.onSuccess { licenseFinding ->
                 licenseFindings += licenseFinding.copy(license = licenseFinding.license.normalize())

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -1152,7 +1152,7 @@ private val DEFAULT_IGNORE_RULE_SCOPE = RuleScope.SCAN
 /**
  * Create a new [FossId] instance with the specified [config].
  */
-private fun createFossId(config: FossIdConfig): FossId = FossId("FossId", emptyMap(), config)
+private fun createFossId(config: FossIdConfig): FossId = FossId("FossId", config)
 
 /**
  * Create a standard [FossIdConfig] whose properties can be partly specified.

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -102,7 +102,6 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SCAN_CODE_KEY
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SCAN_ID_KEY
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SERVER_URL_KEY
@@ -1153,7 +1152,7 @@ private val DEFAULT_IGNORE_RULE_SCOPE = RuleScope.SCAN
 /**
  * Create a new [FossId] instance with the specified [config].
  */
-private fun createFossId(config: FossIdConfig): FossId = FossId("FossId", ScannerConfiguration(), config)
+private fun createFossId(config: FossIdConfig): FossId = FossId("FossId", emptyMap(), config)
 
 /**
  * Create a standard [FossIdConfig] whose properties can be partly specified.

--- a/plugins/scanners/licensee/src/funTest/kotlin/LicenseeFunTest.kt
+++ b/plugins/scanners/licensee/src/funTest/kotlin/LicenseeFunTest.kt
@@ -25,7 +25,7 @@ import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class LicenseeFunTest : AbstractPathScannerWrapperFunTest(setOf(ExpensiveTag)) {
-    override val scanner = Licensee("Licensee", scannerConfig)
+    override val scanner = Licensee("Licensee", emptyMap())
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 100.0f)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -45,23 +45,18 @@ private val JSON = Json {
     namingStrategy = JsonNamingStrategy.SnakeCase
 }
 
-class Licensee internal constructor(
-    name: String,
-    private val scannerConfig: ScannerConfiguration
-) : CommandLinePathScannerWrapper(name) {
+class Licensee internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
     companion object : Logging {
         val CONFIGURATION_OPTIONS = listOf("--json")
     }
 
     class Factory : AbstractScannerWrapperFactory<Licensee>("Licensee") {
-        override fun create(scannerConfig: ScannerConfiguration) = Licensee(type, scannerConfig)
+        override fun create(options: Options) = Licensee(type, options)
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val criteria by lazy {
-        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
-    }
+    override val criteria by lazy { ScannerCriteria.create(details, options) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -59,7 +59,7 @@ class Licensee internal constructor(
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
+    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -33,11 +33,11 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.Options
-import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Os
 
 private val JSON = Json {
@@ -50,7 +50,7 @@ class Licensee internal constructor(name: String, private val options: Options) 
         val CONFIGURATION_OPTIONS = listOf("--json")
     }
 
-    class Factory : AbstractScannerWrapperFactory<Licensee>("Licensee") {
+    class Factory : ScannerWrapperFactory<Licensee>("Licensee") {
         override fun create(options: Options) = Licensee(type, options)
     }
 

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -59,7 +59,9 @@ class Licensee internal constructor(
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
+    override val criteria by lazy {
+        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
+    }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -32,12 +32,12 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
 
 private val JSON = Json {

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
@@ -55,8 +54,7 @@ class Licensee internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<Licensee>("Licensee") {
-        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            Licensee(type, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration) = Licensee(type, scannerConfig)
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")

--- a/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
+++ b/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.utils.spdx.getLicenseText
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class ScanCodeScannerFunTest : AbstractPathScannerWrapperFunTest(setOf(ExpensiveTag)) {
-    override val scanner = ScanCode("ScanCode", scannerConfig)
+    override val scanner = ScanCode("ScanCode", emptyMap())
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", 1, 187), 100.0f),

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
@@ -56,10 +57,7 @@ import org.semver4j.Semver
  * * **"commandLineNonConfig":** Command line options that do not modify the result and should therefore not be
  *   considered in [configuration], like "--processes". Defaults to [DEFAULT_NON_CONFIGURATION_OPTIONS].
  */
-class ScanCode internal constructor(
-    name: String,
-    private val scannerConfig: ScannerConfiguration
-) : CommandLinePathScannerWrapper(name) {
+class ScanCode internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
     companion object : Logging {
         const val SCANNER_NAME = "ScanCode"
 
@@ -94,12 +92,10 @@ class ScanCode internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<ScanCode>(SCANNER_NAME) {
-        override fun create(scannerConfig: ScannerConfiguration) = ScanCode(type, scannerConfig)
+        override fun create(options: Options) = ScanCode(type, options)
     }
 
-    override val criteria by lazy {
-        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
-    }
+    override val criteria by lazy { ScannerCriteria.create(details, options) }
 
     override val configuration by lazy {
         buildList {
@@ -108,11 +104,8 @@ class ScanCode internal constructor(
         }.joinToString(" ")
     }
 
-    private val scanCodeConfiguration = scannerConfig.options?.get("ScanCode").orEmpty()
-
-    private val configurationOptions = scanCodeConfiguration["commandLine"]?.splitOnWhitespace()
-        ?: DEFAULT_CONFIGURATION_OPTIONS
-    private val nonConfigurationOptions = scanCodeConfiguration["commandLineNonConfig"]?.splitOnWhitespace()
+    private val configurationOptions = options["commandLine"]?.splitOnWhitespace() ?: DEFAULT_CONFIGURATION_OPTIONS
+    private val nonConfigurationOptions = options["commandLineNonConfig"]?.splitOnWhitespace()
         ?: DEFAULT_NON_CONFIGURATION_OPTIONS
 
     internal fun getCommandLineOptions(version: String) =

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -30,11 +30,11 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
@@ -91,7 +91,7 @@ class ScanCode internal constructor(name: String, private val options: Options) 
         }
     }
 
-    class Factory : AbstractScannerWrapperFactory<ScanCode>(SCANNER_NAME) {
+    class Factory : ScannerWrapperFactory<ScanCode>(SCANNER_NAME) {
         override fun create(options: Options) = ScanCode(type, options)
     }
 

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -97,7 +97,7 @@ class ScanCode internal constructor(
         override fun create(scannerConfig: ScannerConfiguration) = ScanCode(type, scannerConfig)
     }
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
+    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
 
     override val configuration by lazy {
         buildList {

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -28,13 +28,13 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -97,7 +97,9 @@ class ScanCode internal constructor(
         override fun create(scannerConfig: ScannerConfiguration) = ScanCode(type, scannerConfig)
     }
 
-    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
+    override val criteria by lazy {
+        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
+    }
 
     override val configuration by lazy {
         buildList {

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
@@ -95,8 +94,7 @@ class ScanCode internal constructor(
     }
 
     class Factory : AbstractScannerWrapperFactory<ScanCode>(SCANNER_NAME) {
-        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            ScanCode(type, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration) = ScanCode(type, scannerConfig)
     }
 
     override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -34,12 +34,11 @@ import io.mockk.spyk
 import java.io.File
 
 import org.ossreviewtoolkit.model.PackageType
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 
 class ScanCodeTest : WordSpec({
-    val scanner = ScanCode("ScanCode", ScannerConfiguration())
+    val scanner = ScanCode("ScanCode", emptyMap())
 
     "configuration" should {
         "return the default values if the scanner configuration is empty" {
@@ -49,13 +48,9 @@ class ScanCodeTest : WordSpec({
         "return the non-config values from the scanner configuration" {
             val scannerWithConfig = ScanCode(
                 "ScanCode",
-                ScannerConfiguration(
-                    options = mapOf(
-                        "ScanCode" to mapOf(
-                            "commandLine" to "--command --line",
-                            "commandLineNonConfig" to "--commandLineNonConfig"
-                        )
-                    )
+                mapOf(
+                    "commandLine" to "--command --line",
+                    "commandLineNonConfig" to "--commandLineNonConfig"
                 )
             )
 
@@ -74,13 +69,9 @@ class ScanCodeTest : WordSpec({
         "contain the values from the scanner configuration" {
             val scannerWithConfig = ScanCode(
                 "ScanCode",
-                ScannerConfiguration(
-                    options = mapOf(
-                        "ScanCode" to mapOf(
-                            "commandLine" to "--command --line",
-                            "commandLineNonConfig" to "--commandLineNonConfig"
-                        )
-                    )
+                mapOf(
+                    "commandLine" to "--command --line",
+                    "commandLineNonConfig" to "--commandLineNonConfig"
                 )
             )
 
@@ -91,13 +82,9 @@ class ScanCodeTest : WordSpec({
         "be handled correctly when containing multiple spaces" {
             val scannerWithConfig = ScanCode(
                 "ScanCode",
-                ScannerConfiguration(
-                    options = mapOf(
-                        "ScanCode" to mapOf(
-                            "commandLine" to " --command  --line  ",
-                            "commandLineNonConfig" to "  -n -c "
-                        )
-                    )
+                mapOf(
+                    "commandLine" to " --command  --line  ",
+                    "commandLineNonConfig" to "  -n -c "
                 )
             )
 
@@ -132,13 +119,8 @@ class ScanCodeTest : WordSpec({
     }
 
     "transformVersion()" should {
-        val scanCode = ScanCode(
-            "ScanCode",
-            ScannerConfiguration()
-        )
-
         "work with a version output without a colon" {
-            scanCode.transformVersion(
+            scanner.transformVersion(
                 """
                     ScanCode version 30.0.1
                     ScanCode Output Format version 1.0.0
@@ -148,7 +130,7 @@ class ScanCodeTest : WordSpec({
         }
 
         "work with a version output with a colon" {
-            scanCode.transformVersion(
+            scanner.transformVersion(
                 """
                     ScanCode version: 31.0.0b4
                     ScanCode Output Format version: 2.0.0

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.PathScannerWrapper
@@ -57,8 +56,7 @@ class ScanOss internal constructor(
     private companion object : Logging
 
     class Factory : AbstractScannerWrapperFactory<ScanOss>("SCANOSS") {
-        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            ScanOss(type, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration) = ScanOss(type, scannerConfig)
     }
 
     private val config = ScanOssConfig.create(scannerConfig).also {

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -49,17 +49,14 @@ import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 private const val FAKE_WFP_FILE_NAME = "fake.wfp"
 private const val ARG_FIELD_NAME = "file"
 
-class ScanOss internal constructor(
-    override val name: String,
-    private val scannerConfig: ScannerConfiguration
-) : PathScannerWrapper {
+class ScanOss internal constructor(override val name: String, private val options: Options) : PathScannerWrapper {
     private companion object : Logging
 
     class Factory : AbstractScannerWrapperFactory<ScanOss>("SCANOSS") {
-        override fun create(scannerConfig: ScannerConfiguration) = ScanOss(type, scannerConfig)
+        override fun create(options: Options) = ScanOss(type, options)
     }
 
-    private val config = ScanOssConfig.create(scannerConfig).also {
+    private val config = ScanOssConfig.create(options).also {
         logger.info { "The $name API URL is ${it.apiUrl}." }
     }
 
@@ -74,9 +71,7 @@ class ScanOss internal constructor(
 
     override val configuration = ""
 
-    override val criteria by lazy {
-        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
-    }
+    override val criteria by lazy { ScannerCriteria.create(details, options) }
 
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -74,7 +74,9 @@ class ScanOss internal constructor(
 
     override val configuration = ""
 
-    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
+    override val criteria by lazy {
+        ScannerCriteria.create(details, scannerConfig.options?.get(details.name).orEmpty())
+    }
 
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -38,11 +38,11 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.scanner.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 
 // An arbitrary name to use for the multipart body being sent.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -74,7 +74,7 @@ class ScanOss internal constructor(
 
     override val configuration = ""
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
+    override val criteria by lazy { ScannerCriteria.create(details, scannerConfig) }
 
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -39,10 +39,10 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.config.Options
-import org.ossreviewtoolkit.scanner.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 
 // An arbitrary name to use for the multipart body being sent.
@@ -52,7 +52,7 @@ private const val ARG_FIELD_NAME = "file"
 class ScanOss internal constructor(override val name: String, private val options: Options) : PathScannerWrapper {
     private companion object : Logging
 
-    class Factory : AbstractScannerWrapperFactory<ScanOss>("SCANOSS") {
+    class Factory : ScannerWrapperFactory<ScanOss>("SCANOSS") {
         override fun create(options: Options) = ScanOss(type, options)
     }
 

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -20,8 +20,8 @@
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.common.Options
 
 /**
  * A data class that holds the configuration options supported by the [ScanOss] scanner. An instance of this class is

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 /**
@@ -41,11 +42,9 @@ internal data class ScanOssConfig(
         /** Name of the configuration property for the API key. */
         const val API_KEY_PROPERTY = "apiKey"
 
-        fun create(scannerConfig: ScannerConfiguration): ScanOssConfig {
-            val scanOssOptions = scannerConfig.options?.get("ScanOss")
-
-            val apiUrl = scanOssOptions?.get(API_URL_PROPERTY) ?: ScanOssService.DEFAULT_API_URL
-            val apiKey = scanOssOptions?.get(API_KEY_PROPERTY).orEmpty()
+        fun create(options: Options): ScanOssConfig {
+            val apiUrl = options[API_URL_PROPERTY] ?: ScanOssService.DEFAULT_API_URL
+            val apiKey = options[API_KEY_PROPERTY].orEmpty()
 
             return ScanOssConfig(apiUrl, apiKey)
         }

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssConfigTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssConfigTest.kt
@@ -25,25 +25,22 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.beEmpty
 
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 class ScanOssConfigTest : StringSpec({
     "Default values are used" {
-        with(ScanOssConfig.create(ScannerConfiguration())) {
+        with(ScanOssConfig.create(emptyMap())) {
             apiUrl shouldBe ScanOssService.DEFAULT_API_URL
             apiKey should beEmpty()
         }
     }
 
     "Default values can be overridden" {
-        val scanOssOptions = mapOf(
+        val options = mapOf(
             ScanOssConfig.API_URL_PROPERTY to "url",
             ScanOssConfig.API_KEY_PROPERTY to "key"
         )
 
-        val config = ScannerConfiguration(options = mapOf("ScanOss" to scanOssOptions))
-
-        with(ScanOssConfig.create(config)) {
+        with(ScanOssConfig.create(options)) {
             apiUrl shouldBe "url"
             apiKey shouldBe "key"
         }

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -42,7 +42,6 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
@@ -62,9 +61,8 @@ class ScanOssScannerDirectoryTest : StringSpec({
 
     beforeSpec {
         server.start()
-        val scannerOptions = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
-        val configuration = ScannerConfiguration(options = mapOf("ScanOss" to scannerOptions))
-        scanner = spyk(ScanOss.Factory().create(configuration))
+        val options = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
+        scanner = spyk(ScanOss.Factory().create(options))
     }
 
     afterSpec {

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -42,7 +42,6 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
@@ -65,7 +64,7 @@ class ScanOssScannerDirectoryTest : StringSpec({
         server.start()
         val scannerOptions = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
         val configuration = ScannerConfiguration(options = mapOf("ScanOss" to scannerOptions))
-        scanner = spyk(ScanOss.Factory().create(configuration, DownloaderConfiguration()))
+        scanner = spyk(ScanOss.Factory().create(configuration))
     }
 
     afterSpec {

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
@@ -36,7 +36,6 @@ import java.util.UUID
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 
 private val TEST_FILE_TO_SCAN = File("src/test/assets/filesToScan/ScannerFactory.kt")
@@ -55,9 +54,8 @@ class ScanOssScannerFileTest : StringSpec({
 
     beforeSpec {
         server.start()
-        val scannerOptions = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
-        val configuration = ScannerConfiguration(options = mapOf("ScanOss" to scannerOptions))
-        scanner = spyk(ScanOss.Factory().create(configuration))
+        val options = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
+        scanner = spyk(ScanOss.Factory().create(options))
     }
 
     afterSpec {

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
@@ -36,7 +36,6 @@ import java.util.UUID
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 
@@ -58,7 +57,7 @@ class ScanOssScannerFileTest : StringSpec({
         server.start()
         val scannerOptions = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
         val configuration = ScannerConfiguration(options = mapOf("ScanOss" to scannerOptions))
-        scanner = spyk(ScanOss.Factory().create(configuration, DownloaderConfiguration()))
+        scanner = spyk(ScanOss.Factory().create(configuration))
     }
 
     afterSpec {

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -215,7 +215,7 @@ internal class DummyScanner(override val name: String = "Dummy") : PathScannerWr
     override val version = "1.0.0"
     override val configuration = ""
 
-    override val criteria = ScannerCriteria.forDetails(details)
+    override val criteria = ScannerCriteria.create(details)
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {
         val relevantFiles = path.walk()

--- a/scanner/src/funTest/kotlin/storages/AbstractProvenanceBasedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractProvenanceBasedStorageFunTest.kt
@@ -45,8 +45,6 @@ import org.ossreviewtoolkit.scanner.ProvenanceBasedScanStorage
 import org.ossreviewtoolkit.scanner.ScanStorageException
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 
-import org.semver4j.Semver
-
 abstract class AbstractProvenanceBasedStorageFunTest(vararg listeners: TestListener) : WordSpec() {
     private lateinit var storage: ProvenanceBasedScanStorage
 
@@ -133,7 +131,7 @@ abstract class AbstractProvenanceBasedStorageFunTest(vararg listeners: TestListe
 
             "fail if the provenance contains a VCS path" {
                 val provenance = createRepositoryProvenance(vcsInfo = VcsInfo.valid().copy(path = "path"))
-                val criteria = ScannerCriteria.forDetails(createScannerDetails())
+                val criteria = ScannerCriteria.create(createScannerDetails())
 
                 shouldThrow<ScanStorageException> { storage.read(provenance) }
                 shouldThrow<ScanStorageException> { storage.read(provenance, criteria) }
@@ -148,7 +146,7 @@ abstract class AbstractProvenanceBasedStorageFunTest(vararg listeners: TestListe
 
                 val readResult = storage.read(
                     scanResult1.provenance as KnownProvenance,
-                    ScannerCriteria.forDetails(scanResult1.scanner)
+                    ScannerCriteria.create(scanResult1.scanner)
                 )
 
                 readResult should containExactly(scanResult1)
@@ -158,7 +156,7 @@ abstract class AbstractProvenanceBasedStorageFunTest(vararg listeners: TestListe
                 val scanResult1 = createScanResult(scannerDetails = createScannerDetails(name = "name1"))
                 val scanResult2 = createScanResult(scannerDetails = createScannerDetails(name = "name2"))
                 val scanResult3 = createScanResult(scannerDetails = createScannerDetails(name = "other name"))
-                val criteria = ScannerCriteria.forDetails(scanResult1.scanner).copy(regScannerName = "name.+")
+                val criteria = ScannerCriteria.create(scanResult1.scanner).copy(regScannerName = "name.+")
 
                 storage.write(scanResult1)
                 storage.write(scanResult2)
@@ -175,7 +173,7 @@ abstract class AbstractProvenanceBasedStorageFunTest(vararg listeners: TestListe
                 val scanResultCompatible2 =
                     createScanResult(scannerDetails = createScannerDetails(version = "1.0.1-alpha.1"))
                 val scanResultIncompatible = createScanResult(scannerDetails = createScannerDetails(version = "2.0.0"))
-                val criteria = ScannerCriteria.forDetails(scanResult.scanner, Semver.VersionDiff.PATCH)
+                val criteria = ScannerCriteria.create(scanResult.scanner)
 
                 storage.write(scanResult)
                 storage.write(scanResultCompatible1)

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -97,7 +97,7 @@ abstract class AbstractStorageFunTest(vararg listeners: TestListener) : WordSpec
     private val scannerDetailsCompatibleVersion2 = ScannerDetails("name 1", "1.0.1-alpha.1", "config 1")
     private val scannerDetailsIncompatibleVersion = ScannerDetails("name 1", "1.1.0", "config 1")
 
-    private val scannerCriteriaForDetails1 = ScannerCriteria.forDetails(scannerDetails1, Semver.VersionDiff.PATCH)
+    private val scannerCriteriaForDetails1 = ScannerCriteria.create(scannerDetails1)
 
     private val scanSummaryWithFiles = ScanSummary.EMPTY.copy(
         startTime = Instant.EPOCH + Duration.ofMinutes(1),

--- a/scanner/src/main/kotlin/ScanContext.kt
+++ b/scanner/src/main/kotlin/ScanContext.kt
@@ -19,9 +19,12 @@
 
 package org.ossreviewtoolkit.scanner
 
+import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 /**
  * Additional context information that can be used by a [ScannerWrapper] to alter its behavior.
@@ -40,5 +43,15 @@ data class ScanContext(
     /**
      * The [Excludes] of the project to scan.
      */
-    val excludes: Excludes? = null
+    val excludes: Excludes? = null,
+
+    /**
+     * The detected license mappings configured in the
+     * [scanner configuration][ScannerConfiguration.detectedLicenseMapping]. Can be used by [ScannerWrapper]
+     * implementations where the scanner can return arbitrary license strings which cannot be parsed as
+     * [SpdxExpression]s and can therefore not be returned as a [LicenseFinding] without being mapped first. Should not
+     * be used by scanners where scan results are stored, because then changes in the mapping would not be applied to
+     * stored results.
+     */
+    val detectedLicenseMapping: Map<String, String> = emptyMap()
 )

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -124,7 +124,8 @@ class Scanner(
                 ScanContext(
                     ortResult.labels + labels,
                     PackageType.PROJECT,
-                    ortResult.repository.config.excludes
+                    ortResult.repository.config.excludes,
+                    scannerConfig.detectedLicenseMapping
                 )
             )
         } else {
@@ -139,7 +140,15 @@ class Scanner(
 
             logger.info { "Scanning ${packages.size} package(s) with ${packageScannerWrappers.size} scanner(s)." }
 
-            scan(packages, ScanContext(ortResult.labels, PackageType.PACKAGE, ortResult.repository.config.excludes))
+            scan(
+                packages,
+                ScanContext(
+                    ortResult.labels,
+                    PackageType.PACKAGE,
+                    ortResult.repository.config.excludes,
+                    scannerConfig.detectedLicenseMapping
+                )
+            )
         } else {
             logger.info { "Skipping package scan as no package scanner is configured." }
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -49,7 +49,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.createStorage
@@ -65,6 +64,7 @@ import org.ossreviewtoolkit.scanner.provenance.NestedProvenanceScanResult
 import org.ossreviewtoolkit.scanner.provenance.PackageProvenanceResolver
 import org.ossreviewtoolkit.scanner.provenance.ProvenanceDownloader
 import org.ossreviewtoolkit.scanner.utils.FileListResolver
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.Environment

--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.scanner
 
 import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.config.Options
+import org.ossreviewtoolkit.utils.common.Options
 
 import org.semver4j.Semver
 

--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -23,7 +23,6 @@ import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.Options
 
 import org.semver4j.Semver
-import org.semver4j.Semver.VersionDiff
 
 /**
  * A data class defining selection criteria for scanners.
@@ -86,28 +85,6 @@ data class ScannerCriteria(
          * [scanner details][ScannerDetails] of the corresponding scanner must match the criteria.
          */
         const val PROP_CRITERIA_CONFIGURATION = "configuration"
-
-        /**
-         * Generate a [ScannerCriteria] instance that is compatible with the given [details] and versions that differ
-         * only in the provided [versionDiff].
-         */
-        fun forDetails(details: ScannerDetails, versionDiff: VersionDiff = VersionDiff.NONE): ScannerCriteria {
-            val minVersion = Semver(details.version)
-
-            val maxVersion = when (versionDiff) {
-                VersionDiff.NONE, VersionDiff.PRE_RELEASE, VersionDiff.BUILD -> minVersion.nextPatch()
-                VersionDiff.PATCH -> minVersion.nextMinor()
-                VersionDiff.MINOR -> minVersion.nextMajor()
-                else -> throw IllegalArgumentException("Invalid version difference $versionDiff")
-            }
-
-            return ScannerCriteria(
-                regScannerName = details.name,
-                minVersion = minVersion,
-                maxVersion = maxVersion,
-                configuration = details.configuration
-            )
-        }
 
         /**
          * Return a [ScannerCriteria] instance that is to be used when looking up existing scan results from a

--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.scanner
 
 import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 
 import org.semver4j.Semver
 import org.semver4j.Semver.VersionDiff
@@ -129,14 +129,11 @@ data class ScannerCriteria(
         /**
          * Return a [ScannerCriteria] instance that is to be used when looking up existing scan results from a
          * [ScanResultsStorage]. By default, the properties of this instance are initialized to match the scanner
-         * [details]. These defaults can be overridden by the [ScannerConfiguration.options] property in the provided
-         * [config]: Use properties of the form `scannerName.property`, where `scannerName` is the name of the scanner
-         * the configuration applies to, and `property` is the name of a property of the [ScannerCriteria] class. For
-         * instance, to specify that a specific minimum version of ScanCode is allowed, set this property:
-         * `options.ScanCode.minVersion=3.0.2`.
+         * [details]. These defaults can be overridden by the provided [options]. The keys of the option map must match
+         * names of the [ScannerCriteria] class. For example, to specify that a specific minimum version of the scanner
+         * is allowed, set this option: `minVersion=3.0.2`.
          */
-        fun create(details: ScannerDetails, config: ScannerConfiguration): ScannerCriteria {
-            val options = config.options?.get(details.name).orEmpty()
+        fun create(details: ScannerDetails, options: Options = emptyMap()): ScannerCriteria {
             val scannerVersion = Semver(normalizeVersion(details.version))
             val minVersion = parseVersion(options[PROP_CRITERIA_MIN_VERSION]) ?: scannerVersion
             val maxVersion = parseVersion(options[PROP_CRITERIA_MAX_VERSION]) ?: minVersion.nextMinor()

--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -135,7 +135,7 @@ data class ScannerCriteria(
          * instance, to specify that a specific minimum version of ScanCode is allowed, set this property:
          * `options.ScanCode.minVersion=3.0.2`.
          */
-        fun fromConfig(details: ScannerDetails, config: ScannerConfiguration): ScannerCriteria {
+        fun create(details: ScannerDetails, config: ScannerConfiguration): ScannerCriteria {
             val options = config.options?.get(details.name).orEmpty()
             val scannerVersion = Semver(normalizeVersion(details.version))
             val minVersion = parseVersion(options[PROP_CRITERIA_MIN_VERSION]) ?: scannerVersion

--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -129,7 +129,7 @@ data class ScannerCriteria(
         /**
          * Return a [ScannerCriteria] instance that is to be used when looking up existing scan results from a
          * [ScanResultsStorage]. By default, the properties of this instance are initialized to match the scanner
-         * [details]. These default can be overridden by the [ScannerConfiguration.options] property in the provided
+         * [details]. These defaults can be overridden by the [ScannerConfiguration.options] property in the provided
          * [config]: Use properties of the form `scannerName.property`, where `scannerName` is the name of the scanner
          * the configuration applies to, and `property` is the name of a property of the [ScannerCriteria] class. For
          * instance, to specify that a specific minimum version of ScanCode is allowed, set this property:

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -27,8 +27,8 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 
 /**

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -39,7 +39,7 @@ sealed interface ScannerWrapper {
         /**
          * All [scanner wrapper factories][ScannerWrapperFactory] available in the classpath, associated by their names.
          */
-        val ALL by lazy { Plugin.getAll<ScannerWrapperFactory>() }
+        val ALL by lazy { Plugin.getAll<ScannerWrapperFactory<*>>() }
     }
 
     /**

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -25,26 +25,17 @@ import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
- * A common interface for use with [ServiceLoader] that all [ScannerWrapperFactory] classes need to implement.
+ * A common abstract class for use with [ServiceLoader] that all [ScannerWrapperFactory] classes need to implement.
  */
-interface ScannerWrapperFactory : Plugin {
+abstract class ScannerWrapperFactory<out T : ScannerWrapper>(override val type: String) : Plugin {
     /**
      * Create a [ScannerWrapper] using the provided [options].
      */
-    fun create(options: Options): ScannerWrapper
-}
-
-/**
- * A generic factory class for a [ScannerWrapper].
- */
-abstract class AbstractScannerWrapperFactory<out T : ScannerWrapper>(
-    override val type: String
-) : ScannerWrapperFactory {
-    abstract override fun create(options: Options): T
+    abstract fun create(options: Options): T
 
     /**
      * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners
-     * which are enabled by default via their factories.
+     * wrapper factories which are enabled by default.
      */
     override fun toString() = type
 }

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.scanner
 
 import java.util.ServiceLoader
 
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
@@ -29,9 +29,9 @@ import org.ossreviewtoolkit.utils.common.Plugin
  */
 interface ScannerWrapperFactory : Plugin {
     /**
-     * Create a [ScannerWrapper] using the specified [scannerConfig].
+     * Create a [ScannerWrapper] using the provided [options].
      */
-    fun create(scannerConfig: ScannerConfiguration): ScannerWrapper
+    fun create(options: Options): ScannerWrapper
 }
 
 /**
@@ -40,7 +40,7 @@ interface ScannerWrapperFactory : Plugin {
 abstract class AbstractScannerWrapperFactory<out T : ScannerWrapper>(
     override val type: String
 ) : ScannerWrapperFactory {
-    abstract override fun create(scannerConfig: ScannerConfiguration): T
+    abstract override fun create(options: Options): T
 
     /**
      * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -21,7 +21,6 @@ package org.ossreviewtoolkit.scanner
 
 import java.util.ServiceLoader
 
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.utils.common.Plugin
 
@@ -30,9 +29,9 @@ import org.ossreviewtoolkit.utils.common.Plugin
  */
 interface ScannerWrapperFactory : Plugin {
     /**
-     * Create a [ScannerWrapper] using the specified [scannerConfig] and [downloaderConfig].
+     * Create a [ScannerWrapper] using the specified [scannerConfig].
      */
-    fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): ScannerWrapper
+    fun create(scannerConfig: ScannerConfiguration): ScannerWrapper
 }
 
 /**
@@ -41,7 +40,7 @@ interface ScannerWrapperFactory : Plugin {
 abstract class AbstractScannerWrapperFactory<out T : ScannerWrapper>(
     override val type: String
 ) : ScannerWrapperFactory {
-    abstract override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): T
+    abstract override fun create(scannerConfig: ScannerConfiguration): T
 
     /**
      * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -47,7 +47,6 @@ import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
@@ -125,7 +124,7 @@ class ClearlyDefinedStorage(
             val supportedScanners = toolVersionsByName.mapNotNull { (name, versions) ->
                 // For the ClearlyDefined tool names see https://github.com/clearlydefined/service#tool-name-registry.
                 ScannerWrapper.ALL[name]?.let { factory ->
-                    val scanner = factory.create(ScannerConfiguration())
+                    val scanner = factory.create(emptyMap())
                     (scanner as? CommandLinePathScannerWrapper)?.let { cliScanner -> cliScanner to versions.last() }
                 }.also {
                     if (it == null) logger.debug { "Unsupported tool '$name' for coordinates '$coordinates'." }

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -47,7 +47,6 @@ import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
-import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
@@ -126,7 +125,7 @@ class ClearlyDefinedStorage(
             val supportedScanners = toolVersionsByName.mapNotNull { (name, versions) ->
                 // For the ClearlyDefined tool names see https://github.com/clearlydefined/service#tool-name-registry.
                 ScannerWrapper.ALL[name]?.let { factory ->
-                    val scanner = factory.create(ScannerConfiguration(), DownloaderConfiguration())
+                    val scanner = factory.create(ScannerConfiguration())
                     (scanner as? CommandLinePathScannerWrapper)?.let { cliScanner -> cliScanner to versions.last() }
                 }.also {
                     if (it == null) logger.debug { "Unsupported tool '$name' for coordinates '$coordinates'." }

--- a/scanner/src/test/kotlin/ScannerCriteriaTest.kt
+++ b/scanner/src/test/kotlin/ScannerCriteriaTest.kt
@@ -23,8 +23,6 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.config.Options
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 import org.semver4j.Semver
 
@@ -70,9 +68,7 @@ class ScannerCriteriaTest : WordSpec({
 
     "ScannerCriteria.create()" should {
         "obtain default values from the scanner details" {
-            val config = createScannerConfig(emptyMap())
-
-            val criteria = ScannerCriteria.create(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails)
 
             criteria.regScannerName shouldBe SCANNER_NAME
             criteria.minVersion.version shouldBe SCANNER_VERSION
@@ -80,15 +76,13 @@ class ScannerCriteriaTest : WordSpec({
         }
 
         "obtain values from the configuration" {
-            val config = createScannerConfig(
-                mapOf(
-                    ScannerCriteria.PROP_CRITERIA_NAME to "foo",
-                    ScannerCriteria.PROP_CRITERIA_MIN_VERSION to "1.2.3",
-                    ScannerCriteria.PROP_CRITERIA_MAX_VERSION to "4.5.6"
-                )
+            val options = mapOf(
+                ScannerCriteria.PROP_CRITERIA_NAME to "foo",
+                ScannerCriteria.PROP_CRITERIA_MIN_VERSION to "1.2.3",
+                ScannerCriteria.PROP_CRITERIA_MAX_VERSION to "4.5.6"
             )
 
-            val criteria = ScannerCriteria.create(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails, options)
 
             criteria.regScannerName shouldBe "foo"
             criteria.minVersion.version shouldBe "1.2.3"
@@ -96,23 +90,19 @@ class ScannerCriteriaTest : WordSpec({
         }
 
         "parse versions in a lenient way" {
-            val config = createScannerConfig(
-                mapOf(
-                    ScannerCriteria.PROP_CRITERIA_MIN_VERSION to "1",
-                    ScannerCriteria.PROP_CRITERIA_MAX_VERSION to "3.7"
-                )
+            val options = mapOf(
+                ScannerCriteria.PROP_CRITERIA_MIN_VERSION to "1",
+                ScannerCriteria.PROP_CRITERIA_MAX_VERSION to "3.7"
             )
 
-            val criteria = ScannerCriteria.create(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails, options)
 
             criteria.minVersion.version shouldBe "1.0.0"
             criteria.maxVersion.version shouldBe "3.7.0"
         }
 
         "use an exact configuration matcher" {
-            val config = createScannerConfig(emptyMap())
-
-            val criteria = ScannerCriteria.create(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails)
 
             criteria.configMatcher(testDetails.configuration) shouldBe true
             criteria.configMatcher(testDetails.configuration + "_other") shouldBe false
@@ -177,11 +167,3 @@ private val matchingCriteria = ScannerCriteria(
     maxVersion = Semver(testDetails.version).nextPatch(),
     configMatcher = ScannerCriteria.exactConfigMatcher(testDetails.configuration)
 )
-
-/**
- * Creates a [ScannerConfiguration] with the given properties for the test scanner.
- */
-private fun createScannerConfig(properties: Options): ScannerConfiguration {
-    val options = mapOf(SCANNER_NAME to properties)
-    return ScannerConfiguration(options = options)
-}

--- a/scanner/src/test/kotlin/ScannerCriteriaTest.kt
+++ b/scanner/src/test/kotlin/ScannerCriteriaTest.kt
@@ -27,29 +27,6 @@ import org.ossreviewtoolkit.model.ScannerDetails
 import org.semver4j.Semver
 
 class ScannerCriteriaTest : WordSpec({
-    "ScannerCriteria.forDetails()" should {
-        "create criteria that only match the passed details by default" {
-            val criteria = ScannerCriteria.forDetails(testDetails)
-            val nextPatchVersion = Semver(testDetails.version).nextPatch().toString()
-            val testDetailsForNextPatchVersion = testDetails.copy(version = nextPatchVersion)
-
-            criteria.matches(testDetails) shouldBe true
-            criteria.matches(testDetailsForNextPatchVersion) shouldBe false
-        }
-
-        "can create criteria that match details with respect to a version difference" {
-            val criteria = ScannerCriteria.forDetails(testDetails, Semver.VersionDiff.PATCH)
-            val nextPatchVersion = Semver(testDetails.version).nextPatch().toString()
-            val testDetailsForNextPatchVersion = testDetails.copy(version = nextPatchVersion)
-            val nextMinorVersion = Semver(testDetails.version).nextMinor().toString()
-            val testDetailsForNextMinorVersion = testDetails.copy(version = nextMinorVersion)
-
-            criteria.matches(testDetails) shouldBe true
-            criteria.matches(testDetailsForNextPatchVersion) shouldBe true
-            criteria.matches(testDetailsForNextMinorVersion) shouldBe false
-        }
-    }
-
     "ScannerCriteria.create()" should {
         "obtain default values from the scanner details" {
             val criteria = ScannerCriteria.create(testDetails)

--- a/scanner/src/test/kotlin/ScannerCriteriaTest.kt
+++ b/scanner/src/test/kotlin/ScannerCriteriaTest.kt
@@ -68,11 +68,11 @@ class ScannerCriteriaTest : WordSpec({
         }
     }
 
-    "ScannerCriteria.fromConfig()" should {
+    "ScannerCriteria.create()" should {
         "obtain default values from the scanner details" {
             val config = createScannerConfig(emptyMap())
 
-            val criteria = ScannerCriteria.fromConfig(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails, config)
 
             criteria.regScannerName shouldBe SCANNER_NAME
             criteria.minVersion.version shouldBe SCANNER_VERSION
@@ -88,7 +88,7 @@ class ScannerCriteriaTest : WordSpec({
                 )
             )
 
-            val criteria = ScannerCriteria.fromConfig(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails, config)
 
             criteria.regScannerName shouldBe "foo"
             criteria.minVersion.version shouldBe "1.2.3"
@@ -103,7 +103,7 @@ class ScannerCriteriaTest : WordSpec({
                 )
             )
 
-            val criteria = ScannerCriteria.fromConfig(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails, config)
 
             criteria.minVersion.version shouldBe "1.0.0"
             criteria.maxVersion.version shouldBe "3.7.0"
@@ -112,7 +112,7 @@ class ScannerCriteriaTest : WordSpec({
         "use an exact configuration matcher" {
             val config = createScannerConfig(emptyMap())
 
-            val criteria = ScannerCriteria.fromConfig(testDetails, config)
+            val criteria = ScannerCriteria.create(testDetails, config)
 
             criteria.configMatcher(testDetails.configuration) shouldBe true
             criteria.configMatcher(testDetails.configuration + "_other") shouldBe false

--- a/scanner/src/test/kotlin/ScannerCriteriaTest.kt
+++ b/scanner/src/test/kotlin/ScannerCriteriaTest.kt
@@ -27,22 +27,6 @@ import org.ossreviewtoolkit.model.ScannerDetails
 import org.semver4j.Semver
 
 class ScannerCriteriaTest : WordSpec({
-    "ScannerCriteria" should {
-        "provide a config matcher that accepts every configuration" {
-            ScannerCriteria.ALL_CONFIG_MATCHER("") shouldBe true
-            ScannerCriteria.ALL_CONFIG_MATCHER("foo") shouldBe true
-            ScannerCriteria.ALL_CONFIG_MATCHER("Supercalifragilisticexpialidocious") shouldBe true
-        }
-
-        "provide a config matcher that accepts only exact configuration matches" {
-            val orgConfig = "--info --copyright --licenses"
-            val matcher = ScannerCriteria.exactConfigMatcher(orgConfig)
-
-            matcher(orgConfig) shouldBe true
-            matcher("$orgConfig --more") shouldBe false
-        }
-    }
-
     "ScannerCriteria.forDetails()" should {
         "create criteria that only match the passed details by default" {
             val criteria = ScannerCriteria.forDetails(testDetails)
@@ -73,13 +57,15 @@ class ScannerCriteriaTest : WordSpec({
             criteria.regScannerName shouldBe SCANNER_NAME
             criteria.minVersion.version shouldBe SCANNER_VERSION
             criteria.maxVersion shouldBe Semver(SCANNER_VERSION).nextMinor()
+            criteria.configuration shouldBe SCANNER_CONFIGURATION
         }
 
         "obtain values from the configuration" {
             val options = mapOf(
                 ScannerCriteria.PROP_CRITERIA_NAME to "foo",
                 ScannerCriteria.PROP_CRITERIA_MIN_VERSION to "1.2.3",
-                ScannerCriteria.PROP_CRITERIA_MAX_VERSION to "4.5.6"
+                ScannerCriteria.PROP_CRITERIA_MAX_VERSION to "4.5.6",
+                ScannerCriteria.PROP_CRITERIA_CONFIGURATION to "config"
             )
 
             val criteria = ScannerCriteria.create(testDetails, options)
@@ -87,6 +73,7 @@ class ScannerCriteriaTest : WordSpec({
             criteria.regScannerName shouldBe "foo"
             criteria.minVersion.version shouldBe "1.2.3"
             criteria.maxVersion.version shouldBe "4.5.6"
+            criteria.configuration shouldBe "config"
         }
 
         "parse versions in a lenient way" {
@@ -99,13 +86,6 @@ class ScannerCriteriaTest : WordSpec({
 
             criteria.minVersion.version shouldBe "1.0.0"
             criteria.maxVersion.version shouldBe "3.7.0"
-        }
-
-        "use an exact configuration matcher" {
-            val criteria = ScannerCriteria.create(testDetails)
-
-            criteria.configMatcher(testDetails.configuration) shouldBe true
-            criteria.configMatcher(testDetails.configuration + "_other") shouldBe false
         }
     }
 
@@ -144,26 +124,31 @@ class ScannerCriteriaTest : WordSpec({
             criteria.matches(testDetails) shouldBe false
         }
 
-        "detect a difference reported by the config matcher" {
-            val criteria = matchingCriteria.copy(
-                configMatcher = ScannerCriteria.exactConfigMatcher(testDetails.configuration + "_other")
-            )
+        "detect a scanner configuration that does not match" {
+            val criteria = matchingCriteria.copy(configuration = "${testDetails.configuration}_other")
 
             criteria.matches(testDetails) shouldBe false
+        }
+
+        "ignore the scanner configuration if it is null" {
+            val criteria = matchingCriteria.copy(configuration = null)
+
+            criteria.matches(testDetails) shouldBe true
         }
     }
 })
 
 private const val SCANNER_NAME = "ScannerCriteriaTest"
 private const val SCANNER_VERSION = "3.2.1-rc2"
+private const val SCANNER_CONFIGURATION = "--command-line-option"
 
 /** Test details to match against. */
-private val testDetails = ScannerDetails(SCANNER_NAME, SCANNER_VERSION, "--command-line-option")
+private val testDetails = ScannerDetails(SCANNER_NAME, SCANNER_VERSION, SCANNER_CONFIGURATION)
 
 /** A test instance which should accept the test details. */
 private val matchingCriteria = ScannerCriteria(
     regScannerName = testDetails.name,
     minVersion = Semver(testDetails.version),
     maxVersion = Semver(testDetails.version).nextPatch(),
-    configMatcher = ScannerCriteria.exactConfigMatcher(testDetails.configuration)
+    configuration = testDetails.configuration
 )

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -808,7 +808,7 @@ private class FakePackageScannerWrapper(
     override val configuration = "config"
 
     // Explicit nullability is required here for a mock response.
-    override val criteria: ScannerCriteria? = ScannerCriteria.forDetails(details)
+    override val criteria: ScannerCriteria? = ScannerCriteria.create(details)
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =
         createScanResult(packageProvenanceResolver.resolveProvenance(pkg, sourceCodeOriginPriority), details)
@@ -822,7 +822,7 @@ private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
     override val version = "1.0.0"
     override val configuration = "config"
 
-    override val criteria = ScannerCriteria.forDetails(details)
+    override val criteria = ScannerCriteria.create(details)
 
     override fun scanProvenance(provenance: KnownProvenance, context: ScanContext): ScanResult =
         createScanResult(provenance, details)
@@ -836,7 +836,7 @@ private class FakePathScannerWrapper : PathScannerWrapper {
     override val version = "1.0.0"
     override val configuration = "config"
 
-    override val criteria = ScannerCriteria.forDetails(details)
+    override val criteria = ScannerCriteria.create(details)
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {
         val licenseFindings = path.walk().filter { it.isFile }.mapTo(mutableSetOf()) { file ->

--- a/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
@@ -106,11 +106,7 @@ private val TEST_PACKAGE =
     )
 
 /** The scanner details used by tests. */
-private val SCANNER_CRITERIA =
-    ScannerCriteria(
-        "aScanner", Semver("1.0.0"), Semver("2.0.0"),
-        ScannerCriteria.exactConfigMatcher("aConfig")
-    )
+private val SCANNER_CRITERIA = ScannerCriteria("aScanner", Semver("1.0.0"), Semver("2.0.0"), "aConfig")
 
 /** The template for a ClearlyDefined definitions request. */
 private val DEFINITIONS_TEMPLATE = readDefinitionsTemplate()

--- a/utils/common/src/main/kotlin/Options.kt
+++ b/utils/common/src/main/kotlin/Options.kt
@@ -17,25 +17,9 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.scanner
-
-import java.util.ServiceLoader
-
-import org.ossreviewtoolkit.utils.common.Options
-import org.ossreviewtoolkit.utils.common.Plugin
+package org.ossreviewtoolkit.utils.common
 
 /**
- * A common abstract class for use with [ServiceLoader] that all [ScannerWrapperFactory] classes need to implement.
+ * A typealias for key-value pairs, used in several configuration classes.
  */
-abstract class ScannerWrapperFactory<out T : ScannerWrapper>(override val type: String) : Plugin {
-    /**
-     * Create a [ScannerWrapper] using the provided [options].
-     */
-    abstract fun create(options: Options): T
-
-    /**
-     * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners
-     * wrapper factories which are enabled by default.
-     */
-    override fun toString() = type
-}
+typealias Options = Map<String, String>

--- a/utils/common/src/main/kotlin/PluginManager.kt
+++ b/utils/common/src/main/kotlin/PluginManager.kt
@@ -61,9 +61,9 @@ interface Plugin {
  */
 interface ConfigurablePluginFactory<out PLUGIN> : Plugin {
     /**
-     * Create a new instance of [PLUGIN] from [config].
+     * Create a new instance of [PLUGIN] from [options].
      */
-    fun create(config: Map<String, String>): PLUGIN
+    fun create(options: Options): PLUGIN
 }
 
 /**
@@ -72,7 +72,7 @@ interface ConfigurablePluginFactory<out PLUGIN> : Plugin {
  * that it enforces the separation of parsing the config map and creating the plugin.
  */
 interface TypedConfigurablePluginFactory<CONFIG, out PLUGIN> : ConfigurablePluginFactory<PLUGIN> {
-    override fun create(config: Map<String, String>): PLUGIN = create(parseConfig(config))
+    override fun create(options: Options): PLUGIN = create(parseOptions(options))
 
     /**
      * Create a new instance of [PLUGIN] from [config].
@@ -80,7 +80,7 @@ interface TypedConfigurablePluginFactory<CONFIG, out PLUGIN> : ConfigurablePlugi
     fun create(config: CONFIG): PLUGIN
 
     /**
-     * Parse the [config] map into a [CONFIG] object.
+     * Parse the [options] map into a [CONFIG] object.
      */
-    fun parseConfig(config: Map<String, String>): CONFIG
+    fun parseOptions(options: Options): CONFIG
 }

--- a/utils/common/src/main/kotlin/PluginManager.kt
+++ b/utils/common/src/main/kotlin/PluginManager.kt
@@ -65,3 +65,22 @@ interface ConfigurablePluginFactory<out PLUGIN> : Plugin {
      */
     fun create(config: Map<String, String>): PLUGIN
 }
+
+/**
+ * An interface to be implemented by [configurable plugin factories][ConfigurablePluginFactory] that provide a
+ * [typed configuration class][CONFIG]. The benefit of implementing this interface over [ConfigurablePluginFactory] is
+ * that it enforces the separation of parsing the config map and creating the plugin.
+ */
+interface TypedConfigurablePluginFactory<CONFIG, out PLUGIN> : ConfigurablePluginFactory<PLUGIN> {
+    override fun create(config: Map<String, String>): PLUGIN = create(parseConfig(config))
+
+    /**
+     * Create a new instance of [PLUGIN] from [config].
+     */
+    fun create(config: CONFIG): PLUGIN
+
+    /**
+     * Parse the [config] map into a [CONFIG] object.
+     */
+    fun parseConfig(config: Map<String, String>): CONFIG
+}


### PR DESCRIPTION
Clean-up the scanner API to reduce complexity and adapt the plugin API to prepare for using the API for configurable plugins for more plugins, especially the scanner wrappers. I planned to include this in the same PR, but as this PR has already become very large I will create another PR afterwards. Please see the commit messages for details.