### PR TITLE
fix(MavenSupport): Improve the logic to fixup project paths in SCM URLs

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -286,11 +286,13 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
                     VcsHost.fromUrl(trimmedUrl)?.let { host ->
                         host.toVcsInfo(trimmedUrl)?.let { vcsInfo ->
-                            // Fixup paths that are specified as part of the URL and contain the project name as
-                            // a prefix.
-                            val projectPrefix = "${host.getProject(trimmedUrl)}-"
-                            vcsInfo.path.withoutPrefix(projectPrefix)?.let { path ->
-                                vcsInfo.copy(path = path)
+                            vcsInfo.takeIf { "/" in it.path } ?: run {
+                                // Fixup a single directory that is specified as part of the URL and contains the
+                                // project name as a prefix.
+                                val projectPrefix = "${host.getProject(trimmedUrl)}-"
+                                vcsInfo.path.withoutPrefix(projectPrefix)?.let { path ->
+                                    vcsInfo.copy(path = path)
+                                }
                             }
                         }
                     } ?: VcsInfo(type = VcsType.forName(type), url = trimmedUrl, revision = tag)

--- a/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
@@ -126,7 +126,7 @@ class MavenSupportTest : WordSpec({
             )
         }
 
-        "handle GitHub URLs with the project name as a path prefix" {
+        "handle GitHub URLs with the project name as a directory prefix" {
             val mavenProject = MavenProject().apply {
                 scm = Scm().apply {
                     connection = "scm:git:git://github.com/netty/netty-tcnative.git/netty-tcnative-boringssl-static"
@@ -138,6 +138,22 @@ class MavenSupportTest : WordSpec({
                 url = "git://github.com/netty/netty-tcnative.git",
                 revision = "",
                 path = "boringssl-static"
+            )
+        }
+
+        "handle GitHub URLs with the project name as a deeper path prefix" {
+            val mavenProject = MavenProject().apply {
+                scm = Scm().apply {
+                    connection = "scm:git:https://github.com/spring-projects/spring-modulith/" +
+                        "spring-modulith-starters/spring-modulith-starter-mongodb"
+                }
+            }
+
+            MavenSupport.parseVcsInfo(mavenProject) shouldBe VcsInfo(
+                type = VcsType.GIT,
+                url = "https://github.com/spring-projects/spring-modulith.git",
+                revision = "",
+                path = "spring-modulith-starters/spring-modulith-starter-mongodb"
             )
         }
 


### PR DESCRIPTION
Only remove the project name as a prefix from paths to single directories. For any deeper path, assume that it really exists.

Fixes #7594.