### PR TITLE
refactor(utils): Move ORT directory properties to `Environment`

### DIFF
--- a/utils/ort/src/main/kotlin/Environment.kt
+++ b/utils/ort/src/main/kotlin/Environment.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.utils.ort
 
+import java.io.File
 import java.lang.Runtime
 
 import org.ossreviewtoolkit.utils.common.Os
@@ -92,4 +93,38 @@ data class Environment(
             "GOPATH"
         )
     }
+}
+
+/**
+ * The directory to store ORT (read-write) data in, like archives, caches, configuration, and tools. Defaults to the
+ * ".ort" directory below the current user's home directory.
+ */
+val ortDataDirectory by lazy {
+    Os.env[ORT_DATA_DIR_ENV_NAME]?.takeUnless {
+        it.isEmpty()
+    }?.let {
+        File(it)
+    } ?: Os.userHomeDirectory.resolve(".ort")
+}
+
+/**
+ * The directory to store ORT (read-only) configuration in. Defaults to the "config" directory below the data directory.
+ */
+val ortConfigDirectory by lazy {
+    Os.env[ORT_CONFIG_DIR_ENV_NAME]?.takeUnless {
+        it.isEmpty()
+    }?.let {
+        File(it)
+    } ?: ortDataDirectory.resolve("config")
+}
+
+/**
+ * The directory to store ORT (read-write) tools in. Defaults to the "tools" directory below the data directory.
+ */
+val ortToolsDirectory by lazy {
+    Os.env[ORT_TOOLS_DIR_ENV_NAME]?.takeUnless {
+        it.isEmpty()
+    }?.let {
+        File(it)
+    } ?: ortDataDirectory.resolve("tools")
 }

--- a/utils/ort/src/main/kotlin/Utils.kt
+++ b/utils/ort/src/main/kotlin/Utils.kt
@@ -24,44 +24,10 @@ import java.net.Authenticator
 import java.net.PasswordAuthentication
 import java.net.URI
 
-import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.toSafeUri
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.common.withoutSuffix
-
-/**
- * The directory to store ORT (read-only) configuration in.
- */
-val ortConfigDirectory by lazy {
-    Os.env[ORT_CONFIG_DIR_ENV_NAME]?.takeUnless {
-        it.isEmpty()
-    }?.let {
-        File(it)
-    } ?: ortDataDirectory.resolve("config")
-}
-
-/**
- * The directory to store ORT (read-write) tools in.
- */
-val ortToolsDirectory by lazy {
-    Os.env[ORT_TOOLS_DIR_ENV_NAME]?.takeUnless {
-        it.isEmpty()
-    }?.let {
-        File(it)
-    } ?: ortDataDirectory.resolve("tools")
-}
-
-/**
- * The directory to store ORT (read-write) data in, like caches and archives.
- */
-val ortDataDirectory by lazy {
-    Os.env[ORT_DATA_DIR_ENV_NAME]?.takeUnless {
-        it.isEmpty()
-    }?.let {
-        File(it)
-    } ?: Os.userHomeDirectory.resolve(".ort")
-}
 
 /**
  * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.


### PR DESCRIPTION
These properties are tightly related to environment variables, so it makes more sense to keep them there. Slightly improve their documentation while at it.