### PR TITLE
build(Gradle): Do not apply the built-in `maven-publish` plugin anymore

### DIFF
--- a/buildSrc/src/main/kotlin/ort-plugins-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-plugins-conventions.gradle.kts
@@ -20,7 +20,6 @@
 plugins {
     // Apply core plugins.
     `java-platform`
-    `maven-publish`
 
     // Apply precompiled plugins.
     id("ort-base-conventions")


### PR DESCRIPTION
This is a fixup for bae6ef3.