### PR TITLE
fix(helper-cli): Add VCS plugins as dependencies

### DIFF
--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -30,6 +30,9 @@ application {
 dependencies {
     implementation(project(":analyzer"))
     implementation(project(":downloader"))
+    implementation(project(":plugins:version-control-systems:git-version-control-system"))
+    implementation(project(":plugins:version-control-systems:mercurial-version-control-system"))
+    implementation(project(":plugins:version-control-systems:subversion-version-control-system"))
     implementation(project(":plugins:package-configuration-providers:dir-package-configuration-provider"))
     implementation(project(":plugins:package-curation-providers:file-package-curation-provider"))
     implementation(project(":scanner"))


### PR DESCRIPTION
The helper-cli started running into when trying to download the source code from a VCS [2].

[1] org.ossreviewtoolkit.downloader.DownloadException: Unsupported VCS type 'Git'
[2] https://github.com/oss-review-toolkit/ort/blob/c64efc7c2341293d4eeeac933e6cd8685a9b0365/helper-cli/src/main/kotlin/utils/Extensions.kt#L105C65-L105C65

