### PR TITLE
fix(analyzer): Add a test for dangling embed directives / GoMod

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed-expected-output.yml
@@ -1,0 +1,23 @@
+---
+project:
+  id: "GoMod::gomod_dangling_embed:<REPLACE_REVISION>"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed/go.mod"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "main"
+    dependencies: []
+  - name: "vendor"
+    dependencies: []
+packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed/go.mod
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed/go.mod
@@ -1,0 +1,3 @@
+module gomod_dangling_embed
+
+go 1.19

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed/main.go
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+    _ "embed"
+    "fmt"
+)
+
+//go:generate touch file.txt
+var(
+    //go:embed file.txt
+    file string
+)
+
+func main() {
+    fmt.Println(file)
+    fmt.Println("hello world")
+}

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -82,4 +82,13 @@ class GoModFunTest : StringSpec({
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
+
+    "Source files with dangling embed directives do not yield issues" {
+        val definitionFile = testDir.resolve("gomod-dangling-embed/go.mod")
+        val expectedResultFile = testDir.resolve("gomod-dangling-embed-expected-output.yml")
+
+        val result = create("GoMod").resolveSingleProject(definitionFile)
+
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 })

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -100,7 +100,7 @@ class GoMod(
 
     override fun transformVersion(output: String) = output.removePrefix("go version go").substringBefore(' ')
 
-    override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.19.0")
+    override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.21.1")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> =
         definitionFiles.filterNot { definitionFile ->


### PR DESCRIPTION
The `GoMod` integration does not execute `go generate/go build`, so the embed directive in `main.go` points to a non-existing file. When `GoMod` executes [1] it failed [2] with the previously used Go version 1.20.5. As of [3], with Go version 1.21.1, that issue is fixed.

Add a test to ensure it keeps on working.

Note: It is essential to pass `json=Module` instead of not just
      `-json` [4], because otherwise the issue would still persist on
      Go 1.21.1.

Fixes #5560.

[1] `go list -deps -json=Module -buildvcs=false ./...`
[2] `pattern file.txt: no matching`
[3] 47e45202a2cd04396fe929b8ac856c98f1b94649
[4] 43ad3a777c6b4f59c487faf255ca590e7d48822d

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
