### PR TITLE
refactor(scanner)!: Use a property that holds all nested provenances

### DIFF
--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -172,7 +172,7 @@ internal class ScanController(
      * Return all [KnownProvenance]s contained in [nestedProvenances].
      */
     fun getAllProvenances(): Set<KnownProvenance> =
-        nestedProvenances.values.flatMapTo(mutableSetOf()) { it.getProvenances() }
+        nestedProvenances.values.flatMapTo(mutableSetOf()) { it.allProvenances }
 
     /**
      * Return all scan results.
@@ -186,7 +186,7 @@ internal class ScanController(
     fun getIdsByProvenance(): Map<KnownProvenance, Set<Identifier>> =
         buildMap<_, MutableSet<Identifier>> {
             getNestedProvenancesByPackage().forEach { (pkg, nestedProvenance) ->
-                nestedProvenance.getProvenances().forEach { provenance ->
+                nestedProvenance.allProvenances.forEach { provenance ->
                     getOrPut(provenance) { mutableSetOf() } += pkg.id
                 }
             }
@@ -196,7 +196,7 @@ internal class ScanController(
      * Get all provenances for which no scan result for the provided [scanner] is available.
      */
     private fun getMissingProvenanceScans(scanner: ScannerWrapper, nestedProvenance: NestedProvenance) =
-        nestedProvenance.getProvenances().filter { hasScanResult(scanner, it) }
+        nestedProvenance.allProvenances.filter { hasScanResult(scanner, it) }
 
     /**
      * Return the nested provenance resolution issues associated with the given [provenance].
@@ -310,7 +310,7 @@ internal class ScanController(
      * Return true if [ScanResult]s for the complete [NestedProvenance] of the package are available.
      */
     fun hasCompleteScanResult(scanner: ScannerWrapper, pkg: Package): Boolean =
-        getNestedProvenance(pkg.id)?.getProvenances()?.all { provenance -> hasScanResult(scanner, provenance) } ?: false
+        getNestedProvenance(pkg.id)?.allProvenances?.all { provenance -> hasScanResult(scanner, provenance) } ?: false
 
     /**
      * Return true if a [ScanResult] for the provided [scanner] and [provenance] is available.
@@ -324,7 +324,7 @@ internal class ScanController(
     ): NestedProvenanceScanResult? {
         val nestedProvenance = nestedProvenances[root] ?: return null
 
-        val scanResults = nestedProvenance.getProvenances().associateWith { provenance ->
+        val scanResults = nestedProvenance.allProvenances.associateWith { provenance ->
             getScanResults(provenance).map { it.copy(summary = it.summary.copy(issues = it.summary.issues + issues)) }
         }
 

--- a/scanner/src/main/kotlin/ScanStorages.kt
+++ b/scanner/src/main/kotlin/ScanStorages.kt
@@ -108,7 +108,7 @@ class ScanStorages(
             }
 
             results += readers.filterIsInstance<ProvenanceBasedScanStorageReader>().mapNotNull { reader ->
-                val scanResults = nestedProvenance.getProvenances().associateWith { reader.read(it) }
+                val scanResults = nestedProvenance.allProvenances.associateWith { reader.read(it) }
                 NestedProvenanceScanResult(nestedProvenance, scanResults).takeIf { it.isComplete() }?.merge()
             }.flatten()
         }

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -794,8 +794,7 @@ fun ScanResult.toNestedProvenanceScanResult(nestedProvenance: NestedProvenance):
         findings.map { it.copy(location = it.location.copy(path = it.location.path.removePrefix(provenancePrefix))) }
     }
 
-    val provenances = nestedProvenance.getProvenances()
-    val scanResultsByProvenance = provenances.associateWith { provenance ->
+    val scanResultsByProvenance = nestedProvenance.allProvenances.associateWith { provenance ->
         // TODO: Find a solution for how to associate issues to the correct scan result.
         listOf(
             copy(

--- a/scanner/src/main/kotlin/provenance/NestedProvenance.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenance.kt
@@ -42,6 +42,16 @@ data class NestedProvenance(
     val subRepositories: Map<String, RepositoryProvenance>
 ) {
     /**
+     * The set of all contained [KnownProvenance]s.
+     */
+    @JsonIgnore
+    val allProvenances: Set<KnownProvenance> =
+        buildSet {
+            add(root)
+            addAll(subRepositories.values)
+        }
+
+    /**
      * Return path of the provided [provenance] within this [NestedProvenance]. Throws an [IllegalArgumentException] if
      * the provided [provenance] cannot be found.
      */
@@ -52,14 +62,4 @@ data class NestedProvenance(
 
         throw IllegalArgumentException("Could not find entry for $provenance.")
     }
-
-    /**
-     * Return a set of all contained [KnownProvenance]s.
-     */
-    @JsonIgnore
-    fun getProvenances(): Set<KnownProvenance> =
-        buildSet {
-            add(root)
-            addAll(subRepositories.values)
-        }
 }

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
@@ -41,15 +41,10 @@ data class NestedProvenanceScanResult(
     val scanResults: Map<KnownProvenance, List<ScanResult>>
 ) {
     /**
-     * Return a set of all [KnownProvenance]s contained in [nestedProvenance].
-     */
-    fun getProvenances(): Set<KnownProvenance> = nestedProvenance.allProvenances
-
-    /**
      * Return true if [scanResults] contains at least one scan result for each of the [KnownProvenance]s contained in
      * [nestedProvenance].
      */
-    fun isComplete(): Boolean = getProvenances().all { scanResults[it]?.isNotEmpty() == true }
+    fun isComplete(): Boolean = nestedProvenance.allProvenances.all { scanResults[it]?.isNotEmpty() == true }
 
     /**
      * Filter the contained [ScanResult]s using the [predicate].
@@ -85,8 +80,9 @@ data class NestedProvenanceScanResult(
     fun filterByVcsPath(path: String): NestedProvenanceScanResult {
         if (path.isEmpty()) return this
 
-        val provenances = getProvenances()
-        val provenancesWithVcsPath = provenances.filter { it is RepositoryProvenance && it.vcsInfo.path.isNotBlank() }
+        val provenancesWithVcsPath = nestedProvenance.allProvenances.filter {
+            it is RepositoryProvenance && it.vcsInfo.path.isNotBlank()
+        }
 
         require(provenancesWithVcsPath.isEmpty()) {
             "Cannot filter scan results by VCS path that have a repository provenance with a non-blank VCS path " +
@@ -94,7 +90,7 @@ data class NestedProvenanceScanResult(
                 "provenances have a non-blank VCS path: ${provenancesWithVcsPath.joinToString("\n") { "\t$it" }}."
         }
 
-        val pathsWithinProvenances = provenances.filter {
+        val pathsWithinProvenances = nestedProvenance.allProvenances.filter {
             val provenancePath = getPath(it)
             // Return true if the provenance is on the same branch as the filter path. Otherwise it can be discarded,
             // because all findings would be filtered anyway.

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
@@ -43,7 +43,7 @@ data class NestedProvenanceScanResult(
     /**
      * Return a set of all [KnownProvenance]s contained in [nestedProvenance].
      */
-    fun getProvenances(): Set<KnownProvenance> = nestedProvenance.getProvenances()
+    fun getProvenances(): Set<KnownProvenance> = nestedProvenance.allProvenances
 
     /**
      * Return true if [scanResults] contains at least one scan result for each of the [KnownProvenance]s contained in

--- a/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
+++ b/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
@@ -167,4 +167,4 @@ private val nestedProvenanceScanResult = NestedProvenanceScanResult(
     )
 )
 
-private fun NestedProvenance.getRepositoryUrls() = getProvenances().map { (it as RepositoryProvenance).vcsInfo.url }
+private fun NestedProvenance.getRepositoryUrls() = allProvenances.map { (it as RepositoryProvenance).vcsInfo.url }

--- a/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
+++ b/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
@@ -66,7 +66,7 @@ class NestedProvenanceScanResultTest : WordSpec({
             (filteredResult.nestedProvenance.root as RepositoryProvenance).vcsInfo.path shouldBe "submodules/a/dir"
             filteredResult.nestedProvenance.subRepositories.getValue("submodules/a").vcsInfo.path shouldBe "dir"
 
-            filteredResult.getProvenances().forEach {
+            filteredResult.nestedProvenance.allProvenances.forEach {
                 filteredResult.scanResults.getValue(it).single().provenance shouldBe it
             }
         }


### PR DESCRIPTION
All known provenance information is immutable, so there is no need to have a function recreate the set on each call. Use a property instead, name it `allProvenances` to avoid the need for the `@JsonIgnore` annotation, and inline some related code for simplicity while at it.