### PR TITLE
fix(node): Strip a trailing "/" before creating globs

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm-workspaces/pnpm-workspace.yaml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm-workspaces/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
+  - 'src/app/'
   - 'src/packages/**'
-  - 'src/app/**'

--- a/plugins/package-managers/node/src/main/kotlin/utils/NpmDetection.kt
+++ b/plugins/package-managers/node/src/main/kotlin/utils/NpmDetection.kt
@@ -51,7 +51,9 @@ class NpmDetection(private val definitionFiles: Collection<File>) {
         definitionFiles.associate { file ->
             val projectDir = file.parentFile
             val patterns = NodePackageManager.entries.mapNotNull { it.getWorkspaces(projectDir) }.flatten()
-            projectDir to patterns.map { FileSystems.getDefault().getPathMatcher("glob:$it") }
+            projectDir to patterns.map {
+                FileSystems.getDefault().getPathMatcher("glob:${it.removeSuffix("/")}")
+            }
         }
     }
 

--- a/plugins/package-managers/node/src/test/kotlin/utils/NpmDetectionTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/utils/NpmDetectionTest.kt
@@ -184,7 +184,7 @@ class NpmDetectionTest : WordSpec({
             PNPM.getWorkspaces(projectDir) shouldNotBeNull {
                 mapNotNull {
                     it.withoutPrefix(projectDir.path)
-                }.shouldContainExactly("/src/packages/**", "/src/app/**")
+                }.shouldContainExactly("/src/app/", "/src/packages/**")
             }
         }
 


### PR DESCRIPTION
Otherwise paths will not be matched correctly. This fixes a regression from f99e2ed which did contain the `removeSuffix("/")` call, at least for PNPM.