### PR TITLE
feat(PurlUtils): Add optional parameters to `toPurl`

### DIFF
--- a/model/src/main/kotlin/utils/PurlUtils.kt
+++ b/model/src/main/kotlin/utils/PurlUtils.kt
@@ -86,12 +86,18 @@ fun Identifier.getPurlType() =
  * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on the properties of
  * the [Identifier]. Some issues remain with this specification
  * (see e.g. https://github.com/package-url/purl-spec/issues/33).
+ * Optional [qualifiers] may be given and will be appended to the purl as query parameters e.g.
+ * pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
+ * Optional [subpath] may be given and will be appended to the purl e.g.
+ * pkg:golang/google.golang.org/genproto#googleapis/api/annotations
  *
  * This implementation uses the package type as 'type' purl element as it is used
  * [in the documentation](https://github.com/package-url/purl-spec/blob/master/README.rst#purl).
  * E.g. 'maven' for Gradle projects.
  */
-fun Identifier.toPurl() = if (this == Identifier.EMPTY) "" else createPurl(getPurlType(), namespace, name, version)
+@JvmOverloads
+fun Identifier.toPurl(qualifiers: Map<String, String> = emptyMap(), subpath: String = "") =
+    if (this == Identifier.EMPTY) "" else createPurl(getPurlType(), namespace, name, version, qualifiers, subpath)
 
 /**
  * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on given properties:


### PR DESCRIPTION
The commit https://github.com/bosch-io/oss-review-toolkit/commit/7da5ae93606390b4967755121a8932826931098a changed the visibility of `createPurl`, `toPurl` has
become the only public ORT function for plugins to generate Purls.
Since this function does not support qualifiers nor subpath, these two
parameters have to be added to the function signature with default values.