### PR TITLE
chore(providers): Turn config classes into data classes

### DIFF
--- a/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class DirPackageConfigurationProviderConfig(
+data class DirPackageConfigurationProviderConfig(
     /**
      * The path of the package configuration directory.
      */

--- a/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
@@ -52,7 +52,7 @@ import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 import retrofit2.HttpException
 
-class ClearlyDefinedPackageCurationProviderConfig(
+data class ClearlyDefinedPackageCurationProviderConfig(
     /**
      * The URL of the ClearlyDefined server to use.
      */

--- a/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
+++ b/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class FilePackageCurationProviderConfig(
+data class FilePackageCurationProviderConfig(
     /**
      * The path of the package curation file or directory.
      */


### PR DESCRIPTION
These are property-only classes which are a perfect fit for data classes.