### PR TITLE
test(carthage): Make the test independent of the GitHub org ORT is hosted

### DIFF
--- a/plugins/package-managers/carthage/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
+++ b/plugins/package-managers/carthage/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Carthage:oss-review-toolkit:ort:<REPLACE_REVISION>"
+  id: "Carthage:<REPLACE_GITHUB_ORGANIZATION>:ort:<REPLACE_REVISION>"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
+++ b/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
@@ -35,6 +35,10 @@ class CarthageFunTest : StringSpec({
 
         val result = create("Carthage").resolveSingleProject(definitionFile)
 
-        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+        result.toYaml() should matchExpectedResult(
+            expectedResultFile,
+            definitionFile,
+            mapOf("<REPLACE_GITHUB_ORGANIZATION>" to "oss-review-toolkit")
+        )
     }
 })


### PR DESCRIPTION
Make the test pass also when run from a fork by not depending on the upstream GitHub organization name.