### PR TITLE
fix(VulnerabilityReference): Do not deserialize a lazy property

### DIFF
--- a/model/src/main/kotlin/vulnerabilities/VulnerabilityReference.kt
+++ b/model/src/main/kotlin/vulnerabilities/VulnerabilityReference.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model.vulnerabilities
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 import java.net.URI
 
 /**
@@ -30,6 +32,7 @@ import java.net.URI
  * with a list of references; each reference points to the source of the information and has some detailed information
  * provided by this source.
  */
+@JsonIgnoreProperties(value = ["severity_rating"], allowGetters = true)
 data class VulnerabilityReference(
     /**
      * The URI pointing to details of this vulnerability. This can also be used to derive the source of this


### PR DESCRIPTION
This is a fixup for 8b6fe4f which introduced the `severityRating` property.