### PR TITLE
fix(pub): Do not rely on the package `name` to be present

### DIFF
--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -548,7 +548,7 @@ class Pub(
                         pkgInfoFromLockFile["source"].textValueOrEmpty() == "git" -> {
                             val pkgInfoFromYamlFile = readPackageInfoFromCache(pkgInfoFromLockFile, workingDir)
 
-                            rawName = pkgInfoFromYamlFile["name"].textValue() ?: packageName
+                            rawName = pkgInfoFromYamlFile["name"]?.textValue() ?: packageName
                             description = pkgInfoFromYamlFile["description"].textValueOrEmpty().trim()
                             homepageUrl = pkgInfoFromYamlFile["homepage"].textValueOrEmpty()
                             authors = parseAuthors(pkgInfoFromYamlFile)


### PR DESCRIPTION
If `readPackageInfoFromCache` returns `EMPTY_JSON_NODE`, then `textValue()` throws java.lang.NullPointerException