### PR TITLE
chore: Use new ORT slack subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![TODOs][13]][14] [![REUSE status][15]][16] [![CII][17]][18]
 
 [1]: https://img.shields.io/badge/Join_us_on_Slack!-ort--talk-blue.svg?longCache=true&logo=slack
-[2]: https://join.slack.com/t/ort-talk/shared_invite/zt-1c7yi4sj6-mk7R1fAa6ZdW5MQ6DfAVRg
+[2]: http://slack.oss-review-toolkit.org
 [3]: https://github.com/oss-review-toolkit/ort/actions/workflows/wrapper-validation.yml/badge.svg
 [4]: https://github.com/oss-review-toolkit/ort/actions/workflows/wrapper-validation.yml
 [5]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml/badge.svg

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -74,4 +74,4 @@ a commit to accept the new expected result.
 All contributions are welcome. If you are interested in contributing, please read our
 [contributing guide](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md), and to get quick answers
 to any of your questions we recommend you
-[join our Slack community](https://join.slack.com/t/ort-talk/shared_invite/zt-1c7yi4sj6-mk7R1fAa6ZdW5MQ6DfAVRg).
+[join our Slack community](http://slack.oss-review-toolkit.org).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -129,7 +129,7 @@ const config = {
               },
               {
                 label: 'Slack',
-                href: 'https://join.slack.com/t/ort-talk/shared_invite/zt-1c7yi4sj6-mk7R1fAa6ZdW5MQ6DfAVRg',
+                href: 'http://slack.oss-review-toolkit.org',
               },
             ],
           },


### PR DESCRIPTION
Replace Slack invite links with dedicated subdomain on ORT website so URL is easier to update once invite limit is reached.