### PR TITLE
build: Remove a work-around for older GraalVM releases

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -115,36 +115,32 @@ graalvmNative {
     }
 }
 
-// JDK 20 will only be supported starting with GraalVM 23, see
-// https://www.graalvm.org/release-notes/release-calendar/#planned-releases
-if (JavaVersion.current().majorVersion.toInt() <= 19) {
-    tasks.named<BuildNativeImageTask>("nativeCompile") {
-        // Gradle's "Copy" task cannot handle symbolic links, see https://github.com/gradle/gradle/issues/3982. That is
-        // why links contained in the GraalVM distribution archive get broken during provisioning and are replaced by
-        // empty files. Address this by recreating the links in the toolchain directory.
-        val toolchainDir = options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
-            if (name == "bin") parentFile else this
+tasks.named<BuildNativeImageTask>("nativeCompile") {
+    // Gradle's "Copy" task cannot handle symbolic links, see https://github.com/gradle/gradle/issues/3982. That is why
+    // links contained in the GraalVM distribution archive get broken during provisioning and are replaced by empty
+    // files. Address this by recreating the links in the toolchain directory.
+    val toolchainDir = options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
+        if (name == "bin") parentFile else this
+    }
+
+    val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
+    val emptyFiles = toolchainFiles.filter { it.length() == 0L }
+
+    // Find empty toolchain files that are named like other toolchain files and assume these should have been links.
+    val links = toolchainFiles.mapNotNull { file ->
+        emptyFiles.singleOrNull { it != file && it.name == file.name }?.let {
+            file to it
         }
+    }
 
-        val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
-        val emptyFiles = toolchainFiles.filter { it.length() == 0L }
+    // Fix up symbolic links.
+    links.forEach { (target, link) ->
+        logger.quiet("Fixing up '$link' to link to '$target'.")
 
-        // Find empty toolchain files that are named like other toolchain files and assume these should have been links.
-        val links = toolchainFiles.mapNotNull { file ->
-            emptyFiles.singleOrNull { it != file && it.name == file.name }?.let {
-                file to it
-            }
-        }
-
-        // Fix up symbolic links.
-        links.forEach { (target, link) ->
-            logger.quiet("Fixing up '$link' to link to '$target'.")
-
-            if (link.delete()) {
-                Files.createSymbolicLink(link.toPath(), target.toPath())
-            } else {
-                logger.warn("Unable to delete '$link'.")
-            }
+        if (link.delete()) {
+            Files.createSymbolicLink(link.toPath(), target.toPath())
+        } else {
+            logger.warn("Unable to delete '$link'.")
         }
     }
 }


### PR DESCRIPTION
The recent GraalVM releases support Java 20 (and 21), so the task can be reconfigured unconditionally.