### PR TITLE
test(nuget): Limit length of excessive error messages

### DIFF
--- a/plugins/package-managers/nuget/src/funTest/assets/nuget-expected-output.yml
+++ b/plugins/package-managers/nuget/src/funTest/assets/nuget-expected-output.yml
@@ -27,11 +27,7 @@ project:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "NuGet"
         message: "Failed to get remote metadata for name: 'foobar' version: '1.2.3'.\
-          \ System.Exception: No package metadata found for foobar.1.2.3.\n   at NugetInspector.NugetApi.FindPackageVersion(PackageIdentity\
-          \ pid) in ./nuget-inspector/NugetApi.cs:line 173\n   at NugetInspector.BasePackage.UpdateWithRemoteMetadata(NugetApi\
-          \ nugetApi, Boolean with_details) in ./nuget-inspector/Models.cs:line 342\n\
-          \   at NugetInspector.BasePackage.Update(NugetApi nugetApi, Boolean with_details)\
-          \ in ./nuget-inspector/Models.cs:line 321"
+          \ System.Exception: No package metadata found for foobar.1.2.3."
         severity: "WARNING"
     - id: "NuGet:System:Globalization:4.3.0"
       dependencies:

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
@@ -92,11 +92,18 @@ private fun NuGetInspector.PackageData.getIdentifierWithNamespace(): Identifier 
 
 private fun List<NuGetInspector.PackageData>.toPackageReferences(): Set<PackageReference> =
     mapTo(mutableSetOf()) { data ->
+        val errors = data.errors.map {
+            Issue(source = TYPE, message = it.lineSequence().first(), severity = Severity.ERROR)
+        }
+
+        val warnings = data.warnings.map {
+            Issue(source = TYPE, message = it.lineSequence().first(), severity = Severity.WARNING)
+        }
+
         PackageReference(
             id = data.getIdentifierWithNamespace(),
             dependencies = data.dependencies.toPackageReferences(),
-            issues = data.errors.map { Issue(source = TYPE, message = it, severity = Severity.ERROR) }
-                + data.warnings.map { Issue(source = TYPE, message = it, severity = Severity.WARNING) }
+            issues = errors + warnings
         )
     }
 


### PR DESCRIPTION
For unclear reasons, the length of the error message increased
significantly, and it includes now varying "DevOps Activity IDs". Limit
the length of error / warning messages to the first line only to work
around that.