### PR TITLE
chore(model): Make newly added PURL extension function public

### DIFF
--- a/model/src/main/kotlin/utils/PurlExtensions.kt
+++ b/model/src/main/kotlin/utils/PurlExtensions.kt
@@ -79,7 +79,7 @@ fun Identifier.toPurl(extras: PurlExtras) = toPurl(extras.qualifiers, extras.sub
 /**
  * Encode a [KnownProvenance] to extra qualifying data / a subpath of PURL.
  */
-internal fun KnownProvenance.toPurlExtras(): PurlExtras =
+fun KnownProvenance.toPurlExtras(): PurlExtras =
     when (this) {
         is ArtifactProvenance -> with(sourceArtifact) {
             val checksum = "${hash.algorithm.name.lowercase()}:${hash.value}"
@@ -104,7 +104,7 @@ internal fun KnownProvenance.toPurlExtras(): PurlExtras =
  * Decode [Provenance] from extra qualifying data / a subpath of the PURL represented by this [String]. Return
  * [UnknownProvenance] if extra data is not present.
  */
-internal fun String.toProvenance(): Provenance {
+fun String.toProvenance(): Provenance {
     val extras = substringAfter('?')
 
     fun getQualifierValue(name: String) = extras.substringAfter("$name=").substringBefore('&')


### PR DESCRIPTION
This is a fixup for 758fd7a to be able to use these functions from plugins.