### PR TITLE
Remove `ReporterInput.resolutionProvider` 

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.RuleViolationResolution
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.config.orEmpty
+import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.utils.common.zipWithCollections
 import org.ossreviewtoolkit.utils.spdx.model.SpdxLicenseChoice
@@ -86,7 +87,7 @@ data class OrtResult(
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val labels: Map<String, String> = emptyMap()
-) {
+) : ResolutionProvider {
     companion object {
         /**
          * A constant for an [OrtResult] with an empty repository and all other properties `null`.
@@ -391,32 +392,33 @@ data class OrtResult(
     fun getResolutions(): Resolutions = resolvedConfiguration.resolutions.orEmpty()
 
     /**
-     * Return true if and only if [ruleViolation] is resolved in this [OrtResult].
+     * Return true if and only if [violation] is resolved in this [OrtResult].
      */
-    fun isResolved(ruleViolation: RuleViolation): Boolean =
-        getResolutions().ruleViolations.any { it.matches(ruleViolation) }
+    override fun isResolved(violation: RuleViolation): Boolean =
+        getResolutions().ruleViolations.any { it.matches(violation) }
 
     /**
      * Return true if and only if [vulnerability] is resolved in this [OrtResult].
      */
-    fun isResolved(vulnerability: Vulnerability): Boolean =
+    override fun isResolved(vulnerability: Vulnerability): Boolean =
         getResolutions().vulnerabilities.any { it.matches(vulnerability) }
 
     /**
      * Return the resolutions matching [issue].
      */
-    fun getResolutionsFor(issue: Issue): List<IssueResolution> = getResolutions().issues.filter { it.matches(issue) }
+    override fun getResolutionsFor(issue: Issue): List<IssueResolution> =
+        getResolutions().issues.filter { it.matches(issue) }
 
     /**
-     * Return the resolutions matching [ruleViolation].
+     * Return the resolutions matching [violation].
      */
-    fun getResolutionsFor(ruleViolation: RuleViolation): List<RuleViolationResolution> =
-        getResolutions().ruleViolations.filter { it.matches(ruleViolation) }
+    override fun getResolutionsFor(violation: RuleViolation): List<RuleViolationResolution> =
+        getResolutions().ruleViolations.filter { it.matches(violation) }
 
     /**
      * Return the resolutions matching [vulnerability].
      */
-    fun getResolutionsFor(vulnerability: Vulnerability): List<VulnerabilityResolution> =
+    override fun getResolutionsFor(vulnerability: Vulnerability): List<VulnerabilityResolution> =
         getResolutions().vulnerabilities.filter { it.matches(vulnerability) }
 
     /**

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -388,6 +388,18 @@ data class OrtResult(
     fun getResolutions(): Resolutions = resolvedConfiguration.resolutions.orEmpty()
 
     /**
+     * Return true if and only if [ruleViolation] is resolved in this [OrtResult].
+     */
+    fun isResolved(ruleViolation: RuleViolation): Boolean =
+        getResolutions().ruleViolations.any { it.matches(ruleViolation) }
+
+    /**
+     * Return true if and only if [vulnerability] is resolved in this [OrtResult].
+     */
+    fun isResolved(vulnerability: Vulnerability): Boolean =
+        getResolutions().vulnerabilities.any { it.matches(vulnerability) }
+
+    /**
      * Return all [RuleViolation]s contained in this [OrtResult]. Optionally exclude resolved violations with
      * [omitResolved] and remove violations below the [minSeverity].
      */

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -28,9 +28,12 @@ import org.apache.logging.log4j.kotlin.loggerOf
 
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
+import org.ossreviewtoolkit.model.config.RuleViolationResolution
+import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.utils.common.zipWithCollections
@@ -398,6 +401,23 @@ data class OrtResult(
      */
     fun isResolved(vulnerability: Vulnerability): Boolean =
         getResolutions().vulnerabilities.any { it.matches(vulnerability) }
+
+    /**
+     * Return the resolutions matching [issue].
+     */
+    fun getResolutionsFor(issue: Issue): List<IssueResolution> = getResolutions().issues.filter { it.matches(issue) }
+
+    /**
+     * Return the resolutions matching [ruleViolation].
+     */
+    fun getResolutionsFor(ruleViolation: RuleViolation): List<RuleViolationResolution> =
+        getResolutions().ruleViolations.filter { it.matches(ruleViolation) }
+
+    /**
+     * Return the resolutions matching [vulnerability].
+     */
+    fun getResolutionsFor(vulnerability: Vulnerability): List<VulnerabilityResolution> =
+        getResolutions().vulnerabilities.filter { it.matches(vulnerability) }
 
     /**
      * Return all [RuleViolation]s contained in this [OrtResult]. Optionally exclude resolved violations with

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -257,7 +257,6 @@ class ReporterCommand : OrtCommand(
             ortResult,
             ortConfig,
             packageConfigurationProvider,
-            DefaultResolutionProvider(ortResult.getResolutions()),
             DefaultLicenseTextProvider(licenseTextDirectories),
             copyrightGarbage,
             licenseInfoResolver,

--- a/plugins/reporters/evaluated-model/src/funTest/kotlin/EvaluatedModelReporterFunTest.kt
+++ b/plugins/reporters/evaluated-model/src/funTest/kotlin/EvaluatedModelReporterFunTest.kt
@@ -27,7 +27,6 @@ import io.kotest.matchers.shouldBe
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.PluginConfiguration
-import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.test.getAssetAsString
@@ -66,7 +65,6 @@ class EvaluatedModelReporterFunTest : WordSpec({
 private fun TestConfiguration.generateReport(ortResult: OrtResult, options: Map<String, String> = emptyMap()): String {
     val input = ReporterInput(
         ortResult = ortResult,
-        resolutionProvider = DefaultResolutionProvider.create(ortResult),
         howToFixTextProvider = { "Some how to fix text." }
     )
 

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -142,7 +142,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             ruleViolations = ruleViolations,
             vulnerabilitiesResolutions = vulnerabilitiesResolutions,
             vulnerabilities = vulnerabilities,
-            statistics = with(input) { getStatistics(ortResult, resolutionProvider, licenseInfoResolver, ortConfig) },
+            statistics = with(input) { getStatistics(ortResult, licenseInfoResolver, ortConfig) },
             repository = input.ortResult.repository,
             severeIssueThreshold = input.ortConfig.severeIssueThreshold,
             severeRuleViolationThreshold = input.ortConfig.severeRuleViolationThreshold,

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -29,6 +29,8 @@ import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.ResolvedConfiguration
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.TextLocation
@@ -36,6 +38,8 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.RuleViolationResolution
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
@@ -143,7 +147,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             vulnerabilitiesResolutions = vulnerabilitiesResolutions,
             vulnerabilities = vulnerabilities,
             statistics = with(input) { getStatistics(ortResult, licenseInfoResolver, ortConfig) },
-            repository = input.ortResult.repository,
+            repository = input.ortResult.repository.deduplicateResolutions(),
             severeIssueThreshold = input.ortConfig.severeIssueThreshold,
             severeRuleViolationThreshold = input.ortConfig.severeRuleViolationThreshold,
             repositoryConfiguration = input.ortResult.repository.config.toYaml(),
@@ -604,19 +608,19 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addResolutions(issue: Issue): List<IssueResolution> {
-        val matchingResolutions = input.resolutionProvider.getResolutionsFor(issue)
+        val matchingResolutions = input.ortResult.getResolutionsFor(issue)
 
         return issueResolutions.addIfRequired(matchingResolutions)
     }
 
     private fun addResolutions(ruleViolation: RuleViolation): List<RuleViolationResolution> {
-        val matchingResolutions = input.resolutionProvider.getResolutionsFor(ruleViolation)
+        val matchingResolutions = input.ortResult.getResolutionsFor(ruleViolation)
 
         return ruleViolationResolutions.addIfRequired(matchingResolutions)
     }
 
     private fun addResolutions(vulnerability: Vulnerability): List<VulnerabilityResolution> {
-        val matchingResolutions = input.resolutionProvider.getResolutionsFor(vulnerability)
+        val matchingResolutions = input.ortResult.getResolutionsFor(vulnerability)
 
         return vulnerabilitiesResolutions.addIfRequired(matchingResolutions)
     }
@@ -718,4 +722,25 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
      */
     private fun <T> MutableList<T>.addIfRequired(values: Collection<T>): List<T> =
         values.map { addIfRequired(it) }.distinct()
+
+    /**
+     * Return a copy of the [RepositoryConfiguration] with [Resolutions] that refer to the same instances as the
+     * [ResolvedConfiguration] for equal [Resolutions]. This is required for the [EvaluatedModel] to contained indexed
+     * references instead of duplicate [Resolutions].
+     */
+    private fun Repository.deduplicateResolutions(): Repository {
+        val resolutions = with(config.resolutions) {
+            copy(
+                issues = issues.map { resolution -> issueResolutions.find { resolution == it } ?: resolution },
+                ruleViolations = ruleViolations.map { resolution ->
+                    ruleViolationResolutions.find { resolution == it } ?: resolution
+                },
+                vulnerabilities = vulnerabilities.map { resolution ->
+                    vulnerabilitiesResolutions.find { resolution == it } ?: resolution
+                }
+            )
+        }
+
+        return copy(config = config.copy(resolutions = resolutions))
+    }
 }

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -711,9 +711,9 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         )
 
     /**
-     * Adds the [value] to this list if the list does not already contain an equal item. Returns the item that is
-     * contained in the list. This is important to make sure that there is only one instance of equal items used in the
-     * model, because when Jackson generates IDs each instance gets a new ID, no matter if they are equal or not.
+     * Add the [value] to this list if the list does not already contain an equal item. Return the item contained in the
+     * list. This is important to make sure that there is only one instance of equal items used in the model, because
+     * when Jackson generates IDs each instance gets a new ID, no matter if they are equal or not.
      */
     private fun <T> MutableList<T>.addIfRequired(value: T): T = find { it == value } ?: value.also { add(it) }
 

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -30,6 +30,10 @@ repository:
         reason: "TEST_DEPENDENCY_OF"
         comment: "The scope only contains test dependencies."
     resolutions:
+      issues:
+      - message: "A test issue\\."
+        reason: "CANT_FIX_ISSUE"
+        comment: "A comment explaining why the issue can be ignored."
       rule_violations:
       - message: "Apache-2.0 hint"
         reason: "CANT_FIX_EXCEPTION"
@@ -759,6 +763,10 @@ resolved_configuration:
         comment: "H2 database offers a license choice"
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
+    issues:
+    - message: "A test issue\\."
+      reason: "CANT_FIX_ISSUE"
+      comment: "A comment explaining why the issue can be ignored."
     rule_violations:
     - message: "Apache-2.0 hint"
       reason: "CANT_FIX_EXCEPTION"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -758,6 +758,11 @@ resolved_configuration:
       curations:
         comment: "H2 database offers a license choice"
         concluded_license: "MPL-2.0 OR EPL-1.0"
+  resolutions:
+    rule_violations:
+    - message: "Apache-2.0 hint"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache-2 is not an issue."
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
+++ b/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
@@ -29,7 +29,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.common.unpackZip
@@ -59,12 +58,9 @@ class OpossumReporterFunTest : WordSpec({
 })
 
 private fun TestConfiguration.generateReport(ortResult: OrtResult): String {
-    val input = ReporterInput(
-        ortResult = ortResult,
-        resolutionProvider = DefaultResolutionProvider(ortResult.getRepositoryConfigResolutions())
-    )
-
+    val input = ReporterInput(ortResult)
     val outputDir = tempdir()
+
     OpossumReporter().generateReport(input, outputDir).single().unpackZip(outputDir)
 
     return outputDir.resolve("input.json").readText()

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -592,23 +592,23 @@ scanner:
       end_time: "1970-01-01T00:00:00Z"
   scanners:
     "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0":
-      - "FakeScanner"
+    - "FakeScanner"
     "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0":
-      - "FakeScanner"
+    - "FakeScanner"
     "Ant:junit:junit:4.12":
-      - "Dummy"
+    - "Dummy"
     "Maven:com.foobar:foobar:1.0":
-      - "Dummy"
+    - "Dummy"
     "Maven:com.h2database:h2:1.4.200":
-      - "Dummy"
+    - "Dummy"
     "Maven:org.apache.commons:commons-lang3:3.5":
-      - "Dummy"
+    - "Dummy"
     "Maven:org.apache.commons:commons-text:1.1":
-      - "Dummy"
+    - "Dummy"
     "Maven:org.example.test:example-component:1.11":
-      - "Dummy"
+    - "Dummy"
     "Maven:org.hamcrest:hamcrest-core:1.3":
-      - "Dummy"
+    - "Dummy"
   files:
   - provenance:
       vcs_info:

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -30,6 +30,10 @@ repository:
         reason: "TEST_DEPENDENCY_OF"
         comment: "The scope only contains test dependencies."
     resolutions:
+      issues:
+      - message: "A test issue\\."
+        reason: "CANT_FIX_ISSUE"
+        comment: "A comment explaining why the issue can be ignored."
       rule_violations:
       - message: "Apache-2.0 hint"
         reason: "CANT_FIX_EXCEPTION"
@@ -759,6 +763,10 @@ resolved_configuration:
         comment: "H2 database offers a license choice"
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
+    issues:
+    - message: "A test issue\\."
+      reason: "CANT_FIX_ISSUE"
+      comment: "A comment explaining why the issue can be ignored."
     rule_violations:
     - message: "Apache-2.0 hint"
       reason: "CANT_FIX_EXCEPTION"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -758,6 +758,11 @@ resolved_configuration:
       curations:
         comment: "H2 database offers a license choice"
         concluded_license: "MPL-2.0 OR EPL-1.0"
+  resolutions:
+    rule_violations:
+    - message: "Apache-2.0 hint"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache-2 is not an issue."
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -918,6 +918,10 @@ excludes:
     reason: "TEST_DEPENDENCY_OF"
     comment: "The scope only contains test dependencies."
 resolutions:
+  issues:
+  - message: "A test issue\\."
+    reason: "CANT_FIX_ISSUE"
+    comment: "A comment explaining why the issue can be ignored."
   rule_violations:
   - message: "Apache-2.0 hint"
     reason: "CANT_FIX_EXCEPTION"

--- a/plugins/reporters/static-html/src/funTest/kotlin/StaticHtmlReporterFunTest.kt
+++ b/plugins/reporters/static-html/src/funTest/kotlin/StaticHtmlReporterFunTest.kt
@@ -27,7 +27,6 @@ import io.kotest.matchers.shouldBe
 import javax.xml.transform.TransformerFactory
 
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.ort.Environment
@@ -70,7 +69,6 @@ class StaticHtmlReporterFunTest : WordSpec({
 private fun TestConfiguration.generateReport(ortResult: OrtResult): String {
     val input = ReporterInput(
         ortResult = ortResult,
-        resolutionProvider = DefaultResolutionProvider.create(ortResult),
         howToFixTextProvider = HOW_TO_FIX_TEXT_PROVIDER
     )
 

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -30,7 +30,6 @@ import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.orEmpty
-import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.DependencyRow
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueRow
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueTable
@@ -91,10 +90,10 @@ internal object ReportTableModelMapper {
                         input.ortResult.getRepositoryLicenseChoices()
                     )?.sorted(),
                     analyzerIssues = analyzerIssues.map {
-                        it.toResolvableIssue(input.resolutionProvider, input.howToFixTextProvider)
+                        it.toResolvableIssue(input.ortResult, input.howToFixTextProvider)
                     },
                     scanIssues = scanIssues.map {
-                        it.toResolvableIssue(input.resolutionProvider, input.howToFixTextProvider)
+                        it.toResolvableIssue(input.ortResult, input.howToFixTextProvider)
                     }
                 )
 
@@ -139,7 +138,7 @@ internal object ReportTableModelMapper {
         val labels = input.ortResult.labels.mapKeys { it.key.substringAfter(".") }
 
         val ruleViolations = input.ortResult.getRuleViolations()
-            .map { it.toResolvableViolation(input.resolutionProvider) }
+            .map { it.toResolvableViolation(input.ortResult) }
             .sortedWith(VIOLATION_COMPARATOR)
 
         return ReportTableModel(
@@ -179,11 +178,8 @@ private fun Project.getScopesForDependencies(
     return result
 }
 
-private fun Issue.toResolvableIssue(
-    resolutionProvider: ResolutionProvider,
-    howToFixTextProvider: HowToFixTextProvider
-): ResolvableIssue {
-    val resolutions = resolutionProvider.getResolutionsFor(this)
+private fun Issue.toResolvableIssue(ortResult: OrtResult, howToFixTextProvider: HowToFixTextProvider): ResolvableIssue {
+    val resolutions = ortResult.getResolutionsFor(this)
     return ResolvableIssue(
         source = source,
         description = toString(),
@@ -202,8 +198,8 @@ private fun Issue.toResolvableIssue(
     )
 }
 
-private fun RuleViolation.toResolvableViolation(resolutionProvider: ResolutionProvider): ResolvableViolation {
-    val resolutions = resolutionProvider.getResolutionsFor(this)
+private fun RuleViolation.toResolvableViolation(ortResult: OrtResult): ResolvableViolation {
+    val resolutions = ortResult.getResolutionsFor(this)
     return ResolvableViolation(
         violation = this,
         resolutionDescription = buildString {

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -21,7 +21,6 @@ package org.ossreviewtoolkit.reporter
 
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.PackageConfiguration
@@ -29,9 +28,7 @@ import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
-import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 
 /**
@@ -52,11 +49,6 @@ data class ReporterInput(
      * A [PackageConfigurationProvider], can be used to obtain [PackageConfiguration]s for packages.
      */
     val packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY,
-
-    /**
-     * A [ResolutionProvider], can be used to check which [Issue]s and [RuleViolation]s are resolved.
-     */
-    val resolutionProvider: ResolutionProvider = DefaultResolutionProvider(),
 
     /**
      * A [LicenseTextProvider], can be used to integrate licenses texts into reports.

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -94,5 +94,5 @@ data class ReporterInput(
      * Statistics for [ortResult].
      */
     @Suppress("UNUSED") // This can be used from templates.
-    val statistics: Statistics by lazy { getStatistics(ortResult, resolutionProvider, licenseInfoResolver, ortConfig) }
+    val statistics: Statistics by lazy { getStatistics(ortResult, licenseInfoResolver, ortConfig) }
 }

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -31,7 +31,6 @@ import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.RuleViolationResolution
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.licenses.LicenseView
-import org.ossreviewtoolkit.model.utils.ResolutionProvider
 
 /**
  * This class calculates [Statistics] for a given [OrtResult] and the applicable [IssueResolution]s and
@@ -41,36 +40,28 @@ object StatisticsCalculator {
     /**
      * Return the [Statistics] for the given [ortResult].
      */
-    fun getStatistics(
-        ortResult: OrtResult,
-        resolutionProvider: ResolutionProvider,
-        licenseInfoResolver: LicenseInfoResolver,
-        ortConfig: OrtConfiguration
-    ) = Statistics(
-        repositoryConfiguration = getRepositoryConfigurationStatistics(ortResult),
-        openIssues = getOpenIssues(ortResult, resolutionProvider, ortConfig),
-        openRuleViolations = getOpenRuleViolations(ortResult, resolutionProvider, ortConfig),
-        openVulnerabilities = getOpenVulnerabilities(ortResult, resolutionProvider),
-        dependencyTree = DependencyTreeStatistics(
-            includedProjects = ortResult.getProjects().count { !ortResult.isExcluded(it.id) },
-            excludedProjects = ortResult.getProjects().count { ortResult.isExcluded(it.id) },
-            includedPackages = ortResult.getPackages().count { !ortResult.isExcluded(it.metadata.id) },
-            excludesPackages = ortResult.getPackages().count { ortResult.isExcluded(it.metadata.id) },
-            totalTreeDepth = getTreeDepth(ortResult),
-            includedTreeDepth = getTreeDepth(ortResult = ortResult, ignoreExcluded = true),
-            includedScopes = getIncludedScopes(ortResult),
-            excludedScopes = getExcludedScopes(ortResult)
-        ),
-        licenses = getLicenseStatistics(ortResult, licenseInfoResolver),
-        executionDurationInSeconds = getExecutionDurationInSeconds(ortResult)
-    )
+    fun getStatistics(ortResult: OrtResult, licenseInfoResolver: LicenseInfoResolver, ortConfig: OrtConfiguration) =
+        Statistics(
+            repositoryConfiguration = getRepositoryConfigurationStatistics(ortResult),
+            openIssues = getOpenIssues(ortResult, ortConfig),
+            openRuleViolations = getOpenRuleViolations(ortResult, ortConfig),
+            openVulnerabilities = getOpenVulnerabilities(ortResult),
+            dependencyTree = DependencyTreeStatistics(
+                includedProjects = ortResult.getProjects().count { !ortResult.isExcluded(it.id) },
+                excludedProjects = ortResult.getProjects().count { ortResult.isExcluded(it.id) },
+                includedPackages = ortResult.getPackages().count { !ortResult.isExcluded(it.metadata.id) },
+                excludesPackages = ortResult.getPackages().count { ortResult.isExcluded(it.metadata.id) },
+                totalTreeDepth = getTreeDepth(ortResult),
+                includedTreeDepth = getTreeDepth(ortResult = ortResult, ignoreExcluded = true),
+                includedScopes = getIncludedScopes(ortResult),
+                excludedScopes = getExcludedScopes(ortResult)
+            ),
+            licenses = getLicenseStatistics(ortResult, licenseInfoResolver),
+            executionDurationInSeconds = getExecutionDurationInSeconds(ortResult)
+        )
 
-    private fun getOpenRuleViolations(
-        ortResult: OrtResult,
-        resolutionProvider: ResolutionProvider,
-        ortConfig: OrtConfiguration
-    ): IssueStatistics {
-        val openRuleViolations = ortResult.getRuleViolations().filterNot { resolutionProvider.isResolved(it) }
+    private fun getOpenRuleViolations(ortResult: OrtResult, ortConfig: OrtConfiguration): IssueStatistics {
+        val openRuleViolations = ortResult.getRuleViolations(omitResolved = true)
 
         return IssueStatistics(
             errors = openRuleViolations.count { it.severity == Severity.ERROR },
@@ -80,12 +71,8 @@ object StatisticsCalculator {
         )
     }
 
-    private fun getOpenIssues(
-        ortResult: OrtResult,
-        resolutionProvider: ResolutionProvider,
-        ortConfig: OrtConfiguration
-    ): IssueStatistics {
-        val openIssues = ortResult.getOpenIssues(Severity.HINT).filterNot { resolutionProvider.isResolved(it) }
+    private fun getOpenIssues(ortResult: OrtResult, ortConfig: OrtConfiguration): IssueStatistics {
+        val openIssues = ortResult.getOpenIssues(Severity.HINT)
 
         return IssueStatistics(
             errors = openIssues.count { it.severity == Severity.ERROR },
@@ -95,9 +82,8 @@ object StatisticsCalculator {
         )
     }
 
-    private fun getOpenVulnerabilities(ortResult: OrtResult, resolutionProvider: ResolutionProvider): Int =
-        ortResult.getVulnerabilities(omitExcluded = true).values.flatten()
-            .filterNot { resolutionProvider.isResolved(it) }.size
+    private fun getOpenVulnerabilities(ortResult: OrtResult): Int =
+        ortResult.getVulnerabilities(omitExcluded = true, omitResolved = true).values.flatten().size
 
     private fun getTreeDepth(ortResult: OrtResult, ignoreExcluded: Boolean = false): Int =
         ortResult


### PR DESCRIPTION
As of the addition of `OrtResult.resolvedConfiguration`, the ORT result is self-contained WRT to package configurations,
resolutions and curations. So, in theory the `OrtResult` can be passed to each respective `Reporter` without 
any accompanying provider, e.g. `ResolutionProvider`, `CurationProvider` as you name it. This would be less complicated to handle: e.g. make the `ReporterCommand` first include all the data in `OrtResult` and then pass around the `OrtResult` to the reporters.

If you look at the functions `OrtResult.getOpenIssues()` or `OrtResult.getResolutions()`, these consider only resolutions from the repository configuration, but not the ones from the resolved configuration. So, the result of these functions can normally only be used by further processing it with some matching against data from a `ResolutionProvider`. This inconvenience would be removed if just all data was included in `OrtResult` and actually also used by its member functions.

This PR implements this only for the resolution provider. 
An analog PR should be done for package configurations, which would allow to implement filtering issues by `affectedPath` / path excludes within `OrtResult.getIssues()`.





