### PR TITLE
chore(model): Improve `Identifier.toString()`

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -124,4 +124,6 @@ data class Identifier(
      */
     fun toPath(separator: String = "/", emptyValue: String = "unknown"): String =
         sanitizedComponents.joinToString(separator) { it.encodeOr(emptyValue) }
+
+    override fun toString(): String = toCoordinates()
 }


### PR DESCRIPTION
The string returned by `toCoordinates()` seems nicer than the default implementation.
