### PR TITLE
chore(docker): Use the output of `printSemVersion` as `ORT_VERSION`

### DIFF
--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Get ORT current version
         run: |
-          ORT_VERSION=$(./gradlew -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+          ORT_VERSION=$(./gradlew -q printSemVersion)
           echo "ORT_VERSION=${ORT_VERSION}" >> $GITHUB_ENV
 
       - name: Set up Docker build

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Get ORT current version
         run: |
-          ORT_VERSION=$(./gradlew -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+          ORT_VERSION=$(./gradlew -q printSemVersion)
           echo "ORT_VERSION=${ORT_VERSION}" >> $GITHUB_ENV
 
       - name: Set up Docker build

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -20,7 +20,7 @@
 set -e -o pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-ORT_VERSION=$("$GIT_ROOT/gradlew" -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+ORT_VERSION=$("$GIT_ROOT/gradlew" -q printSemVersion)
 DOCKER_IMAGE_ROOT="${DOCKER_IMAGE_ROOT:-ghcr.io/oss-review-toolkit}"
 
 echo "Setting ORT_VERSION to $ORT_VERSION."


### PR DESCRIPTION
Previously, the value looked like 3.0.0-SNAPSHOT. Change it to the form like `3.0.0-389da0c-SNAPSHOT`, so that it is possible to figure out from which sources ORT has been built.
