### PR TITLE
Populate score and method properties for vulnerability ratings in CycloneDX SBOM report

### DIFF
--- a/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.json
+++ b/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.json
@@ -249,7 +249,9 @@
           "source": {
             "url": "https://cves.example.org/cve1"
           },
-          "severity": "medium"
+          "score": 6.0,
+          "severity": "medium",
+          "method": "CVSSv2"
         }
       ],
       "description": "A vulnerability description",

--- a/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.xml
+++ b/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.xml
@@ -139,7 +139,9 @@
           <source>
             <url>https://cves.example.org/cve1</url>
           </source>
+          <score>6.0</score>
           <severity>medium</severity>
+          <method>CVSSv2</method>
         </rating>
       </ratings>
       <description>A vulnerability description</description>

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -273,6 +273,9 @@ class CycloneDxReporter : Reporter {
                                 .apply { url = reference.url.toString() }
                             severity = org.cyclonedx.model.vulnerability.Vulnerability.Rating.Severity
                                 .fromString(reference.severityRating.lowercase())
+                            score = reference.severity?.toDoubleOrNull()
+                            method = org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method
+                                .fromString(reference.scoringSystem)
                         }
                     }
                     affects = mutableListOf(

--- a/reporter/src/testFixtures/kotlin/TestData.kt
+++ b/reporter/src/testFixtures/kotlin/TestData.kt
@@ -408,7 +408,7 @@ val VULNERABILITY = Vulnerability(
     summary = "A vulnerability summary",
     description = "A vulnerability description",
     references = listOf(
-        VulnerabilityReference(URI("https://cves.example.org/cve1"), "Cvss2", "6.0")
+        VulnerabilityReference(URI("https://cves.example.org/cve1"), "CVSSv2", "6.0")
     )
 )
 


### PR DESCRIPTION
This PR populates the [score](https://cyclonedx.org/docs/1.5/json/#vulnerabilities_items_ratings_items_score) and [method](https://cyclonedx.org/docs/1.5/json/#vulnerabilities_items_ratings_items_method) properties for the vulnerability rating when reporter generates a CycloneDX SBOM report.
