### PR TITLE
fix(model): Keep the old "options" as a alias for "config"

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.utils.FileArchiver
@@ -83,6 +84,7 @@ data class ScannerConfiguration(
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"
      * for the ScanCode wrapper. See the documentation of the scanner for available options.
      */
+    @JsonAlias("options")
     val config: Map<String, PluginConfiguration>? = null,
 
     /**


### PR DESCRIPTION
This is a fixup for 712c448 to allow for deserializing older results.