### PR TITLE
fix(scanner): Keep the VCS path for a package scanner's reference package

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -60,13 +60,14 @@ data class ArtifactProvenance(
  */
 data class RepositoryProvenance(
     /**
-     * The VCS repository that was downloaded.
+     * The VCS information that was used for [resolving the revision][resolvedRevision]. It potentially still contains
+     * an unresolved "moving" VCS revision (e.g. a branch or tag name).
      */
     val vcsInfo: VcsInfo,
 
     /**
-     * The VCS revision of the source code that was downloaded, resolved from [vcsInfo] during download. Must not be
-     * blank, and must also be fixed revision, e.g. the SHA1 of a Git commit instead of a branch or tag name.
+     * The VCS revision resolved from [VCS information][vcsInfo]. It must neither be blank nor a "moving" VCS revision
+     * like a branch or tag name, but a fixed revision (e.g. the SHA1 of a Git commit).
      */
     val resolvedRevision: String
 ) : KnownProvenance {

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -252,10 +252,6 @@ class FossId internal constructor(
             pkg.vcsProcessed.revision.isEmpty() ->
                 "Package '${pkg.id.toCoordinates()}' has an empty VCS revision and cannot be scanned."
 
-            pkg.vcsProcessed.path.isNotEmpty() ->
-                "Ignoring package '${pkg.id.toCoordinates()}' from '${pkg.vcsProcessed.url}' as it has path " +
-                    "'${pkg.vcsProcessed.path}' set and scanning cannot be limited to paths."
-
             else -> null
         }
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -64,7 +64,6 @@ import org.ossreviewtoolkit.clients.fossid.model.status.ScanStatus
 import org.ossreviewtoolkit.clients.fossid.runScan
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Issue
-import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
@@ -236,11 +235,12 @@ class FossId internal constructor(
     private fun createSingleIssueSummary(startTime: Instant, issue: Issue) =
         ScanSummary.EMPTY.copy(startTime = startTime, endTime = Instant.now(), issues = listOf(issue))
 
-    override fun scanPackage(pkg: Package, nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult {
+    override fun scanPackage(nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult {
         val startTime = Instant.now()
 
         // FossId actually never uses the provenance determined by the scanner, but determines the source code to
-        // download itself based on the passed VCS information.
+        // download itself based on the passed VCS URL and revision, disregarding any VCS path.
+        val pkg = context.coveredPackages.first()
         val provenance = pkg.vcsProcessed.revision.takeUnless { it.isBlank() }
             ?.let { RepositoryProvenance(pkg.vcsProcessed, it) } ?: UnknownProvenance
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -560,6 +560,7 @@ class FossIdTest : WordSpec({
             val projectCode = projectCode(PROJECT)
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
+            val pkgId = createIdentifier(index = 1)
             val vcsInfo = createVcsInfo()
 
             val service = FossIdRestService.create(config.serverUrl)
@@ -586,15 +587,7 @@ class FossIdTest : WordSpec({
 
             shouldTimeout(1000.milliseconds) {
                 runInterruptible {
-                    fossId.scanPackage(
-                        createPackage(createIdentifier(index = 1), vcsInfo),
-                        null,
-                        ScanContext(
-                            labels = emptyMap(),
-                            packageType = PackageType.PACKAGE,
-                            Excludes()
-                        )
-                    )
+                    fossId.scan(createPackage(pkgId, vcsInfo))
                 }
             }
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -91,6 +91,7 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Snippet as OrtSnippet
@@ -107,6 +108,7 @@ import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SERVER_URL_
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.convertGitUrlToProjectName
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
+import org.ossreviewtoolkit.scanner.provenance.NestedProvenance
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 @Suppress("LargeClass")
@@ -1128,8 +1130,8 @@ private const val API_KEY = "fossId-API-key"
 /** A test project name. */
 private const val PROJECT = "fossId-test-project"
 
-/** A test revision. */
-private const val REVISION = "test-revision"
+/** A (resolved) test revision. */
+private const val REVISION = "0123456789012345678901234567890123456789"
 
 /** The version to be reported by the FossID server. */
 private const val FOSSID_VERSION = "2021.2.2"
@@ -1595,4 +1597,19 @@ private fun FossId.scan(
     pkg: Package,
     labels: Map<String, String> = emptyMap(),
     excludes: Excludes = Excludes()
-): ScanResult = scanPackage(pkg, null, ScanContext(labels, PackageType.PACKAGE, excludes))
+): ScanResult =
+    scanPackage(
+        nestedProvenance = NestedProvenance(
+            root = RepositoryProvenance(
+                vcsInfo = pkg.vcsProcessed,
+                resolvedRevision = pkg.vcsProcessed.revision
+            ),
+            subRepositories = emptyMap()
+        ),
+        context = ScanContext(
+            labels = labels,
+            packageType = PackageType.PACKAGE,
+            excludes = excludes,
+            coveredPackages = listOf(pkg)
+        )
+    )

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -335,14 +335,7 @@ class Scanner(
                     return@scanner
                 }
 
-                // Create a reference package with any VCS path removed, to ensure the full repository is scanned.
-                val referencePackage = packagesWithIncompleteScanResult.first().let { pkg ->
-                    if (provenance is RepositoryProvenance) {
-                        pkg.copy(vcsProcessed = pkg.vcsProcessed.copy(path = ""))
-                    } else {
-                        pkg
-                    }
-                }
+                val referencePackage = packagesWithIncompleteScanResult.first()
 
                 if (packagesWithIncompleteScanResult.size > 1) {
                     logger.info {

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -336,6 +336,7 @@ class Scanner(
                 }
 
                 val referencePackage = packagesWithIncompleteScanResult.first()
+                val nestedProvenance = controller.getNestedProvenance(referencePackage.id) ?: return@scanner
 
                 if (packagesWithIncompleteScanResult.size > 1) {
                     logger.info {
@@ -367,7 +368,6 @@ class Scanner(
                 }
 
                 packagesWithIncompleteScanResult.forEach processResults@{ pkg ->
-                    val nestedProvenance = controller.getNestedProvenance(pkg.id) ?: return@processResults
                     val nestedProvenanceScanResult = scanResult.toNestedProvenanceScanResult(nestedProvenance)
                     controller.addNestedScanResult(scanner, nestedProvenanceScanResult)
 

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -84,7 +84,7 @@ sealed interface ScannerWrapper {
  * A wrapper interface for scanners that operate on [Package]s and download the package source code themselves.
  */
 interface PackageScannerWrapper : ScannerWrapper {
-    fun scanPackage(pkg: Package, nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult
+    fun scanPackage(nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult
 }
 
 /**

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -133,9 +133,9 @@ class ScannerTest : WordSpec({
             val pkgWithVcs = Package.new(name = "repository").withValidVcs()
 
             val scannerWrapper = spyk(FakePackageScannerWrapper()) {
-                every { scanPackage(pkgWithArtifact, any(), any()) } returns
+                every { scanPackage(any(), any()) } returns
                     createScanResult(pkgWithArtifact.artifactProvenance(), details)
-                every { scanPackage(pkgWithVcs, any(), any()) } returns
+                every { scanPackage(any(), any()) } returns
                     createScanResult(pkgWithVcs.repositoryProvenance(), details)
             }
 
@@ -159,8 +159,8 @@ class ScannerTest : WordSpec({
             )
 
             verify(exactly = 1) {
-                scannerWrapper.scanPackage(pkgWithArtifact, any(), any())
-                scannerWrapper.scanPackage(pkgWithVcs, any(), any())
+                scannerWrapper.scanPackage(any(), createContext().copy(coveredPackages = listOf(pkgWithArtifact)))
+                scannerWrapper.scanPackage(any(), createContext().copy(coveredPackages = listOf(pkgWithVcs)))
             }
         }
 
@@ -348,7 +348,7 @@ class ScannerTest : WordSpec({
             )
 
             verify(exactly = 0) {
-                scannerWrapper.scanPackage(pkgWithArtifact, any(), any())
+                scannerWrapper.scanPackage(any(), createContext().copy(coveredPackages = listOf(pkgWithArtifact)))
             }
         }
 
@@ -377,7 +377,7 @@ class ScannerTest : WordSpec({
 
             verify(exactly = 1) {
                 reader.read(pkgWithArtifact, any())
-                scannerWrapper.scanPackage(pkgWithArtifact, any(), any())
+                scannerWrapper.scanPackage(any(), createContext().copy(coveredPackages = listOf(pkgWithArtifact)))
             }
         }
 
@@ -895,7 +895,7 @@ private class FakePackageScannerWrapper(override val name: String = "fake") : Pa
     override val readFromStorage = true
     override val writeToStorage = true
 
-    override fun scanPackage(pkg: Package, nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult =
+    override fun scanPackage(nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult =
         createScanResult(nestedProvenance?.root ?: UnknownProvenance, details)
 }
 


### PR DESCRIPTION
Previously, package scanner implementations did not get any information about which VCS path a package is located at in a VCS repository. However, that information might still be required, e.g. to point to the exact "file tree" for browsing the code of a package.

So keep the VCS path as part of the package. Now that package scanners do also get the (nested) provenance, that should be used to determine the root repository the package is located at.

The only package scanner implementation in ORT's code base is for FossId, which already handles a non-empty path by skipping the package as FossId cannot limit scans to sub-paths.

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
