### PR TITLE
build(scanner): Do not hard-code the dependency on scanner plugins

### DIFF
--- a/plugins/commands/scanner/build.gradle.kts
+++ b/plugins/commands/scanner/build.gradle.kts
@@ -25,8 +25,6 @@ plugins {
 dependencies {
     api(project(":plugins:commands:command-api"))
 
-    implementation(platform(project(":plugins:scanners")))
-
     implementation(project(":scanner"))
     implementation(project(":model"))
     implementation(project(":utils:common-utils"))

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -57,7 +57,6 @@ import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.plugins.commands.api.utils.writeOrtResult
-import org.ossreviewtoolkit.plugins.scanners.scancode.ScanCode
 import org.ossreviewtoolkit.scanner.ScanStorages
 import org.ossreviewtoolkit.scanner.Scanner
 import org.ossreviewtoolkit.scanner.ScannerWrapper
@@ -115,7 +114,7 @@ class ScannerCommand : OrtCommand(
     private val scanners by option(
         "--scanners", "-s",
         help = "A comma-separated list of scanners to use.\nPossible values are: ${ScannerWrapper.ALL.keys}"
-    ).convertToScannerWrapperFactories().default(listOf(ScanCode.Factory()))
+    ).convertToScannerWrapperFactories().default(listOfNotNull(ScannerWrapper.ALL["ScanCode"]))
 
     private val projectScanners by option(
         "--project-scanners",

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -114,7 +114,8 @@ class ScannerCommand : OrtCommand(
     private val scanners by option(
         "--scanners", "-s",
         help = "A comma-separated list of scanners to use.\nPossible values are: ${ScannerWrapper.ALL.keys}"
-    ).convertToScannerWrapperFactories().default(listOfNotNull(ScannerWrapper.ALL["ScanCode"]))
+    ).convertToScannerWrapperFactories()
+        .default(listOfNotNull(ScannerWrapper.ALL.values.singleOrNull() ?: ScannerWrapper.ALL["ScanCode"]))
 
     private val projectScanners by option(
         "--project-scanners",


### PR DESCRIPTION
Slightly change the logic for selecting the default scanner: If there is only a single scanner available, use that one, otherwise try to use ScanCode as usual.