### PR TITLE
chore(github): Remove the duplicate Batect wrapper validation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,8 +155,6 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         gradle-home-cache-cleanup: true
-    - name: Validate Batect wrapper scripts
-      uses: batect/batect-wrapper-validation-action@v0
     - name: Run functional tests that do require external tools
       run: |
           echo "Running as $(id)."


### PR DESCRIPTION
This is already being done as part of `wrapper-validation.yml`.