### PR TITLE
fix(cargo): Allow `metadata` to be missing again

### DIFF
--- a/plugins/package-managers/cargo/src/main/kotlin/CargoLockFile.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/CargoLockFile.kt
@@ -32,7 +32,7 @@ internal data class CargoLockFile(
     @SerialName("package")
     val packages: List<Package>,
 
-    val metadata: Map<String, String>
+    val metadata: Map<String, String> = emptyMap()
 ) {
     /**
      * See https://docs.rs/cargo-lock/latest/cargo_lock/package/struct.Package.html.


### PR DESCRIPTION
This fixes a bug introduced by the port to kotlinx-serialization [1]. Resolves #7825.

[1]: https://github.com/oss-review-toolkit/ort/pull/7709