### PR TITLE
fix: Add advisor plugins to the plugin classpath for distribution

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.mordant)
     implementation(libs.slf4j)
 
+    "pluginClasspath"(platform(project(":plugins:advisors")))
     "pluginClasspath"(platform(project(":plugins:commands")))
     "pluginClasspath"(platform(project(":plugins:package-configuration-providers")))
     "pluginClasspath"(platform(project(":plugins:package-curation-providers")))


### PR DESCRIPTION
Without this, building the distribution would not necessarily build the advisor plugins.