### PR TITLE
refactor(GoMod)!: Do not use the revision as project version

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::gomod_dangling_embed:<REPLACE_REVISION>"
+  id: "GoMod::gomod_dangling_embed:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gomod-dangling-embed/go.mod"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-synthetic-test-project:<REPLACE_REVISION>"
+  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-synthetic-test-project:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::gomod_no_deps:<REPLACE_REVISION>"
+  id: "GoMod::gomod_no_deps:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-synthetic-test-project:<REPLACE_REVISION>"
+  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-synthetic-test-project:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-unused-deps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-unused-deps-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::gomod_unused_deps:<REPLACE_REVISION>"
+  id: "GoMod::gomod_unused_deps:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-workspaces-main-module-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-workspaces-main-module-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-workspaces:<REPLACE_REVISION>"
+  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-workspaces:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gomod-workspaces/go.mod"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-workspaces-sub-module-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-workspaces-sub-module-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-workspaces/other-module:<REPLACE_REVISION>"
+  id: "GoMod::github.com/oss-review-toolkit/ort/gomod-workspaces/other-module:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gomod-workspaces/other-module/go.mod"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -144,7 +144,7 @@ class GoMod(
                             type = managerName,
                             namespace = "",
                             name = projectId.name,
-                            version = projectVcs.revision
+                            version = ""
                         ),
                         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                         authors = emptySet(), // Go mod doesn't support author information.


### PR DESCRIPTION
Go modules do not have a dedicated metadata field for specifying the version. The only way a version can be defined for a module is via a VCS tag. So, stop using the revision as version for consistency with other package manager integrations. This also simplifies an upcoming change.

Part of #7649.