### PR TITLE
chore(docker): Adjust build frequency

### DIFF
--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -19,14 +19,14 @@ name: Mega Docker extended image
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
   pull_request:
     paths:
       - '.versions'
       - 'Dockerfile'
       - 'Dockerfile-extended'
   push:
-    branches:
-      - main
     tags:
       - '*'
   workflow_run:

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -19,13 +19,13 @@ name: Mega Docker runtime image
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
   pull_request:
     paths:
       - '.versions'
       - 'Dockerfile'
   push:
-    branches:
-      - main
     tags:
       - '*'
 


### PR DESCRIPTION
depends on:  https://github.com/oss-review-toolkit/ort/pull/7581

Intermediary Docker images will be built nightly at 04:00 and be tagged as <VERSION>-SNAPSHOT.
Same to workflow_dispatch events.

Push tag events will tag Docker images to the release version.
