### PR TITLE
fix(docker): Enable build on schedule event

### DIFF
--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -19,18 +19,6 @@ name: Docker extended runtime image
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 4 * * *'
-  pull_request:
-    paths:
-      - '.versions'
-      - 'Dockerfile'
-      - 'Dockerfile-extended'
-      - '.github/workflows/docker-ort-runtime.yml'
-      - '.github/workflows/docker-ort-runtime-ext.yml'
-  push:
-    tags:
-      - '*'
   workflow_run:
     workflows:
       - 'Docker runtime image'
@@ -153,7 +141,6 @@ jobs:
             SWIFT_VERSION=${{ env.SWIFT_VERSION }}
 
   runtime_extended_image:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     name: Build ORT extended image
     needs: [ android_image, dart_image, dotnet_image, haskell_image, scala_image, swift_image ]
     runs-on: ubuntu-22.04
@@ -198,7 +185,7 @@ jobs:
         with:
           context: .
           file: Dockerfile-extended
-          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          push: true
           load: false
           tags: |
             ${{ steps.meta-ort.outputs.tags }}

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -207,7 +207,6 @@ jobs:
             type=raw,value=${{ env.ORT_VERSION }}
 
       - name: Build ORT runtime image
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
After move to scheduled build, main images are building only on push and workflow_dispatch events.
Noticed after some mistake PR done on Ort Github CI repository.

