### PR TITLE
fix: Failing fun tests running inside Docker

### DIFF
--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -33,7 +33,7 @@ ARG ORT_VERSION="DOCKER-SNAPSHOT"
 ARG NUGET_INSPECTOR_VERSION=0.9.12
 
 # Set this to the Python Inspector version to use.
-ARG PYTHON_INSPECTOR_VERSION="0.9.8"
+ARG PYTHON_INSPECTOR_VERSION="0.9.6"
 
 # Set this to the ScanCode version to use.
 ARG SCANCODE_VERSION="32.0.6"

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-no-dev-group-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-no-dev-group-expected-output.yml
@@ -16,8 +16,6 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
-  - name: "dev"
-    dependencies: []
   - name: "main"
     dependencies:
     - id: "PyPI::graphviz:0.19.1"

--- a/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-lib.yml
+++ b/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-lib.yml
@@ -104,7 +104,7 @@ project:
         dependencies:
         - id: "SPM:apple:swift-atomics:1.2.0"
         - id: "SPM:apple:swift-collections:1.0.5"
-    - id: "SPM:vapor:routing-kit:4.8.0"
+    - id: "SPM:vapor:routing-kit:4.8.1"
       dependencies:
       - id: "SPM:apple:swift-log:1.5.3"
     - id: "SPM:vapor:websocket-kit:2.14.0"
@@ -610,8 +610,8 @@ packages:
     url: "https://github.com/vapor/multipart-kit.git"
     revision: "4.5.4"
     path: ""
-- id: "SPM:vapor:routing-kit:4.8.0"
-  purl: "pkg:swift/vapor/routing-kit@4.8.0"
+- id: "SPM:vapor:routing-kit:4.8.1"
+  purl: "pkg:swift/vapor/routing-kit@4.8.1"
   authors:
   - "vapor"
   declared_licenses: []
@@ -631,12 +631,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/vapor/routing-kit.git"
-    revision: "4.8.0"
+    revision: "4.8.1"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/vapor/routing-kit.git"
-    revision: "4.8.0"
+    revision: "4.8.1"
     path: ""
 - id: "SPM:vapor:websocket-kit:2.14.0"
   purl: "pkg:swift/vapor/websocket-kit@2.14.0"


### PR DESCRIPTION
Recently, PRs got merged where fun tests runs in Docker have been skipped. These two issues seem to have slipped through.

Note: I've verified locally that PoetryFunTest produces the same diff for `python-inspector` version 0.9.6 and 0.9.8.

