### PR TITLE
fix(docker): Install Git LFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     dirmngr \
     gcc \
     git \
+    git-lfs \
     g++ \
     gnupg2 \
     iproute2 \
@@ -64,7 +65,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     unzip \
     wget \
     xz-utils \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && git lfs install
 
 RUN echo $LANG > /etc/locale.gen \
     && locale-gen $LANG \

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -119,6 +119,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
         zlib1g-dev \
         # Install VCS tools (no specific versions required here).
         git \
+        git-lfs \
         mercurial \
         subversion \
         # Install package managers (in versions known to work).
@@ -142,7 +143,8 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
         libstdc++6 \
         libunwind8 \
     && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    git lfs install
 
 COPY scripts/*.sh /opt/ort/bin/
 COPY "$CRT_FILES" /tmp/certificates/


### PR DESCRIPTION
There are projects which use Git LFS for
`gradle/wrapper/gradle-wrapper.jar`.  Without Git LFS installed, an analysis of the project yields an empty project without dependencies.

Fix that issue by installing Git LFS.

