### PR TITLE
chore(scanner): Trivially improve the wording of log messages

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -353,7 +353,7 @@ class Scanner(
                 }
 
                 logger.info {
-                    "Scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.name} started."
+                    "Starting scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.name}."
                 }
 
                 // Filter the scan context to hide the excludes from scanner with scan matcher.
@@ -361,7 +361,7 @@ class Scanner(
                 val scanResult = scanner.scanPackage(referencePackage, filteredContext)
 
                 logger.info {
-                    "Scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.name}' finished."
+                    "Finished scan of '${referencePackage.id.toCoordinates()}' with package scanner '${scanner.name}'."
                 }
 
                 packagesWithIncompleteScanResult.forEach processResults@{ pkg ->


### PR DESCRIPTION
Strictly speaking, scanning has not yet started at the time of logging. Change the wording accordingly, and adapt the logging on finishing accordingly.