### PR TITLE
Remove `ReporterInput.packageConfigurationProvider`

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.setPackageConfigurations
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.expandTilde
 
@@ -77,13 +78,11 @@ internal class ListCopyrightsCommand : CliktCommand(
 
     override fun run() {
         val ortResult = readOrtResult(ortFile)
+            .setPackageConfigurations(DirPackageConfigurationProvider(packageConfigurationsDir))
         val copyrightGarbage = copyrightGarbageFile?.readValue<CopyrightGarbage>().orEmpty()
-        val packageConfigurationProvider = DirPackageConfigurationProvider(packageConfigurationsDir)
 
-        val copyrightStatements = ortResult.processAllCopyrightStatements(
-            copyrightGarbage = copyrightGarbage.items,
-            packageConfigurationProvider = packageConfigurationProvider
-        ).filter { packageId == null || it.packageId == packageId }
+        val copyrightStatements = ortResult.processAllCopyrightStatements(copyrightGarbage = copyrightGarbage.items)
+            .filter { packageId == null || it.packageId == packageId }
             .filter { licenseId == null || it.license.toString() == licenseId }
             .groupBy({ it.statement }, { it.rawStatements })
             .mapValues { it.value.flatten().toSortedSet() }

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -108,13 +108,12 @@ internal fun OrtResult.downloadSources(id: Identifier, sourceCodeOrigin: SourceC
 internal fun OrtResult.processAllCopyrightStatements(
     omitExcluded: Boolean = true,
     copyrightGarbage: Set<String> = emptySet(),
-    addAuthorsToCopyrights: Boolean = false,
-    packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY
+    addAuthorsToCopyrights: Boolean = false
 ): List<ProcessedCopyrightStatement> {
     val result = mutableListOf<ProcessedCopyrightStatement>()
 
     val licenseInfoResolver = createLicenseInfoResolver(
-        packageConfigurationProvider = packageConfigurationProvider,
+        packageConfigurationProvider = this,
         copyrightGarbage = CopyrightGarbage(copyrightGarbage.toSortedSet()),
         addAuthorsToCopyrights = addAuthorsToCopyrights
     )

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -113,7 +113,6 @@ internal fun OrtResult.processAllCopyrightStatements(
     val result = mutableListOf<ProcessedCopyrightStatement>()
 
     val licenseInfoResolver = createLicenseInfoResolver(
-        packageConfigurationProvider = this,
         copyrightGarbage = CopyrightGarbage(copyrightGarbage.toSortedSet()),
         addAuthorsToCopyrights = addAuthorsToCopyrights
     )

--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -27,17 +27,13 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.filterByVcsPath
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
 
 /**
  * The default [LicenseInfoProvider] that collects license information from an [ortResult].
  */
-class DefaultLicenseInfoProvider(
-    val ortResult: OrtResult,
-    private val packageConfigurationProvider: PackageConfigurationProvider
-) : LicenseInfoProvider {
+class DefaultLicenseInfoProvider(val ortResult: OrtResult) : LicenseInfoProvider {
     private val licenseInfo: ConcurrentMap<Identifier, LicenseInfo> = ConcurrentHashMap()
 
     override fun get(id: Identifier) = licenseInfo.getOrPut(id) { createLicenseInfo(id) }
@@ -112,7 +108,7 @@ class DefaultLicenseInfoProvider(
                 ortResult.repository.config.excludes.paths,
                 ortResult.repository.getRelativePath(project.vcsProcessed).orEmpty()
             )
-        } ?: packageConfigurationProvider.getPackageConfigurations(id, provenance).let { packageConfigurations ->
+        } ?: ortResult.getPackageConfigurations(id, provenance).let { packageConfigurations ->
             Configuration(
                 packageConfigurations.flatMap { it.licenseFindingCurations },
                 packageConfigurations.flatMap { it.pathExcludes },

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -70,12 +70,11 @@ fun OrtResult.setResolutions(resolutionProvider: ResolutionProvider): OrtResult 
  * instead of calling this function multiple times for better performance.
  */
 fun OrtResult.createLicenseInfoResolver(
-    packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY,
     copyrightGarbage: CopyrightGarbage = CopyrightGarbage(),
     addAuthorsToCopyrights: Boolean = false,
     archiver: FileArchiver? = null
 ) = LicenseInfoResolver(
-    DefaultLicenseInfoProvider(this, packageConfigurationProvider),
+    DefaultLicenseInfoProvider(this),
     copyrightGarbage,
     addAuthorsToCopyrights,
     archiver,

--- a/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
+++ b/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
@@ -22,10 +22,8 @@ package org.ossreviewtoolkit.model.licenses
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-
 class DefaultLicenseInfoProviderTest : WordSpec({
-    val defaultLicenseInfoProvider = DefaultLicenseInfoProvider(ortResult, PackageConfigurationProvider.EMPTY)
+    val defaultLicenseInfoProvider = DefaultLicenseInfoProvider(ortResult)
 
     "declaredLicenseInfo" should {
         "contain author information for package" {

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -29,14 +29,13 @@ import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.utils.FileArchiver
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.test.createDefault
 import org.ossreviewtoolkit.utils.test.transformingCollectionMatcher
 
 class LicenseViewTest : WordSpec() {
     private val licenseInfoResolver = LicenseInfoResolver(
-        provider = DefaultLicenseInfoProvider(ortResult, PackageConfigurationProvider.EMPTY),
+        provider = DefaultLicenseInfoProvider(ortResult),
         copyrightGarbage = CopyrightGarbage(),
         addAuthorsToCopyrights = false,
         archiver = FileArchiver.createDefault()

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -302,10 +302,7 @@ class EvaluatorCommand : OrtCommand(
         val copyrightGarbage = copyrightGarbageFile.takeIf { it.isFile }?.readValue<CopyrightGarbage>().orEmpty()
 
         val licenseInfoResolver = LicenseInfoResolver(
-            provider = DefaultLicenseInfoProvider(
-                ortResult = ortResultInput,
-                packageConfigurationProvider = ortResultInput
-            ),
+            provider = DefaultLicenseInfoProvider(ortResultInput),
             copyrightGarbage = copyrightGarbage,
             addAuthorsToCopyrights = ortConfig.addAuthorsToCopyrights,
             archiver = ortConfig.scanner.archive.createFileArchiver(),

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -297,10 +297,15 @@ class EvaluatorCommand : OrtCommand(
         val packageConfigurationProvider =
             CompositePackageConfigurationProvider(*enabledPackageConfigurationProviders.toTypedArray())
 
+        ortResultInput = ortResultInput.setPackageConfigurations(packageConfigurationProvider)
+
         val copyrightGarbage = copyrightGarbageFile.takeIf { it.isFile }?.readValue<CopyrightGarbage>().orEmpty()
 
         val licenseInfoResolver = LicenseInfoResolver(
-            provider = DefaultLicenseInfoProvider(ortResultInput, packageConfigurationProvider),
+            provider = DefaultLicenseInfoProvider(
+                ortResult = ortResultInput,
+                packageConfigurationProvider = ortResultInput
+            ),
             copyrightGarbage = copyrightGarbage,
             addAuthorsToCopyrights = ortConfig.addAuthorsToCopyrights,
             archiver = ortConfig.scanner.archive.createFileArchiver(),
@@ -325,7 +330,6 @@ class EvaluatorCommand : OrtCommand(
         // Note: This overwrites any existing EvaluatorRun from the input file.
         val ortResultOutput = ortResultInput.copy(evaluator = evaluatorRun)
             .mergeLabels(labels)
-            .setPackageConfigurations(packageConfigurationProvider)
             .setResolutions(resolutionProvider)
 
         outputDir?.let { absoluteOutputDir ->

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -54,6 +54,7 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
+import org.ossreviewtoolkit.model.utils.setPackageConfigurations
 import org.ossreviewtoolkit.model.utils.setResolutions
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
@@ -234,6 +235,8 @@ class ReporterCommand : OrtCommand(
             }
         }
 
+        ortResult = ortResult.setPackageConfigurations(packageConfigurationProvider)
+
         val copyrightGarbage = copyrightGarbageFile.takeIf { it.isFile }?.readValue<CopyrightGarbage>().orEmpty()
 
         val licenseInfoResolver = LicenseInfoResolver(
@@ -256,7 +259,7 @@ class ReporterCommand : OrtCommand(
         val input = ReporterInput(
             ortResult,
             ortConfig,
-            packageConfigurationProvider,
+            ortResult,
             DefaultLicenseTextProvider(licenseTextDirectories),
             copyrightGarbage,
             licenseInfoResolver,

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -240,7 +240,7 @@ class ReporterCommand : OrtCommand(
         val copyrightGarbage = copyrightGarbageFile.takeIf { it.isFile }?.readValue<CopyrightGarbage>().orEmpty()
 
         val licenseInfoResolver = LicenseInfoResolver(
-            provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
+            provider = DefaultLicenseInfoProvider(ortResult),
             copyrightGarbage = copyrightGarbage,
             addAuthorsToCopyrights = ortConfig.addAuthorsToCopyrights,
             archiver = ortConfig.scanner.archive.createFileArchiver(),

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -259,7 +259,6 @@ class ReporterCommand : OrtCommand(
         val input = ReporterInput(
             ortResult,
             ortConfig,
-            ortResult,
             DefaultLicenseTextProvider(licenseTextDirectories),
             copyrightGarbage,
             licenseInfoResolver,

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -222,7 +222,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         if (input.ortResult.isProject(id)) {
             input.ortResult.repository.config.curations.licenseFindings
         } else {
-            input.packageConfigurationProvider.getPackageConfigurations(id, provenance)
+            input.ortResult.getPackageConfigurations(id, provenance)
                 .flatMap { it.licenseFindingCurations }
         }
 
@@ -230,7 +230,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         if (input.ortResult.isProject(id)) {
             input.ortResult.getExcludes().paths
         } else {
-            input.packageConfigurationProvider.getPackageConfigurations(id, provenance)
+            input.ortResult.getPackageConfigurations(id, provenance)
                 .flatMap { it.pathExcludes }
         }
 

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -23,12 +23,10 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.OrtConfiguration
-import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 
 /**
@@ -44,11 +42,6 @@ data class ReporterInput(
      * The [OrtConfiguration], can be used by the reporter to adapt the output based on how ORT is configured.
      */
     val ortConfig: OrtConfiguration = OrtConfiguration(),
-
-    /**
-     * A [PackageConfigurationProvider], can be used to obtain [PackageConfiguration]s for packages.
-     */
-    val packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY,
 
     /**
      * A [LicenseTextProvider], can be used to integrate licenses texts into reports.

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -64,7 +64,7 @@ data class ReporterInput(
      * A resolver for license information for the projects and packages contained in [ortResult].
      */
     val licenseInfoResolver: LicenseInfoResolver = LicenseInfoResolver(
-        provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
+        provider = DefaultLicenseInfoProvider(ortResult),
         copyrightGarbage = copyrightGarbage,
         addAuthorsToCopyrights = ortConfig.addAuthorsToCopyrights,
         archiver = ortConfig.scanner.archive.createFileArchiver(),


### PR DESCRIPTION
This PR first of all ensures that the `evaluator` and `reporter` and `list-copyrights` commands add all package configurations to the `OrtResult` before passing it around, and applies resulting simplifications.

This prepares for changing `OrtResult.getIssues()` to filter the issues by path excludes in a following PR.
As a I nice side effect, package configurations are now only resolved once per CLI command run instead of multiple times. 

Part of #7921.
