### PR TITLE
analyzer: Support references to local modules with `GoMod`

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules-embed-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-submodules-embed-expected-output.yml
@@ -1,0 +1,265 @@
+---
+projects:
+- id: "GoMod::app:<REPLACE_REVISION>"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "main"
+    dependencies:
+    - id: "Go::github.com/fatih/color:1.15.0"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "Go::github.com/mattn/go-colorable:0.1.13"
+        linkage: "PROJECT_STATIC"
+        dependencies:
+        - id: "Go::github.com/mattn/go-isatty:0.0.17"
+          linkage: "PROJECT_STATIC"
+          dependencies:
+          - id: "Go::golang.org/x/sys:0.6.0"
+            linkage: "PROJECT_STATIC"
+      - id: "Go::github.com/mattn/go-isatty:0.0.17"
+        linkage: "PROJECT_STATIC"
+        dependencies:
+        - id: "Go::golang.org/x/sys:0.6.0"
+          linkage: "PROJECT_STATIC"
+      - id: "Go::golang.org/x/sys:0.6.0"
+        linkage: "PROJECT_STATIC"
+    - id: "GoMod::utils:<REPLACE_REVISION>"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "Go::github.com/google/uuid:1.0.0"
+        linkage: "PROJECT_STATIC"
+      - id: "Go::github.com/pborman/uuid:1.2.1"
+        linkage: "PROJECT_STATIC"
+        dependencies:
+        - id: "Go::github.com/google/uuid:1.0.0"
+          linkage: "PROJECT_STATIC"
+  - name: "vendor"
+    dependencies:
+    - id: "Go::github.com/fatih/color:1.15.0"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "Go::github.com/mattn/go-colorable:0.1.13"
+        linkage: "PROJECT_STATIC"
+        dependencies:
+        - id: "Go::github.com/mattn/go-isatty:0.0.17"
+          linkage: "PROJECT_STATIC"
+          dependencies:
+          - id: "Go::golang.org/x/sys:0.6.0"
+            linkage: "PROJECT_STATIC"
+      - id: "Go::github.com/mattn/go-isatty:0.0.17"
+        linkage: "PROJECT_STATIC"
+        dependencies:
+        - id: "Go::golang.org/x/sys:0.6.0"
+          linkage: "PROJECT_STATIC"
+      - id: "Go::golang.org/x/sys:0.6.0"
+        linkage: "PROJECT_STATIC"
+    - id: "GoMod::utils:<REPLACE_REVISION>"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "Go::github.com/google/uuid:1.0.0"
+        linkage: "PROJECT_STATIC"
+      - id: "Go::github.com/pborman/uuid:1.2.1"
+        linkage: "PROJECT_STATIC"
+        dependencies:
+        - id: "Go::github.com/google/uuid:1.0.0"
+          linkage: "PROJECT_STATIC"
+- id: "GoMod::utils:<REPLACE_REVISION>"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH_UTILS>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH_UTILS>"
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH_UTILS>"
+  homepage_url: ""
+  scopes:
+  - name: "main"
+    dependencies:
+    - id: "Go::github.com/pborman/uuid:1.2.1"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "Go::github.com/google/uuid:1.0.0"
+        linkage: "PROJECT_STATIC"
+  - name: "vendor"
+    dependencies:
+    - id: "Go::github.com/pborman/uuid:1.2.1"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "Go::github.com/google/uuid:1.0.0"
+        linkage: "PROJECT_STATIC"
+packages:
+- id: "Go::github.com/fatih/color:1.15.0"
+  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@1.15.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/fatih/color"
+    revision: "12126ed593697635c525b302836b292b657ea573"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fatih/color.git"
+    revision: "12126ed593697635c525b302836b292b657ea573"
+    path: ""
+- id: "Go::github.com/google/uuid:1.0.0"
+  purl: "pkg:golang/github.com%2Fgoogle%2Fuuid@1.0.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/google/uuid"
+    revision: "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/google/uuid.git"
+    revision: "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+    path: ""
+- id: "Go::github.com/mattn/go-colorable:0.1.13"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@0.1.13"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/mattn/go-colorable"
+    revision: "11a925cff3d38c293ddc8c05a16b504e3e2c63be"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/mattn/go-colorable.git"
+    revision: "11a925cff3d38c293ddc8c05a16b504e3e2c63be"
+    path: ""
+- id: "Go::github.com/mattn/go-isatty:0.0.17"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@0.0.17"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/mattn/go-isatty"
+    revision: "ed75e619dc0f0489fd4062163a7d061eaa249b9c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/mattn/go-isatty.git"
+    revision: "ed75e619dc0f0489fd4062163a7d061eaa249b9c"
+    path: ""
+- id: "Go::github.com/pborman/uuid:1.2.1"
+  purl: "pkg:golang/github.com%2Fpborman%2Fuuid@1.2.1"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/pborman/uuid"
+    revision: "5b6091a6a160ee5ce12917b21ab96acec2a4fdc0"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pborman/uuid.git"
+    revision: "5b6091a6a160ee5ce12917b21ab96acec2a4fdc0"
+    path: ""
+- id: "Go::golang.org/x/sys:0.6.0"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@0.6.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://go.googlesource.com/sys"
+    revision: "c7a1bf9a0b0aa7c0c0e35a435924dd68e64d1653"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://go.googlesource.com/sys"
+    revision: "c7a1bf9a0b0aa7c0c0e35a435924dd68e64d1653"
+    path: ""

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -20,9 +20,11 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 
+import java.io.File
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
@@ -93,12 +95,28 @@ class GoModFunTest : StringSpec({
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 
-    "Local module dependencies make the analysis fail" {
-        // TODO: Implement support for local dependencies, see https://github.com/oss-review-toolkit/ort/issues/7649.
-        val definitionFile = testDir.resolve("gomod-submodules/app/go.mod")
+    "Project dependencies with a (relative) local module dependency are detected correctly" {
+        val definitionFileApp = testDir.resolve("gomod-submodules/app/go.mod")
+        val definitionFileUtils = testDir.resolve("gomod-submodules/utils/go.mod")
+        val expectedResultFile = testDir.resolve("gomod-submodules-embed-expected-output.yml")
+        val expectedDefinitionFilePathUtils = getDefinitionFilePath(definitionFileUtils)
 
-        val result = create("GoMod").resolveSingleProject(definitionFile)
+        val result = create("GoMod").collateMultipleProjects(definitionFileApp, definitionFileUtils)
 
-        result.issues shouldHaveSize 1
+        result.withResolvedScopes().toYaml() should matchExpectedResult(
+            expectedResultFile,
+            definitionFileApp,
+            custom = mapOf(
+                "<REPLACE_DEFINITION_FILE_PATH_UTILS>" to expectedDefinitionFilePathUtils,
+                "<REPLACE_PATH_UTILS>" to expectedDefinitionFilePathUtils.substringBeforeLast('/')
+            )
+        )
     }
 })
+
+private fun getDefinitionFilePath(definitionFile: File): String {
+    val projectDir = definitionFile.parentFile
+    val vcsDir = checkNotNull(VersionControlSystem.forDirectory(projectDir))
+    val path = vcsDir.getPathToRoot(projectDir)
+    return "$path/${definitionFile.name}"
+}


### PR DESCRIPTION
The only way of referencing a module on the local file system from another is by specifying a relative or absolute path via a replace directive. This is currently not supported by ORT's Go Modules integration.

Implement that support, so that a reference inbetween two modules on the local file system gets represent as a `PackageReference` between the corresponding `Project`s (in ORT speak). However, keep on failing in case a referenced module is not located within the analysis root, because that would violate ORT's package manager API.

Fixes #7649.
