### PR TITLE
docs(scanner): Improve logging for packages with incomplete scan results

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -346,10 +346,9 @@ class Scanner(
 
                 if (packagesWithIncompleteScanResult.size > 1) {
                     logger.info {
-                        val packageIds = packagesWithIncompleteScanResult.drop(1)
-                            .joinToString("\n") { "\t${it.id.toCoordinates()}" }
-                        "Scanning package '${referencePackage.id.toCoordinates()}' as reference for these packages " +
-                            "with the same provenance:\n$packageIds"
+                        "Consolidating the following packages with the same provenance to a single repository scan " +
+                            "associated with the first package ('${referencePackage.id.toCoordinates()}'): " +
+                            packagesWithIncompleteScanResult.joinToString("\n") { "\t${it.id.toCoordinates()}" }
                     }
                 }
 


### PR DESCRIPTION
A user does not know that the reference package has its path removed, so the original message sounded as if the package is scanned as a substitute for others. Clarify that by rewording the log message.