### PR TITLE
test: Run analyzer functional tests outside of Docker

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -134,7 +134,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         gradle-home-cache-cleanup: true
-        arguments: --scan -Ptests.exclude=org.ossreviewtoolkit.cli.*,org.ossreviewtoolkit.analyzer.*,org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
+        arguments: --scan -Ptests.exclude=org.ossreviewtoolkit.cli.*,org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
     - name: Upload code coverage data
       uses: codecov/codecov-action@v3
       with:

--- a/batect.yml
+++ b/batect.yml
@@ -87,5 +87,5 @@ tasks:
       - buildFunTest
     run:
       container: run
-      command: "'./gradlew funTest jacocoFunTestReport -Ptests.include=org.ossreviewtoolkit.cli.*,org.ossreviewtoolkit.analyzer.*,org.ossreviewtoolkit.plugins.packagemanagers.* $(sed \"s/true/--scan/;s/false//\" <<< \"$GRADLE_BUILD_SCAN\")'"
+      command: "'./gradlew funTest jacocoFunTestReport -Ptests.include=org.ossreviewtoolkit.cli.*,org.ossreviewtoolkit.plugins.packagemanagers.* $(sed \"s/true/--scan/;s/false//\" <<< \"$GRADLE_BUILD_SCAN\")'"
       entrypoint: /bin/bash --login -c


### PR DESCRIPTION
As all package manager implementations are split out to plugin projects by now, "core" analyzer functional tests do not require external tools anymore and can be run outside of Docker.