### PR TITLE
build(Gradle): Explicitly set name for `buildSrc` module

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+rootProject.name = "buildSrc"
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
This silences the following warning which was introduced with e769b0b:

  Project accessors enabled, but root project name not explicitly set
  for 'buildSrc'. Checking out the project in different folders will
  impact the generated code and implicitly the buildscript classpath,
  breaking caching.
