### PR TITLE
chore(stack)!: Temporarily remove Stack from Dockerfile-legacy and disable Stack and Pub tests

### DIFF
--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -163,7 +163,8 @@ RUN /opt/ort/bin/export_proxy_certificates.sh /tmp/certificates/ && \
     # Install golang in order to have `go mod` as package manager.
     curl -ksS https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar -C /opt -xz && \
     curl -ksS https://raw.githubusercontent.com/golang/dep/v$GO_DEP_VERSION/install.sh | sh && \
-    curl -ksS https://raw.githubusercontent.com/commercialhaskell/stack/v$HASKELL_STACK_VERSION/etc/scripts/get-stack.sh | sh && \
+    # Temporarily disable installation of Stack as GitHub runners are running out of disk space.
+    #curl -ksS https://raw.githubusercontent.com/commercialhaskell/stack/v$HASKELL_STACK_VERSION/etc/scripts/get-stack.sh | sh && \
     mkdir -p $SWIFT_HOME && \
     curl -L https://download.swift.org/swift-$SWIFT_VERSION-release/ubuntu2204/swift-$SWIFT_VERSION-RELEASE/swift-$SWIFT_VERSION-RELEASE-ubuntu22.04.tar.gz \
         | tar -xz -C $SWIFT_HOME --strip-components=2 && \

--- a/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
+++ b/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
@@ -38,7 +38,9 @@ import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class PubFunTest : WordSpec({
     "Pub" should {
-        "resolve dart http dependencies correctly" {
+        // TODO: Tests are temporarily disabled to prevent Bootstrapping of the Flutter SDK as GitHub runners are
+        //       running out of disk space. Enable them again once a better solution was implemented.
+        "resolve dart http dependencies correctly".config(enabled = false) {
             val definitionFile = getAssetFile("projects/external/dart-http/pubspec.yaml")
             val expectedResultFile = getAssetFile("projects/external/dart-http-expected-output.yml")
             val lockFile = definitionFile.resolveSibling("pubspec.lock").also {
@@ -54,7 +56,7 @@ class PubFunTest : WordSpec({
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }
 
-        "resolve dependencies for a project with dependencies without a static version" {
+        "resolve dependencies for a project with dependencies without a static version".config(enabled = false) {
             val definitionFile = getAssetFile("projects/synthetic/any-version/pubspec.yaml")
             val expectedResultFile = getAssetFile("projects/synthetic/pub-expected-output-any-version.yml")
 
@@ -63,7 +65,7 @@ class PubFunTest : WordSpec({
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }
 
-        "resolve multi-module dependencies correctly" {
+        "resolve multi-module dependencies correctly".config(enabled = false) {
             val definitionFile = getAssetFile("projects/synthetic/multi-module/pubspec.yaml")
             val expectedResultFile = getAssetFile("projects/synthetic/pub-expected-output-multi-module.yml")
 
@@ -74,7 +76,7 @@ class PubFunTest : WordSpec({
             }
         }
 
-        "resolve dependencies for a project with Flutter, Android and Cocoapods" {
+        "resolve dependencies for a project with Flutter, Android and Cocoapods".config(enabled = false) {
             val definitionFile = getAssetFile(
                 "projects/synthetic/flutter-project-with-android-and-cocoapods/pubspec.yaml"
             )
@@ -90,7 +92,7 @@ class PubFunTest : WordSpec({
             }
         }
 
-        "show an error if no lockfile is present" {
+        "show an error if no lockfile is present".config(enabled = false) {
             val definitionFile = getAssetFile("projects/synthetic/no-lockfile/pubspec.yaml")
 
             val result = create("Pub").resolveSingleProject(definitionFile)

--- a/plugins/package-managers/stack/src/funTest/kotlin/StackFunTest.kt
+++ b/plugins/package-managers/stack/src/funTest/kotlin/StackFunTest.kt
@@ -31,7 +31,9 @@ import org.ossreviewtoolkit.utils.test.matchExpectedResult
 
 class StackFunTest : WordSpec({
     "Resolving project dependencies" should {
-        "succeed for quickcheck-state-machine" {
+        // TODO: Tests are temporarily disabled as GitHub runners are running out of disk space. Enable them again once
+        //       a better solution was implemented.
+        "succeed for quickcheck-state-machine".config(enabled = false) {
             val definitionFile = getAssetFile("projects/external/quickcheck-state-machine/stack.yaml")
             val suffix = "-windows".takeIf { Os.isWindows }.orEmpty()
             val expectedResultFile = getAssetFile(
@@ -43,7 +45,7 @@ class StackFunTest : WordSpec({
             result.toYaml() should matchExpectedResult(expectedResultFile)
         }
 
-        "succeed for stack-yesodweb-simple" {
+        "succeed for stack-yesodweb-simple".config(enabled = false) {
             val definitionFile = getAssetFile("projects/synthetic/stack-yesodweb-simple/stack.yaml")
             val expectedResultFile = getAssetFile("projects/synthetic/stack-yesodweb-simple-expected-output.yml")
 


### PR DESCRIPTION
Temporarily remove Stack from the Dockerfile-legacy and disable the `StackFunTest` as GitHub runners are running out of disk space and the Stack installation requires a lot. Other candidates would have been Pub or SPM as they also take a lot of disk space, but those package managers are more actively used.