### PR TITLE
fix(analyzer-command): Resolve repo config correctly if input is a file

### DIFF
--- a/plugins/commands/analyzer/src/main/kotlin/AnalyzerCommand.kt
+++ b/plugins/commands/analyzer/src/main/kotlin/AnalyzerCommand.kt
@@ -95,7 +95,7 @@ class AnalyzerCommand : OrtCommand(
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
         .convert { it.absoluteFile.normalize() }
-        .defaultLazy { inputDir.resolve(ORT_REPO_CONFIG_FILENAME) }
+        .defaultLazy { (inputDir.takeUnless { it.isFile } ?: inputDir.parentFile).resolve(ORT_REPO_CONFIG_FILENAME) }
         .configurationGroup()
 
     private val resolutionsFile by option(


### PR DESCRIPTION
For the special case if only one package manager is enabled and the input is a file instead of directory, resolve the repository configuration file correctly, i.e. relative to the parent, as there is no explicit analyzer root directory in this case.