### PR TITLE
fix(common-utils): Do not extract TAR directory entries as files

### DIFF
--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -258,7 +258,9 @@ fun InputStream.unpackZip(targetDirectory: File) =
 fun InputStream.unpackTar(targetDirectory: File, filter: (ArchiveEntry) -> Boolean = { true }) =
     TarArchiveInputStream(this).unpack(
         targetDirectory,
-        { entry -> !(entry as TarArchiveEntry).isFile || File(entry.name).isAbsolute || !filter(entry) },
+        { entry ->
+            (entry as TarArchiveEntry).isDirectory || !entry.isFile || File(entry.name).isAbsolute || !filter(entry)
+        },
         { entry -> (entry as TarArchiveEntry).mode }
     )
 


### PR DESCRIPTION
This works around [1]. Still keep the `isFile` check to be on the safe side and e.g. skip links.

Resolves #8098.

[1]: https://issues.apache.org/jira/browse/COMPRESS-657