### PR TITLE
chore(Qodana): Use the non-EAP version of the JVM linter

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -19,4 +19,4 @@ profile:
   name: qodana.recommended
 include:
   - name: CheckDependencyLicenses
-linter: jetbrains/qodana-jvm-community:2023.2-eap
+linter: jetbrains/qodana-jvm-community:2023.2


### PR DESCRIPTION
This is currently the latest version, see [1].

[1]: https://hub.docker.com/r/jetbrains/qodana-jvm-community/tags