### PR TITLE
build: Include platform projects when running from Gradle or the IDE

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -22,19 +22,12 @@ plugins {
     id("ort-application-conventions")
 }
 
-configurations {
-    create("pluginClasspath")
-}
+configurations.dependencyScope("pluginClasspath")
+configurations["runtimeClasspath"].extendsFrom(configurations["pluginClasspath"])
 
 application {
     applicationName = "ort"
     mainClass = "org.ossreviewtoolkit.cli.OrtMainKt"
-
-    applicationDistribution.from(configurations["pluginClasspath"]) {
-        // Copy to "lib" instead of "plugin" to avoid duplicate dependency artifacts for core plugins.
-        into("lib")
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Use a Gradle 8.4 `dependencyScope` [1] to extend the `runtimeClasspath` with the `pluginClasspath`. This improves the solution from 1708ac3 by supporting to run ORT from Gradle or the IDE with platform projects / plugins in the classpath, but still do not publish them as part of the "dependencyManagement" in the POM. See [2] for context.

[1]: https://docs.gradle.org/8.4/release-notes.html#easier-to-create-role-focused-configurations
[2]: https://github.com/gradle/gradle/issues/10861#issuecomment-576562961