### PR TITLE
Add properties to configure if scan results are read from or written to the scan storages

### DIFF
--- a/plugins/commands/requirements/src/main/kotlin/RequirementsCommand.kt
+++ b/plugins/commands/requirements/src/main/kotlin/RequirementsCommand.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.spdx.scanCodeLicenseTextDir
 
@@ -89,8 +89,8 @@ class RequirementsCommand : OrtCommand(
                         logger.debug { "$it is a $category." }
                         it.getDeclaredConstructor(
                             String::class.java,
-                            ScannerMatcherConfig::class.java
-                        ).newInstance("", ScannerMatcherConfig.EMPTY)
+                            ScannerWrapperConfig::class.java
+                        ).newInstance("", ScannerWrapperConfig.EMPTY)
                     }
 
                     VersionControlSystem::class.java.isAssignableFrom(it) -> {

--- a/plugins/scanners/askalono/src/funTest/kotlin/AskalonoFunTest.kt
+++ b/plugins/scanners/askalono/src/funTest/kotlin/AskalonoFunTest.kt
@@ -21,11 +21,11 @@ package org.ossreviewtoolkit.plugins.scanners.askalono
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 
 class AskalonoFunTest : AbstractPathScannerWrapperFunTest() {
-    override val scanner = Askalono("Askalono", ScannerMatcherConfig.EMPTY)
+    override val scanner = Askalono("Askalono", ScannerWrapperConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 1.0f)

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerMatcher
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -45,17 +45,17 @@ private const val CONFIDENCE_NOTICE = "Confidence threshold not high enough for 
 
 private val JSON = Json { ignoreUnknownKeys = true }
 
-class Askalono internal constructor(name: String, private val matcherConfig: ScannerMatcherConfig) :
+class Askalono internal constructor(name: String, private val wrapperConfig: ScannerWrapperConfig) :
     CommandLinePathScannerWrapper(name) {
     class Factory : ScannerWrapperFactory<Unit>("Askalono") {
-        override fun create(config: Unit, matcherConfig: ScannerMatcherConfig) = Askalono(type, matcherConfig)
+        override fun create(config: Unit, wrapperConfig: ScannerWrapperConfig) = Askalono(type, wrapperConfig)
 
         override fun parseConfig(options: Options, secrets: Options) = Unit
     }
 
     override val configuration = ""
 
-    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
+    override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -57,6 +57,10 @@ class Askalono internal constructor(name: String, private val wrapperConfig: Sca
 
     override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
+    override val readFromStorage by lazy { wrapperConfig.readFromStorageWithDefault(matcher) }
+
+    override val writeToStorage by lazy { wrapperConfig.writeToStorageWithDefault(matcher) }
+
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)
 

--- a/plugins/scanners/boyterlc/src/funTest/kotlin/BoyterLcFunTest.kt
+++ b/plugins/scanners/boyterlc/src/funTest/kotlin/BoyterLcFunTest.kt
@@ -21,11 +21,11 @@ package org.ossreviewtoolkit.plugins.scanners.boyterlc
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 
 class BoyterLcFunTest : AbstractPathScannerWrapperFunTest() {
-    override val scanner = BoyterLc("BoyterLc", ScannerMatcherConfig.EMPTY)
+    override val scanner = BoyterLc("BoyterLc", ScannerWrapperConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 0.98388565f),

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerMatcher
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 private val JSON = Json { ignoreUnknownKeys = true }
 
-class BoyterLc internal constructor(name: String, private val matcherConfig: ScannerMatcherConfig) :
+class BoyterLc internal constructor(name: String, private val wrapperConfig: ScannerWrapperConfig) :
     CommandLinePathScannerWrapper(name) {
     companion object {
         val CONFIGURATION_OPTIONS = listOf(
@@ -54,14 +54,14 @@ class BoyterLc internal constructor(name: String, private val matcherConfig: Sca
     }
 
     class Factory : ScannerWrapperFactory<Unit>("BoyterLc") {
-        override fun create(config: Unit, matcherConfig: ScannerMatcherConfig) = BoyterLc(type, matcherConfig)
+        override fun create(config: Unit, wrapperConfig: ScannerWrapperConfig) = BoyterLc(type, wrapperConfig)
 
         override fun parseConfig(options: Options, secrets: Options) = Unit
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
+    override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -63,6 +63,10 @@ class BoyterLc internal constructor(name: String, private val wrapperConfig: Sca
 
     override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
+    override val readFromStorage by lazy { wrapperConfig.readFromStorageWithDefault(matcher) }
+
+    override val writeToStorage by lazy { wrapperConfig.writeToStorageWithDefault(matcher) }
+
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -78,7 +78,7 @@ import org.ossreviewtoolkit.scanner.PackageScannerWrapper
 import org.ossreviewtoolkit.scanner.ProvenanceScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerMatcher
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.enumSetOf
@@ -170,7 +170,7 @@ class FossId internal constructor(
     }
 
     class Factory : ScannerWrapperFactory<FossIdConfig>("FossId") {
-        override fun create(config: FossIdConfig, matcherConfig: ScannerMatcherConfig) = FossId(type, config)
+        override fun create(config: FossIdConfig, wrapperConfig: ScannerWrapperConfig) = FossId(type, config)
 
         override fun parseConfig(options: Options, secrets: Options) = FossIdConfig.create(options, secrets)
     }

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -97,7 +97,8 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
  */
 class FossId internal constructor(
     override val name: String,
-    private val config: FossIdConfig
+    private val config: FossIdConfig,
+    private val wrapperConfig: ScannerWrapperConfig
 ) : PackageScannerWrapper {
     companion object {
         @JvmStatic
@@ -170,7 +171,8 @@ class FossId internal constructor(
     }
 
     class Factory : ScannerWrapperFactory<FossIdConfig>("FossId") {
-        override fun create(config: FossIdConfig, wrapperConfig: ScannerWrapperConfig) = FossId(type, config)
+        override fun create(config: FossIdConfig, wrapperConfig: ScannerWrapperConfig) =
+            FossId(type, config, wrapperConfig)
 
         override fun parseConfig(options: Options, secrets: Options) = FossIdConfig.create(options, secrets)
     }
@@ -205,6 +207,10 @@ class FossId internal constructor(
     override val configuration = ""
 
     override val matcher: ScannerMatcher? = null
+
+    override val readFromStorage by lazy { wrapperConfig.readFromStorageWithDefault(matcher) }
+
+    override val writeToStorage by lazy { wrapperConfig.writeToStorageWithDefault(matcher) }
 
     private suspend fun getProject(projectCode: String): Project? =
         service.getProject(config.user, config.apiKey, projectCode).run {

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -106,6 +106,7 @@ import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SCAN_ID_KEY
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SERVER_URL_KEY
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.convertGitUrlToProjectName
 import org.ossreviewtoolkit.scanner.ScanContext
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 @Suppress("LargeClass")
@@ -1151,7 +1152,7 @@ private val DEFAULT_IGNORE_RULE_SCOPE = RuleScope.SCAN
 /**
  * Create a new [FossId] instance with the specified [config].
  */
-private fun createFossId(config: FossIdConfig): FossId = FossId("FossId", config)
+private fun createFossId(config: FossIdConfig): FossId = FossId("FossId", config, ScannerWrapperConfig.EMPTY)
 
 /**
  * Create a standard [FossIdConfig] whose properties can be partly specified.

--- a/plugins/scanners/licensee/src/funTest/kotlin/LicenseeFunTest.kt
+++ b/plugins/scanners/licensee/src/funTest/kotlin/LicenseeFunTest.kt
@@ -21,12 +21,12 @@ package org.ossreviewtoolkit.plugins.scanners.licensee
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class LicenseeFunTest : AbstractPathScannerWrapperFunTest(setOf(ExpensiveTag)) {
-    override val scanner = Licensee("Licensee", ScannerMatcherConfig.EMPTY)
+    override val scanner = Licensee("Licensee", ScannerWrapperConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", TextLocation.UNKNOWN_LINE), 100.0f)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScannerMatcher
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -46,21 +46,21 @@ private val JSON = Json {
     namingStrategy = JsonNamingStrategy.SnakeCase
 }
 
-class Licensee internal constructor(name: String, private val matcherConfig: ScannerMatcherConfig) :
+class Licensee internal constructor(name: String, private val wrapperConfig: ScannerWrapperConfig) :
     CommandLinePathScannerWrapper(name) {
     companion object {
         val CONFIGURATION_OPTIONS = listOf("--json")
     }
 
     class Factory : ScannerWrapperFactory<Unit>("Licensee") {
-        override fun create(config: Unit, matcherConfig: ScannerMatcherConfig) = Licensee(type, matcherConfig)
+        override fun create(config: Unit, wrapperConfig: ScannerWrapperConfig) = Licensee(type, wrapperConfig)
 
         override fun parseConfig(options: Options, secrets: Options) = Unit
     }
 
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
 
-    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
+    override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
+++ b/plugins/scanners/licensee/src/main/kotlin/Licensee.kt
@@ -62,6 +62,10 @@ class Licensee internal constructor(name: String, private val wrapperConfig: Sca
 
     override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
+    override val readFromStorage by lazy { wrapperConfig.readFromStorageWithDefault(matcher) }
+
+    override val writeToStorage by lazy { wrapperConfig.writeToStorageWithDefault(matcher) }
+
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)
 

--- a/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
+++ b/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
@@ -26,14 +26,14 @@ import io.kotest.matchers.string.startWith
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.scanners.AbstractPathScannerWrapperFunTest
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.getLicenseText
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class ScanCodeScannerFunTest : AbstractPathScannerWrapperFunTest(setOf(ExpensiveTag)) {
-    override val scanner = ScanCode("ScanCode", ScanCodeConfig.EMPTY, ScannerMatcherConfig.EMPTY)
+    override val scanner = ScanCode("ScanCode", ScanCodeConfig.EMPTY, ScannerWrapperConfig.EMPTY)
 
     override val expectedFileLicenses = listOf(
         LicenseFinding("Apache-2.0", TextLocation("LICENSE", 1, 187), 100.0f),

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -109,6 +109,10 @@ class ScanCode internal constructor(
 
     override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
+    override val readFromStorage by lazy { wrapperConfig.readFromStorageWithDefault(matcher) }
+
+    override val writeToStorage by lazy { wrapperConfig.writeToStorageWithDefault(matcher) }
+
     override val configuration by lazy {
         buildList {
             addAll(configurationOptions)

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerMatcher
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
@@ -62,10 +62,10 @@ import org.semver4j.Semver
 class ScanCode internal constructor(
     name: String,
     config: ScanCodeConfig,
-    private val matcherConfig: ScannerMatcherConfig
+    private val wrapperConfig: ScannerWrapperConfig
 ) : CommandLinePathScannerWrapper(name) {
     // This constructor is required by the `RequirementsCommand`.
-    constructor(name: String, matcherConfig: ScannerMatcherConfig) : this(name, ScanCodeConfig.EMPTY, matcherConfig)
+    constructor(name: String, wrapperConfig: ScannerWrapperConfig) : this(name, ScanCodeConfig.EMPTY, wrapperConfig)
 
     companion object {
         const val SCANNER_NAME = "ScanCode"
@@ -101,13 +101,13 @@ class ScanCode internal constructor(
     }
 
     class Factory : ScannerWrapperFactory<ScanCodeConfig>(SCANNER_NAME) {
-        override fun create(config: ScanCodeConfig, matcherConfig: ScannerMatcherConfig) =
-            ScanCode(type, config, matcherConfig)
+        override fun create(config: ScanCodeConfig, wrapperConfig: ScannerWrapperConfig) =
+            ScanCode(type, config, wrapperConfig)
 
         override fun parseConfig(options: Options, secrets: Options) = ScanCodeConfig.create(options)
     }
 
-    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
+    override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
     override val configuration by lazy {
         buildList {

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -35,11 +35,11 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.scanner.ScanContext
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 
 class ScanCodeTest : WordSpec({
-    val scanner = ScanCode("ScanCode", ScanCodeConfig.EMPTY, ScannerMatcherConfig.EMPTY)
+    val scanner = ScanCode("ScanCode", ScanCodeConfig.EMPTY, ScannerWrapperConfig.EMPTY)
 
     "configuration" should {
         "return the default values if the scanner configuration is empty" {
@@ -53,7 +53,7 @@ class ScanCodeTest : WordSpec({
                     commandLine = "--command --line",
                     commandLineNonConfig = "--commandLineNonConfig"
                 ),
-                ScannerMatcherConfig.EMPTY
+                ScannerWrapperConfig.EMPTY
             )
 
             scannerWithConfig.configuration shouldBe "--command --line --json-pp"
@@ -75,7 +75,7 @@ class ScanCodeTest : WordSpec({
                     commandLine = "--command --line",
                     commandLineNonConfig = "--commandLineNonConfig"
                 ),
-                ScannerMatcherConfig.EMPTY
+                ScannerWrapperConfig.EMPTY
             )
 
             scannerWithConfig.getCommandLineOptions("31.2.4").joinToString(" ") shouldBe
@@ -89,7 +89,7 @@ class ScanCodeTest : WordSpec({
                     commandLine = " --command  --line  ",
                     commandLineNonConfig = "  -n -c "
                 ),
-                ScannerMatcherConfig.EMPTY
+                ScannerWrapperConfig.EMPTY
             )
 
             scannerWithConfig.getCommandLineOptions("31.2.4") shouldBe listOf("--command", "--line", "-n", "-c")

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.scanner.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerMatcher
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
@@ -53,11 +53,11 @@ private const val ARG_FIELD_NAME = "file"
 class ScanOss internal constructor(
     override val name: String,
     config: ScanOssConfig,
-    private val matcherConfig: ScannerMatcherConfig
+    private val wrapperConfig: ScannerWrapperConfig
 ) : PathScannerWrapper {
     class Factory : ScannerWrapperFactory<ScanOssConfig>("SCANOSS") {
-        override fun create(config: ScanOssConfig, matcherConfig: ScannerMatcherConfig) =
-            ScanOss(type, config, matcherConfig)
+        override fun create(config: ScanOssConfig, wrapperConfig: ScannerWrapperConfig) =
+            ScanOss(type, config, wrapperConfig)
 
         override fun parseConfig(options: Options, secrets: Options) =
             ScanOssConfig.create(options, secrets).also { logger.info { "The $type API URL is ${it.apiUrl}." } }
@@ -74,7 +74,7 @@ class ScanOss internal constructor(
 
     override val configuration = ""
 
-    override val matcher by lazy { ScannerMatcher.create(details, matcherConfig) }
+    override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -76,6 +76,10 @@ class ScanOss internal constructor(
 
     override val matcher by lazy { ScannerMatcher.create(details, wrapperConfig.matcherConfig) }
 
+    override val readFromStorage by lazy { wrapperConfig.readFromStorageWithDefault(matcher) }
+
+    override val writeToStorage by lazy { wrapperConfig.writeToStorageWithDefault(matcher) }
+
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.
      * However, for anonymity, a unique identifier should be generated and used instead. This property holds the

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.scanner.ScanContext
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 private val TEST_DIRECTORY_TO_SCAN = File("src/test/assets/filesToScan")
@@ -63,7 +63,7 @@ class ScanOssScannerDirectoryTest : StringSpec({
     beforeSpec {
         server.start()
         val config = ScanOssConfig(apiUrl = "http://localhost:${server.port()}", apiKey = "")
-        scanner = spyk(ScanOss.Factory().create(config, ScannerMatcherConfig.EMPTY))
+        scanner = spyk(ScanOss.Factory().create(config, ScannerWrapperConfig.EMPTY))
     }
 
     afterSpec {

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.scanner.ScanContext
-import org.ossreviewtoolkit.scanner.ScannerMatcherConfig
+import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 
 private val TEST_FILE_TO_SCAN = File("src/test/assets/filesToScan/ScannerFactory.kt")
 
@@ -56,7 +56,7 @@ class ScanOssScannerFileTest : StringSpec({
     beforeSpec {
         server.start()
         val config = ScanOssConfig(apiUrl = "http://localhost:${server.port()}", apiKey = "")
-        scanner = spyk(ScanOss.Factory().create(config, ScannerMatcherConfig.EMPTY))
+        scanner = spyk(ScanOss.Factory().create(config, ScannerWrapperConfig.EMPTY))
     }
 
     afterSpec {

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -216,6 +216,8 @@ internal class DummyScanner(override val name: String = "Dummy") : PathScannerWr
     override val configuration = ""
 
     override val matcher = ScannerMatcher.create(details)
+    override val readFromStorage = true
+    override val writeToStorage = true
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {
         val relevantFiles = path.walk()

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -370,7 +370,7 @@ class Scanner(
                     controller.addNestedScanResult(scanner, nestedProvenanceScanResult)
 
                     // TODO: Run in coroutine.
-                    if (scanner.matcher != null) {
+                    if (scanner.writeToStorage) {
                         storeNestedScanResult(pkg, nestedProvenanceScanResult)
                     }
                 }
@@ -503,6 +503,7 @@ class Scanner(
     private fun readStoredPackageResults(controller: ScanController) {
         controller.scanners.forEach { scanner ->
             val scannerMatcher = scanner.matcher ?: return@forEach
+            if (!scanner.readFromStorage) return@forEach
 
             controller.packages.forEach pkg@{ pkg ->
                 val nestedProvenance = controller.findNestedProvenance(pkg.id) ?: return@pkg
@@ -532,6 +533,7 @@ class Scanner(
     private fun readStoredProvenanceResults(controller: ScanController) {
         controller.scanners.forEach { scanner ->
             val scannerMatcher = scanner.matcher ?: return@forEach
+            if (!scanner.readFromStorage) return@forEach
 
             controller.getAllProvenances().forEach provenance@{ provenance ->
                 if (controller.hasScanResult(scanner, provenance)) return@provenance

--- a/scanner/src/main/kotlin/ScannerMatcher.kt
+++ b/scanner/src/main/kotlin/ScannerMatcher.kt
@@ -62,7 +62,6 @@ data class ScannerMatcher(
     val configuration: String?
 ) {
     companion object {
-
         /**
          * Return a [ScannerMatcher] instance that is to be used when looking up existing scan results from a
          * [ScanResultsStorage]. By default, the properties of this instance are initialized to match the scanner

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -71,9 +71,20 @@ sealed interface ScannerWrapper {
      * name of a property of the [ScannerMatcher] class. For instance, to specify that a specific minimum version of
      * ScanCode is allowed, set this property: `config.ScanCode.options.minVersion=3.0.2`.
      *
-     * If this property is null, it means that the results of this [ScannerWrapper] cannot be stored in a scan storage.
+     * If this property is null, it means that the results of this [ScannerWrapper] cannot be read from a scan storage.
      */
     val matcher: ScannerMatcher?
+
+    /**
+     * If `true`, scan results for this scanner shall be read from the configured scan storages. Enabling this option
+     * requires that the [matcher] is not `null`.
+     */
+    val readFromStorage: Boolean
+
+    /**
+     * If `true`, scan results for this scanner shall be written to the configured scan storages.
+     */
+    val writeToStorage: Boolean
 }
 
 /**

--- a/scanner/src/main/kotlin/ScannerWrapperConfig.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperConfig.kt
@@ -28,18 +28,54 @@ data class ScannerWrapperConfig(
     /**
      * The configuration for the [ScannerMatcher].
      */
-    val matcherConfig: ScannerMatcherConfig
+    val matcherConfig: ScannerMatcherConfig,
+
+    /**
+     * If `true`, scan results of this scanner shall be read from the configured scan storages. If `null`, the default
+     * value of the [ScannerWrapper] implementation will be used.
+     */
+    val readFromStorage: Boolean?,
+
+    /**
+     * If `true`, scan results for this scanner shall be written to the configured scan storages. If `null`, the default
+     * value of the [ScannerWrapper] implementation will be used.
+     */
+    val writeToStorage: Boolean?
 ) {
     companion object {
-        val EMPTY = ScannerWrapperConfig(ScannerMatcherConfig.EMPTY)
+        val EMPTY = ScannerWrapperConfig(
+            matcherConfig = ScannerMatcherConfig.EMPTY,
+            readFromStorage = null,
+            writeToStorage = null
+        )
+
+        /**
+         * The name of the boolean property to configure if scan results shall be read from the configured scan
+         * storages.
+         */
+        internal const val PROP_READ_FROM_STORAGE = "readFromStorage"
+
+        /**
+         * The name of the boolean property to configure if scan results shall be written to the configured scan
+         * storages.
+         */
+        internal const val PROP_WRITE_TO_STORAGE = "writeToStorage"
+
+        private val properties = listOf(PROP_READ_FROM_STORAGE, PROP_WRITE_TO_STORAGE)
 
         /**
          * Create a [ScannerWrapperConfig] from the provided [options]. Return the created config and the options
          * without the properties that were used to create the [ScannerWrapperConfig].
          */
         fun create(options: Options): Pair<ScannerWrapperConfig, Options> {
-            val (matcherConfig, filteredOptions) = ScannerMatcherConfig.create(options)
-            return ScannerWrapperConfig(matcherConfig) to filteredOptions
+            val (matcherConfig, filteredOptionsFromMatcher) = ScannerMatcherConfig.create(options)
+            val filteredOptions = filteredOptionsFromMatcher.filterKeys { it !in properties }
+
+            return ScannerWrapperConfig(
+                matcherConfig = matcherConfig,
+                readFromStorage = options[PROP_READ_FROM_STORAGE]?.toBooleanStrict(),
+                writeToStorage = options[PROP_WRITE_TO_STORAGE]?.toBooleanStrict()
+            ) to filteredOptions
         }
     }
 }

--- a/scanner/src/main/kotlin/ScannerWrapperConfig.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperConfig.kt
@@ -31,6 +31,8 @@ data class ScannerWrapperConfig(
     val matcherConfig: ScannerMatcherConfig
 ) {
     companion object {
+        val EMPTY = ScannerWrapperConfig(ScannerMatcherConfig.EMPTY)
+
         /**
          * Create a [ScannerWrapperConfig] from the provided [options]. Return the created config and the options
          * without the properties that were used to create the [ScannerWrapperConfig].

--- a/scanner/src/main/kotlin/ScannerWrapperConfig.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperConfig.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import org.ossreviewtoolkit.utils.common.Options
+
+/**
+ * A class to hold the configuration that is common to all [ScannerWrapper]s.
+ */
+data class ScannerWrapperConfig(
+    /**
+     * The configuration for the [ScannerMatcher].
+     */
+    val matcherConfig: ScannerMatcherConfig
+) {
+    companion object {
+        /**
+         * Create a [ScannerWrapperConfig] from the provided [options]. Return the created config and the options
+         * without the properties that were used to create the [ScannerWrapperConfig].
+         */
+        fun create(options: Options): Pair<ScannerWrapperConfig, Options> {
+            val (matcherConfig, filteredOptions) = ScannerMatcherConfig.create(options)
+            return ScannerWrapperConfig(matcherConfig) to filteredOptions
+        }
+    }
+}

--- a/scanner/src/main/kotlin/ScannerWrapperConfig.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperConfig.kt
@@ -78,4 +78,14 @@ data class ScannerWrapperConfig(
             ) to filteredOptions
         }
     }
+
+    /**
+     * Return [readFromStorage] if it is not `null`, otherwise return `true` if the provided [matcher] is not `null`.
+     */
+    fun readFromStorageWithDefault(matcher: ScannerMatcher?) = readFromStorage ?: (matcher != null)
+
+    /**
+     * Return [writeToStorage] if it is not `null`, otherwise return `true` if the provided [matcher] is not `null`.
+     */
+    fun writeToStorageWithDefault(matcher: ScannerMatcher?) = writeToStorage ?: (matcher != null)
 }

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -44,7 +44,7 @@ abstract class ScannerWrapperFactory<CONFIG>(override val type: String) :
     abstract fun create(config: CONFIG, matcherConfig: ScannerMatcherConfig): ScannerWrapper
 
     /**
-     * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners
+     * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanner
      * wrapper factories which are enabled by default.
      */
     override fun toString() = type

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -30,8 +30,8 @@ import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
 abstract class ScannerWrapperFactory<CONFIG>(override val type: String) :
     TypedConfigurablePluginFactory<CONFIG, ScannerWrapper> {
     override fun create(options: Options, secrets: Options): ScannerWrapper {
-        val (matcherConfig, filteredOptions) = ScannerMatcherConfig.create(options)
-        return create(parseConfig(filteredOptions, secrets), matcherConfig)
+        val (wrapperConfig, filteredOptions) = ScannerWrapperConfig.create(options)
+        return create(parseConfig(filteredOptions, secrets), wrapperConfig)
     }
 
     final override fun create(config: CONFIG): ScannerWrapper {
@@ -39,9 +39,9 @@ abstract class ScannerWrapperFactory<CONFIG>(override val type: String) :
     }
 
     /**
-     * Create a [ScannerWrapper] from the provided [config] and [matcherConfig].
+     * Create a [ScannerWrapper] from the provided [config] and [wrapperConfig].
      */
-    abstract fun create(config: CONFIG, matcherConfig: ScannerMatcherConfig): ScannerWrapper
+    abstract fun create(config: CONFIG, wrapperConfig: ScannerWrapperConfig): ScannerWrapper
 
     /**
      * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanner

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -809,6 +809,8 @@ private class FakePackageScannerWrapper(
 
     // Explicit nullability is required here for a mock response.
     override val matcher: ScannerMatcher? = ScannerMatcher.create(details)
+    override val readFromStorage = true
+    override val writeToStorage = true
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =
         createScanResult(packageProvenanceResolver.resolveProvenance(pkg, sourceCodeOriginPriority), details)
@@ -823,6 +825,8 @@ private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
     override val configuration = "config"
 
     override val matcher = ScannerMatcher.create(details)
+    override val readFromStorage = true
+    override val writeToStorage = true
 
     override fun scanProvenance(provenance: KnownProvenance, context: ScanContext): ScanResult =
         createScanResult(provenance, details)
@@ -837,6 +841,8 @@ private class FakePathScannerWrapper : PathScannerWrapper {
     override val configuration = "config"
 
     override val matcher = ScannerMatcher.create(details)
+    override val readFromStorage = true
+    override val writeToStorage = true
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {
         val licenseFindings = path.walk().filter { it.isFile }.mapTo(mutableSetOf()) { file ->

--- a/scanner/src/test/kotlin/ScannerWrapperConfigTest.kt
+++ b/scanner/src/test/kotlin/ScannerWrapperConfigTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+class ScannerWrapperConfigTest : WordSpec({
+    "ScannerWrapperConfig.create()" should {
+        "obtain values from the options" {
+            val options = mapOf(
+                ScannerMatcherConfig.PROP_CRITERIA_NAME to "foo",
+                ScannerMatcherConfig.PROP_CRITERIA_MIN_VERSION to "1.2.3",
+                ScannerMatcherConfig.PROP_CRITERIA_MAX_VERSION to "4.5.6",
+                ScannerMatcherConfig.PROP_CRITERIA_CONFIGURATION to "config"
+            )
+
+            with(ScannerWrapperConfig.create(options).first) {
+                with(matcherConfig) {
+                    regScannerName shouldBe "foo"
+                    minVersion shouldBe "1.2.3"
+                    maxVersion shouldBe "4.5.6"
+                    configuration shouldBe "config"
+                }
+            }
+        }
+
+        "filter used properties from the options" {
+            val options = mapOf(
+                ScannerMatcherConfig.PROP_CRITERIA_NAME to "foo",
+                ScannerMatcherConfig.PROP_CRITERIA_MIN_VERSION to "1.2.3",
+                ScannerMatcherConfig.PROP_CRITERIA_MAX_VERSION to "4.5.6",
+                ScannerMatcherConfig.PROP_CRITERIA_CONFIGURATION to "config",
+                "other" to "value"
+            )
+
+            ScannerWrapperConfig.create(options).second shouldContainExactly mapOf("other" to "value")
+        }
+    }
+})

--- a/scanner/src/test/kotlin/ScannerWrapperConfigTest.kt
+++ b/scanner/src/test/kotlin/ScannerWrapperConfigTest.kt
@@ -30,7 +30,9 @@ class ScannerWrapperConfigTest : WordSpec({
                 ScannerMatcherConfig.PROP_CRITERIA_NAME to "foo",
                 ScannerMatcherConfig.PROP_CRITERIA_MIN_VERSION to "1.2.3",
                 ScannerMatcherConfig.PROP_CRITERIA_MAX_VERSION to "4.5.6",
-                ScannerMatcherConfig.PROP_CRITERIA_CONFIGURATION to "config"
+                ScannerMatcherConfig.PROP_CRITERIA_CONFIGURATION to "config",
+                ScannerWrapperConfig.PROP_READ_FROM_STORAGE to "false",
+                ScannerWrapperConfig.PROP_WRITE_TO_STORAGE to "true"
             )
 
             with(ScannerWrapperConfig.create(options).first) {
@@ -40,6 +42,9 @@ class ScannerWrapperConfigTest : WordSpec({
                     maxVersion shouldBe "4.5.6"
                     configuration shouldBe "config"
                 }
+
+                readFromStorage shouldBe false
+                writeToStorage shouldBe true
             }
         }
 


### PR DESCRIPTION
Add properties to configure for each scanner if scan results are read from or written to the configured scan storages. Please see the commit messages for details.

**Breaking API change:**
* The `ScannerWrapperFactory.create()` function now gets a `ScannerWrapperConfig` instead of a `ScannerMatcherConfig`.
* The `ScannerWrapper` interface now requires implementing the two new properties `readFromStorage: Boolean` and `writeToStorage: Boolean`.