### PR TITLE
fix(AdvisorRecord): Merge all properties of vulnerabilities

### DIFF
--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -121,8 +121,8 @@ data class AdvisorRecord(
 }
 
 /**
- * Merge this list of [Vulnerability] objects by combining vulnerabilities with the same ID and merging their
- * references.
+ * Merge this collection of [Vulnerability] objects by combining vulnerabilities with the same ID and merging their
+ * references. Other [Vulnerability] properties are taken from the first object which has any such property set.
  */
 private fun Collection<Vulnerability>.mergeVulnerabilities(): List<Vulnerability> {
     val vulnerabilitiesById = groupByTo(sortedMapOf()) { it.id }
@@ -130,10 +130,12 @@ private fun Collection<Vulnerability>.mergeVulnerabilities(): List<Vulnerability
 }
 
 /**
- * Merge this (non-empty) list of [Vulnerability] objects (which are expected to have the same ID) by to a single
- * [Vulnerability] that contains all the references from the source vulnerabilities (with duplicates removed).
+ * Merge this (non-empty) collection of [Vulnerability] objects (which are expected to have the same ID) to a single
+ * [Vulnerability] that contains all the references from the original vulnerabilities (with duplicates removed). Other
+ * [Vulnerability] properties are taken from the first object which has any such property set.
  */
 private fun Collection<Vulnerability>.mergeReferences(): Vulnerability {
     val references = flatMapTo(mutableSetOf()) { it.references }
-    return Vulnerability(id = first().id, references = references.toList())
+    val entry = find { it.summary != null || it.description != null } ?: first()
+    return entry.copy(references = references.toList())
 }


### PR DESCRIPTION
Do not leave the `summary` and `description` at their `null` default values but take them from the first vulnerability. Update the documentation accordingly and also generally improve the wording while at it.