### PR TITLE
docker: set correct version for runtime

### DIFF
--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-name: Mega Docker extended image
+name: Docker extended runtime image
 
 on:
   workflow_dispatch:
@@ -31,7 +31,7 @@ on:
       - '*'
   workflow_run:
     workflows:
-      - 'Mega Docker runtime image'
+      - 'Docker runtime image'
     types:
       - completed
 

--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -24,6 +24,8 @@ on:
       - '.versions'
       - 'Dockerfile'
       - 'Dockerfile-extended'
+      - '.github/workflows/docker-ort-runtime.yml'
+      - '.github/workflows/docker-ort-runtime-ext.yml'
   push:
     branches:
       - main
@@ -162,6 +164,13 @@ jobs:
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get ORT current version
+        run: |
+          ORT_VERSION=$(./gradlew -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+          echo "ORT_VERSION=${ORT_VERSION}" >> $GITHUB_ENV
 
       - name: Set up Docker build
         uses: docker/setup-buildx-action@v3
@@ -180,7 +189,9 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-extended
           tags: |
-            type=raw,sha,enable=true,format=short
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=pep440,pattern={{version}}
+            type=raw,value=${{ env.ORT_VERSION }}
 
       - name: Build ORT extended runtime image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -205,7 +205,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-extended:latest
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
-            ort=docker-image://${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:latest
+            ort=docker-image://${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:${{ env.ORT_VERSION }}
             android=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/android:latest
             swift=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/swift:latest
             scala=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/scala:latest

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-name: Mega Docker runtime image
+name: Docker runtime image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -221,6 +221,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:latest
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
+            base=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/base:latest
             nodejs=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/nodejs:latest
             python=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/python:latest
             rust=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/rust:latest

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -215,7 +215,7 @@ jobs:
           push: true
           load: false
           build-args: |
-            NODEJS_VERSION=${{ env.NODEJS_VERSION }}
+            ORT_VERSION=${{ env.ORT_VERSION }}
           tags: |
             ${{ steps.meta-ort.outputs.tags }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:latest

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -23,6 +23,7 @@ on:
     paths:
       - '.versions'
       - 'Dockerfile'
+      - '.github/workflows/docker-ort-runtime.yml'
   push:
     branches:
       - main
@@ -172,10 +173,17 @@ jobs:
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set environment variables
         run: |
           cat .versions >> $GITHUB_ENV
+
+      - name: Get ORT current version
+        run: |
+          ORT_VERSION=$(./gradlew -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+          echo "ORT_VERSION=${ORT_VERSION}" >> $GITHUB_ENV
 
       - name: Set up Docker build
         uses: docker/setup-buildx-action@v3
@@ -194,7 +202,9 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort
           tags: |
-            type=raw,sha,enable=true,format=short
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=pep440,pattern={{version}}
+            type=raw,value=${{ env.ORT_VERSION }}
 
       - name: Build ORT runtime image
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -20,10 +20,10 @@
 set -e -o pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-GIT_REVISION=$("$GIT_ROOT/gradlew" -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+ORT_VERSION=$("$GIT_ROOT/gradlew" -q properties --property version | sed -nr "s/version: (.+)/\1/p")
 DOCKER_IMAGE_ROOT="${DOCKER_IMAGE_ROOT:-ghcr.io/oss-review-toolkit}"
 
-echo "Setting ORT_VERSION to $GIT_REVISION."
+echo "Setting ORT_VERSION to $ORT_VERSION."
 
 # shellcheck disable=SC1091
 . .versions
@@ -101,8 +101,8 @@ image_build golang ort/golang "$GO_VERSION" \
     "$@"
 
 # Runtime ORT image
-image_build run ort "$GIT_REVISION" \
-    --build-arg NODEJS_VERSION="$NODEJS_VERSION" \
+image_build run ort "$ORT_VERSION" \
+    --build-arg ORT_VERSION="$ORT_VERSION" \
     --build-context "base=docker-image://${DOCKER_IMAGE_ROOT}/ort/base:latest" \
     --build-context "python=docker-image://${DOCKER_IMAGE_ROOT}/ort/python:latest" \
     --build-context "nodejs=docker-image://${DOCKER_IMAGE_ROOT}/ort/nodejs:latest" \
@@ -155,9 +155,10 @@ image_build haskell ort/haskell "$HASKELL_STACK_VERSION" \
 # Runtime extended ORT image
 docker buildx build \
     --file Dockerfile-extended \
-    --tag "${DOCKER_IMAGE_ROOT}/ort-extended:$GIT_REVISION" \
+    --tag "${DOCKER_IMAGE_ROOT}/ort-extended:$ORT_VERSION" \
     --tag "${DOCKER_IMAGE_ROOT}/ort-extended:latest" \
-    --build-context "ort=docker-image://${DOCKER_IMAGE_ROOT}/ort:latest" \
+    --build-arg ORT_VERSION="$ORT_VERSION" \
+    --build-context "ort=docker-image://${DOCKER_IMAGE_ROOT}/ort:${ORT_VERSION}" \
     --build-context "sbt=docker-image://${DOCKER_IMAGE_ROOT}/ort/sbt:latest" \
     --build-context "dotnet=docker-image://${DOCKER_IMAGE_ROOT}/ort/dotnet:latest" \
     --build-context "swift=docker-image://${DOCKER_IMAGE_ROOT}/ort/swift:latest" \


### PR DESCRIPTION
Main version is caught in the same manner as the
docker_build script, with gradlew.
Tag event will create the version with defined tag.
