### PR TITLE
chore(Jenkinsfile): Set the semver4j revision to the latest tag

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         string(
             name: 'PROJECT_VCS_REVISION',
             description: 'Optional VCS revision of the project (prefix Git tags with "refs/tags/").',
-            defaultValue: ''
+            defaultValue: 'refs/tags/v3.1.0'
         )
 
         credentials(


### PR DESCRIPTION
The latest tag is more likely to have results in public scan storages like ClearlyDefined.