### PR TITLE
chore(plugins): Get all package configuration / curation plugins lazily

### DIFF
--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.utils.common.getDuplicates
 interface PackageConfigurationProviderFactory<CONFIG> :
     TypedConfigurablePluginFactory<CONFIG, PackageConfigurationProvider> {
     companion object {
-        val ALL = Plugin.getAll<PackageConfigurationProviderFactory<*>>()
+        val ALL by lazy { Plugin.getAll<PackageConfigurationProviderFactory<*>>() }
 
         /**
          * Create a new (identifier, provider instance) tuple for each

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.utils.common.getDuplicates
  */
 interface PackageCurationProviderFactory<CONFIG> : TypedConfigurablePluginFactory<CONFIG, PackageCurationProvider> {
     companion object {
-        val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
+        val ALL by lazy { Plugin.getAll<PackageCurationProviderFactory<*>>() }
 
         /**
          * Return a new (identifier, provider instance) tuple for each


### PR DESCRIPTION
Scanning the classpath for plugin implementations can be expensive, so only do this when needed for package configuration / curation providers, like already done for other plugin types.