### PR TITLE
chore(docker): Fix installing Node.js in the legacy image

### DIFF
--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -99,7 +99,8 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     apt-get install -y --no-install-recommends ca-certificates gnupg software-properties-common && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
-    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Building the legacy docker on CI does not work anymore because the way
how Node.js has to be installed has changed, see [1]. So, migrate the
installation accordingly.

[1] https://github.com/nodesource/distributions/issues/1576#issuecomment-1698012034

