### PR TITLE
deps(git-repo): Upgrade to the latest stable git-repo release

### DIFF
--- a/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
@@ -47,7 +47,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 /**
  * The branch or tag of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
  */
-private const val GIT_REPO_BRANCH = "v2.21"
+private const val GIT_REPO_REV = "v2.39"
 
 /**
  * The minimal manifest structure as used by the wrapping "manifest.xml" file as of repo version 2.4. For the full
@@ -169,7 +169,7 @@ class GitRepo : VersionControlSystem(), CommandLineTool {
             "--groups=all",
             "--no-repo-verify",
             "--no-clone-bundle",
-            "--repo-branch=$GIT_REPO_BRANCH",
+            "--repo-rev=$GIT_REPO_REV",
             "-u", repoUrl,
             *manifestOptions.toTypedArray()
         )


### PR DESCRIPTION
This fixes the "fatal: unable to detect ssh version" error when parsing some OpenSSH version strings, see [1]. Also account for the `--repo-branch` option being renamed to `--repo-rev`.

[1]: https://gerrit.googlesource.com/git-repo/+/90f574f02e0b8432de2ad03951ea74df3464dc38