### PR TITLE
feat: improve resolving of maven based dependencies

### DIFF
--- a/.github/workflows/docker-ort.yml
+++ b/.github/workflows/docker-ort.yml
@@ -19,8 +19,8 @@ name: ORT Docker Image
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 4 * * *'
+#  schedule:
+#    - cron: '0 4 * * *'
   pull_request:
     paths:
       - '.versions'

--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -62,6 +62,7 @@ import org.eclipse.aether.repository.MirrorSelector
 import org.eclipse.aether.repository.RemoteRepository
 import org.eclipse.aether.repository.WorkspaceReader
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest
+import org.eclipse.aether.resolution.ArtifactRequest
 import org.eclipse.aether.spi.connector.ArtifactDownload
 import org.eclipse.aether.spi.connector.layout.RepositoryLayout
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider
@@ -499,43 +500,15 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
     private fun requestRemoteArtifact(
         artifact: Artifact,
-        repositories: List<RemoteRepository>,
-        useReposFromDependencies: Boolean
+        artifactRepository: RemoteRepository,
+        allRepositories: List<RemoteRepository>,
     ): RemoteArtifact {
-        val allRepositories = if (useReposFromDependencies) {
-            val repoSystem = containerLookup<RepositorySystem>()
-
-            // Create an artifact descriptor to get the list of repositories from the related POM file.
-            val artifactDescriptorRequest = ArtifactDescriptorRequest(artifact, repositories, "project")
-            val artifactDescriptorResult = repoSystem
-                .readArtifactDescriptor(repositorySystemSession, artifactDescriptorRequest)
-            repositories + artifactDescriptorResult.repositories
-        } else {
-            repositories
-        }.toSet()
-
         val cacheKey = "$artifact@$allRepositories"
 
         remoteArtifactCache.read(cacheKey)?.let {
             logger.debug { "Reading remote artifact for '$artifact' from disk cache." }
             return it.fromYaml()
         }
-
-        // Filter out local repositories, as remote artifacts should never point to files on the local disk.
-        val remoteRepositories = allRepositories.filterNot {
-            // Some (Linux) file URIs do not start with "file://" but look like "file:/opt/android-sdk-linux".
-            it.url.startsWith("file:/")
-        }.map { repository ->
-            val proxy = repositorySystemSession.proxySelector.getProxy(repository)
-            val authentication = repositorySystemSession.authenticationSelector.getAuthentication(repository)
-            RemoteRepository.Builder(repository).setAuthentication(authentication).setProxy(proxy).build()
-        }.toSet()
-
-        if (allRepositories.size > remoteRepositories.size) {
-            logger.debug { "Ignoring local repositories ${allRepositories - remoteRepositories}." }
-        }
-
-        logger.debug { "Searching for '$artifact' in $remoteRepositories." }
 
         data class ArtifactLocationInfo(
             val repository: RemoteRepository,
@@ -546,7 +519,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
         val repositoryLayoutProvider = containerLookup<RepositoryLayoutProvider>()
 
-        val locationInfo = remoteRepositories.mapNotNull { repository ->
+        val locationInfo = listOf(artifactRepository).mapNotNull { repository ->
             val repositoryLayout = runCatching {
                 repositoryLayoutProvider.newRepositoryLayout(repositorySystemSession, repository)
             }.onFailure {
@@ -562,8 +535,6 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             }
         }
 
-        val remoteRepositoryManager = containerLookup<RemoteRepositoryManager>()
-        val repositoryConnectorProvider = containerLookup<RepositoryConnectorProvider>()
         val transporterProvider = containerLookup<TransporterProvider>()
 
         // Check the remote repositories for the availability of the artifact.
@@ -571,73 +542,32 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
         locationInfo.forEach { info ->
             logger.debug { "Trying to download artifact '$artifact' from ${info.downloadUrl}." }
 
-            val snapshot = artifact.isSnapshot
-            val policy = remoteRepositoryManager.getPolicy(
-                repositorySystemSession, info.repository, !snapshot, snapshot
-            )
+            val checksumLocations = info.layout.getChecksumLocations(artifact, false, info.location)
 
-            val localPath = repositorySystemSession.localRepositoryManager
-                .getPathForRemoteArtifact(artifact, info.repository, "project")
-            val downloadFile = File(repositorySystemSession.localRepositoryManager.repository.basedir, localPath)
+            // TODO: Could store multiple checksums in model instead of only the first.
+            val checksumLocation = checksumLocations.first()
 
-            val artifactDownload = ArtifactDownload(artifact, "project", downloadFile, policy.checksumPolicy)
-            artifactDownload.isExistenceCheck = true
-            artifactDownload.listener = object : AbstractTransferListener() {
-                override fun transferFailed(event: TransferEvent?) {
-                    logger.debug {
-                        "Transfer failed for repository with ID '${info.repository.id}': $event"
-                    }
-                }
+            logger.info { "Getting checksum for '$artifact' in '${info.repository}' ${checksumLocation}." }
 
-                override fun transferSucceeded(event: TransferEvent?) {
-                    logger.debug { "Transfer succeeded: $event" }
-                }
+            val transporter = transporterProvider.newTransporter(repositorySystemSession, info.repository)
+
+            val hash = runCatching {
+                val task = GetTask(checksumLocation.location)
+                transporter.get(task)
+
+                parseChecksum(task.dataString, checksumLocation.checksumAlgorithmFactory.name)
+            }.getOrElse {
+                it.showStackTrace()
+
+                logger.warn { "Could not get checksum for '$artifact': ${it.collectMessages()}" }
+
+                // Fall back to an empty hash.
+                Hash.NONE
             }
 
-            try {
-                wrapMavenSession {
-                    repositoryConnectorProvider.newRepositoryConnector(repositorySystemSession, info.repository).use {
-                        it.get(listOf(artifactDownload), null)
-                    }
-                }
-            } catch (e: NoRepositoryConnectorException) {
-                e.showStackTrace()
-
-                logger.warn { "Could not create connector for repository '${info.repository}': ${e.collectMessages()}" }
-
-                return@forEach
-            }
-
-            if (artifactDownload.exception == null) {
-                logger.debug { "Found '$artifact' in '${info.repository}'." }
-
-                val checksumLocations = info.layout.getChecksumLocations(artifact, false, info.location)
-
-                // TODO: Could store multiple checksums in model instead of only the first.
-                val checksumLocation = checksumLocations.first()
-
-                val transporter = transporterProvider.newTransporter(repositorySystemSession, info.repository)
-
-                val hash = runCatching {
-                    val task = GetTask(checksumLocation.location)
-                    transporter.get(task)
-
-                    parseChecksum(task.dataString, checksumLocation.checksumAlgorithmFactory.name)
-                }.getOrElse {
-                    it.showStackTrace()
-
-                    logger.warn { "Could not get checksum for '$artifact': ${it.collectMessages()}" }
-
-                    // Fall back to an empty hash.
-                    Hash.NONE
-                }
-
-                return RemoteArtifact(info.downloadUrl, hash).also { remoteArtifact ->
-                    logger.debug { "Writing remote artifact for '$artifact' to disk cache." }
-                    remoteArtifactCache.write(cacheKey, remoteArtifact.toYaml())
-                }
-            } else {
-                logger.debug { artifactDownload.exception.collectMessages() }
+            return RemoteArtifact(info.downloadUrl, hash).also { remoteArtifact ->
+                logger.debug { "Writing remote artifact for '$artifact' to disk cache." }
+                remoteArtifactCache.write(cacheKey, remoteArtifact.toYaml())
             }
         }
 
@@ -719,9 +649,31 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
         val declaredLicenses = parseLicenses(mavenProject)
         val declaredLicensesProcessed = processDeclaredLicenses(declaredLicenses)
 
+        // retrieve the pom file for the artifact to know from which repository it is coming
+        val pomArtifact = artifact.let {
+            DefaultArtifact(it.groupId, it.artifactId, it.classifier, "pom", it.version)
+        }
+        val pomArtifactRequest = ArtifactRequest(pomArtifact, repositories, "project")
+        val result = containerLookup<RepositorySystem>().resolveArtifact(repositorySystemSession, pomArtifactRequest)
+        val artifactRepository = result.repository as RemoteRepository
+
+        // reconstruct all repositories that would be used for resolving the artifact
+        // the repositories are used to construct a cache key for the artifact
+        val allRepositories = if (useReposFromDependencies) {
+            val repoSystem = containerLookup<RepositorySystem>()
+
+            // Create an artifact descriptor to get the list of repositories from the related POM file.
+            val artifactDescriptorRequest = ArtifactDescriptorRequest(artifact, repositories, "project")
+            val artifactDescriptorResult = repoSystem
+                .readArtifactDescriptor(repositorySystemSession, artifactDescriptorRequest)
+            repositories + artifactDescriptorResult.repositories
+        } else {
+            repositories
+        }.toSet()
+
         val binaryRemoteArtifact = localProject?.let {
             RemoteArtifact.EMPTY
-        } ?: requestRemoteArtifact(artifact, repositories, useReposFromDependencies)
+        } ?: requestRemoteArtifact(artifact, artifactRepository, allRepositories.toList())
 
         val isBinaryArtifactModified = isArtifactModified(artifact, binaryRemoteArtifact)
 
@@ -733,7 +685,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
                     DefaultArtifact(it.groupId, it.artifactId, "sources", "jar", it.version)
                 }
 
-                requestRemoteArtifact(sourceArtifact, repositories, useReposFromDependencies)
+                requestRemoteArtifact(sourceArtifact, artifactRepository, allRepositories.toList())
             }
         }
 


### PR DESCRIPTION
This fixes #7965 .

Opening a draft PR to dicuss the speed improvements.

The idea of this change is as follow:

- let the pom file being resolve initially so that it is present in the local maven repository
- resolve the pom file of the artifact using resolveArtifact which will take advantage of the local repo and gives information from which repo it was resolved
- use the resolve repository to retrieve the checksum files for the binary / source artifacts

With this changes it works pretty fast. There are some assumptions that might not be ok for the general case:

- it is assumed that sources are located in the same repository as the binary artifact itself, imho this is a safe assumption to make
- when a checksum file is present it is assumed that the artifact is also present (otherwise the default resolution mechanism of maven would be broken imho)
- right now, if no checksum is found for an artifact, an empty hash is assumed, but the artifact is still returned as it exists, we could add a safe-guard to do a PeekTask in case no checksum is found to verify that the artifact exists