### PR TITLE
docs(jenkins): Clarify that the credentials type should be for HTTP

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
 
         credentials(
             name: 'PROJECT_VCS_CREDENTIALS',
-            description: 'Optional Jenkins credentials to use for the VCS checkout.',
+            description: 'Optional HTTP credentials to use for the VCS checkout.',
             defaultValue: ''
         )
 
@@ -84,7 +84,7 @@ pipeline {
 
         credentials(
             name: 'ORT_CONFIG_VCS_CREDENTIALS',
-            description: 'Optional Jenkins credentials to use for the VCS checkout.',
+            description: 'Optional HTTP credentials to use for the VCS checkout.',
             defaultValue: ''
         )
 


### PR DESCRIPTION
Later steps use the `usernamePassword()` pipeline function [1] which assumes credentials to be composed of a username and password for HTTP authentication. Clarify this to avoid users specifying e.g. SSH credentials which would result in

    ERROR: Credentials 'jenkins-ssh' is of type 'SSH Username with private
    key' where 'com.cloudbees.plugins.credentials.common.StandardUsername
    PasswordCredentials' was expected

[1]: https://www.jenkins.io/doc/pipeline/steps/credentials-binding/