### PR TITLE
test(analyzer): Test detecting local module dependencies with GoMod

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules-embed-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules-embed-expected-output.yml
@@ -1,0 +1,27 @@
+---
+project:
+  id: "GoMod::src/funTest/assets/projects/synthetic/gomod-submodules/app/go.mod:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/go.mod"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scope_names: []
+packages: []
+issues:
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "GoMod"
+  message: "GoMod failed to resolve dependencies for path 'src/funTest/assets/projects/synthetic/gomod-submodules/app/go.mod':\
+    \ IllegalArgumentException: Expected exactly one unique package without version\
+    \ but got Identifier(type=GoMod, namespace=, name=app, version=), Identifier(type=Go,\
+    \ namespace=, name=../utils, version=)."
+  severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/go.mod
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/go.mod
@@ -1,0 +1,18 @@
+module app
+
+go 1.19
+
+require (
+	github.com/fatih/color v1.15.0
+	github.com/oss-review-toolkit/ort/utils v1.2.3
+)
+
+require (
+	github.com/google/uuid v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/pborman/uuid v1.2.1 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+)
+
+replace github.com/oss-review-toolkit/ort/utils => ../utils

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/go.sum
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/go.sum
@@ -1,0 +1,14 @@
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
+github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
+github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/main.go
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/app/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+    "github.com/fatih/color"
+    "github.com/oss-review-toolkit/ort/utils"
+)
+
+func main() {
+    color.New(color.FgCyan).Println(utils.GetText())
+}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/utils/go.mod
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/utils/go.mod
@@ -1,0 +1,7 @@
+module utils
+
+go 1.19
+
+require github.com/pborman/uuid v1.2.1
+
+require github.com/google/uuid v1.0.0 // indirect

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/utils/go.sum
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/utils/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
+github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
+github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/utils/texts.go
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules/utils/texts.go
@@ -1,0 +1,8 @@
+package utils
+
+import "github.com/pborman/uuid"
+
+func GetText() string {
+  return uuid.NewRandom().String()
+}
+

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -91,4 +91,14 @@ class GoModFunTest : StringSpec({
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
+
+    "Local module dependencies make the analysis fail" {
+        // TODO: Implement support for local dependencies, see https://github.com/oss-review-toolkit/ort/issues/7649.
+        val definitionFile = testDir.resolve("gomod-submodules/app/go.mod")
+        val expectedResultFile = testDir.resolve("gomod-submodules-embed-expected-output.yml")
+
+        val result = create("GoMod").resolveSingleProject(definitionFile)
+
+        result.withInvariantIssues().toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 })


### PR DESCRIPTION
This illustrates that local module dependencies are currently not supported, and prepares for supporting it in a following change.

This is a preparation for implementing #7649.