### PR TITLE
test(python): Upgrade `markupsafe` to version 1.1.0

### DIFF
--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -28,7 +28,7 @@ project:
       - id: "PyPI::itsdangerous:0.24"
       - id: "PyPI::jinja2:2.11.3"
         dependencies:
-        - id: "PyPI::markupsafe:1.0"
+        - id: "PyPI::markupsafe:1.1.0"
       - id: "PyPI::werkzeug:0.15.3"
 packages:
 - id: "PyPI::click:6.7"
@@ -161,8 +161,8 @@ packages:
     url: "https://github.com/pallets/jinja.git"
     revision: ""
     path: ""
-- id: "PyPI::markupsafe:1.0"
-  purl: "pkg:pypi/markupsafe@1.0"
+- id: "PyPI::markupsafe:1.1.0"
+  purl: "pkg:pypi/markupsafe@1.1.0"
   authors:
   - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
@@ -173,17 +173,17 @@ packages:
     mapped:
       BSD: "BSD-3-Clause"
       BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
-  homepage_url: "http://github.com/pallets/markupsafe"
+  description: "Safely add untrusted strings to HTML/XML markup."
+  homepage_url: "https://www.palletsprojects.com/p/markupsafe/"
   binary_artifact:
-    url: ""
+    url: "https://files.pythonhosted.org/packages/94/7a/34f53c66e0f9070b273c083d674581158426f2670cfd03f07fec375f0325/MarkupSafe-1.1.0-cp27-cp27m-manylinux1_x86_64.whl"
     hash:
-      value: ""
-      algorithm: ""
+      value: "525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c"
+      algorithm: "SHA-256"
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    url: "https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz"
     hash:
-      value: "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+      value: "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
       algorithm: "SHA-256"
   vcs:
     type: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip/requirements.txt
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip/requirements.txt
@@ -2,5 +2,5 @@ click==6.7
 Flask==1.0
 itsdangerous==0.24
 Jinja2==2.11.3
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 Werkzeug==0.15.3

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -24,7 +24,7 @@ project:
       - id: "PyPI::itsdangerous:0.24"
       - id: "PyPI::jinja2:2.10.1"
         dependencies:
-        - id: "PyPI::markupsafe:1.0"
+        - id: "PyPI::markupsafe:1.1.0"
       - id: "PyPI::werkzeug:0.15.3"
 packages:
 - id: "PyPI::click:6.7"
@@ -159,8 +159,8 @@ packages:
     url: ""
     revision: ""
     path: ""
-- id: "PyPI::markupsafe:1.0"
-  purl: "pkg:pypi/markupsafe@1.0"
+- id: "PyPI::markupsafe:1.1.0"
+  purl: "pkg:pypi/markupsafe@1.1.0"
   authors:
   - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
@@ -171,17 +171,17 @@ packages:
     mapped:
       BSD: "BSD-3-Clause"
       BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
-  homepage_url: "http://github.com/pallets/markupsafe"
+  description: "Safely add untrusted strings to HTML/XML markup."
+  homepage_url: "https://www.palletsprojects.com/p/markupsafe/"
   binary_artifact:
     url: ""
     hash:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    url: "https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz"
     hash:
-      value: "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+      value: "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
       algorithm: "SHA-256"
   vcs:
     type: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv/Pipfile
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv/Pipfile
@@ -10,7 +10,7 @@ click = "==6.7"
 itsdangerous = "==0.24"
 Flask = "==1.0"
 Jinja2 = "==2.10.1"
-MarkupSafe = "==1.0"
+MarkupSafe = "==1.1.0"
 Werkzeug = "==0.15.3"
 
 [requires]

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv/Pipfile.lock
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv/Pipfile.lock
@@ -49,10 +49,37 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
+                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
+                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
+                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
+                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
+                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
+                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
+                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
+                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
+                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
+                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
+                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
+                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
+                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
+                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
+                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
+                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
+                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
+                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
+                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
+                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
+                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
+                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
+                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
+                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
+                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
+                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
+                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
             "index": "pypi",
-            "version": "==1.0"
+            "version": "==1.1"
         },
         "werkzeug": {
             "hashes": [

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
@@ -24,7 +24,7 @@ project:
       - id: "PyPI::itsdangerous:0.24"
       - id: "PyPI::jinja2:2.11.3"
         dependencies:
-        - id: "PyPI::markupsafe:1.0"
+        - id: "PyPI::markupsafe:1.1.0"
       - id: "PyPI::werkzeug:0.15.3"
 packages:
 - id: "PyPI::click:6.7"
@@ -157,8 +157,8 @@ packages:
     url: "https://github.com/pallets/jinja.git"
     revision: ""
     path: ""
-- id: "PyPI::markupsafe:1.0"
-  purl: "pkg:pypi/markupsafe@1.0"
+- id: "PyPI::markupsafe:1.1.0"
+  purl: "pkg:pypi/markupsafe@1.1.0"
   authors:
   - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
@@ -169,17 +169,17 @@ packages:
     mapped:
       BSD: "BSD-3-Clause"
       BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
-  homepage_url: "http://github.com/pallets/markupsafe"
+  description: "Safely add untrusted strings to HTML/XML markup."
+  homepage_url: "https://www.palletsprojects.com/p/markupsafe/"
   binary_artifact:
     url: ""
     hash:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    url: "https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz"
     hash:
-      value: "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+      value: "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
       algorithm: "SHA-256"
   vcs:
     type: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/python-inspector/requirements.txt
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/python-inspector/requirements.txt
@@ -3,5 +3,5 @@ Flask==1.0
 itsdangerous<0.25
 license-expression ; platform_system == "Windows"
 Jinja2==2.11.3
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 Werkzeug==0.15.3

--- a/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
@@ -46,6 +46,6 @@ class PythonInspectorFunTest : StringSpec({
 
         result.projects should haveSize(2)
         result.resolvedDependenciesGraph should haveSize(1)
-        result.packages should haveSize(10)
+        result.packages should haveSize(11)
     }
 })


### PR DESCRIPTION
When Python inspector 0.9.8 and above analyzes a project containing `markupsafe` version 1.0.0 as dependency (with option `--analyze-setup-py-insecurely`), then it crashes for unknown reason, see also [1]. Upgrading `markupsafe` to 1.1.0 works around that issue. Do so, in order to prepare for upgrading Python inspector.

[1] https://github.com/nexB/python-inspector/issues/133
