### PR TITLE
refactor(model)!: Improve `ResolutionProvider`s getter names

### DIFF
--- a/model/src/main/kotlin/utils/ConfigurationResolver.kt
+++ b/model/src/main/kotlin/utils/ConfigurationResolver.kt
@@ -95,11 +95,9 @@ object ConfigurationResolver {
         vulnerabilities: List<Vulnerability>,
         resolutionProvider: ResolutionProvider
     ): Resolutions {
-        val issueResolutions = issues.flatMap { resolutionProvider.getIssueResolutionsFor(it) }.distinct()
-        val ruleViolationResolutions =
-            ruleViolations.flatMap { resolutionProvider.getRuleViolationResolutionsFor(it) }.distinct()
-        val vulnerabilityResolutions =
-            vulnerabilities.flatMap { resolutionProvider.getVulnerabilityResolutionsFor(it) }.distinct()
+        val issueResolutions = issues.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
+        val ruleViolationResolutions = ruleViolations.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
+        val vulnerabilityResolutions = vulnerabilities.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
 
         return Resolutions(issueResolutions, ruleViolationResolutions, vulnerabilityResolutions)
     }

--- a/model/src/main/kotlin/utils/ConfigurationResolver.kt
+++ b/model/src/main/kotlin/utils/ConfigurationResolver.kt
@@ -94,11 +94,9 @@ object ConfigurationResolver {
         ruleViolations: List<RuleViolation>,
         vulnerabilities: List<Vulnerability>,
         resolutionProvider: ResolutionProvider
-    ): Resolutions {
-        val issueResolutions = issues.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
-        val ruleViolationResolutions = ruleViolations.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
-        val vulnerabilityResolutions = vulnerabilities.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
-
-        return Resolutions(issueResolutions, ruleViolationResolutions, vulnerabilityResolutions)
-    }
+    ) = Resolutions(
+        issues = issues.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct(),
+        ruleViolations = ruleViolations.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct(),
+        vulnerabilities = vulnerabilities.flatMap { resolutionProvider.getResolutionsFor(it) }.distinct()
+    )
 }

--- a/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
@@ -45,11 +45,11 @@ class DefaultResolutionProvider(private val resolutions: Resolutions = Resolutio
         }
     }
 
-    override fun getIssueResolutionsFor(issue: Issue) = resolutions.issues.filter { it.matches(issue) }
+    override fun getResolutionsFor(issue: Issue) = resolutions.issues.filter { it.matches(issue) }
 
-    override fun getRuleViolationResolutionsFor(violation: RuleViolation) =
+    override fun getResolutionsFor(violation: RuleViolation) =
         resolutions.ruleViolations.filter { it.matches(violation) }
 
-    override fun getVulnerabilityResolutionsFor(vulnerability: Vulnerability) =
+    override fun getResolutionsFor(vulnerability: Vulnerability) =
         resolutions.vulnerabilities.filter { it.matches(vulnerability) }
 }

--- a/model/src/main/kotlin/utils/ResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/ResolutionProvider.kt
@@ -33,30 +33,30 @@ interface ResolutionProvider {
     /**
      * Get all issue resolutions that match [issue].
      */
-    fun getIssueResolutionsFor(issue: Issue): List<IssueResolution>
+    fun getResolutionsFor(issue: Issue): List<IssueResolution>
 
     /**
      * Get all rule violation resolutions that match [violation].
      */
-    fun getRuleViolationResolutionsFor(violation: RuleViolation): List<RuleViolationResolution>
+    fun getResolutionsFor(violation: RuleViolation): List<RuleViolationResolution>
 
     /**
      * Get all vulnerability resolutions that match [vulnerability].
      */
-    fun getVulnerabilityResolutionsFor(vulnerability: Vulnerability): List<VulnerabilityResolution>
+    fun getResolutionsFor(vulnerability: Vulnerability): List<VulnerabilityResolution>
 
     /**
      * Return true if there is at least one issue resolution that matches [issue].
      */
-    fun isResolved(issue: Issue): Boolean = getIssueResolutionsFor(issue).isNotEmpty()
+    fun isResolved(issue: Issue): Boolean = getResolutionsFor(issue).isNotEmpty()
 
     /**
      * Return true if there is at least one rule violation resolution that matches [violation].
      */
-    fun isResolved(violation: RuleViolation): Boolean = getRuleViolationResolutionsFor(violation).isNotEmpty()
+    fun isResolved(violation: RuleViolation): Boolean = getResolutionsFor(violation).isNotEmpty()
 
     /**
      * Return true if there is at least one vulnerability resolution that matches [vulnerability].
      */
-    fun isResolved(vulnerability: Vulnerability): Boolean = getVulnerabilityResolutionsFor(vulnerability).isNotEmpty()
+    fun isResolved(vulnerability: Vulnerability): Boolean = getResolutionsFor(vulnerability).isNotEmpty()
 }

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -604,19 +604,19 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addResolutions(issue: Issue): List<IssueResolution> {
-        val matchingResolutions = input.resolutionProvider.getIssueResolutionsFor(issue)
+        val matchingResolutions = input.resolutionProvider.getResolutionsFor(issue)
 
         return issueResolutions.addIfRequired(matchingResolutions)
     }
 
     private fun addResolutions(ruleViolation: RuleViolation): List<RuleViolationResolution> {
-        val matchingResolutions = input.resolutionProvider.getRuleViolationResolutionsFor(ruleViolation)
+        val matchingResolutions = input.resolutionProvider.getResolutionsFor(ruleViolation)
 
         return ruleViolationResolutions.addIfRequired(matchingResolutions)
     }
 
     private fun addResolutions(vulnerability: Vulnerability): List<VulnerabilityResolution> {
-        val matchingResolutions = input.resolutionProvider.getVulnerabilityResolutionsFor(vulnerability)
+        val matchingResolutions = input.resolutionProvider.getResolutionsFor(vulnerability)
 
         return vulnerabilitiesResolutions.addIfRequired(matchingResolutions)
     }

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -183,7 +183,7 @@ private fun Issue.toResolvableIssue(
     resolutionProvider: ResolutionProvider,
     howToFixTextProvider: HowToFixTextProvider
 ): ResolvableIssue {
-    val resolutions = resolutionProvider.getIssueResolutionsFor(this)
+    val resolutions = resolutionProvider.getResolutionsFor(this)
     return ResolvableIssue(
         source = source,
         description = toString(),
@@ -203,7 +203,7 @@ private fun Issue.toResolvableIssue(
 }
 
 private fun RuleViolation.toResolvableViolation(resolutionProvider: ResolutionProvider): ResolvableViolation {
-    val resolutions = resolutionProvider.getRuleViolationResolutionsFor(this)
+    val resolutions = resolutionProvider.getResolutionsFor(this)
     return ResolvableViolation(
         violation = this,
         resolutionDescription = buildString {


### PR DESCRIPTION
Use shorter names and make the naming consistent with the overloaded `isResolved()` function.

