### PR TITLE
Use `<pre>` block for issue messages

### DIFF
--- a/plugins/reporters/web-app-template/src/components/IssuesTable.js
+++ b/plugins/reporters/web-app-template/src/components/IssuesTable.js
@@ -205,6 +205,7 @@ class IssuesTable extends React.Component {
                 key: 'message',
                 textWrap: 'word-break',
                 title: 'Message',
+                render: (text) => <pre>{text}</pre>,
                 ...getColumnSearchProps('message', filteredInfo, this)
             }
         );


### PR DESCRIPTION
Issue messages are mostly pre-formatted tool output, with linebreaks and alignment in the string. Wrapping the messages in `<pre>` blocks preserves this when displaying the messages, making them easier to read and understand.