### PR TITLE
refactor(downloader): Use more specific provenance return types

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -95,7 +95,7 @@ class Downloader(private val config: DownloaderConfiguration) {
         outputDirectory: File,
         dryRun: Boolean,
         exception: DownloadException
-    ): Provenance? {
+    ): RepositoryProvenance? {
         val vcsMark = TimeSource.Monotonic.markNow()
 
         try {
@@ -105,10 +105,10 @@ class Downloader(private val config: DownloaderConfiguration) {
 
             if (!isCargoPackageWithSourceArtifact) {
                 val result = downloadFromVcs(pkg, outputDirectory, dryRun = dryRun)
-                val vcsInfo = (result as RepositoryProvenance).vcsInfo
 
                 logger.info {
-                    "Downloaded source code for '${pkg.id.toCoordinates()}' from $vcsInfo in ${vcsMark.elapsedNow()}."
+                    "Downloaded source code for '${pkg.id.toCoordinates()}' from ${result.vcsInfo} in " +
+                        "${vcsMark.elapsedNow()}."
                 }
 
                 return result
@@ -144,7 +144,7 @@ class Downloader(private val config: DownloaderConfiguration) {
         outputDirectory: File,
         dryRun: Boolean,
         exception: DownloadException
-    ): Provenance? {
+    ): ArtifactProvenance? {
         val sourceArtifactMark = TimeSource.Monotonic.markNow()
 
         try {
@@ -179,7 +179,7 @@ class Downloader(private val config: DownloaderConfiguration) {
      * Download the source code of the [package][pkg] to the [outputDirectory] using its VCS information. If [recursive]
      * is `true`, any nested repositories (like Git submodules or Mercurial subrepositories) are downloaded, too. If
      * [dryRun] is `true`, no actual download happens but the source code is only checked to be available. A
-     * [Provenance] is returned on success or a [DownloadException] is thrown in case of failure.
+     * [RepositoryProvenance] is returned on success or a [DownloadException] is thrown in case of failure.
      */
     @JvmOverloads
     fun downloadFromVcs(
@@ -187,7 +187,7 @@ class Downloader(private val config: DownloaderConfiguration) {
         outputDirectory: File,
         recursive: Boolean = true,
         dryRun: Boolean = false
-    ): Provenance {
+    ): RepositoryProvenance {
         if (pkg.vcsProcessed.url.isBlank()) {
             val hint = when (pkg.id.type) {
                 "Bundler", "Gem" ->
@@ -300,14 +300,14 @@ class Downloader(private val config: DownloaderConfiguration) {
 
     /**
      * Download the [sourceArtifact] and unpack it to the [outputDirectory]. If [dryRun] is `true`, no actual download
-     * happens but the source code is only checked to be available. A [Provenance] is returned on success or a
+     * happens but the source code is only checked to be available. An [ArtifactProvenance] is returned on success or a
      * [DownloadException] is thrown in case of failure.
      */
     fun downloadSourceArtifact(
         sourceArtifact: RemoteArtifact,
         outputDirectory: File,
         dryRun: Boolean = false
-    ): Provenance {
+    ): ArtifactProvenance {
         if (sourceArtifact.url.isBlank()) {
             throw DownloadException("No source artifact URL provided.")
         }


### PR DESCRIPTION
A VCS download can only return a `RepositoryProvenance` and an artifact download can only return an `ArtifactProvenance`. The previous code could have also raised the question how `Provenance?` and `UnknownProvenance` are semantically different, which is now not the case anymore as only a `KnownProvenance` is ever returned.