### PR TITLE
reporter: Prepare `ReportTabelModelMapper` for some clean-ups

### DIFF
--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
@@ -36,9 +36,9 @@ import org.ossreviewtoolkit.model.licenses.ResolvedLicense
 import org.ossreviewtoolkit.utils.common.zipWithCollections
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
-fun Collection<ReportTableModel.ResolvableIssue>.containsUnresolved() = any { !it.isResolved }
+internal fun Collection<ReportTableModel.ResolvableIssue>.containsUnresolved() = any { !it.isResolved }
 
-data class ReportTableModel(
+internal data class ReportTableModel(
     /**
      * The [VcsInfo] for the scanned project.
      */

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter
+package org.ossreviewtoolkit.plugins.reporters.statichtml
 
 import java.util.SortedMap
 

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter
+package org.ossreviewtoolkit.plugins.reporters.statichtml
 
 import org.ossreviewtoolkit.model.DependencyNavigator
 import org.ossreviewtoolkit.model.Identifier
@@ -32,12 +32,13 @@ import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
-import org.ossreviewtoolkit.reporter.ReportTableModel.DependencyRow
-import org.ossreviewtoolkit.reporter.ReportTableModel.IssueRow
-import org.ossreviewtoolkit.reporter.ReportTableModel.IssueTable
-import org.ossreviewtoolkit.reporter.ReportTableModel.ProjectTable
-import org.ossreviewtoolkit.reporter.ReportTableModel.ResolvableIssue
-import org.ossreviewtoolkit.reporter.ReportTableModel.ResolvableViolation
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.DependencyRow
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueRow
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueTable
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ProjectTable
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ResolvableIssue
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ResolvableViolation
+import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 
 /**
  * A mapper which converts an [OrtResult] to a [ReportTableModel].

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -80,7 +80,7 @@ internal object ReportTableModelMapper {
                     it.summary.issues
                 }
 
-                val packageForId = ortResult.getPackage(id)?.metadata ?: ortResult.getProject(id)?.toPackage()
+                val packageForId = ortResult.getPackageOrProject(id)?.metadata
 
                 val row = DependencyRow(
                     id = id,

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -80,12 +80,12 @@ internal object ReportTableModelMapper {
                     it.summary.issues
                 }
 
-                val packageForId = ortResult.getPackageOrProject(id)?.metadata
+                val pkg = ortResult.getPackageOrProject(id)?.metadata
 
                 val row = DependencyRow(
                     id = id,
-                    sourceArtifact = packageForId?.sourceArtifact.orEmpty(),
-                    vcsInfo = packageForId?.vcsProcessed.orEmpty(),
+                    sourceArtifact = pkg?.sourceArtifact.orEmpty(),
+                    vcsInfo = pkg?.vcsProcessed.orEmpty(),
                     scopes = scopesForDependencies[id].orEmpty().toSortedMap(),
                     concludedLicense = concludedLicense,
                     declaredLicenses = declaredLicenses,

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 /**
  * A mapper which converts an [OrtResult] to a [ReportTableModel].
  */
-object ReportTableModelMapper {
+internal object ReportTableModelMapper {
     fun map(
         ortResult: OrtResult,
         licenseInfoResolver: LicenseInfoResolver,

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -48,14 +48,11 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseLocation
 import org.ossreviewtoolkit.model.yamlMapper
-import org.ossreviewtoolkit.reporter.ReportTableModel
-import org.ossreviewtoolkit.reporter.ReportTableModel.IssueTable
-import org.ossreviewtoolkit.reporter.ReportTableModel.ProjectTable
-import org.ossreviewtoolkit.reporter.ReportTableModel.ResolvableIssue
-import org.ossreviewtoolkit.reporter.ReportTableModelMapper
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueTable
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ProjectTable
+import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ResolvableIssue
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
-import org.ossreviewtoolkit.reporter.containsUnresolved
 import org.ossreviewtoolkit.utils.common.isValidUri
 import org.ossreviewtoolkit.utils.common.joinNonBlank
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -73,12 +73,7 @@ class StaticHtmlReporter : Reporter {
     private val licensesSha1 = mutableMapOf<String, String>()
 
     override fun generateReport(input: ReporterInput, outputDir: File, config: PluginConfiguration): List<File> {
-        val reportTableModel = ReportTableModelMapper.map(
-            input.ortResult,
-            input.licenseInfoResolver,
-            input.resolutionProvider,
-            input.howToFixTextProvider
-        )
+        val reportTableModel = ReportTableModelMapper.map(input)
 
         val html = renderHtml(reportTableModel)
         val outputFile = outputDir.resolve(reportFilename)


### PR DESCRIPTION
Make the model internal and turn it to a class, to simplify cleaning up the code in a following PR.