### PR TITLE
feat(helper-cli): Re-filter scan summaries by the VCS path

### DIFF
--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -19,18 +19,16 @@
 
 package org.ossreviewtoolkit.model.licenses
 
-import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Provenance
-import org.ossreviewtoolkit.model.RepositoryProvenance
-import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.filterByVcsPath
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
 
 /**
@@ -124,11 +122,4 @@ class DefaultLicenseInfoProvider(
                 ""
             )
         }
-}
-
-internal fun ScanResult.filterByVcsPath(path: String): ScanResult {
-    if (provenance !is RepositoryProvenance) return this
-
-    return takeUnless { provenance.vcsInfo.path != path && File(path).startsWith(File(provenance.vcsInfo.path)) }
-        ?: filterByPath(path)
 }

--- a/model/src/main/kotlin/utils/ScanResultUtils.kt
+++ b/model/src/main/kotlin/utils/ScanResultUtils.kt
@@ -19,12 +19,14 @@
 
 package org.ossreviewtoolkit.model.utils
 
+import java.io.File
 import java.time.Instant
 
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.SnippetFinding
@@ -117,4 +119,11 @@ private fun Map<String, List<ScanResult>>.mergeSnippetFindings(): Set<SnippetFin
     }
 
     return findings
+}
+
+fun ScanResult.filterByVcsPath(path: String): ScanResult {
+    if (provenance !is RepositoryProvenance) return this
+
+    return takeUnless { provenance.vcsInfo.path != path && File(path).startsWith(File(provenance.vcsInfo.path)) }
+        ?: filterByPath(path)
 }

--- a/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
+++ b/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
@@ -20,15 +20,8 @@
 package org.ossreviewtoolkit.model.licenses
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeTypeOf
 
-import org.ossreviewtoolkit.model.RepositoryProvenance
-import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.ScannerDetails
-import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 
 class DefaultLicenseInfoProviderTest : WordSpec({
@@ -43,31 +36,4 @@ class DefaultLicenseInfoProviderTest : WordSpec({
             defaultLicenseInfoProvider.get(project.id).declaredLicenseInfo.authors shouldBe projectAuthors
         }
     }
-
-    "filterByVcsPath()" should {
-        "return identity if the target path is not a subdirectory of the scan result's VCS path" {
-            val scanResult = createScanResult("a/b")
-
-            listOf("", "a").forAll { path ->
-                scanResult.filterByVcsPath(path) shouldBe scanResult
-            }
-        }
-
-        "return filtered scan result if the target path is a subdirectory of the scan result's VCS path" {
-            val scanResult = createScanResult("a/b")
-
-            scanResult.filterByPath("a/b/c").provenance
-                .shouldBeTypeOf<RepositoryProvenance>().vcsInfo.path shouldBe "a/b/c"
-        }
-    }
 })
-
-private fun createScanResult(vcsPath: String) =
-    ScanResult(
-        provenance = RepositoryProvenance(
-            vcsInfo = VcsInfo.EMPTY.copy(path = vcsPath),
-            resolvedRevision = "0000000000000000000000000000000000000000"
-        ),
-        summary = ScanSummary.EMPTY,
-        scanner = ScannerDetails.EMPTY
-    )

--- a/model/src/test/kotlin/utils/ScanResultUtilsTest.kt
+++ b/model/src/test/kotlin/utils/ScanResultUtilsTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.VcsInfo
+
+class ScanResultUtilsTest : WordSpec({
+    "filterByVcsPath()" should {
+        "return identity if the target path is not a subdirectory of the scan result's VCS path" {
+            val scanResult = createScanResult("a/b")
+
+            listOf("", "a").forAll { path ->
+                scanResult.filterByVcsPath(path) shouldBe scanResult
+            }
+        }
+
+        "return filtered scan result if the target path is a subdirectory of the scan result's VCS path" {
+            val scanResult = createScanResult("a/b")
+
+            scanResult.filterByPath("a/b/c").provenance
+                .shouldBeTypeOf<RepositoryProvenance>().vcsInfo.path shouldBe "a/b/c"
+        }
+    }
+})
+
+private fun createScanResult(vcsPath: String) =
+    ScanResult(
+        provenance = RepositoryProvenance(
+            vcsInfo = VcsInfo.EMPTY.copy(path = vcsPath),
+            resolvedRevision = "0000000000000000000000000000000000000000"
+        ),
+        summary = ScanSummary.EMPTY,
+        scanner = ScannerDetails.EMPTY
+    )


### PR DESCRIPTION
Make the impact of narrowing down a VCS path visible in the `list-licenses` command, without requiring a re-scan.