### PR TITLE
feat(docker): Change the image tagging process

### DIFF
--- a/.github/workflows/docker-ort-runtime-ext.yml
+++ b/.github/workflows/docker-ort-runtime-ext.yml
@@ -177,8 +177,10 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-extended
           tags: |
             type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=schedule,pattern=snapshot
             type=pep440,pattern={{version}}
             type=raw,value=${{ env.ORT_VERSION }}
+            type=ref,event=tag
 
       - name: Build ORT extended runtime image
         uses: docker/build-push-action@v5
@@ -189,7 +191,6 @@ jobs:
           load: false
           tags: |
             ${{ steps.meta-ort.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-extended:latest
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
             ort=docker-image://${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:${{ env.ORT_VERSION }}

--- a/.github/workflows/docker-ort-runtime.yml
+++ b/.github/workflows/docker-ort-runtime.yml
@@ -203,8 +203,10 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort
           tags: |
             type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=schedule,pattern=snapshot
             type=pep440,pattern={{version}}
             type=raw,value=${{ env.ORT_VERSION }}
+            type=ref,event=tag
 
       - name: Build ORT runtime image
         uses: docker/build-push-action@v5
@@ -218,7 +220,6 @@ jobs:
             ORT_VERSION=${{ env.ORT_VERSION }}
           tags: |
             ${{ steps.meta-ort.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:latest
           labels: ${{ steps.meta.outputs.labels }}
           build-contexts: |
             base=docker-image://${{ env.REGISTRY }}/${{ github.repository }}/base:latest


### PR DESCRIPTION
To avoid confusion over the 'latest' tag always set for daily builds, these builds will be tagged as 'snapshot' instead of 'latest', together with the current snapshot version.

The 'latest' docker tag will only occur with the version release during a push tag event.

