### PR TITLE
build: Drop the build part from the SemVer to get rid of the "+"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,12 @@ semver {
 
 // Only override a default version (which usually is "unspecified"), but not a custom version.
 if (version == Project.DEFAULT_VERSION) {
-    version = semver.semVersion.takeIf { it.isPreRelease } ?: semver.version
+    version = semver.semVersion.takeIf { it.isPreRelease }
+        // To get rid of a build part's "+" prefix because Docker tags do not support it, use only the original "build"
+        // part as the "pre-release" part.
+        ?.toString()?.replace("${semver.defaultPreRelease}+", "")
+        // Fall back to a plain version without pre-release or build parts.
+        ?: semver.version
 }
 
 logger.lifecycle("Building ORT version $version.")


### PR DESCRIPTION
Docker tags do not support "+" as part of their name [1], so turn e.g. "3.0.1-SNAPSHOT+003.sha.cc0865e" into "3.0.1-003.sha.cc0865e" by using the build part as the pre-release part. SemVer sorting rules [2] are still so that 3.0.1-003.sha.cc0865e < 3.0.1.

[1]: https://github.com/moby/moby/issues/16304
[2]: https://semver.org/#spec-item-11