### PR TITLE
refactor(go): Migrate GoDep TOML parsing to kotlinx-serialization

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,6 @@ slf4j = "2.0.9"
 springCore = "5.3.30"
 svnkit = "1.10.11"
 sw360Client = "17.0.1-m2"
-toml4j = "0.7.2"
 wiremock = "3.0.1"
 xz = "1.9"
 
@@ -159,7 +158,6 @@ slf4j = { module = "org.slf4j:slf4j-api ", version.ref = "slf4j" }
 springCore = { module = "org.springframework:spring-core", version.ref = "springCore" }
 svnkit = { module = "org.tmatesoft.svnkit:svnkit", version.ref = "svnkit" }
 sw360Client = { module = "org.eclipse.sw360:client", version.ref = "sw360Client" }
-toml4j = { module = "com.moandjiezana.toml:toml4j", version.ref = "toml4j" }
 wiremock = { module = "com.github.tomakehurst:wiremock", version.ref = "wiremock" }
 xz = { module = "org.tukaani:xz", version.ref = "xz" }
 

--- a/plugins/package-managers/go/build.gradle.kts
+++ b/plugins/package-managers/go/build.gradle.kts
@@ -43,12 +43,7 @@ dependencies {
     implementation(project(":utils:spdx-utils"))
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.toml4j)
-    constraints {
-        implementation("com.google.code.gson:gson:2.10.1") {
-            because("Earlier versions have vulnerabilities.")
-        }
-    }
+    implementation(libs.tomlkt)
 
     funTestImplementation(testFixtures(project(":analyzer")))
 }

--- a/plugins/package-managers/go/src/main/kotlin/GoDepLockFile.kt
+++ b/plugins/package-managers/go/src/main/kotlin/GoDepLockFile.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.go
+
+import kotlinx.serialization.Serializable
+
+/**
+ * See https://golang.github.io/dep/docs/Gopkg.lock.html.
+ */
+@Serializable
+internal data class GoDepLockFile(
+    val projects: List<Project> = emptyList()
+) {
+    @Serializable
+    data class Project(
+        val name: String,
+        val packages: List<String>,
+        val revision: String,
+        val version: String? = null
+    )
+}


### PR DESCRIPTION
This allows to get rid of toml4j which had no releases since 2017 and
depends on GSON, which has vulnerabilities.