### PR TITLE
refactor(VersionControlSystem): Implement the `Plugin` interface

### DIFF
--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -151,7 +151,7 @@ class VersionControlSystemTest : WordSpec({
  */
 private class VersionControlSystemTestImpl(
     tool: CommandLineTool?,
-    override val type: VcsType = VcsType.UNKNOWN,
+    override val type: String = VcsType.UNKNOWN.toString(),
     override val latestRevisionNames: List<String> = emptyList()
 ) : VersionControlSystem(tool) {
     override fun getVersion(): String = "0"

--- a/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
+++ b/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
@@ -395,7 +395,8 @@ class DownloaderCommand : OrtCommand(
                 Package.EMPTY.copy(id = dummyId, sourceArtifact = RemoteArtifact.EMPTY.copy(url = projectUrl))
             } else {
                 val vcs = VersionControlSystem.forUrl(projectUrl)
-                val vcsType = vcsTypeOption?.let { VcsType.forName(it) } ?: (vcs?.type ?: VcsType.UNKNOWN)
+                val vcsType = listOfNotNull(vcsTypeOption, vcs?.type).map { VcsType.forName(it) }.firstOrNull()
+                    ?: VcsType.UNKNOWN
                 val vcsRevision = vcsRevisionOption ?: vcs?.getDefaultBranchName(projectUrl).orEmpty()
 
                 val vcsInfo = VcsInfo(

--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -99,7 +99,7 @@ class Git : VersionControlSystem(), CommandLineTool {
 
     private val versionRegex = Regex("[Gg]it [Vv]ersion (?<version>[\\d.a-z-]+)(\\s.+)?")
 
-    override val type = VcsType.GIT
+    override val type = VcsType.GIT.toString()
     override val priority = 100
     override val latestRevisionNames = listOf("HEAD", "@")
 
@@ -123,7 +123,7 @@ class Git : VersionControlSystem(), CommandLineTool {
     override fun getWorkingTree(vcsDirectory: File): WorkingTree =
         GitWorkingTree(
             workingDir = vcsDirectory,
-            vcsType = type,
+            vcsType = VcsType.forName(type),
             repositoryUrlPrefixReplacements = REPOSITORY_URL_PREFIX_REPLACEMENTS
         )
 

--- a/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
@@ -67,7 +67,7 @@ private data class Include(
 )
 
 class GitRepo : VersionControlSystem(), CommandLineTool {
-    override val type = VcsType.GIT_REPO
+    override val type = VcsType.GIT_REPO.toString()
     override val priority = 50
     override val latestRevisionNames = listOf("HEAD", "@")
 
@@ -91,16 +91,17 @@ class GitRepo : VersionControlSystem(), CommandLineTool {
 
     override fun getWorkingTree(vcsDirectory: File): WorkingTree {
         val repoRoot = vcsDirectory.searchUpwardsForSubdirectory(".repo")
+        val vcsType = VcsType.forName(type)
 
         return if (repoRoot == null) {
-            object : GitWorkingTree(vcsDirectory, type) {
+            object : GitWorkingTree(vcsDirectory, vcsType) {
                 override fun isValid() = false
             }
         } else {
             // GitRepo is special in that the workingDir points to the Git working tree of the manifest files, yet
             // the root path is the directory containing the ".repo" directory. This way Git operations work on a valid
             // Git repository, but path operations work relative to the path GitRepo was initialized in.
-            object : GitWorkingTree(repoRoot.resolve(".repo/manifests"), type) {
+            object : GitWorkingTree(repoRoot.resolve(".repo/manifests"), vcsType) {
                 // Return the path to the manifest as part of the VCS information, as that is required to recreate the
                 // working tree.
                 override fun getInfo(): VcsInfo {

--- a/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
+++ b/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
@@ -47,7 +47,7 @@ object MercurialCommand : CommandLineTool {
 }
 
 class Mercurial : VersionControlSystem(MercurialCommand) {
-    override val type = VcsType.MERCURIAL
+    override val type = VcsType.MERCURIAL.toString()
     override val priority = 20
     override val latestRevisionNames = listOf("tip")
 
@@ -55,7 +55,8 @@ class Mercurial : VersionControlSystem(MercurialCommand) {
 
     override fun getDefaultBranchName(url: String) = "default"
 
-    override fun getWorkingTree(vcsDirectory: File): WorkingTree = MercurialWorkingTree(vcsDirectory, type)
+    override fun getWorkingTree(vcsDirectory: File): WorkingTree =
+        MercurialWorkingTree(vcsDirectory, VcsType.forName(type))
 
     override fun isApplicableUrlInternal(vcsUrl: String) = ProcessCapture("hg", "identify", vcsUrl).isSuccess
 

--- a/plugins/version-control-systems/subversion/src/main/kotlin/Subversion.kt
+++ b/plugins/version-control-systems/subversion/src/main/kotlin/Subversion.kt
@@ -58,7 +58,7 @@ class Subversion : VersionControlSystem() {
         setAuthenticationManager(ortAuthManager)
     }
 
-    override val type = VcsType.SUBVERSION
+    override val type = VcsType.SUBVERSION.toString()
     override val priority = 10
     override val latestRevisionNames = listOf("HEAD")
 
@@ -67,7 +67,7 @@ class Subversion : VersionControlSystem() {
     override fun getDefaultBranchName(url: String) = "trunk"
 
     override fun getWorkingTree(vcsDirectory: File): WorkingTree =
-        SubversionWorkingTree(vcsDirectory, type, clientManager)
+        SubversionWorkingTree(vcsDirectory, VcsType.forName(type), clientManager)
 
     override fun isApplicableUrlInternal(vcsUrl: String) =
         try {


### PR DESCRIPTION
Align with all other ORT plugin types and implement the `Plugin` interface. This will allow for some common handling of all types of plugins in an upcoming change. Also see [1] for context.

[1]: https://github.com/oss-review-toolkit/ort/issues/6507