### PR TITLE
ci(github): Enable auto-release of artifacts from staging to production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_SONATYPE_AUTOMATIC_RELEASE: true
         run: ./gradlew publishAllPublicationsToMavenCentralRepository
       - name: Build ORT Distributions
         run: ./gradlew :cli:distZip :helper-cli:distZip


### PR DESCRIPTION
Publishing already closes the staging repository at Sonatype, but releasing to production requires an extra step, see [1].

[1]: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#__tabbed_6_3