### PR TITLE
feat(ort-utils): Find names even if the version has an (ignorable) suffix

### DIFF
--- a/utils/ort/src/main/kotlin/Utils.kt
+++ b/utils/ort/src/main/kotlin/Utils.kt
@@ -37,7 +37,8 @@ var printStackTrace = false
 private val versionSeparators = listOf('-', '_', '.')
 private val versionSeparatorsPattern = versionSeparators.joinToString("", "[", "]")
 
-private val ignorablePrefixSuffixPattern = listOf("rel", "release", "final").joinToString("|", "(", ")")
+private val ignorablePrefixSuffix = listOf("rel", "release", "final")
+private val ignorablePrefixSuffixPattern = ignorablePrefixSuffix.joinToString("|", "(", ")")
 private val ignorablePrefixSuffixRegex = Regex(
     "(^$ignorablePrefixSuffixPattern$versionSeparatorsPattern|$versionSeparatorsPattern$ignorablePrefixSuffixPattern$)"
 )
@@ -61,6 +62,10 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
     val separatorRegex = Regex(versionSeparatorsPattern)
     versionSeparators.mapTo(versionVariants) {
         VersionVariant(versionLower.replace(separatorRegex, it.toString()), listOf(it))
+    }
+
+    ignorablePrefixSuffix.mapTo(versionVariants) {
+        VersionVariant(versionLower.removeSuffix(it).trimEnd(*versionSeparators.toCharArray()), versionSeparators)
     }
 
     // The list of supported version separators.

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -253,6 +253,16 @@ class UtilsTest : WordSpec({
 
             filterVersionNames("3.9.0.99", names).shouldContainExactly("3.9.0.99-a3d9827", "sdk-3.9.0.99", "v3.9.0.99")
         }
+
+        "find names that match the version without an ignorable suffix" {
+            val names = listOf(
+                "6.2.8",
+                "6.2.9",
+                "6.2.10"
+            )
+
+            filterVersionNames("6.2.9.Final", names).shouldContainExactly("6.2.9")
+        }
     }
 
     "normalizeVcsUrl" should {


### PR DESCRIPTION
So far ignorable suffixes were only ignored from the given (tag) names. Extend the logic to also ignore them from the given version.