### PR TITLE
feat(model): Sort the detected license mapping during serialization

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
@@ -52,6 +53,7 @@ data class ScannerConfiguration(
      * Mappings from licenses returned by the scanner to valid SPDX licenses. Note that these mappings are only applied
      * in new scans, stored scan results are not affected.
      */
+    @JsonPropertyOrder(alphabetic = true)
     val detectedLicenseMapping: Map<String, String> = mapOf(
         // https://scancode-licensedb.aboutcode.org/?search=generic
         "LicenseRef-scancode-agpl-generic-additional-terms" to SpdxConstants.NOASSERTION,

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -197,20 +197,20 @@ scanner:
     create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
+      LicenseRef-scancode-free-unknown: "NOASSERTION"
       LicenseRef-scancode-generic-cla: "NOASSERTION"
       LicenseRef-scancode-generic-exception: "NOASSERTION"
       LicenseRef-scancode-generic-export-compliance: "NOASSERTION"
       LicenseRef-scancode-generic-tos: "NOASSERTION"
       LicenseRef-scancode-generic-trademark: "NOASSERTION"
       LicenseRef-scancode-gpl-generic-additional-terms: "NOASSERTION"
-      LicenseRef-scancode-patent-disclaimer: "NOASSERTION"
-      LicenseRef-scancode-warranty-disclaimer: "NOASSERTION"
       LicenseRef-scancode-other-copyleft: "NOASSERTION"
       LicenseRef-scancode-other-permissive: "NOASSERTION"
-      LicenseRef-scancode-free-unknown: "NOASSERTION"
+      LicenseRef-scancode-patent-disclaimer: "NOASSERTION"
       LicenseRef-scancode-unknown: "NOASSERTION"
       LicenseRef-scancode-unknown-license-reference: "NOASSERTION"
       LicenseRef-scancode-unknown-spdx: "NOASSERTION"
+      LicenseRef-scancode-warranty-disclaimer: "NOASSERTION"
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/*.spdx.yml"

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -116,20 +116,20 @@ scanner:
     create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
+      LicenseRef-scancode-free-unknown: "NOASSERTION"
       LicenseRef-scancode-generic-cla: "NOASSERTION"
       LicenseRef-scancode-generic-exception: "NOASSERTION"
       LicenseRef-scancode-generic-export-compliance: "NOASSERTION"
       LicenseRef-scancode-generic-tos: "NOASSERTION"
       LicenseRef-scancode-generic-trademark: "NOASSERTION"
       LicenseRef-scancode-gpl-generic-additional-terms: "NOASSERTION"
-      LicenseRef-scancode-patent-disclaimer: "NOASSERTION"
-      LicenseRef-scancode-warranty-disclaimer: "NOASSERTION"
       LicenseRef-scancode-other-copyleft: "NOASSERTION"
       LicenseRef-scancode-other-permissive: "NOASSERTION"
-      LicenseRef-scancode-free-unknown: "NOASSERTION"
+      LicenseRef-scancode-patent-disclaimer: "NOASSERTION"
       LicenseRef-scancode-unknown: "NOASSERTION"
       LicenseRef-scancode-unknown-license-reference: "NOASSERTION"
       LicenseRef-scancode-unknown-spdx: "NOASSERTION"
+      LicenseRef-scancode-warranty-disclaimer: "NOASSERTION"
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/*.spdx.yml"


### PR DESCRIPTION
Sort `ScannerConfiguration.detectedLicenseMapping` during serialization to have a stable order in ORT result files. This helps when comparing ORT result files from different sources.