### PR TITLE
chore(notifier): Explain why `slf4j-log4j12` is excluded

### DIFF
--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(libs.jiraRestClientApi)
     implementation(libs.jiraRestClientApp) {
         exclude("org.slf4j", "slf4j-log4j12")
+            .because("the SLF4J implementation from Log4j 2 is used")
     }
 
     testImplementation(libs.greenmail)


### PR DESCRIPTION
The reason also is in the Git history, but this is more visible.