### PR TITLE
ci(renovate): Disable patch-level updates for the AWS S3 dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,13 @@
         "org.springframework:spring-core"
       ],
       "allowedVersions": "< 6.0.0"
+    },
+    {
+      "matchPackageNames": [
+        "software.amazon.awssdk:s3"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
These come almost on a daily basis without usually bringing any value to ORT.