### PR TITLE
fix(node): Do not crash on projects that do not set a version

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/utils/NpmSupport.kt
+++ b/plugins/package-managers/node/src/main/kotlin/utils/NpmSupport.kt
@@ -28,6 +28,8 @@ import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 
+internal const val NON_EXISTING_SEMVER = "0.0.0"
+
 /**
  * Expand an NPM shortcut [url] to a regular URL as used for dependencies, see
  * https://docs.npmjs.com/cli/v7/configuring-npm/package-json#urls-as-dependencies.


### PR DESCRIPTION
The originally linked and newly linked NPM docs are somewhat contradictory in this regard, but actual tests show that local NPM projects indeed do not need to have a version set in order for `npm install` / `npm ci` to work, so avoid ORT crashing with a `NullPointerException` in this case.

For now, only address the issue for a missing `version` field by falling back to "0.0.0" which should never be used for a package with a real (semantic) version. The version must be set to something non-empty to satisfy the `require()` statement in line 393.

A future improvement should also handle a missing `name` field and fall back to a project name derived from the project's path (and probably other properties). However, that should be done consistently for all package managers via a global helper function.