### PR TITLE
build(Gradle): Fix publishing the `gradle-model` artifact

### DIFF
--- a/plugins/package-managers/gradle-model/build.gradle.kts
+++ b/plugins/package-managers/gradle-model/build.gradle.kts
@@ -20,4 +20,5 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-kotlin-conventions")
+    id("ort-publication-conventions")
 }


### PR DESCRIPTION
This needs to be published as it is not only a dependency of the embedded `gradle-plugin`, but also of the `gradle-inspector` and the "legacy" `gradle-package-manager`, see how [1] refers to it (under the wrong group name, as publishing conventions were not applied so far).

[1]: https://repo.maven.apache.org/maven2/org/ossreviewtoolkit/plugins/package-managers/2.0.0/package-managers-2.0.0.pom