### PR TITLE
docs(Npm): Do not say to implement dedicated support for peer dependencies

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -227,7 +227,7 @@ open class Npm(
             )
         )
 
-        // TODO: add support for peerDependencies and bundledDependencies.
+        // TODO: Add support for bundledDependencies.
 
         return listOf(
             ProjectAnalyzerResult(


### PR DESCRIPTION
NPM's peer dependencies are not regular dependencies in a "peer" scope, but 'Some way of saying, "I only work when plugged in to version 1.2.x of my host package, so if you install me, be sure that it's alongside a compatible host."' [1]. So they are more like what Gradle would call a "dependency constraint" [2].

As any recent version of NPM "will automatically install peerDependencies if they are not explicitly depended upon higher in the dependency tree" [3], ORT's NPM implementation will pick them up when parsing the installed modules, so no further handling is needed.

Resolves #95.

[1]: https://nodejs.org/en/blog/npm/peer-dependencies#the-solution-peer-dependencies
[2]: https://docs.gradle.org/current/userguide/dependency_management_terminology.html#sub:terminology_dependency_constraint
[3]: https://nodejs.org/en/blog/npm/peer-dependencies#using-peer-dependencies