### PR TITLE
chore(commands): Deprecate the `--skip-excluded` options

### DIFF
--- a/plugins/commands/advisor/src/main/kotlin/AdvisorCommand.kt
+++ b/plugins/commands/advisor/src/main/kotlin/AdvisorCommand.kt
@@ -25,6 +25,7 @@ import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.deprecated
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
@@ -106,7 +107,7 @@ class AdvisorCommand : OrtCommand(
     private val skipExcluded by option(
         "--skip-excluded",
         help = "Do not check excluded projects or packages."
-    ).flag()
+    ).flag().deprecated("Use the global option 'ort -P ort.advisor.skipExcluded=... advise' instead.")
 
     override fun run() {
         val outputFiles = outputFormats.mapTo(mutableSetOf()) { format ->

--- a/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
+++ b/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
@@ -26,6 +26,7 @@ import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.groups.single
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.deprecated
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
@@ -190,7 +191,7 @@ class DownloaderCommand : OrtCommand(
     private val skipExcluded by option(
         "--skip-excluded",
         help = "Do not download excluded projects or packages. Works only with the '--ort-file' parameter."
-    ).flag()
+    ).flag().deprecated("Use the global option 'ort -P ort.downloader.skipExcluded=... download' instead.")
 
     private val dryRun by option(
         "--dry-run",

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -26,6 +26,7 @@ import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.deprecated
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
@@ -118,7 +119,7 @@ class ScannerCommand : OrtCommand(
     private val skipExcluded by option(
         "--skip-excluded",
         help = "Do not scan excluded projects or packages. Works only with the '--ort-file' parameter."
-    ).flag()
+    ).flag().deprecated("Use the global option 'ort -P ort.scanner.skipExcluded=... scan' instead.")
 
     private val resolutionsFile by option(
         "--resolutions-file",


### PR DESCRIPTION
This is a follow-up to 67297b2.