### PR TITLE
fix(helper-cli): Remove `package.json` from path exclude generator

### DIFF
--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -263,7 +263,6 @@ private val PATH_EXCLUDE_REASON_FOR_FILENAME = listOf(
     "makefile.*" to BUILD_TOOL_OF,
     "mkdocs.yml" to BUILD_TOOL_OF,
     "package-lock.json" to BUILD_TOOL_OF,
-    "package.json" to BUILD_TOOL_OF,
     "proguard-rules.pro" to BUILD_TOOL_OF,
     "runsuite.c" to TEST_OF,
     "runtest.c" to TEST_OF,

--- a/helper-cli/src/test/assets/path-exclude-gen/expected-exclude-patterns.txt
+++ b/helper-cli/src/test/assets/path-exclude-gen/expected-exclude-patterns.txt
@@ -81,7 +81,6 @@ native/libffi/libtool-ldflags
 objectivec/DevTools/**
 org.abego.treelayout.demo/**
 package-lock.json
-package.json
 runtime/Perl5/Build.PL
 samples/SupportLeanbackDemos/**
 setup.cfg

--- a/helper-cli/src/test/assets/path-exclude-gen/expected-file-exclude-patterns.txt
+++ b/helper-cli/src/test/assets/path-exclude-gen/expected-file-exclude-patterns.txt
@@ -66,7 +66,6 @@ libxml2-2.9.14/runtest.c
 mkdocs.yml
 native/libffi/libtool-ldflags
 package-lock.json
-package.json
 runtime/Perl5/Build.PL
 setup.cfg
 setup.py


### PR DESCRIPTION
The `package.json` is included in the distributed artifacts.

