### PR TITLE
refactor(scanner)!: Use the configurable plugin API for scanner wrappers

### DIFF
--- a/plugins/commands/requirements/src/main/kotlin/RequirementsCommand.kt
+++ b/plugins/commands/requirements/src/main/kotlin/RequirementsCommand.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.spdx.scanCodeLicenseTextDir
 
@@ -88,8 +89,8 @@ class RequirementsCommand : OrtCommand(
                         logger.debug { "$it is a $category." }
                         it.getDeclaredConstructor(
                             String::class.java,
-                            Map::class.java
-                        ).newInstance("", emptyMap<String, String>())
+                            ScannerMatcherConfig::class.java
+                        ).newInstance("", ScannerMatcherConfig.EMPTY)
                     }
 
                     VersionControlSystem::class.java.isAssignableFrom(it) -> {

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -177,10 +177,10 @@ class ScannerCommand : OrtCommand(
     ): OrtResult {
         val packageScannerWrappers = scannerWrapperFactories
             .takeIf { PackageType.PACKAGE in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty()) }
+            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty(), emptyMap()) }
         val projectScannerWrappers = projectScannerWrapperFactories
             .takeIf { PackageType.PROJECT in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty()) }
+            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty(), emptyMap()) }
 
         if (projectScannerWrappers.isNotEmpty()) {
             echo("Scanning projects with:")

--- a/plugins/scanners/askalono/src/funTest/kotlin/AskalonoFunTest.kt
+++ b/plugins/scanners/askalono/src/funTest/kotlin/AskalonoFunTest.kt
@@ -21,10 +21,11 @@ package org.ossreviewtoolkit.plugins.scanners.askalono
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 
 class AskalonoFunTest : AbstractPathScannerWrapperFunTest() {
-    override val scanner = Askalono("Askalono", emptyMap())
+    override val scanner = Askalono("Askalono", ScannerMatcherConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 1.0f)

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerMatcher
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -44,14 +45,17 @@ private const val CONFIDENCE_NOTICE = "Confidence threshold not high enough for 
 
 private val JSON = Json { ignoreUnknownKeys = true }
 
-class Askalono internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
-    class Factory : ScannerWrapperFactory<Askalono>("Askalono") {
-        override fun create(options: Options) = Askalono(type, options)
+class Askalono internal constructor(name: String, private val matcherConfig: ScannerMatcherConfig) :
+    CommandLinePathScannerWrapper(name) {
+    class Factory : ScannerWrapperFactory<Unit>("Askalono") {
+        override fun create(config: Unit, matcherConfig: ScannerMatcherConfig) = Askalono(type, matcherConfig)
+
+        override fun parseConfig(options: Options, secrets: Options) = Unit
     }
 
     override val configuration = ""
 
-    override val matcher by lazy { ScannerMatcher.create(details, options) }
+    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/funTest/kotlin/BoyterLcFunTest.kt
+++ b/plugins/scanners/boyterlc/src/funTest/kotlin/BoyterLcFunTest.kt
@@ -21,10 +21,11 @@ package org.ossreviewtoolkit.plugins.scanners.boyterlc
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 
 class BoyterLcFunTest : AbstractPathScannerWrapperFunTest() {
-    override val scanner = BoyterLc("BoyterLc", emptyMap())
+    override val scanner = BoyterLc("BoyterLc", ScannerMatcherConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 0.98388565f),

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerMatcher
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -43,7 +44,8 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 private val JSON = Json { ignoreUnknownKeys = true }
 
-class BoyterLc internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
+class BoyterLc internal constructor(name: String, private val matcherConfig: ScannerMatcherConfig) :
+    CommandLinePathScannerWrapper(name) {
     companion object {
         val CONFIGURATION_OPTIONS = listOf(
             "--confidence", "0.95", // Cut-off value to only get most relevant matches.
@@ -51,13 +53,15 @@ class BoyterLc internal constructor(name: String, private val options: Options) 
         )
     }
 
-    class Factory : ScannerWrapperFactory<BoyterLc>("BoyterLc") {
-        override fun create(options: Options) = BoyterLc(type, options)
+    class Factory : ScannerWrapperFactory<Unit>("BoyterLc") {
+        override fun create(config: Unit, matcherConfig: ScannerMatcherConfig) = BoyterLc(type, matcherConfig)
+
+        override fun parseConfig(options: Options, secrets: Options) = Unit
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val matcher by lazy { ScannerMatcher.create(details, options) }
+    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -78,6 +78,7 @@ import org.ossreviewtoolkit.scanner.PackageScannerWrapper
 import org.ossreviewtoolkit.scanner.ProvenanceScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerMatcher
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.enumSetOf
@@ -168,14 +169,16 @@ class FossId internal constructor(
             )
     }
 
-    class Factory : ScannerWrapperFactory<FossId>("FossId") {
-        override fun create(options: Options) = FossId(type, FossIdConfig.create(options))
+    class Factory : ScannerWrapperFactory<FossIdConfig>("FossId") {
+        override fun create(config: FossIdConfig, matcherConfig: ScannerMatcherConfig) = FossId(type, config)
+
+        override fun parseConfig(options: Options, secrets: Options) = FossIdConfig.create(options)
     }
 
     /**
      * The qualifier of a scan when delta scans are enabled.
      */
-    internal enum class DeltaTag {
+    enum class DeltaTag {
         /**
          * Qualifier used when there is no scan and the first one is created.
          */

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -73,7 +73,7 @@ import org.ossreviewtoolkit.utils.common.Options
  *
  * every repository URL would be added credentials. Mappings are applied in the order they are defined.
  */
-internal data class FossIdConfig(
+data class FossIdConfig(
     /** The URL where the FossID service is running. */
     val serverUrl: String,
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.kotlin.logger
  * * **deltaTag** (scan code only): If delta scans is enabled, this qualifies the scan as an *origin* scan or a *delta*
  * scan.
  */
-internal class FossIdNamingProvider(
+class FossIdNamingProvider(
     private val namingProjectPattern: String?,
     private val namingScanPattern: String?,
     private val namingConventionVariables: Map<String, String>

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
  * The URLs used by FossId can sometimes be different from the normal package URLs. For instance, credentials may need
  * to be added, or a different protocol may be used. This class takes care of such mappings.
  */
-internal class FossIdUrlProvider private constructor(
+class FossIdUrlProvider private constructor(
     /**
      * The URL mapping. URLs matched by a key [Regex] are replaced by the URL in the value. The replacement string can
      * refer to matched groups of the [Regex]. It can also contain the variables [VAR_USERNAME] and [VAR_PASSWORD] to

--- a/plugins/scanners/licensee/src/funTest/kotlin/LicenseeFunTest.kt
+++ b/plugins/scanners/licensee/src/funTest/kotlin/LicenseeFunTest.kt
@@ -21,11 +21,12 @@ package org.ossreviewtoolkit.plugins.scanners.licensee
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class LicenseeFunTest : AbstractPathScannerWrapperFunTest(setOf(ExpensiveTag)) {
-    override val scanner = Licensee("Licensee", emptyMap())
+    override val scanner = Licensee("Licensee", ScannerMatcherConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 100.0f)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerMatcher
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -45,18 +46,21 @@ private val JSON = Json {
     namingStrategy = JsonNamingStrategy.SnakeCase
 }
 
-class Licensee internal constructor(name: String, private val options: Options) : CommandLinePathScannerWrapper(name) {
+class Licensee internal constructor(name: String, private val matcherConfig: ScannerMatcherConfig) :
+    CommandLinePathScannerWrapper(name) {
     companion object {
         val CONFIGURATION_OPTIONS = listOf("--json")
     }
 
-    class Factory : ScannerWrapperFactory<Licensee>("Licensee") {
-        override fun create(options: Options) = Licensee(type, options)
+    class Factory : ScannerWrapperFactory<Unit>("Licensee") {
+        override fun create(config: Unit, matcherConfig: ScannerMatcherConfig) = Licensee(type, matcherConfig)
+
+        override fun parseConfig(options: Options, secrets: Options) = Unit
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val matcher by lazy { ScannerMatcher.create(details, options) }
+    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
+++ b/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
@@ -26,13 +26,14 @@ import io.kotest.matchers.string.startWith
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.getLicenseText
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class ScanCodeScannerFunTest : AbstractPathScannerWrapperFunTest(setOf(ExpensiveTag)) {
-    override val scanner = ScanCode("ScanCode", emptyMap())
+    override val scanner = ScanCode("ScanCode", ScanCodeConfig.EMPTY, ScannerMatcherConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", 1, 187), 100.0f),

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeConfig.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeConfig.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.scanners.scancode
+
+import org.ossreviewtoolkit.utils.common.Options
+
+data class ScanCodeConfig(
+    val commandLine: String?,
+    val commandLineNonConfig: String?
+) {
+    companion object {
+        val EMPTY = ScanCodeConfig(null, null)
+
+        private const val COMMAND_LINE_PROPERTY = "commandLine"
+        private const val COMMAND_LINE_NON_CONFIG_PROPERTY = "commandLineNonConfig"
+
+        fun create(options: Options) =
+            ScanCodeConfig(options[COMMAND_LINE_PROPERTY], options[COMMAND_LINE_NON_CONFIG_PROPERTY])
+    }
+}

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -35,10 +35,11 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.scanner.ScanContext
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 
 class ScanCodeTest : WordSpec({
-    val scanner = ScanCode("ScanCode", emptyMap())
+    val scanner = ScanCode("ScanCode", ScanCodeConfig.EMPTY, ScannerMatcherConfig.EMPTY)
 
     "configuration" should {
         "return the default values if the scanner configuration is empty" {
@@ -48,10 +49,11 @@ class ScanCodeTest : WordSpec({
         "return the non-config values from the scanner configuration" {
             val scannerWithConfig = ScanCode(
                 "ScanCode",
-                mapOf(
-                    "commandLine" to "--command --line",
-                    "commandLineNonConfig" to "--commandLineNonConfig"
-                )
+                ScanCodeConfig(
+                    commandLine = "--command --line",
+                    commandLineNonConfig = "--commandLineNonConfig"
+                ),
+                ScannerMatcherConfig.EMPTY
             )
 
             scannerWithConfig.configuration shouldBe "--command --line --json-pp"
@@ -69,10 +71,11 @@ class ScanCodeTest : WordSpec({
         "contain the values from the scanner configuration" {
             val scannerWithConfig = ScanCode(
                 "ScanCode",
-                mapOf(
-                    "commandLine" to "--command --line",
-                    "commandLineNonConfig" to "--commandLineNonConfig"
-                )
+                ScanCodeConfig(
+                    commandLine = "--command --line",
+                    commandLineNonConfig = "--commandLineNonConfig"
+                ),
+                ScannerMatcherConfig.EMPTY
             )
 
             scannerWithConfig.getCommandLineOptions("31.2.4").joinToString(" ") shouldBe
@@ -82,10 +85,11 @@ class ScanCodeTest : WordSpec({
         "be handled correctly when containing multiple spaces" {
             val scannerWithConfig = ScanCode(
                 "ScanCode",
-                mapOf(
-                    "commandLine" to " --command  --line  ",
-                    "commandLineNonConfig" to "  -n -c "
-                )
+                ScanCodeConfig(
+                    commandLine = " --command  --line  ",
+                    commandLineNonConfig = "  -n -c "
+                ),
+                ScannerMatcherConfig.EMPTY
             )
 
             scannerWithConfig.getCommandLineOptions("31.2.4") shouldBe listOf("--command", "--line", "-n", "-c")

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.utils.common.Options
  * created from the options contained in a [ScannerConfiguration] object under the key _ScanOss_. It offers the
  * following configuration options:
  */
-internal data class ScanOssConfig(
+data class ScanOssConfig(
     /** URL of the ScanOSS server. */
     val apiUrl: String,
 

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.scanner.ScanContext
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 private val TEST_DIRECTORY_TO_SCAN = File("src/test/assets/filesToScan")
@@ -61,8 +62,8 @@ class ScanOssScannerDirectoryTest : StringSpec({
 
     beforeSpec {
         server.start()
-        val options = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
-        scanner = spyk(ScanOss.Factory().create(options))
+        val config = ScanOssConfig(apiUrl = "http://localhost:${server.port()}", apiKey = "")
+        scanner = spyk(ScanOss.Factory().create(config, ScannerMatcherConfig.EMPTY))
     }
 
     afterSpec {

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.scanner.ScanContext
+import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
 
 private val TEST_FILE_TO_SCAN = File("src/test/assets/filesToScan/ScannerFactory.kt")
 
@@ -54,8 +55,8 @@ class ScanOssScannerFileTest : StringSpec({
 
     beforeSpec {
         server.start()
-        val options = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
-        scanner = spyk(ScanOss.Factory().create(options))
+        val config = ScanOssConfig(apiUrl = "http://localhost:${server.port()}", apiKey = "")
+        scanner = spyk(ScanOss.Factory().create(config, ScannerMatcherConfig.EMPTY))
     }
 
     afterSpec {

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -117,7 +117,7 @@ class ClearlyDefinedStorage(
             val supportedScanners = toolVersionsByName.mapNotNull { (name, versions) ->
                 // For the ClearlyDefined tool names see https://github.com/clearlydefined/service#tool-name-registry.
                 ScannerWrapper.ALL[name]?.let { factory ->
-                    val scanner = factory.create(emptyMap())
+                    val scanner = factory.create(emptyMap(), emptyMap())
                     (scanner as? CommandLinePathScannerWrapper)?.let { cliScanner -> cliScanner to versions.last() }
                 }.also {
                     if (it == null) logger.debug { "Unsupported tool '$name' for coordinates '$coordinates'." }

--- a/scanner/src/test/kotlin/ScannerMatcherTest.kt
+++ b/scanner/src/test/kotlin/ScannerMatcherTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.scanner
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.ScannerDetails
@@ -38,14 +39,14 @@ class ScannerMatcherTest : WordSpec({
         }
 
         "obtain values from the configuration" {
-            val options = mapOf(
-                ScannerMatcher.PROP_CRITERIA_NAME to "foo",
-                ScannerMatcher.PROP_CRITERIA_MIN_VERSION to "1.2.3",
-                ScannerMatcher.PROP_CRITERIA_MAX_VERSION to "4.5.6",
-                ScannerMatcher.PROP_CRITERIA_CONFIGURATION to "config"
+            val config = ScannerMatcherConfig(
+                regScannerName = "foo",
+                minVersion = "1.2.3",
+                maxVersion = "4.5.6",
+                configuration = "config"
             )
 
-            val matcher = ScannerMatcher.create(testDetails, options)
+            val matcher = ScannerMatcher.create(testDetails, config)
 
             matcher.regScannerName shouldBe "foo"
             matcher.minVersion.version shouldBe "1.2.3"
@@ -54,9 +55,9 @@ class ScannerMatcherTest : WordSpec({
         }
 
         "parse versions in a lenient way" {
-            val options = mapOf(
-                ScannerMatcher.PROP_CRITERIA_MIN_VERSION to "1",
-                ScannerMatcher.PROP_CRITERIA_MAX_VERSION to "3.7"
+            val options = ScannerMatcherConfig(
+                minVersion = "1",
+                maxVersion = "3.7"
             )
 
             val matcher = ScannerMatcher.create(testDetails, options)
@@ -111,6 +112,36 @@ class ScannerMatcherTest : WordSpec({
             val matcher = matchingCriteria.copy(configuration = null)
 
             matcher.matches(testDetails) shouldBe true
+        }
+    }
+
+    "ScannerMatcherConfig.create()" should {
+        "obtain values from the options" {
+            val options = mapOf(
+                ScannerMatcherConfig.PROP_CRITERIA_NAME to "foo",
+                ScannerMatcherConfig.PROP_CRITERIA_MIN_VERSION to "1.2.3",
+                ScannerMatcherConfig.PROP_CRITERIA_MAX_VERSION to "4.5.6",
+                ScannerMatcherConfig.PROP_CRITERIA_CONFIGURATION to "config"
+            )
+
+            with(ScannerMatcherConfig.create(options).first) {
+                regScannerName shouldBe "foo"
+                minVersion shouldBe "1.2.3"
+                maxVersion shouldBe "4.5.6"
+                configuration shouldBe "config"
+            }
+        }
+
+        "filter matcher properties from the options" {
+            val options = mapOf(
+                ScannerMatcherConfig.PROP_CRITERIA_NAME to "foo",
+                ScannerMatcherConfig.PROP_CRITERIA_MIN_VERSION to "1.2.3",
+                ScannerMatcherConfig.PROP_CRITERIA_MAX_VERSION to "4.5.6",
+                ScannerMatcherConfig.PROP_CRITERIA_CONFIGURATION to "config",
+                "other" to "value"
+            )
+
+            ScannerMatcherConfig.create(options).second shouldContainExactly mapOf("other" to "value")
         }
     }
 })


### PR DESCRIPTION
Use the `TypedConfigurablePluginFactory` interface as base for the `ScannerWrapperFactory` to further align the plugin APIs. While at it, extract the logic to parse the scanner matcher properties to a central place to not have to repeat the properties in the configuration classes for all scanner wrappers. This also makes it possible to use `Unit` as configuration class for scanners that do not offer any configuration options.

As this change makes the configuration classes of the scanner wrappers part of the public API, they must not be `internal` anymore.

Scanners that provide secret configuration options will be migrated to read them from the `secrets` map instead of the `options` map in later commits.

**Breaking API change:**
The `ScannerWrapperFactory` API was changed so all scanner wrapper plugins need to be adapted. See the PR diff for examples.