### PR TITLE
refactor(maven)!: Make the `container` property private

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -330,7 +330,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             }
     }
 
-    val container = createContainer()
+    private val container = createContainer()
     private val repositorySystemSession = createRepositorySystemSession(workspaceReader)
 
     // The MavenSettingsBuilder class is deprecated, but internally it uses its successor SettingsBuilder. Calling


### PR DESCRIPTION
This is and should not be used outside of this class.