### PR TITLE
build(Gradle): Use dashes to group dependencies

### DIFF
--- a/advisor/build.gradle.kts
+++ b/advisor/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 
     testImplementation(libs.mockk)
 }

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation(projects.downloader)
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 
     funTestImplementation(platform(projects.plugins.packageManagers))
 
@@ -40,6 +40,6 @@ dependencies {
 
     testFixturesImplementation(projects.utils.testUtils)
 
-    testFixturesImplementation(libs.kotestAssertionsCore)
-    testFixturesImplementation(libs.kotestRunnerJunit5)
+    testFixturesImplementation(libs.kotest.assertions.core)
+    testFixturesImplementation(libs.kotest.runner.junit5)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,12 +39,12 @@ repositories {
 dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 
-    implementation(libs.detektPlugin)
-    implementation(libs.dokkatooPlugin)
-    implementation(libs.graalVmNativeImagePlugin)
     implementation(libs.jgit)
-    implementation(libs.kotlinPlugin)
-    implementation(libs.mavenPublishPlugin)
+    implementation(libs.plugin.detekt)
+    implementation(libs.plugin.dokkatoo)
+    implementation(libs.plugin.graalVmNativeImage)
+    implementation(libs.plugin.kotlin)
+    implementation(libs.plugin.mavenPublish)
 }
 
 val javaVersion = JavaVersion.current()

--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -130,7 +130,7 @@ graalvmNative {
 dependencies {
     implementation(libs.logbackClassic)
 
-    runtimeOnly(libs.log4jApiToSlf4j)
+    runtimeOnly(libs.log4j.api.slf4j)
 }
 
 tasks.named<BuildNativeImageTask>("nativeCompile") {

--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -61,8 +61,8 @@ testing {
             dependencies {
                 implementation(project(":utils:test-utils"))
 
-                implementation(libs.kotestAssertionsCore)
-                implementation(libs.kotestRunnerJunit5)
+                implementation(libs.kotest.assertions.core)
+                implementation(libs.kotest.runner.junit5)
             }
         }
 
@@ -99,7 +99,7 @@ dependencies {
 
     "detektPlugins"("io.gitlab.arturbosch.detekt:detekt-formatting:${libs.versions.detektPlugin.get()}")
 
-    implementation(libs.log4jApiKotlin)
+    implementation(libs.log4j.api.kotlin)
 }
 
 detekt {

--- a/clients/clearly-defined/build.gradle.kts
+++ b/clients/clearly-defined/build.gradle.kts
@@ -32,9 +32,9 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.kotlinxCoroutines)
-    implementation(libs.retrofitConverterKotlinxSerialization)
-    implementation(libs.retrofitConverterScalars)
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.retrofit.converter.kotlinxSerialization)
+    implementation(libs.retrofit.converter.scalars)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/clients/fossid-webapp/build.gradle.kts
+++ b/clients/fossid-webapp/build.gradle.kts
@@ -26,9 +26,9 @@ dependencies {
     api(libs.okhttp)
     api(libs.retrofit)
 
-    implementation(libs.jacksonModuleKotlin)
-    implementation(libs.kotlinxCoroutines)
-    implementation(libs.retrofitConverterJackson)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.retrofit.converter.jackson)
 
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)

--- a/clients/github-graphql/build.gradle.kts
+++ b/clients/github-graphql/build.gradle.kts
@@ -44,7 +44,7 @@ graphql {
 }
 
 dependencies {
-    api(libs.ktorClientCore)
+    api(libs.ktor.client.core)
 
     implementation(libs.bundles.kotlinxSerialization)
     implementation(libs.graphQlKtorClient)

--- a/clients/nexus-iq/build.gradle.kts
+++ b/clients/nexus-iq/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.retrofitConverterKotlinxSerialization)
+    implementation(libs.retrofit.converter.kotlinxSerialization)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/clients/oss-index/build.gradle.kts
+++ b/clients/oss-index/build.gradle.kts
@@ -30,5 +30,5 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.retrofitConverterKotlinxSerialization)
+    implementation(libs.retrofit.converter.kotlinxSerialization)
 }

--- a/clients/osv/build.gradle.kts
+++ b/clients/osv/build.gradle.kts
@@ -32,10 +32,10 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.retrofitConverterKotlinxSerialization)
-    implementation(libs.retrofitConverterScalars)
+    implementation(libs.retrofit.converter.kotlinxSerialization)
+    implementation(libs.retrofit.converter.scalars)
 
-    testImplementation(libs.kotestAssertionsJson)
+    testImplementation(libs.kotest.assertions.json)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/clients/scanoss/build.gradle.kts
+++ b/clients/scanoss/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.retrofitConverterKotlinxSerialization)
+    implementation(libs.retrofit.converter.kotlinxSerialization)
 
     testImplementation(libs.wiremock)
 }

--- a/clients/vulnerable-code/build.gradle.kts
+++ b/clients/vulnerable-code/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
-    implementation(libs.retrofitConverterKotlinxSerialization)
+    implementation(libs.retrofit.converter.kotlinxSerialization)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -26,10 +26,10 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.detektApi)
+    compileOnly(libs.detekt.api)
 
-    testImplementation(libs.detektApi)
-    testImplementation(libs.detektTest)
+    testImplementation(libs.detekt.api)
+    testImplementation(libs.detekt.test)
 }
 
 configurations.all {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,77 +73,79 @@ kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versio
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]
+# These are Maven coordinates for Gradle plugins, which is necessary to use them in precompiled plugin scripts.
+plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
+plugin-dokkatoo = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version.ref = "dokkatooPlugin" }
+plugin-graalVmNativeImage = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "graalVmNativeImagePlugin" }
+plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
+
 antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
-asciidoctorjPdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = "asciidoctorjPdf" }
+asciidoctorj-pdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = "asciidoctorjPdf" }
 awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 cvssCalculator = { module = "us.springett:cvss-calculator", version.ref = "cvssCalculator" }
 cyclonedx = { module = "org.cyclonedx:cyclonedx-core-java", version.ref = "cyclonedx" }
-detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
-detektApi = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detektPlugin" }
-detektTest = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detektPlugin" }
+detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detektPlugin" }
+detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detektPlugin" }
 diffUtils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "diffUtils" }
 diskLruCache = { module = "com.jakewharton:disklrucache", version.ref = "diskLruCache" }
-dokkatooPlugin = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version.ref = "dokkatooPlugin" }
-exposedCore = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
-exposedDao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
-exposedJavaTime = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
-exposedJdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
-exposedJson = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+exposed-javaTime = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
 flexmark = { module = "com.vladsch.flexmark:flexmark", version.ref = "flexmark" }
 freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
-graalVmNativeImagePlugin = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "graalVmNativeImagePlugin" }
 graphQlKtorClient = { module = "com.expediagroup:graphql-kotlin-ktor-client", version.ref = "graphQlPlugin" }
 greenmail = { module = "com.icegreen:greenmail", version.ref = "greenmail" }
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
-hopliteCore = { module = "com.sksamuel.hoplite:hoplite-core", version.ref = "hoplite" }
-hopliteYaml = { module = "com.sksamuel.hoplite:hoplite-yaml", version.ref = "hoplite" }
-jacksonAnnotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-jacksonCore = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
-jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
-jacksonDataformatXml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
-jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
-jacksonDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
-jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+hoplite-core = { module = "com.sksamuel.hoplite:hoplite-core", version.ref = "hoplite" }
+hoplite-yaml = { module = "com.sksamuel.hoplite:hoplite-yaml", version.ref = "hoplite" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jakartaMail = { module = "com.sun.mail:jakarta.mail", version.ref = "jakartaMail" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
-jgitSshApache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit" }
-jgitSshApacheAgent = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent", version.ref = "jgit" }
-jiraRestClientApi = { module = "com.atlassian.jira:jira-rest-java-client-api", version.ref = "jiraRestClient" }
-jiraRestClientApp = { module = "com.atlassian.jira:jira-rest-java-client-app", version.ref = "jiraRestClient" }
+jgit-ssh-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit" }
+jgit-ssh-apache-agent = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent", version.ref = "jgit" }
+jiraRestClient-api = { module = "com.atlassian.jira:jira-rest-java-client-api", version.ref = "jiraRestClient" }
+jiraRestClient-app = { module = "com.atlassian.jira:jira-rest-java-client-app", version.ref = "jiraRestClient" }
 jruby = { module = "org.jruby:jruby", version.ref = "jruby" }
 jslt = { module = "com.schibsted.spt.data:jslt", version.ref = "jslt" }
 jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
-kotestAssertionsCore = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-kotestAssertionsJson = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }
-kotestExtensionsJunitXml = { module = "io.kotest:kotest-extensions-junitxml", version.ref = "kotest" }
-kotestFrameworkApi = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
-kotestFrameworkEngine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
-kotestRunnerJunit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
-kotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
-kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
-kotlinxHtml = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinxHtml" }
-kotlinxSerializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
-kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }
+kotest-extensions-junitXml = { module = "io.kotest:kotest-extensions-junitxml", version.ref = "kotest" }
+kotest-framework-api = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
+kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinxHtml" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version.ref = "tomlkt" }
-ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktorClientOkHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
-log4jApi = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4jApi" }
-log4jApiKotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4jApiKotlin" }
-log4jApiToSlf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4jApi" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4jApi" }
+log4j-api-kotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4jApiKotlin" }
+log4j-api-slf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4jApi" }
 logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-mavenCompat = { module = "org.apache.maven:maven-compat", version.ref = "maven" }
-mavenCore = { module = "org.apache.maven:maven-core", version.ref = "maven" }
-mavenModel = { module = "org.apache.maven:maven-model", version.ref = "maven" }
-mavenModelBuilder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven" }
-mavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
-mavenResolverApi = { module = "org.apache.maven.resolver:maven-resolver-api", version.ref = "mavenResolver" }
-mavenResolverConnectorBasic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "mavenResolver" }
-mavenResolverTransportFile = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref = "mavenResolver" }
-mavenResolverTransportHttp = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "mavenResolver" }
-mavenResolverTransportWagon = { module = "org.apache.maven.resolver:maven-resolver-transport-wagon", version.ref = "mavenResolver" }
+maven-compat = { module = "org.apache.maven:maven-compat", version.ref = "maven" }
+maven-core = { module = "org.apache.maven:maven-core", version.ref = "maven" }
+maven-model = { module = "org.apache.maven:maven-model", version.ref = "maven" }
+maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven" }
+maven-resolver-api = { module = "org.apache.maven.resolver:maven-resolver-api", version.ref = "mavenResolver" }
+maven-resolver-connector-basic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "mavenResolver" }
+maven-resolver-transport-file = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref = "mavenResolver" }
+maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "mavenResolver" }
+maven-resolver-transport-wagon = { module = "org.apache.maven.resolver:maven-resolver-transport-wagon", version.ref = "mavenResolver" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mordant = { module = "com.github.ajalt.mordant:mordant", version.ref = "mordant" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
@@ -151,9 +153,9 @@ postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 postgresEmbedded = { module = "com.opentable.components:otj-pg-embedded", version.ref = "postgresEmbedded" }
 reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofitConverterJackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "retrofit" }
-retrofitConverterKotlinxSerialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitConverterKotlinxSerialization" }
-retrofitConverterScalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
+retrofit-converter-jackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "retrofit" }
+retrofit-converter-kotlinxSerialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitConverterKotlinxSerialization" }
+retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 saxonHe = { module = "net.sf.saxon:Saxon-HE", version.ref = "saxonHe" }
 scanoss = { module = "com.scanoss:scanner", version.ref = "scanoss" }
 semver4j = { module = "org.semver4j:semver4j", version.ref = "semver4j" }
@@ -165,7 +167,7 @@ wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 xz = { module = "org.tukaani:xz", version.ref = "xz" }
 
 [bundles]
-exposed = ["exposedCore", "exposedDao", "exposedJdbc", "exposedJavaTime", "exposedJson"]
-hoplite = ["hopliteCore", "hopliteYaml"]
-kotlinxSerialization = ["kotlinxSerializationCore", "kotlinxSerializationJson"]
-mavenResolver = ["mavenResolverConnectorBasic", "mavenResolverTransportFile", "mavenResolverTransportHttp", "mavenResolverTransportWagon"]
+exposed = ["exposed-core", "exposed-dao", "exposed-jdbc", "exposed-javaTime", "exposed-json"]
+hoplite = ["hoplite-core", "hoplite-yaml"]
+kotlinxSerialization = ["kotlinx-serialization-core", "kotlinx-serialization-json"]
+mavenResolver = ["maven-resolver-connector-basic", "maven-resolver-transport-file", "maven-resolver-transport-http", "maven-resolver-transport-wagon"]

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -43,11 +43,11 @@ dependencies {
 
     implementation(libs.clikt)
     implementation(libs.commonsCompress)
-    implementation(libs.exposedCore)
+    implementation(libs.exposed.core)
     implementation(libs.hikari)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.module.kotlin)
     implementation(libs.jslt)
-    implementation(libs.log4jApi)
+    implementation(libs.log4j.api)
     implementation(libs.slf4j)
 
     "pluginClasspath"(platform(projects.plugins.versionControlSystems))

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -27,16 +27,16 @@ dependencies {
     api(projects.utils.ortUtils)
     api(projects.utils.spdxUtils)
 
-    api(libs.jacksonDatabind)
-    api(libs.jacksonDataformatXml)
-    api(libs.jacksonDataformatYaml)
-    api(libs.log4jApi)
+    api(libs.jackson.databind)
+    api(libs.jackson.dataformat.xml)
+    api(libs.jackson.dataformat.yaml)
+    api(libs.log4j.api)
 
     implementation(libs.bundles.exposed)
     implementation(libs.bundles.hoplite)
     implementation(libs.hikari)
-    implementation(libs.jacksonDatatypeJsr310)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.datatype.jsr310)
+    implementation(libs.jackson.module.kotlin)
     implementation(libs.postgres)
     implementation(libs.semver4j)
 

--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-scripting-common")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm-host")
     implementation(libs.jakartaMail)
-    implementation(libs.jiraRestClientApi)
-    implementation(libs.jiraRestClientApp) {
+    implementation(libs.jiraRestClient.api)
+    implementation(libs.jiraRestClient.app) {
         exclude("org.slf4j", "slf4j-log4j12")
             .because("the SLF4J implementation from Log4j 2 is used")
     }

--- a/plugins/advisors/github/build.gradle.kts
+++ b/plugins/advisors/github/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation(projects.utils.commonUtils)
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.kotlinxCoroutines)
-    implementation(libs.ktorClientOkHttp)
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.ktor.client.okHttp)
 
     testImplementation(libs.mockk)
 }

--- a/plugins/commands/advisor/build.gradle.kts
+++ b/plugins/commands/advisor/build.gradle.kts
@@ -31,5 +31,5 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     implementation(libs.clikt)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 }

--- a/plugins/commands/api/build.gradle.kts
+++ b/plugins/commands/api/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
 
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
 }

--- a/plugins/commands/compare/build.gradle.kts
+++ b/plugins/commands/compare/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
 
     implementation(libs.clikt)
     implementation(libs.diffUtils)
-    implementation(libs.jacksonDataformatYaml)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.module.kotlin)
 }

--- a/plugins/commands/config/build.gradle.kts
+++ b/plugins/commands/config/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(projects.utils.commonUtils)
 
     implementation(libs.clikt)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonDataformatYaml)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.module.kotlin)
 }

--- a/plugins/commands/downloader/build.gradle.kts
+++ b/plugins/commands/downloader/build.gradle.kts
@@ -32,5 +32,5 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     implementation(libs.clikt)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 }

--- a/plugins/commands/migrate/build.gradle.kts
+++ b/plugins/commands/migrate/build.gradle.kts
@@ -30,5 +30,5 @@ dependencies {
     implementation(projects.utils.commonUtils)
 
     implementation(libs.clikt)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.module.kotlin)
 }

--- a/plugins/commands/reporter/build.gradle.kts
+++ b/plugins/commands/reporter/build.gradle.kts
@@ -36,5 +36,5 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     implementation(libs.clikt)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 }

--- a/plugins/commands/scanner/build.gradle.kts
+++ b/plugins/commands/scanner/build.gradle.kts
@@ -31,5 +31,5 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     implementation(libs.clikt)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 }

--- a/plugins/package-managers/bower/build.gradle.kts
+++ b/plugins/package-managers/bower/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonDatabind)
+    implementation(libs.jackson.databind)
 
     funTestImplementation(testFixtures(projects.analyzer))
 }

--- a/plugins/package-managers/bundler/build.gradle.kts
+++ b/plugins/package-managers/bundler/build.gradle.kts
@@ -31,9 +31,9 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonDataformatYaml)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
     implementation(libs.jruby)
 
     funTestImplementation(testFixtures(projects.analyzer))

--- a/plugins/package-managers/carthage/build.gradle.kts
+++ b/plugins/package-managers/carthage/build.gradle.kts
@@ -31,9 +31,9 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.module.kotlin)
 
     funTestImplementation(testFixtures(projects.analyzer))
 

--- a/plugins/package-managers/cocoapods/build.gradle.kts
+++ b/plugins/package-managers/cocoapods/build.gradle.kts
@@ -37,10 +37,10 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonAnnotations)
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonDataformatYaml)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
 
     funTestImplementation(testFixtures(projects.analyzer))
 }

--- a/plugins/package-managers/composer/build.gradle.kts
+++ b/plugins/package-managers/composer/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonDatabind)
+    implementation(libs.jackson.databind)
 
     funTestImplementation(testFixtures(projects.analyzer))
 }

--- a/plugins/package-managers/conan/build.gradle.kts
+++ b/plugins/package-managers/conan/build.gradle.kts
@@ -37,10 +37,10 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonDataformatYaml)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.module.kotlin)
 
     funTestImplementation(testFixtures(projects.analyzer))
 }

--- a/plugins/package-managers/gradle-plugin/build.gradle.kts
+++ b/plugins/package-managers/gradle-plugin/build.gradle.kts
@@ -35,8 +35,8 @@ gradlePlugin {
 dependencies {
     api(projects.plugins.packageManagers.gradleModel)
 
-    api(libs.mavenModel)
-    api(libs.mavenModelBuilder)
+    api(libs.maven.model)
+    api(libs.maven.model.builder)
 }
 
 tasks.register<Jar>("fatJar") {

--- a/plugins/package-managers/gradle/build.gradle.kts
+++ b/plugins/package-managers/gradle/build.gradle.kts
@@ -33,8 +33,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     implementation("org.gradle:gradle-tooling-api:${gradle.gradleVersion}")
-    implementation(libs.mavenCore)
-    implementation(libs.mavenResolverApi)
+    implementation(libs.maven.core)
+    implementation(libs.maven.resolver.api)
 
     funTestImplementation(testFixtures(projects.analyzer))
 

--- a/plugins/package-managers/maven/build.gradle.kts
+++ b/plugins/package-managers/maven/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
     api(projects.analyzer)
     api(projects.model)
 
-    api(libs.mavenCore)
-    api(libs.mavenResolverApi)
+    api(libs.maven.core)
+    api(libs.maven.resolver.api)
 
     implementation(projects.downloader)
     implementation(projects.utils.commonUtils)
@@ -37,7 +37,7 @@ dependencies {
     runtimeOnly(libs.bundles.mavenResolver)
 
     // TODO: Remove this once https://issues.apache.org/jira/browse/MNG-6561 is resolved.
-    runtimeOnly(libs.mavenCompat)
+    runtimeOnly(libs.maven.compat)
 
     funTestImplementation(testFixtures(projects.analyzer))
 

--- a/plugins/package-managers/node/build.gradle.kts
+++ b/plugins/package-managers/node/build.gradle.kts
@@ -33,17 +33,17 @@ dependencies {
         because("This is a CommandLineTool.")
     }
 
-    api(libs.jacksonDatabind)
+    api(libs.jackson.databind)
 
     implementation(projects.downloader)
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonAnnotations)
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDataformatYaml)
-    implementation(libs.jacksonModuleKotlin)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.kotlinx.coroutines)
 
     funTestImplementation(testFixtures(projects.analyzer))
 

--- a/plugins/package-managers/pub/build.gradle.kts
+++ b/plugins/package-managers/pub/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonDataformatYaml)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
 
     funTestImplementation(projects.plugins.packageManagers.gradlePackageManager)
 

--- a/plugins/package-managers/spdx/build.gradle.kts
+++ b/plugins/package-managers/spdx/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
     implementation(libs.okhttp)
 
     funTestImplementation(projects.plugins.packageManagers.conanPackageManager)

--- a/plugins/package-managers/stack/build.gradle.kts
+++ b/plugins/package-managers/stack/build.gradle.kts
@@ -37,10 +37,10 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonAnnotations)
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.module.kotlin)
 
     funTestImplementation(testFixtures(projects.analyzer))
 }

--- a/plugins/reporters/asciidoc/build.gradle.kts
+++ b/plugins/reporters/asciidoc/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     implementation(libs.asciidoctorj)
 
-    runtimeOnly(libs.asciidoctorjPdf)
+    runtimeOnly(libs.asciidoctorj.pdf)
 
     funTestImplementation(testFixtures(projects.reporter))
 }

--- a/plugins/reporters/cyclonedx/build.gradle.kts
+++ b/plugins/reporters/cyclonedx/build.gradle.kts
@@ -34,5 +34,5 @@ dependencies {
 
     funTestImplementation(testFixtures(projects.reporter))
 
-    funTestImplementation(libs.kotestAssertionsJson)
+    funTestImplementation(libs.kotest.assertions.json)
 }

--- a/plugins/reporters/evaluated-model/build.gradle.kts
+++ b/plugins/reporters/evaluated-model/build.gradle.kts
@@ -27,13 +27,13 @@ dependencies {
     api(projects.reporter)
     api(projects.utils.spdxUtils)
 
-    api(libs.jacksonAnnotations)
-    api(libs.jacksonDatabind)
+    api(libs.jackson.annotations)
+    api(libs.jackson.databind)
 
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDataformatYaml)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.dataformat.yaml)
 
     funTestImplementation(testFixtures(projects.reporter))
 }

--- a/plugins/reporters/fossid/build.gradle.kts
+++ b/plugins/reporters/fossid/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(projects.utils.commonUtils)
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 
     testImplementation(libs.mockk)
 }

--- a/plugins/reporters/opossum/build.gradle.kts
+++ b/plugins/reporters/opossum/build.gradle.kts
@@ -31,6 +31,6 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonAnnotations)
-    implementation(libs.jacksonDatabind)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.databind)
 }

--- a/plugins/reporters/spdx/build.gradle.kts
+++ b/plugins/reporters/spdx/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jacksonDatabind)
+    implementation(libs.jackson.databind)
 
     funTestImplementation(libs.jsonSchemaValidator)
 }

--- a/plugins/reporters/static-html/build.gradle.kts
+++ b/plugins/reporters/static-html/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     implementation(libs.flexmark)
-    implementation(libs.kotlinxHtml)
+    implementation(libs.kotlinx.html)
 
     // This is required to not depend on the version of Apache Xalan bundled with the JDK. Otherwise, the formatting of
     // the HTML generated in StaticHtmlReporter is slightly different with different Java versions.

--- a/plugins/reporters/trustsource/build.gradle.kts
+++ b/plugins/reporters/trustsource/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
     funTestImplementation(testFixtures(projects.reporter))
 
-    funTestImplementation(libs.kotestAssertionsJson)
+    funTestImplementation(libs.kotest.assertions.json)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/plugins/scanners/fossid/build.gradle.kts
+++ b/plugins/scanners/fossid/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)

--- a/plugins/scanners/scanoss/build.gradle.kts
+++ b/plugins/scanners/scanoss/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(projects.utils.commonUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
     implementation(libs.scanoss)
 
     funTestApi(testFixtures(projects.scanner))

--- a/plugins/version-control-systems/git/build.gradle.kts
+++ b/plugins/version-control-systems/git/build.gradle.kts
@@ -35,13 +35,13 @@ dependencies {
 
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-    implementation(libs.jacksonDataformatXml)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.xml)
     implementation(libs.jgit)
-    implementation(libs.jgitSshApache)
+    implementation(libs.jgit.ssh.apache)
 
-    runtimeOnly(libs.jgitSshApacheAgent) {
+    runtimeOnly(libs.jgit.ssh.apache.agent) {
         exclude(group = "org.apache.sshd", module = "sshd-sftp")
             .because("it is not required for cloning via SSH and causes issues with GraalVM native images")
     }

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     // Only the Java plugin's built-in "test" source set automatically depends on the test fixtures.
     funTestImplementation(testFixtures(project))
 
-    funTestImplementation(libs.kotestAssertionsJson)
+    funTestImplementation(libs.kotest.assertions.json)
 
     testFixturesImplementation(projects.utils.testUtils)
 }

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -36,10 +36,10 @@ dependencies {
 
     implementation(libs.bundles.exposed)
     implementation(libs.hikari)
-    implementation(libs.jacksonModuleKotlin)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.kotlinx.coroutines)
     implementation(libs.postgres)
-    implementation(libs.retrofitConverterJackson)
+    implementation(libs.retrofit.converter.jackson)
     implementation(libs.sw360Client)
 
     funTestApi(testFixtures(projects.scanner))
@@ -51,11 +51,11 @@ dependencies {
 
     testImplementation(libs.bundles.kotlinxSerialization)
     testImplementation(libs.mockk)
-    testImplementation(libs.retrofitConverterKotlinxSerialization)
+    testImplementation(libs.retrofit.converter.kotlinxSerialization)
     testImplementation(libs.wiremock)
 
-    testFixturesImplementation(libs.kotestAssertionsCore)
-    testFixturesImplementation(libs.kotestRunnerJunit5)
+    testFixturesImplementation(libs.kotest.assertions.core)
+    testFixturesImplementation(libs.kotest.runner.junit5)
 }
 
 tasks.named<KotlinCompile>("compileTestKotlin") {

--- a/utils/common/build.gradle.kts
+++ b/utils/common/build.gradle.kts
@@ -24,11 +24,11 @@ plugins {
 
 dependencies {
     api(libs.commonsCompress)
-    api(libs.jacksonDatabind)
+    api(libs.jackson.databind)
     api(libs.semver4j)
 
     implementation(libs.diskLruCache)
-    implementation(libs.log4jApi)
+    implementation(libs.log4j.api)
     implementation(libs.springCore)
 
     runtimeOnly(libs.xz)

--- a/utils/ort/build.gradle.kts
+++ b/utils/ort/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
     implementation(libs.awsS3)
     implementation(libs.commonsCompress)
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 
     testImplementation(libs.mockk)
 }

--- a/utils/scripting/build.gradle.kts
+++ b/utils/scripting/build.gradle.kts
@@ -30,5 +30,5 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm-host")
-    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinx.coroutines)
 }

--- a/utils/spdx/build.gradle.kts
+++ b/utils/spdx/build.gradle.kts
@@ -72,15 +72,15 @@ sourceSets.configureEach {
 dependencies {
     antlr(libs.antlr)
 
-    api(libs.jacksonDatabind)
+    api(libs.jackson.databind)
 
     implementation(projects.utils.commonUtils)
 
-    implementation(libs.jacksonDataformatYaml)
-    implementation(libs.jacksonDatatypeJsr310)
-    implementation(libs.jacksonModuleKotlin)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.datatype.jsr310)
+    implementation(libs.jackson.module.kotlin)
 
-    testImplementation(libs.kotestAssertionsJson)
+    testImplementation(libs.kotest.assertions.json)
 }
 
 if (Authenticator.getDefault() == null) {

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -26,18 +26,18 @@ dependencies {
     api(projects.model)
     api(projects.plugins.versionControlSystems.gitVersionControlSystem)
 
-    api(libs.kotestAssertionsCore)
-    api(libs.kotestFrameworkApi)
+    api(libs.kotest.assertions.core)
+    api(libs.kotest.framework.api)
 
     implementation(projects.downloader)
     implementation(projects.utils.ortUtils)
 
     implementation(libs.diffUtils)
-    implementation(libs.jacksonModuleKotlin)
-    implementation(libs.kotestExtensionsJunitXml)
-    implementation(libs.kotestFrameworkEngine)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.kotest.extensions.junitXml)
+    implementation(libs.kotest.framework.engine)
     implementation(libs.postgresEmbedded)
 
-    runtimeOnly(libs.log4jApiToSlf4j)
+    runtimeOnly(libs.log4j.api.slf4j)
     runtimeOnly(libs.logbackClassic)
 }


### PR DESCRIPTION
Use dashes in `libs.versions.toml` to group dependencies to improve overview. For example, `libs.jacksonDataformatXml` becomes `libs.jackson.dataformat.xml`.