### PR TITLE
chore(scancode): Make the `internal` timeout constant `private`

### DIFF
--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -72,7 +72,7 @@ class ScanCode internal constructor(
 
         private const val LICENSE_REFERENCES_OPTION_VERSION = "32.0.0"
         private const val OUTPUT_FORMAT = "json-pp"
-        internal const val TIMEOUT = 300
+        private const val TIMEOUT = 300
 
         /**
          * Configuration options that are relevant for [configuration] because they change the result file.


### PR DESCRIPTION
This can even be private by now.