### PR TITLE
feat(reporter)!: Support secrets in reporter options

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -50,6 +50,7 @@ import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.NotifierConfiguration
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.SendMailConfiguration
@@ -132,7 +133,9 @@ class ExamplesFunTest : StringSpec({
         val report = reporter.generateReport(
             ReporterInput(OrtResult.EMPTY),
             outputDir,
-            mapOf("pdf.theme.file" to examplesDir.resolve("asciidoctor-pdf-theme.yml").path)
+            PluginConfiguration(
+                mapOf("pdf.theme.file" to examplesDir.resolve("asciidoctor-pdf-theme.yml").path)
+            )
         )
 
         report shouldHaveSize 1

--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -165,12 +165,12 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "options": {
+                "config": {
                     "$ref": "#/definitions/ReporterOptions"
                 }
             },
             "required": [
-                "options"
+                "config"
             ]
         },
         "ReporterOptions": {

--- a/model/src/main/kotlin/config/PluginConfiguration.kt
+++ b/model/src/main/kotlin/config/PluginConfiguration.kt
@@ -41,6 +41,14 @@ data class PluginConfiguration(
     @JsonIgnore
     val secrets: Options = emptyMap()
 ) {
+    companion object {
+        /**
+         * Constant for an empty [PluginConfiguration] that contains no options and no secrets. This constant can be
+         * used as a default if no configuration was provided.
+         */
+        val EMPTY = PluginConfiguration()
+    }
+
     /**
      * Return a string representation of the object that does not contain the [secrets].
      */

--- a/model/src/main/kotlin/config/ReporterConfiguration.kt
+++ b/model/src/main/kotlin/config/ReporterConfiguration.kt
@@ -19,18 +19,16 @@
 
 package org.ossreviewtoolkit.model.config
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
-import org.ossreviewtoolkit.utils.common.Options
+import com.fasterxml.jackson.annotation.JsonInclude
 
 /**
  * The base configuration model of the reporter.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ReporterConfiguration(
     /**
      * Reporter specific configuration options. The key needs to match the name of the reporter class, e.g. "FossId"
      * for the FossId reporter. See the documentation of the reporter for available options.
      */
-    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    val options: Map<String, Options>? = null
+    val config: Map<String, PluginConfiguration>? = null
 )

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -333,11 +333,13 @@ ort:
           sslrootcert: /defaultdir/root.crt
 
   reporter:
-    options:
+    config:
       FossId:
-        serverUrl: 'https://fossid.example.com/instance/'
-        user: user
-        apiKey: XYZ
+        options:
+          serverUrl: 'https://fossid.example.com/instance/'
+        secrets:
+          user: user
+          apiKey: XYZ
 
   notifier:
     mail:

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -381,12 +381,14 @@ class OrtConfigurationTest : WordSpec({
             }
 
             with(ortConfig.reporter) {
-                options shouldNotBeNull {
+                config shouldNotBeNull {
                     keys shouldContainExactlyInAnyOrder setOf("FossId")
 
                     get("FossId") shouldNotBeNull {
-                        this shouldContainExactly mapOf(
-                            "serverUrl" to "https://fossid.example.com/instance/",
+                        options shouldContainExactly mapOf(
+                            "serverUrl" to "https://fossid.example.com/instance/"
+                        )
+                        secrets shouldContainExactly mapOf(
                             "user" to "user",
                             "apiKey" to "XYZ"
                         )

--- a/model/src/test/kotlin/config/ReporterConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ReporterConfigurationTest.kt
@@ -20,18 +20,20 @@
 package org.ossreviewtoolkit.model.config
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 import java.io.File
 
 import org.ossreviewtoolkit.model.fromYaml
 import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ReporterConfigurationTest : WordSpec({
-    "Generic reporter options" should {
-        "not be serialized as they might contain sensitive information" {
-            rereadReporterConfig(loadReporterConfig()).options should beNull()
+    "Reporter secrets" should {
+        "not be serialized as they contain sensitive information" {
+            rereadReporterConfig(loadReporterConfig()).config?.get("FossId").shouldNotBeNull {
+                secrets shouldBe emptyMap()
+            }
         }
     }
 })

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.longs.beInRange
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_VULNERABILITIES
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -48,7 +49,7 @@ class PdfTemplateReporterFunTest : StringSpec({
             PdfTemplateReporter().generateReport(
                 ReporterInput(ORT_RESULT),
                 tempdir(),
-                mapOf("pdf.theme.file" to "dummy.file")
+                PluginConfiguration(mapOf("pdf.theme.file" to "dummy.file"))
             )
         }
     }
@@ -58,7 +59,7 @@ class PdfTemplateReporterFunTest : StringSpec({
             PdfTemplateReporter().generateReport(
                 ReporterInput(ORT_RESULT),
                 tempdir(),
-                mapOf("pdf.fonts.dir" to "fake.path")
+                PluginConfiguration(mapOf("pdf.fonts.dir" to "fake.path"))
             )
         }
     }

--- a/plugins/reporters/asciidoc/src/main/kotlin/AsciiDocTemplateReporter.kt
+++ b/plugins/reporters/asciidoc/src/main/kotlin/AsciiDocTemplateReporter.kt
@@ -26,6 +26,7 @@ import org.asciidoctor.Attributes
 import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.plugins.reporters.freemarker.FreemarkerTemplateProcessor
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -67,10 +68,10 @@ open class AsciiDocTemplateReporter(private val backend: String, override val ty
     protected open fun processTemplateOptions(outputDir: File, options: MutableMap<String, String>): Attributes =
         Attributes.builder().build()
 
-    final override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    final override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val asciiDocOutputDir = createOrtTempDir("asciidoc")
 
-        val templateOptions = options.toMutableMap()
+        val templateOptions = config.options.toMutableMap()
         val asciidoctorAttributes = processTemplateOptions(asciiDocOutputDir, templateOptions)
         val asciiDocFiles = generateAsciiDocFiles(input, asciiDocOutputDir, templateOptions)
         val reports = processAsciiDocFiles(input, outputDir, asciiDocFiles, asciidoctorAttributes)

--- a/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationReporter.kt
+++ b/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationReporter.kt
@@ -24,6 +24,7 @@ import java.io.File
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -44,7 +45,7 @@ class CtrlXAutomationReporter : Reporter {
 
     override val type = "CtrlXAutomation"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val reportFile = outputDir.resolve(REPORT_FILENAME)
 
         val packages = input.ortResult.getPackages(omitExcluded = true)

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
@@ -137,20 +138,20 @@ class CycloneDxReporter : Reporter {
             }
         }
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val outputFiles = mutableListOf<File>()
 
         val projects = input.ortResult.getProjects(omitExcluded = true).sortedBy { it.id }
         val packages = input.ortResult.getPackages(omitExcluded = true).sortedBy { it.metadata.id }
 
         val schemaVersion = CycloneDxSchema.Version.entries.find {
-            it.versionString == options[OPTION_SCHEMA_VERSION]
+            it.versionString == config.options[OPTION_SCHEMA_VERSION]
         } ?: DEFAULT_SCHEMA_VERSION
 
-        val dataLicense = options[OPTION_DATA_LICENSE] ?: DEFAULT_DATA_LICENSE.id
-        val createSingleBom = !options[OPTION_SINGLE_BOM].isFalse()
+        val dataLicense = config.options[OPTION_DATA_LICENSE] ?: DEFAULT_DATA_LICENSE.id
+        val createSingleBom = !config.options[OPTION_SINGLE_BOM].isFalse()
 
-        val outputFileFormats = options[OPTION_OUTPUT_FILE_FORMATS]
+        val outputFileFormats = config.options[OPTION_OUTPUT_FILE_FORMATS]
             ?.split(",")
             ?.mapTo(mutableSetOf()) { FileFormat.valueOf(it.uppercase()) }
             ?: setOf(FileFormat.XML)

--- a/plugins/reporters/evaluated-model/src/funTest/kotlin/EvaluatedModelReporterFunTest.kt
+++ b/plugins/reporters/evaluated-model/src/funTest/kotlin/EvaluatedModelReporterFunTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
@@ -71,5 +72,6 @@ private fun TestConfiguration.generateReport(ortResult: OrtResult, options: Map<
 
     val outputDir = tempdir()
 
-    return EvaluatedModelReporter().generateReport(input, outputDir, options).single().readText().normalizeLineBreaks()
+    return EvaluatedModelReporter().generateReport(input, outputDir, PluginConfiguration(options))
+        .single().readText().normalizeLineBreaks()
 }

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelReporter.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelReporter.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.reporters.evaluatedmodel
 import java.io.File
 
 import org.ossreviewtoolkit.model.FileFormat
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 
@@ -42,11 +43,14 @@ class EvaluatedModelReporter : Reporter {
 
     override val type = "EvaluatedModel"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val evaluatedModel = EvaluatedModel.create(input, options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean())
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
+        val evaluatedModel = EvaluatedModel.create(
+            input,
+            config.options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean()
+        )
 
         val outputFiles = mutableListOf<File>()
-        val outputFileFormats = options[OPTION_OUTPUT_FILE_FORMATS]
+        val outputFileFormats = config.options[OPTION_OUTPUT_FILE_FORMATS]
             ?.split(',')
             ?.mapTo(mutableSetOf()) { FileFormat.forExtension(it) }
             ?: setOf(FileFormat.JSON)

--- a/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
+++ b/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.clients.fossid.generateReport
 import org.ossreviewtoolkit.clients.fossid.model.report.ReportType
 import org.ossreviewtoolkit.clients.fossid.model.report.SelectionType
 import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -68,23 +69,23 @@ class FossIdReporter : Reporter {
 
     override val type = "FossId"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val serverUrl = requireNotNull(options[SERVER_URL_PROPERTY]) {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
+        val serverUrl = requireNotNull(config.options[SERVER_URL_PROPERTY]) {
             "No FossID server URL configuration found."
         }
-        val apiKey = requireNotNull(options[API_KEY_PROPERTY]) {
+        val apiKey = requireNotNull(config.options[API_KEY_PROPERTY]) {
             "No FossID API Key configuration found."
         }
-        val user = requireNotNull(options[USER_PROPERTY]) {
+        val user = requireNotNull(config.options[USER_PROPERTY]) {
             "No FossID User configuration found."
         }
-        val reportType = options[REPORT_TYPE_PROPERTY]?.let {
+        val reportType = config.options[REPORT_TYPE_PROPERTY]?.let {
             runCatching {
                 ReportType.valueOf(it)
             }.getOrNull()
         } ?: ReportType.HTML_DYNAMIC
 
-        val selectionType = options[SELECTION_TYPE_PROPERTY]?.let {
+        val selectionType = config.options[SELECTION_TYPE_PROPERTY]?.let {
             runCatching {
                 SelectionType.valueOf(it)
             }.getOrNull()

--- a/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
+++ b/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
@@ -73,10 +73,10 @@ class FossIdReporter : Reporter {
         val serverUrl = requireNotNull(config.options[SERVER_URL_PROPERTY]) {
             "No FossID server URL configuration found."
         }
-        val apiKey = requireNotNull(config.options[API_KEY_PROPERTY]) {
+        val apiKey = requireNotNull(config.secrets[API_KEY_PROPERTY]) {
             "No FossID API Key configuration found."
         }
-        val user = requireNotNull(config.options[USER_PROPERTY]) {
+        val user = requireNotNull(config.secrets[USER_PROPERTY]) {
             "No FossID User configuration found."
         }
         val reportType = config.options[REPORT_TYPE_PROPERTY]?.let {

--- a/plugins/reporters/fossid/src/main/kotlin/FossIdSnippetReporter.kt
+++ b/plugins/reporters/fossid/src/main/kotlin/FossIdSnippetReporter.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.plugins.reporters.fossid
 
 import java.io.File
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.plugins.reporters.asciidoc.HtmlTemplateReporter
 import org.ossreviewtoolkit.plugins.reporters.freemarker.FreemarkerTemplateProcessor
 import org.ossreviewtoolkit.reporter.Reporter
@@ -35,11 +36,13 @@ class FossIdSnippetReporter : Reporter by delegateReporter {
 
     override val type = "FossIdSnippet"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val hasFossIdResults = input.ortResult.scanner?.scanResults?.any { it.scanner.name == "FossId" } ?: false
         require(hasFossIdResults) { "No FossID scan results have been found." }
 
-        val extendedOptions = options + (FreemarkerTemplateProcessor.OPTION_TEMPLATE_ID to TEMPLATE_NAME)
+        val extendedOptions = config.copy(
+            options = config.options + (FreemarkerTemplateProcessor.OPTION_TEMPLATE_ID to TEMPLATE_NAME)
+        )
         return delegateReporter.generateReport(input, outputDir, extendedOptions)
     }
 }

--- a/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
+++ b/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
@@ -63,7 +63,9 @@ private const val SERVER_URL_SAMPLE = "https://fossid.example.com/instance/"
 private const val API_KEY_SAMPLE = "XYZ"
 private const val USER_KEY_SAMPLE = "user"
 private val DEFAULT_OPTIONS = mapOf(
-    FossIdReporter.SERVER_URL_PROPERTY to SERVER_URL_SAMPLE,
+    FossIdReporter.SERVER_URL_PROPERTY to SERVER_URL_SAMPLE
+)
+private val DEFAULT_SECRETS = mapOf(
     FossIdReporter.API_KEY_PROPERTY to API_KEY_SAMPLE,
     FossIdReporter.USER_PROPERTY to USER_KEY_SAMPLE
 )
@@ -101,7 +103,7 @@ class FossIdReporterTest : WordSpec({
                 val input = createReporterInput()
                 reporter.generateReport(
                     input,
-                    DEFAULT_OPTIONS.filterNot { it.key == FossIdReporter.API_KEY_PROPERTY }
+                    secrets = DEFAULT_SECRETS.filterNot { it.key == FossIdReporter.API_KEY_PROPERTY }
                 )
             }
             exception shouldHaveMessage "No FossID API Key configuration found."
@@ -113,7 +115,7 @@ class FossIdReporterTest : WordSpec({
                 val input = createReporterInput()
                 reporter.generateReport(
                     input,
-                    DEFAULT_OPTIONS.filterNot { it.key == FossIdReporter.USER_PROPERTY }
+                    secrets = DEFAULT_SECRETS.filterNot { it.key == FossIdReporter.USER_PROPERTY }
                 )
             }
             exception shouldHaveMessage "No FossID User configuration found."
@@ -243,8 +245,11 @@ class FossIdReporterTest : WordSpec({
     }
 })
 
-private fun FossIdReporter.generateReport(input: ReporterInput, options: Options = DEFAULT_OPTIONS) =
-    generateReport(input, DIRECTORY_SAMPLE, PluginConfiguration(options))
+private fun FossIdReporter.generateReport(
+    input: ReporterInput,
+    options: Options = DEFAULT_OPTIONS,
+    secrets: Options = DEFAULT_SECRETS
+) = generateReport(input, DIRECTORY_SAMPLE, PluginConfiguration(options, secrets))
 
 private fun createReporterMock(): Pair<FossIdRestService, FossIdReporter> {
     mockkObject(FossIdRestService)

--- a/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
+++ b/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
@@ -51,10 +51,12 @@ import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.test.scannerRunOf
 
 private const val SERVER_URL_SAMPLE = "https://fossid.example.com/instance/"
@@ -87,7 +89,6 @@ class FossIdReporterTest : WordSpec({
                 val input = createReporterInput()
                 reporter.generateReport(
                     input,
-                    DIRECTORY_SAMPLE,
                     DEFAULT_OPTIONS.filterNot { it.key == FossIdReporter.SERVER_URL_PROPERTY }
                 )
             }
@@ -100,7 +101,6 @@ class FossIdReporterTest : WordSpec({
                 val input = createReporterInput()
                 reporter.generateReport(
                     input,
-                    DIRECTORY_SAMPLE,
                     DEFAULT_OPTIONS.filterNot { it.key == FossIdReporter.API_KEY_PROPERTY }
                 )
             }
@@ -113,7 +113,6 @@ class FossIdReporterTest : WordSpec({
                 val input = createReporterInput()
                 reporter.generateReport(
                     input,
-                    DIRECTORY_SAMPLE,
                     DEFAULT_OPTIONS.filterNot { it.key == FossIdReporter.USER_PROPERTY }
                 )
             }
@@ -124,7 +123,7 @@ class FossIdReporterTest : WordSpec({
             val (serviceMock, reporterMock) = createReporterMock()
             val input = createReporterInput()
 
-            reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
+            reporterMock.generateReport(input)
 
             coVerify(exactly = 0) {
                 serviceMock.generateReport(any(), any(), any(), any(), any(), any())
@@ -135,7 +134,7 @@ class FossIdReporterTest : WordSpec({
             val (serviceMock, reporterMock) = createReporterMock()
             val input = createReporterInput(SCANCODE_1)
 
-            reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
+            reporterMock.generateReport(input)
 
             coVerify(exactly = 1) {
                 serviceMock.generateReport(
@@ -154,7 +153,7 @@ class FossIdReporterTest : WordSpec({
             val input = createReporterInput(SCANCODE_1)
 
             reporterMock.generateReport(
-                input, DIRECTORY_SAMPLE,
+                input,
                 DEFAULT_OPTIONS + (FossIdReporter.REPORT_TYPE_PROPERTY to ReportType.XLSX.name)
             )
 
@@ -174,7 +173,7 @@ class FossIdReporterTest : WordSpec({
             val (serviceMock, reporterMock) = createReporterMock()
             val input = createReporterInput(SCANCODE_1)
 
-            reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
+            reporterMock.generateReport(input)
 
             coVerify(exactly = 1) {
                 serviceMock.generateReport(
@@ -193,7 +192,7 @@ class FossIdReporterTest : WordSpec({
             val input = createReporterInput(SCANCODE_1)
 
             reporterMock.generateReport(
-                input, DIRECTORY_SAMPLE,
+                input,
                 DEFAULT_OPTIONS + (FossIdReporter.SELECTION_TYPE_PROPERTY to SelectionType.INCLUDE_COPYLEFT.name)
             )
 
@@ -213,7 +212,7 @@ class FossIdReporterTest : WordSpec({
             val (serviceMock, reporterMock) = createReporterMock()
             val input = createReporterInput(SCANCODE_1, SCANCODE_2)
 
-            reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
+            reporterMock.generateReport(input)
 
             coVerifyAll {
                 serviceMock.generateReport(USER_KEY_SAMPLE, API_KEY_SAMPLE, SCANCODE_1, any(), any(), any())
@@ -225,7 +224,7 @@ class FossIdReporterTest : WordSpec({
             val (serviceMock, reporterMock) = createReporterMock()
             val input = createReporterInput("$SCANCODE_1,$SCANCODE_2")
 
-            reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
+            reporterMock.generateReport(input)
 
             coVerifyAll {
                 serviceMock.generateReport(USER_KEY_SAMPLE, API_KEY_SAMPLE, SCANCODE_1, any(), any(), any())
@@ -237,12 +236,15 @@ class FossIdReporterTest : WordSpec({
             val (_, reporterMock) = createReporterMock()
             val input = createReporterInput(SCANCODE_1)
 
-            val result = reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
+            val result = reporterMock.generateReport(input)
 
             result shouldContainExactly listOf(FILE_SAMPLE)
         }
     }
 })
+
+private fun FossIdReporter.generateReport(input: ReporterInput, options: Options = DEFAULT_OPTIONS) =
+    generateReport(input, DIRECTORY_SAMPLE, PluginConfiguration(options))
 
 private fun createReporterMock(): Pair<FossIdRestService, FossIdReporter> {
     mockkObject(FossIdRestService)

--- a/plugins/reporters/freemarker/src/funTest/kotlin/PlainTextTemplateReporterFunTest.kt
+++ b/plugins/reporters/freemarker/src/funTest/kotlin/PlainTextTemplateReporterFunTest.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
 import org.ossreviewtoolkit.model.config.FileStorageConfiguration
 import org.ossreviewtoolkit.model.config.LocalFileStorageConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseCategorization
 import org.ossreviewtoolkit.model.licenses.LicenseCategory
@@ -94,8 +95,9 @@ private fun TestConfiguration.generateReport(
     )
 
     val outputDir = tempdir()
+    val reporterConfig = PluginConfiguration(options)
 
-    return PlainTextTemplateReporter().generateReport(input, outputDir, options).single().readText()
+    return PlainTextTemplateReporter().generateReport(input, outputDir, reporterConfig).single().readText()
 }
 
 private fun createLicenseClassifications(): LicenseClassifications {

--- a/plugins/reporters/freemarker/src/main/kotlin/PlainTextTemplateReporter.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/PlainTextTemplateReporter.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.plugins.reporters.freemarker
 
 import java.io.File
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 
@@ -48,8 +49,8 @@ class PlainTextTemplateReporter : Reporter {
 
     private val templateProcessor = FreemarkerTemplateProcessor(TEMPLATE_DIRECTORY)
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val templateOptions = options.toMutableMap()
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
+        val templateOptions = config.options.toMutableMap()
 
         if (FreemarkerTemplateProcessor.OPTION_TEMPLATE_PATH !in templateOptions) {
             templateOptions.putIfAbsent(FreemarkerTemplateProcessor.OPTION_TEMPLATE_ID, DEFAULT_TEMPLATE_ID)

--- a/plugins/reporters/gitlab/src/funTest/kotlin/GitLabLicenseModelReporterFunTest.kt
+++ b/plugins/reporters/gitlab/src/funTest/kotlin/GitLabLicenseModelReporterFunTest.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
@@ -68,7 +69,7 @@ private fun TestConfiguration.generateReport(ortResult: OrtResult, skipExcluded:
     GitLabLicenseModelReporter().generateReport(
         input = ReporterInput(ortResult = ortResult),
         outputDir = tempdir(),
-        options = mapOf(GitLabLicenseModelReporter.OPTION_SKIP_EXCLUDED to skipExcluded.toString())
+        config = PluginConfiguration(mapOf(GitLabLicenseModelReporter.OPTION_SKIP_EXCLUDED to skipExcluded.toString()))
     ).single().readText().normalizeLineBreaks()
 
 private fun createOrtResult(): OrtResult {

--- a/plugins/reporters/gitlab/src/main/kotlin/GitLabLicenseModelReporter.kt
+++ b/plugins/reporters/gitlab/src/main/kotlin/GitLabLicenseModelReporter.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.isTrue
@@ -54,8 +55,8 @@ class GitLabLicenseModelReporter : Reporter {
 
     private val reportFilename = "gl-license-scanning-report.json"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val skipExcluded = options[OPTION_SKIP_EXCLUDED].isTrue()
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
+        val skipExcluded = config.options[OPTION_SKIP_EXCLUDED].isTrue()
 
         val licenseModel = GitLabLicenseModelMapper.map(input.ortResult, skipExcluded)
         val licenseModelJson = JSON.encodeToString(licenseModel)

--- a/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
+++ b/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
@@ -65,7 +65,7 @@ private fun TestConfiguration.generateReport(ortResult: OrtResult): String {
     )
 
     val outputDir = tempdir()
-    OpossumReporter().generateReport(input, outputDir, emptyMap()).single().unpackZip(outputDir)
+    OpossumReporter().generateReport(input, outputDir).single().unpackZip(outputDir)
 
     return outputDir.resolve("input.json").readText()
 }

--- a/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
+++ b/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
@@ -42,6 +42,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.utils.getPurlType
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.reporter.Reporter
@@ -533,8 +534,8 @@ class OpossumReporter : Reporter {
         return opossumInput
     }
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val maxDepth = options.getOrDefault(OPTION_SCANNER_MAX_DEPTH, "3").toInt()
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
+        val maxDepth = config.options.getOrDefault(OPTION_SCANNER_MAX_DEPTH, "3").toInt()
         val opossumInput = generateOpossumInput(input.ortResult, maxDepth)
         val outputFile = outputDir.resolve("report.opossum")
 

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -50,6 +50,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
@@ -136,7 +137,9 @@ private fun TestConfiguration.generateReport(
         SpdxDocumentReporter.OPTION_OUTPUT_FILE_FORMATS to format.toString()
     ) + extraReporterOptions
 
-    return SpdxDocumentReporter().generateReport(input, outputDir, reportOptions).single().readText()
+    return SpdxDocumentReporter().generateReport(input, outputDir, PluginConfiguration(reportOptions))
+        .single()
+        .readText()
         .normalizeLineBreaks()
 }
 

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -23,6 +23,7 @@ import java.io.File
 
 import org.apache.logging.log4j.kotlin.logger
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.spdx.SpdxCompoundExpression
@@ -62,17 +63,17 @@ class SpdxDocumentReporter : Reporter {
 
     override val type = "SpdxDocument"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val outputFileFormats = options[OPTION_OUTPUT_FILE_FORMATS]
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
+        val outputFileFormats = config.options[OPTION_OUTPUT_FILE_FORMATS]
             ?.split(',')
             ?.mapTo(mutableSetOf()) { FileFormat.valueOf(it.uppercase()) }
             ?: setOf(FileFormat.YAML)
 
         val params = SpdxDocumentModelMapper.SpdxDocumentParams(
-            documentName = options.getOrDefault(OPTION_DOCUMENT_NAME, DOCUMENT_NAME_DEFAULT_VALUE),
-            documentComment = options.getOrDefault(OPTION_DOCUMENT_COMMENT, ""),
-            creationInfoComment = options.getOrDefault(OPTION_CREATION_INFO_COMMENT, ""),
-            fileInformationEnabled = options.getOrDefault(OPTION_FILE_INFORMATION_ENABLED, "true").toBoolean()
+            documentName = config.options.getOrDefault(OPTION_DOCUMENT_NAME, DOCUMENT_NAME_DEFAULT_VALUE),
+            documentComment = config.options.getOrDefault(OPTION_DOCUMENT_COMMENT, ""),
+            creationInfoComment = config.options.getOrDefault(OPTION_CREATION_INFO_COMMENT, ""),
+            fileInformationEnabled = config.options.getOrDefault(OPTION_FILE_INFORMATION_ENABLED, "true").toBoolean()
         )
 
         val spdxDocument = SpdxDocumentModelMapper.map(

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseLocation
@@ -82,7 +83,7 @@ class StaticHtmlReporter : Reporter {
     private val css = javaClass.getResource("/static-html-reporter.css").readText()
     private val licensesSha1 = mutableMapOf<String, String>()
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val reportTableModel = ReportTableModelMapper.map(
             input.ortResult,
             input.licenseInfoResolver,

--- a/plugins/reporters/trustsource/src/main/kotlin/TrustSourceReporter.kt
+++ b/plugins/reporters/trustsource/src/main/kotlin/TrustSourceReporter.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
 
 import org.ossreviewtoolkit.model.DependencyNode
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -38,7 +39,7 @@ class TrustSourceReporter : Reporter {
 
     private val reportFilename = "trustsource-report.json"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val outputFile = outputDir.resolve(reportFilename)
 
         val nav = input.ortResult.dependencyNavigator

--- a/plugins/reporters/web-app/src/main/kotlin/WebAppReporter.kt
+++ b/plugins/reporters/web-app/src/main/kotlin/WebAppReporter.kt
@@ -27,6 +27,7 @@ import java.util.zip.Deflater
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import org.apache.commons.compress.compressors.gzip.GzipParameters
 
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.plugins.reporters.evaluatedmodel.EvaluatedModel
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -49,9 +50,12 @@ class WebAppReporter : Reporter {
 
     private val reportFilename = "scan-report-web-app.html"
 
-    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+    override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
         val template = javaClass.getResource("/scan-report-template.html").readText()
-        val evaluatedModel = EvaluatedModel.create(input, options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean())
+        val evaluatedModel = EvaluatedModel.create(
+            input,
+            config.options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean()
+        )
 
         val index = template.indexOf(PLACEHOLDER)
         val prefix = template.substring(0, index)

--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.reporter
 import java.io.File
 
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
@@ -38,7 +39,11 @@ interface Reporter : Plugin {
     /**
      * Generate a report for the provided [input] and write the generated file(s) to the [outputDir]. If and how the
      * [input] data is used depends on the specific reporter implementation, taking into account any format-specific
-     * [options]. The list of generated report files is returned.
+     * [config]. The list of generated report files is returned.
      */
-    fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String> = emptyMap()): List<File>
+    fun generateReport(
+        input: ReporterInput,
+        outputDir: File,
+        config: PluginConfiguration = PluginConfiguration.EMPTY
+    ): List<File>
 }


### PR DESCRIPTION
Some reporter implementations need access to secrets. Therefore, align the `ReporterConfiguration` class with the configuration classes for Advisor and Scanner which use `PluginConfiguration` to distinguish between plain options and secrets.
