### PR TITLE
build(Docker): Align the `python-inspector` version on 0.9.8

### DIFF
--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -33,7 +33,7 @@ ARG ORT_VERSION="DOCKER-SNAPSHOT"
 ARG NUGET_INSPECTOR_VERSION=0.9.12
 
 # Set this to the Python Inspector version to use.
-ARG PYTHON_INSPECTOR_VERSION="0.9.6"
+ARG PYTHON_INSPECTOR_VERSION="0.9.8"
 
 # Set this to the ScanCode version to use.
 ARG SCANCODE_VERSION="32.0.6"


### PR DESCRIPTION
The other Docker files already use that version.