### PR TITLE
Scanner: Take secret options into use

### DIFF
--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -169,7 +169,7 @@ scanner:
     tool_versions: {}
   config:
     archive: null
-    options: null
+    config: null
     storages:
       postgresStorage: !<.PostgresStorageConfiguration>
         connection:

--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -314,8 +314,8 @@
                 "fileListStorage": {
                     "$ref": "#/definitions/FileListStorage"
                 },
-                "options": {
-                    "$ref": "#/definitions/ScannerOptions"
+                "config": {
+                    "$ref": "#/definitions/ScannerConfig"
                 },
                 "storages": {
                     "$ref": "#/definitions/Storages"
@@ -474,7 +474,7 @@
                 "type": "string"
             }
         },
-        "ScannerOptions": {
+        "ScannerConfig": {
             "type": "object",
             "additionalProperties": {
                 "type": "object"

--- a/model/src/main/kotlin/config/PluginConfiguration.kt
+++ b/model/src/main/kotlin/config/PluginConfiguration.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
+import org.ossreviewtoolkit.utils.common.Options
+
+/**
+ * The configuration of [configurable plugins][ConfigurablePluginFactory].
+ */
+data class PluginConfiguration(
+    /**
+     * The configuration options of the plugin. See the specific implementation for available configuration options.
+     */
+    val options: Options = emptyMap(),
+
+    /**
+     * The configuration secrets of the plugin. See the specific implementation for available secret options.
+     *
+     * This property is not serialized to ensure that secrets do not appear in serialized output.
+     */
+    @JsonIgnore
+    val secrets: Options = emptyMap()
+) {
+    /**
+     * Return a string representation of the object that does not contain the [secrets].
+     */
+    override fun toString() = "${this::class.simpleName}(options=$options)"
+}

--- a/model/src/main/kotlin/config/ProviderPluginConfiguration.kt
+++ b/model/src/main/kotlin/config/ProviderPluginConfiguration.kt
@@ -64,9 +64,8 @@ data class ProviderPluginConfiguration(
     @JsonIgnore
     val secrets: Options = emptyMap()
 ) {
-    override fun toString(): String {
-        // Do not use the generated toString function for the data class to ensure that the output does not contain the
-        // secret options.
-        return "${this::class.simpleName}(type=$type, id=$id, enabled=$enabled, options=$options)"
-    }
+    /**
+     * Return a string representation of the object that does not contain the [secrets].
+     */
+    override fun toString() = "${this::class.simpleName}(type=$type, id=$id, enabled=$enabled, options=$options)"
 }

--- a/model/src/main/kotlin/config/ProviderPluginConfiguration.kt
+++ b/model/src/main/kotlin/config/ProviderPluginConfiguration.kt
@@ -23,11 +23,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 
 import com.sksamuel.hoplite.ConfigAlias
 
+import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
- * The configuration of provider plugins.
+ * The configuration of provider [plugins][ConfigurablePluginFactory]. This class is used when multiple instances of the
+ * same type of plugin should be configurable, like it is for example possible for package curation providers.
+ * Therefore, each configured plugin gets a unique [id] in addition to the plugin [type] to be able to distinguish
+ * different configurations for the same plugin type.
  */
 data class ProviderPluginConfiguration(
     /**

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.utils.FileArchiver
-import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
@@ -84,7 +83,7 @@ data class ScannerConfiguration(
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"
      * for the ScanCode wrapper. See the documentation of the scanner for available options.
      */
-    val options: Map<String, Options>? = null,
+    val config: Map<String, PluginConfiguration>? = null,
 
     /**
      * A map with the configurations of the scan result storages available. Based on this information the actual

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -202,44 +202,46 @@ ort:
           sslrootcert: /defaultdir/root.crt
           parallelTransactions: 5
 
-    options:
-      # A map of maps from scanner class names to scanner-specific key-value pairs.
+    config:
+      # A map from scanner plugin types to the plugin configuration.
       ScanCode:
-        # Command line options that affect the ScanCode output. If changed, stored scan results that were created with
-        # different options are not reused.
-        commandLine: '--copyright --license --info --strip-root --timeout 300'
+        options:
+          # Command line options that affect the ScanCode output. If changed, stored scan results that were created with
+          # different options are not reused.
+          commandLine: '--copyright --license --info --strip-root --timeout 300'
 
-        # Command line options that do not affect the ScanCode output.
-        commandLineNonConfig: '--processes 4'
+          # Command line options that do not affect the ScanCode output.
+          commandLineNonConfig: '--processes 4'
 
-        # Criteria for matching stored scan results. These can be configured for any scanner that uses semantic
-        # versioning. Note that the 'maxVersion' is exclusive and not part of the range of accepted versions.
-        minVersion: '3.2.1-rc2'
-        maxVersion: '32.0.0'
+          # Criteria for matching stored scan results. These can be configured for any scanner that uses semantic
+          # versioning. Note that the 'maxVersion' is exclusive and not part of the range of accepted versions.
+          minVersion: '3.2.1-rc2'
+          maxVersion: '32.0.0'
 
       FossId:
-        serverUrl: 'https://fossid.example.com/instance/'
-        user: user
-        apiKey: XYZ
+        options:
+          serverUrl: 'https://fossid.example.com/instance/'
+          user: user
+          apiKey: XYZ
 
-        namingProjectPattern: '$Var1_$Var2'
-        namingScanPattern: '$Var1_#projectBaseCode_$Var3'
-        namingVariableVar1: myOrg
-        namingVariableVar2: myTeam
-        namingVariableVar3: myUnit
+          namingProjectPattern: '$Var1_$Var2'
+          namingScanPattern: '$Var1_#projectBaseCode_$Var3'
+          namingVariableVar1: myOrg
+          namingVariableVar2: myTeam
+          namingVariableVar3: myUnit
 
-        waitForResult: false
+          waitForResult: false
 
-        keepFailedScans: false
-        deltaScans: true
-        deltaScanLimit: 10
+          keepFailedScans: false
+          deltaScans: true
+          deltaScanLimit: 10
 
-        detectLicenseDeclarations: true
-        detectCopyrightStatements: true
+          detectLicenseDeclarations: true
+          detectCopyrightStatements: true
 
-        timeout: 60
+          timeout: 60
 
-        urlMappingExample: "https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}"
+          urlMappingExample: "https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}"
 
     storages:
       local:

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -245,6 +245,12 @@ ort:
           user: user
           apiKey: XYZ
 
+      SCANOSS:
+        options:
+          apiUrl: 'https://osskb.org/api/'
+        secrets:
+          apiKey: 'your API key'
+
     storages:
       local:
         backend:

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -221,8 +221,6 @@ ort:
       FossId:
         options:
           serverUrl: 'https://fossid.example.com/instance/'
-          user: user
-          apiKey: XYZ
 
           namingProjectPattern: '$Var1_$Var2'
           namingScanPattern: '$Var1_#projectBaseCode_$Var3'
@@ -242,6 +240,10 @@ ort:
           timeout: 60
 
           urlMappingExample: "https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}"
+
+        secrets:
+          user: user
+          apiKey: XYZ
 
     storages:
       local:

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -262,6 +262,11 @@ class OrtConfigurationTest : WordSpec({
                             "apiKey" to "XYZ"
                         )
                     }
+
+                    get("SCANOSS") shouldNotBeNull {
+                        options shouldContainExactly mapOf("apiUrl" to "https://osskb.org/api/")
+                        secrets shouldContainExactly mapOf("apiKey" to "your API key")
+                    }
                 }
 
                 storages shouldNotBeNull {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -242,8 +242,6 @@ class OrtConfigurationTest : WordSpec({
 
                         options shouldContainExactly mapOf(
                             "serverUrl" to "https://fossid.example.com/instance/",
-                            "user" to "user",
-                            "apiKey" to "XYZ",
                             "namingProjectPattern" to "\$Var1_\$Var2",
                             "namingScanPattern" to "\$Var1_#projectBaseCode_\$Var3",
                             "namingVariableVar1" to "myOrg",
@@ -257,6 +255,11 @@ class OrtConfigurationTest : WordSpec({
                             "detectCopyrightStatements" to "true",
                             "timeout" to "60",
                             "urlMappingExample" to urlMapping
+                        )
+
+                        secrets shouldContainExactly mapOf(
+                            "user" to "user",
+                            "apiKey" to "XYZ"
                         )
                     }
                 }

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -226,9 +226,9 @@ class OrtConfigurationTest : WordSpec({
                     }
                 }
 
-                options shouldNotBeNull {
+                config shouldNotBeNull {
                     get("ScanCode") shouldNotBeNull {
-                        this shouldContainExactly mapOf(
+                        options shouldContainExactly mapOf(
                             "commandLine" to "--copyright --license --info --strip-root --timeout 300",
                             "commandLineNonConfig" to "--processes 4",
                             "minVersion" to "3.2.1-rc2",
@@ -240,7 +240,7 @@ class OrtConfigurationTest : WordSpec({
                         val urlMapping = "https://my-repo.example.org(?<repoPath>.*) -> " +
                             "ssh://my-mapped-repo.example.org\${repoPath}"
 
-                        this shouldContainExactly mapOf(
+                        options shouldContainExactly mapOf(
                             "serverUrl" to "https://fossid.example.com/instance/",
                             "user" to "user",
                             "apiKey" to "XYZ",

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -177,10 +177,16 @@ class ScannerCommand : OrtCommand(
     ): OrtResult {
         val packageScannerWrappers = scannerWrapperFactories
             .takeIf { PackageType.PACKAGE in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty(), emptyMap()) }
+            .map {
+                val config = ortConfig.scanner.config?.get(it.type)
+                it.create(config?.options.orEmpty(), config?.secrets.orEmpty())
+            }
         val projectScannerWrappers = projectScannerWrapperFactories
             .takeIf { PackageType.PROJECT in packageTypes }.orEmpty()
-            .map { it.create(ortConfig.scanner.options?.get(it.type).orEmpty(), emptyMap()) }
+            .map {
+                val config = ortConfig.scanner.config?.get(it.type)
+                it.create(config?.options.orEmpty(), config?.secrets.orEmpty())
+            }
 
         if (projectScannerWrappers.isNotEmpty()) {
             echo("Scanning projects with:")

--- a/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
@@ -213,7 +213,6 @@ scanner:
       LicenseRef-scancode-unknown: "NOASSERTION"
       LicenseRef-scancode-unknown-license-reference: "NOASSERTION"
       LicenseRef-scancode-unknown-spdx: "NOASSERTION"
-    options: {}
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/*.spdx.yml"

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -172,7 +172,7 @@ class FossId internal constructor(
     class Factory : ScannerWrapperFactory<FossIdConfig>("FossId") {
         override fun create(config: FossIdConfig, matcherConfig: ScannerMatcherConfig) = FossId(type, config)
 
-        override fun parseConfig(options: Options, secrets: Options) = FossIdConfig.create(options)
+        override fun parseConfig(options: Options, secrets: Options) = FossIdConfig.create(options, secrets)
     }
 
     /**
@@ -190,7 +190,6 @@ class FossId internal constructor(
         DELTA
     }
 
-    private val secretKeys = listOf("apiKey", "user")
     private val namingProvider = config.createNamingProvider()
     private val urlProvider = config.createUrlProvider()
 
@@ -206,11 +205,6 @@ class FossId internal constructor(
     override val configuration = ""
 
     override val matcher: ScannerMatcher? = null
-
-    override fun filterSecretOptions(options: Options) =
-        options.mapValues { (k, v) ->
-            v.takeUnless { k in secretKeys }.orEmpty()
-        }
 
     private suspend fun getProject(projectCode: String): Project? =
         service.getProject(config.user, config.apiKey, projectCode).run {

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -88,7 +88,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 /**
  * A wrapper for [FossID](https://fossid.com/).
  *
- * This scanner can be configured in [ScannerConfiguration.options]. For the options available and their documentation
+ * This scanner can be configured in [ScannerConfiguration.config]. For the options available and their documentation
  * refer to [FossIdConfig].
  *
  * This scanner was implemented before the introduction of [provenance based scanning][ProvenanceScannerWrapper].

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -29,27 +29,28 @@ import org.ossreviewtoolkit.utils.common.Options
  * created from the [Options] contained in a [ScannerConfiguration] object under the key _FossId_. It offers the
  * following configuration options:
  *
- * * **"serverUrl":** The URL of the FossID server.
- * * **"user":** The user to connect to the FossID server.
- * * **"apiKey":** The API key of the user which connects to the FossID server.
- * * **"waitForResult":** When set to false, ORT does not wait for repositories to be downloaded nor scans to be
+ * * **"options.serverUrl":** The URL of the FossID server.
+ * * **"secrets.user":** The user to connect to the FossID server.
+ * * **"secrets.apiKey":** The API key of the user which connects to the FossID server.
+ * * **"options.waitForResult":** When set to false, ORT does not wait for repositories to be downloaded nor scans to be
  *   completed. As a consequence, scan results won't be available in ORT result.
- * * **"deltaScans":** If set, ORT will create delta scans. When only changes in a repository need to be scanned,
- *   delta scans reuse the identifications of the latest scan on this repository to reduce the amount of findings. If
- *   *deltaScans* is set and no scan exist yet, an initial scan called "origin" scan will be created.
- * * **"deltaScanLimit":** This setting can be used to limit the number of delta scans to keep for a given repository.
- *   So if another delta scan is created, older delta scans are deleted until this number is reached. If unspecified, no
- *   limit is enforced on the number of delta scans to keep. This property is evaluated only if *deltaScans* is enabled.
- * * **"detectLicenseDeclaration":** When set, the FossID scan is configured to automatically detect file license
- *   declarations.
- * * **"detectCopyrightStatements":** When set, the FossID scan is configured to automatically detect copyright
+ * * **"options.deltaScans":** If set, ORT will create delta scans. When only changes in a repository need to be
+ *   scanned, delta scans reuse the identifications of the latest scan on this repository to reduce the amount of
+ *   findings. If *deltaScans* is set and no scan exist yet, an initial scan called "origin" scan will be created.
+ * * **"options.deltaScanLimit":** This setting can be used to limit the number of delta scans to keep for a given
+ *   repository. So if another delta scan is created, older delta scans are deleted until this number is reached. If
+ *   unspecified, no limit is enforced on the number of delta scans to keep. This property is evaluated only if
+ *   *deltaScans* is enabled.
+ * * **"options.detectLicenseDeclaration":** When set, the FossID scan is configured to automatically detect file
+ *   license declarations.
+ * * **"options.detectCopyrightStatements":** When set, the FossID scan is configured to automatically detect copyright
  *   statements.
  *
  * Naming conventions options. If they are not set, default naming conventions are used.
- * * **"namingProjectPattern":** A pattern for project names when projects are created on the FossID instance. Contains
- *   variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
+ * * **"options.namingProjectPattern":** A pattern for project names when projects are created on the FossID instance.
+ *   Contains variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
  *   [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
- * * **"namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
+ * * **"options.namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
  *
  * URL mapping options. These options allow transforming the URLs of specific repositories before they are passed to
  * the FossID service. This may be necessary if FossID uses a different mechanism to clone a repository, e.g. via SSH
@@ -161,14 +162,14 @@ data class FossIdConfig(
         @JvmStatic
         private val DEFAULT_TIMEOUT = 60
 
-        fun create(options: Options): FossIdConfig {
+        fun create(options: Options, secrets: Options): FossIdConfig {
             require(options.isNotEmpty()) { "No FossID Scanner configuration found." }
 
             val serverUrl = options[SERVER_URL_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID server URL configuration found.")
-            val user = options[USER_PROPERTY]
+            val user = secrets[USER_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID User configuration found.")
-            val apiKey = options[API_KEY_PROPERTY]
+            val apiKey = secrets[API_KEY_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID API Key configuration found.")
 
             val waitForResult = options[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
@@ -50,8 +51,8 @@ import org.semver4j.Semver
 /**
  * A wrapper for [ScanCode](https://github.com/nexB/scancode-toolkit).
  *
- * This scanner can be configured in [ScannerConfiguration.options] using the key "ScanCode". It offers the following
- * configuration options:
+ * This scanner can be configured in [ScannerConfiguration.config] using the key "ScanCode". It offers the following
+ * configuration [options][PluginConfiguration.options]:
  *
  * * **"commandLine":** Command line options that modify the result. These are added to the [ScannerDetails] when
  *   looking up results from the [ScanResultsStorage]. Defaults to [DEFAULT_CONFIGURATION_OPTIONS].

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -60,7 +60,7 @@ class ScanOss internal constructor(
             ScanOss(type, config, matcherConfig)
 
         override fun parseConfig(options: Options, secrets: Options) =
-            ScanOssConfig.create(options).also { logger.info { "The $type API URL is ${it.apiUrl}." } }
+            ScanOssConfig.create(options, secrets).also { logger.info { "The $type API URL is ${it.apiUrl}." } }
     }
 
     private val service = ScanOssService.create(config.apiUrl)

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -25,8 +25,11 @@ import org.ossreviewtoolkit.utils.common.Options
 
 /**
  * A data class that holds the configuration options supported by the [ScanOss] scanner. An instance of this class is
- * created from the options contained in a [ScannerConfiguration] object under the key _ScanOss_. It offers the
+ * created from the [scanner config][ScannerConfiguration.config] object under the key _ScanOss_. It offers the
  * following configuration options:
+ *
+ * **"options.apiUrl":** The URL of the ScanOSS server.
+ * **"secrets.apiKey":** The API key to authenticate with the ScanOSS server.
  */
 data class ScanOssConfig(
     /** URL of the ScanOSS server. */
@@ -42,9 +45,9 @@ data class ScanOssConfig(
         /** Name of the configuration property for the API key. */
         const val API_KEY_PROPERTY = "apiKey"
 
-        fun create(options: Options): ScanOssConfig {
+        fun create(options: Options, secrets: Options): ScanOssConfig {
             val apiUrl = options[API_URL_PROPERTY] ?: ScanOssService.DEFAULT_API_URL
-            val apiKey = options[API_KEY_PROPERTY].orEmpty()
+            val apiKey = secrets[API_KEY_PROPERTY].orEmpty()
 
             return ScanOssConfig(apiUrl, apiKey)
         }

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssConfigTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssConfigTest.kt
@@ -28,19 +28,17 @@ import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 
 class ScanOssConfigTest : StringSpec({
     "Default values are used" {
-        with(ScanOssConfig.create(emptyMap())) {
+        with(ScanOssConfig.create(emptyMap(), emptyMap())) {
             apiUrl shouldBe ScanOssService.DEFAULT_API_URL
             apiKey should beEmpty()
         }
     }
 
     "Default values can be overridden" {
-        val options = mapOf(
-            ScanOssConfig.API_URL_PROPERTY to "url",
-            ScanOssConfig.API_KEY_PROPERTY to "key"
-        )
+        val options = mapOf(ScanOssConfig.API_URL_PROPERTY to "url")
+        val secrets = mapOf(ScanOssConfig.API_KEY_PROPERTY to "key")
 
-        with(ScanOssConfig.create(options)) {
+        with(ScanOssConfig.create(options, secrets)) {
             apiUrl shouldBe "url"
             apiKey shouldBe "key"
         }

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -211,7 +211,6 @@ scanner:
       LicenseRef-scancode-unknown: "NOASSERTION"
       LicenseRef-scancode-unknown-license-reference: "NOASSERTION"
       LicenseRef-scancode-unknown-spdx: "NOASSERTION"
-    options: {}
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/*.spdx.yml"

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -130,7 +130,6 @@ scanner:
       LicenseRef-scancode-unknown: "NOASSERTION"
       LicenseRef-scancode-unknown-license-reference: "NOASSERTION"
       LicenseRef-scancode-unknown-spdx: "NOASSERTION"
-    options: {}
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/*.spdx.yml"

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -49,7 +49,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
-import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.createStorage
@@ -155,29 +154,11 @@ class Scanner(
 
         val endTime = Instant.now()
 
-        val filteredScannerConfigs = mutableMapOf<String, PluginConfiguration>()
-
-        projectScannerWrappers.forEach { scannerWrapper ->
-            scannerConfig.config?.get(scannerWrapper.name)?.let { config ->
-                filteredScannerConfigs[scannerWrapper.name] =
-                    config.copy(options = scannerWrapper.filterSecretOptions(config.options))
-            }
-        }
-
-        packageScannerWrappers.forEach { scannerWrapper ->
-            scannerConfig.config?.get(scannerWrapper.name)?.let { config ->
-                filteredScannerConfigs[scannerWrapper.name] =
-                    config.copy(options = scannerWrapper.filterSecretOptions(config.options))
-            }
-        }
-
-        val filteredScannerConfig = scannerConfig.copy(config = filteredScannerConfigs)
-
         val scannerRun = ScannerRun(
             startTime = startTime,
             endTime = endTime,
             environment = Environment(),
-            config = filteredScannerConfig,
+            config = scannerConfig,
             provenances = projectResults.provenances + packageResults.provenances,
             scanResults = projectResults.scanResults + packageResults.scanResults,
             files = projectResults.files + packageResults.files,

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -29,7 +29,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
@@ -75,11 +74,6 @@ sealed interface ScannerWrapper {
      * If this property is null, it means that the results of this [ScannerWrapper] cannot be stored in a scan storage.
      */
     val matcher: ScannerMatcher?
-
-    /**
-     * Filter the scanner-specific options to remove / obfuscate any secrets, like credentials.
-     */
-    fun filterSecretOptions(options: Options): Options = options
 }
 
 /**

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -27,6 +27,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Plugin
@@ -66,10 +67,10 @@ sealed interface ScannerWrapper {
     /**
      * The [ScannerMatcher] object to be used when looking up existing scan results from a scan storage. By default,
      * the properties of this object are initialized by the scanner implementation. These defaults can be overridden
-     * with the [ScannerConfiguration.options] property: Use properties of the form `scannerName.property`, where
-     * `scannerName` is the name of the scanner and `property` is the name of a property of the [ScannerMatcher]
-     * class. For instance, to specify that a specific minimum version of ScanCode is allowed, set this property:
-     * `options.ScanCode.minScannerVersion=3.0.2`.
+     * with the scanner specific [options][PluginConfiguration.options] in [ScannerConfiguration.config]: Use properties
+     * of the form `scannerName.options.property`, where `scannerName` is the name of the scanner and `property` is the
+     * name of a property of the [ScannerMatcher] class. For instance, to specify that a specific minimum version of
+     * ScanCode is allowed, set this property: `config.ScanCode.options.minVersion=3.0.2`.
      *
      * If this property is null, it means that the results of this [ScannerWrapper] cannot be stored in a scan storage.
      */


### PR DESCRIPTION
Take the secret options into use for scanner wrapper plugins. Please see the commit messages for details.

**Breaking change:**
The configuration for scanner wrappers was changed, see the diff of the `reference.yml` in this PR for examples.