### PR TITLE
refactor(Poetry): Improve the IDs of projects

### DIFF
--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Poetry::poetry-from-poetry:<REPLACE_REVISION>"
+  id: "Poetry::src/funTest/assets/projects/synthetic/poetry/poetry.lock:<REPLACE_REVISION>"
   definition_file_path: "plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry/poetry.lock"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/plugins/package-managers/python/src/main/kotlin/Poetry.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Poetry.kt
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -76,6 +77,12 @@ class Poetry(
             .map { projectAnalyzerResult ->
                 projectAnalyzerResult.copy(
                     project = projectAnalyzerResult.project.copy(
+                        id = Identifier(
+                            type = managerName,
+                            namespace = "",
+                            name = definitionFile.relativeTo(analysisRoot).path,
+                            version = VersionControlSystem.getCloneInfo(definitionFile.parentFile).revision
+                        ),
                         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path
                     )
                 )


### PR DESCRIPTION
Do not use the filename of the generated requirements file as part of the identifier for a rationale analog to [1]. Furthermore, use include the definition file path relative to the analyzer root to ensure that the project ID is unique within the ORT file.

While at it, stop re-using any logic for deriving the identifier from `Pip`, because some parts of the logic do not make sense to use. For example, it does not make sense to derive a name and a version from a sibling setup.py, because that would be unrelated to the poetry lockfile being analyzed.

Note: This change could be regarded as a left-over from [1].

[1] d647cc7ffc1a83c607c46055c7fe8882ec88b16c