### PR TITLE
test(ClearlyDefinedStorageFunTest): Update expected results

### DIFF
--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -63,6 +63,11 @@ interface ClearlyDefinedService {
         val JSON = Json { encodeDefaults = false }
 
         /**
+         * The JSON (de-)serialization object used by this service for errors.
+         */
+        val JSON_FOR_ERRORS = Json(JSON) { ignoreUnknownKeys = true }
+
+        /**
          * Create a ClearlyDefined service instance for communicating with the given [server], optionally using a
          * pre-built OkHttp [client].
          */
@@ -287,7 +292,7 @@ suspend fun <T> ClearlyDefinedService.call(block: suspend ClearlyDefinedService.
         block()
     } catch (e: HttpException) {
         val errorMessage = e.response()?.errorBody()?.let {
-            val errorResponse = ClearlyDefinedService.JSON.decodeFromString<ErrorResponse>(it.string())
+            val errorResponse = ClearlyDefinedService.JSON_FOR_ERRORS.decodeFromString<ErrorResponse>(it.string())
             val innerError = errorResponse.error.innererror
 
             "The ClearlyDefined service call failed with: ${innerError.message}"

--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -295,7 +295,7 @@ suspend fun <T> ClearlyDefinedService.call(block: suspend ClearlyDefinedService.
             val errorResponse = ClearlyDefinedService.JSON_FOR_ERRORS.decodeFromString<ErrorResponse>(it.string())
             val innerError = errorResponse.error.innererror
 
-            "The ClearlyDefined service call failed with: ${innerError.message}"
+            "The ClearlyDefined service call failed. ${innerError.name}: ${innerError.message}"
         } ?: "The ClearlyDefined service call failed with code ${e.code()}: ${e.message()}"
 
         throw IOException(errorMessage, e)

--- a/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -70,30 +70,6 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
         }
     }
 
-    "The development server" should {
-        val provider = ClearlyDefinedPackageCurationProvider(Server.DEVELOPMENT)
-
-        "return an existing curation for the platform-express NPM package" {
-            val packages = createPackagesFromIds("NPM:@nestjs:platform-express:6.2.3")
-
-            withRetry {
-                val curations = provider.getCurationsFor(packages)
-
-                curations.map { it.data.concludedLicense } shouldHaveSingleElement "Apache-1.0".toSpdx()
-            }
-        }
-
-        "return no curation for a non-existing dummy Maven package" {
-            val packages = createPackagesFromIds("Maven:group:name:1.2.3")
-
-            withRetry {
-                val curations = provider.getCurationsFor(packages)
-
-                curations should beEmpty()
-            }
-        }
-    }
-
     "Curations" should {
         "get filtered by score" {
             val config = ClearlyDefinedPackageCurationProviderConfig(

--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -29,12 +29,8 @@ import java.time.Instant
 import kotlin.time.Duration.Companion.seconds
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
-import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.Hash
-import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
@@ -47,7 +43,7 @@ import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
 class ClearlyDefinedStorageFunTest : StringSpec({
     val storage = ClearlyDefinedStorage(ClearlyDefinedStorageConfiguration(Server.PRODUCTION.apiUrl))
 
-    "Scan results for ScanCode 3.0.2 should be read correctly" {
+    "Scan results for 'semver4j' from ScanCode should be read correctly" {
         val id = Identifier("Maven:com.vdurmont:semver4j:3.1.0")
 
         withRetry {
@@ -55,29 +51,36 @@ class ClearlyDefinedStorageFunTest : StringSpec({
 
             results.shouldBeSuccess {
                 it shouldContain ScanResult(
-                    provenance = ArtifactProvenance(
-                        sourceArtifact = RemoteArtifact(
-                            url = "https://search.maven.org/remotecontent" +
-                                "?filepath=com/vdurmont/semver4j/3.1.0/semver4j-3.1.0-sources.jar",
-                            hash = Hash(
-                                value = "0de1248f09dfe8df3b021c84e0642ee222cceb13",
-                                algorithm = HashAlgorithm.SHA1
-                            )
-                        )
+                    provenance = RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/vdurmont/semver4j/tree/88912638db3f6112a2b345f1638ced33a0a606e1",
+                            revision = "88912638db3f6112a2b345f1638ced33a0a606e1"
+                        ),
+                        resolvedRevision = "88912638db3f6112a2b345f1638ced33a0a606e1"
                     ),
                     scanner = ScannerDetails(
                         name = "ScanCode",
-                        version = "3.0.2",
-                        configuration = "input /tmp/cd-2rGiCR --classify true --copyright true --email true " +
-                            "--generated true --info true --is-license-text true --json-pp /tmp/cd-0EjTZ7 " +
-                            "--license true --license-clarity-score true --license-diag true --license-text true " +
-                            "--package true --processes 2 --strip-root true --summary true --summary-key-files " +
-                            "true --timeout 1000.0 --url true"
+                        version = "30.1.0",
+                        configuration = "input /tmp/cd-BxlI4n --classify true --copyright true --email true " +
+                            "--generated true --info true --is-license-text true --json-pp /tmp/cd-d8WH1p " +
+                            "--license true --license-clarity-score true --license-text true " +
+                            "--license-text-diagnostics true --package true --processes 2 --strip-root true " +
+                            "--summary true --summary-key-files true --timeout 1000.0 --url true"
                     ),
                     summary = ScanSummary.EMPTY.copy(
-                        startTime = Instant.parse("2020-02-14T00:36:14.000335513Z"),
-                        endTime = Instant.parse("2020-02-14T00:36:37.000492119Z"),
+                        startTime = Instant.parse("2023-09-27T08:28:44.000244665Z"),
+                        endTime = Instant.parse("2023-09-27T08:29:22.000369368Z"),
                         licenseFindings = setOf(
+                            LicenseFinding(
+                                license = "BSD-3-Clause",
+                                location = TextLocation(
+                                    path = "META-INF/maven/com.vdurmont/semver4j/pom.xml",
+                                    startLine = 28,
+                                    endLine = 34
+                                ),
+                                score = 75.0f
+                            ),
                             LicenseFinding(
                                 license = "MIT",
                                 location = TextLocation(
@@ -85,7 +88,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                                     startLine = 30,
                                     endLine = 31
                                 ),
-                                score = 60.87f
+                                score = 83.33f
                             )
                         )
                     )
@@ -94,7 +97,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
         }
     }
 
-    "Scan results for ScanCode 30.1.0 should be read correctly" {
+    "Scan results for 'hoplite-core' from ScanCode should be read correctly" {
         val id = Identifier("Maven:com.sksamuel.hoplite:hoplite-core:2.1.3")
 
         withRetry {


### PR DESCRIPTION
A manual harvest was triggered for `semver4j` on ClearlyDefined today by myself for testing, so the expected ScanCode result data needs to be updated.