### PR TITLE
fix(ClearlyDefinedStorage): Properly parse returned VCS URLs

### DIFF
--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -54,7 +54,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                     provenance = RepositoryProvenance(
                         vcsInfo = VcsInfo(
                             type = VcsType.GIT,
-                            url = "https://github.com/vdurmont/semver4j/tree/88912638db3f6112a2b345f1638ced33a0a606e1",
+                            url = "https://github.com/vdurmont/semver4j.git",
                             revision = "88912638db3f6112a2b345f1638ced33a0a606e1"
                         ),
                         resolvedRevision = "88912638db3f6112a2b345f1638ced33a0a606e1"
@@ -108,7 +108,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                     provenance = RepositoryProvenance(
                         vcsInfo = VcsInfo(
                             type = VcsType.GIT,
-                            url = "https://github.com/sksamuel/hoplite/tree/b3bf5d7bd3814cb7576091acfecd097cb3a79e72",
+                            url = "https://github.com/sksamuel/hoplite.git",
                             revision = "b3bf5d7bd3814cb7576091acfecd097cb3a79e72"
                         ),
                         resolvedRevision = "b3bf5d7bd3814cb7576091acfecd097cb3a79e72"
@@ -141,7 +141,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                 result.map { it.provenance } shouldContain RepositoryProvenance(
                     vcsInfo = VcsInfo(
                         type = VcsType.GIT,
-                        url = "https://github.com/bropat/ioBroker.eusec/tree/327b125548c9b806490085a2dacfdfc6e7776803",
+                        url = "https://github.com/bropat/ioBroker.eusec.git",
                         revision = "327b125548c9b806490085a2dacfdfc6e7776803"
                     ),
                     resolvedRevision = "327b125548c9b806490085a2dacfdfc6e7776803"

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.clients.clearlydefined.ComponentType
 import org.ossreviewtoolkit.clients.clearlydefined.Coordinates
 import org.ossreviewtoolkit.clients.clearlydefined.toCoordinates
+import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
@@ -44,8 +45,6 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.UnknownProvenance
-import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
@@ -214,12 +213,7 @@ class ClearlyDefinedStorage(
 
             sourceLocation.type == ComponentType.GIT -> {
                 RepositoryProvenance(
-                    vcsInfo = VcsInfo(
-                        type = VcsType.GIT,
-                        url = sourceLocation.url.orEmpty(),
-                        revision = sourceLocation.revision,
-                        path = sourceLocation.path.orEmpty()
-                    ),
+                    vcsInfo = VcsHost.parseUrl(sourceLocation.url.orEmpty()),
                     resolvedRevision = sourceLocation.revision
                 )
             }


### PR DESCRIPTION
ClearlyDefined returns VCS URLs like [1] which makes the provenance matcher fail as it checks for [2] (plus the revision independently). Properly parse the VCS URL returned by ClearlyDefined to fix this.

[1]: https://github.com/vdurmont/semver4j/tree/88912638db3f6112a2b345f1638ced33a0a606e1
[2]: https://github.com/vdurmont/semver4j.git