### PR TITLE
refactor(poetry): Improve the definition file paths

### DIFF
--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
@@ -1,7 +1,7 @@
 ---
 project:
   id: "Poetry::poetry-from-poetry:<REPLACE_REVISION>"
-  definition_file_path: "plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry/requirements-from-poetry.txt"
+  definition_file_path: "plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry/poetry.lock"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:

--- a/plugins/package-managers/python/src/main/kotlin/Poetry.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Poetry.kt
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -72,6 +73,13 @@ class Poetry(
 
         return Pip(managerName, analysisRoot, analyzerConfig, repoConfig)
             .resolveDependencies(requirementsFile, labels)
+            .map { projectAnalyzerResult ->
+                projectAnalyzerResult.copy(
+                    project = projectAnalyzerResult.project.copy(
+                        definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path
+                    )
+                )
+            }
             .also { requirementsFile.delete() }
     }
 }


### PR DESCRIPTION
In order to do it's job, `Poetry.kt` generates a requirements file and then relies on `Pip.kt` to do the analysis. The resulting `ProjectAnalyzerResult`s uses the paths to these generated requirements files as definiton file paths. This does not make sense, because:

1. The generation of the files is an implementation detail.
2. The generated files do not exist in the code repository which can lead to confusion, in particular also these get referenced from ORT configuration / path excludes.

Fix that by patching up the `ProjectAnalyzerResult`s to recover the original definition file name.
