### PR TITLE
chore(deps): Add libmagic as fallback for typecode-libmagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     coreutils \
     curl \
     dirmngr \
+    file \
     gcc \
     git \
     git-lfs \
@@ -50,6 +51,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libarchive-tools \
     libffi-dev \
     libgmp-dev \
+    libmagic1 \
     libz-dev \
     locales \
     lzma \


### PR DESCRIPTION
Python typecode-libmagic need a fallback on platforms that don't have the library plugin capability, mostly linux/aarch64 images. Ubuntu specific need the libmagic1 system library and file utility.

