### PR TITLE
build(application): Set the "Main-Class" attribute

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -177,3 +177,7 @@ tasks.named<CreateStartScripts>("startScripts") {
         )
     }
 }
+
+tasks.withType<Jar>().configureEach {
+    manifest.attributes["Main-Class"] = application.mainClass
+}


### PR DESCRIPTION
This is not actually done by Gradle's application plugin, so set it manually to allow the JAR to be run via `java -jar ...`.