### PR TITLE
scanner: Adhere to `Issue.affectedPath` when filtering scan issues

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -114,15 +114,18 @@ data class ScanSummary(
             directories = paths
         ).values.flatten().mapTo(mutableSetOf()) { it.location.path }
 
-        fun TextLocation.matchesPaths() =
+        fun String.matchesPaths() =
             paths.any { filterPath ->
-                this.path.startsWith("$filterPath/") || this.path in applicableLicenseFiles
+                startsWith("$filterPath/") || this in applicableLicenseFiles
             }
+
+        fun TextLocation.matchesPaths() = path.matchesPaths()
 
         return copy(
             licenseFindings = licenseFindings.filterTo(mutableSetOf()) { it.location.matchesPaths() },
             copyrightFindings = copyrightFindings.filterTo(mutableSetOf()) { it.location.matchesPaths() },
-            snippetFindings = snippetFindings.filterTo(mutableSetOf()) { it.sourceLocation.matchesPaths() }
+            snippetFindings = snippetFindings.filterTo(mutableSetOf()) { it.sourceLocation.matchesPaths() },
+            issues = issues.filter { it.affectedPath?.matchesPaths() ?: true }
         )
     }
 
@@ -136,7 +139,8 @@ data class ScanSummary(
         return copy(
             licenseFindings = licenseFindings.filterTo(mutableSetOf()) { !matcher.matches(it.location.path) },
             copyrightFindings = copyrightFindings.filterTo(mutableSetOf()) { !matcher.matches(it.location.path) },
-            snippetFindings = snippetFindings.filterTo(mutableSetOf()) { !matcher.matches(it.sourceLocation.path) }
+            snippetFindings = snippetFindings.filterTo(mutableSetOf()) { !matcher.matches(it.sourceLocation.path) },
+            issues = issues.filter { it.affectedPath == null || !matcher.matches(it.affectedPath) }
         )
     }
 }

--- a/model/src/test/kotlin/ScanSummaryTest.kt
+++ b/model/src/test/kotlin/ScanSummaryTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+
+class ScanSummaryTest : WordSpec({
+    "filterByPaths()" should {
+        val summary = createSummaryWithFindingPaths(
+            "a/file.txt",
+            "b/c/file.txt",
+            "d/file.txt"
+        )
+
+        val filteredSummary = summary.filterByPaths(listOf("a", "b/c"))
+
+        "filter copyright findings" {
+            filteredSummary.copyrightFindings.map { it.location.path } should
+                containExactly("a/file.txt", "b/c/file.txt")
+        }
+
+        "filter license findings" {
+            filteredSummary.licenseFindings.map { it.location.path } should
+                containExactly("a/file.txt", "b/c/file.txt")
+        }
+
+        "filter snippet findings" {
+            filteredSummary.snippetFindings.map { it.sourceLocation.path } should
+                containExactly("a/file.txt", "b/c/file.txt")
+        }
+    }
+})
+
+private fun createSummaryWithFindingPaths(vararg paths: String): ScanSummary {
+    fun textLocation(path: String) = TextLocation(path = path, startLine = 1, endLine = 2)
+
+    return ScanSummary.EMPTY.copy(
+        licenseFindings = paths.mapTo(mutableSetOf()) { path ->
+            LicenseFinding(
+                license = SpdxExpression.parse("MIT"),
+                location = textLocation(path)
+            )
+        },
+        copyrightFindings = paths.mapTo(mutableSetOf()) { path ->
+            CopyrightFinding(
+                statement = "Some statement",
+                location = textLocation(path)
+            )
+        },
+        snippetFindings = paths.mapTo(mutableSetOf()) { path ->
+            SnippetFinding(
+                sourceLocation = textLocation(path),
+                snippets = emptySet()
+            )
+        }
+    )
+}

--- a/model/src/test/kotlin/ScanSummaryTest.kt
+++ b/model/src/test/kotlin/ScanSummaryTest.kt
@@ -27,7 +27,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 class ScanSummaryTest : WordSpec({
     "filterByPaths()" should {
-        val summary = createSummaryWithFindingPaths(
+        val summary = createSummaryWithFindingAndIssuePaths(
             "a/file.txt",
             "b/c/file.txt",
             "d/file.txt"
@@ -49,10 +49,15 @@ class ScanSummaryTest : WordSpec({
             filteredSummary.snippetFindings.map { it.sourceLocation.path } should
                 containExactly("a/file.txt", "b/c/file.txt")
         }
+
+        "filter issues" {
+            filteredSummary.issues.map { it.affectedPath } should
+                containExactly("a/file.txt", "b/c/file.txt")
+        }
     }
 })
 
-private fun createSummaryWithFindingPaths(vararg paths: String): ScanSummary {
+private fun createSummaryWithFindingAndIssuePaths(vararg paths: String): ScanSummary {
     fun textLocation(path: String) = TextLocation(path = path, startLine = 1, endLine = 2)
 
     return ScanSummary.EMPTY.copy(
@@ -72,6 +77,13 @@ private fun createSummaryWithFindingPaths(vararg paths: String): ScanSummary {
             SnippetFinding(
                 sourceLocation = textLocation(path),
                 snippets = emptySet()
+            )
+        },
+        issues = paths.map { path ->
+            Issue(
+                source = "Some source",
+                message = "Some message.",
+                affectedPath = path
             )
         }
     )

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModelMapper.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModelMapper.kt
@@ -179,7 +179,8 @@ private fun mapTimeoutErrors(issues: MutableList<Issue>): Boolean {
             val timeout = match.groups["timeout"]!!.value
 
             fullError.copy(
-                message = "ERROR: Timeout after $timeout seconds while scanning file '$file'."
+                message = "ERROR: Timeout after $timeout seconds while scanning file '$file'.",
+                affectedPath = file
             )
         } else {
             onlyTimeoutErrors = false

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeResultParserTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeResultParserTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
 
 import java.io.File
@@ -110,8 +111,11 @@ class ScanCodeResultParserTest : FreeSpec({
                 }
 
                 "properly map the timeout issue" {
-                    summary.issues.single().message shouldStartWith
+                    val issue = summary.issues.single()
+
+                    issue.message shouldStartWith
                         "ERROR: Timeout after (?<timeout>\\d+) seconds while scanning file '.eslintignore'\\.".toRegex()
+                    issue.affectedPath shouldBe ".eslintignore"
                 }
             }
         }


### PR DESCRIPTION
Eliminate some irrelevant issues from the report, to reduce the need for manually creating irrelevant resolutions. 

Note: The stored scan results do not have the `affectedPath` set. However, the deserialization of scan results has been          
           adjusted so that `affectedPath` is properly set during deserialization and there the filtering works even for old 
           stored scan results.

Part of #7921.