### PR TITLE
SPM: Improve the format for identifiers

### DIFF
--- a/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-app.yml
+++ b/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-app.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "SPM:oss-review-toolkit:src/funTest/assets/projects/synthetic/spm-app/Package.resolved:<REPLACE_REVISION>"
+  id: "SPM::src/funTest/assets/projects/synthetic/spm-app/Package.resolved:<REPLACE_REVISION>"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-app.yml
+++ b/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-app.yml
@@ -16,34 +16,8 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: "<REPLACE_URL_PROCESSED>"
 packages:
-- id: "SPM:apple:llbuild:9.0.8"
-  purl: "pkg:swift/apple/llbuild@9.0.8"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://github.com/apple/swift-llbuild.git"
-    revision: "9.0.8"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/apple/swift-llbuild.git"
-    revision: "9.0.8"
-    path: ""
-- id: "SPM:apple:swift-argument-parser:0.2.0"
-  purl: "pkg:swift/apple/swift-argument-parser@0.2.0"
+- id: "SPM::github.com/apple/swift-argument-parser:0.2.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-argument-parser@0.2.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -68,8 +42,8 @@ packages:
     url: "https://github.com/apple/swift-argument-parser.git"
     revision: "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0"
     path: ""
-- id: "SPM:apple:swift-crypto:"
-  purl: "pkg:swift/apple/swift-crypto@"
+- id: "SPM::github.com/apple/swift-crypto:"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-crypto@"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -94,8 +68,34 @@ packages:
     url: "https://github.com/apple/swift-crypto.git"
     revision: ""
     path: ""
-- id: "SPM:braze-inc:Appboy_iOS_SDK:branch-master"
-  purl: "pkg:swift/braze-inc/Appboy_iOS_SDK@branch-master"
+- id: "SPM::github.com/apple/swift-llbuild:9.0.8"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-llbuild@9.0.8"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/apple/swift-llbuild.git"
+    revision: "9.0.8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/apple/swift-llbuild.git"
+    revision: "9.0.8"
+    path: ""
+- id: "SPM::github.com/braze-inc/braze-ios-sdk:branch-master"
+  purl: "pkg:swift/github.com%2Fbraze-inc%2Fbraze-ios-sdk@branch-master"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -120,8 +120,8 @@ packages:
     url: "https://github.com/braze-inc/braze-ios-sdk.git"
     revision: ""
     path: ""
-- id: "SPM:grpc:grpc-swift:revision-efb67a324eaf1696b50e66bc471a53690e41fbf6"
-  purl: "pkg:swift/grpc/grpc-swift@revision-efb67a324eaf1696b50e66bc471a53690e41fbf6"
+- id: "SPM::github.com/grpc/grpc-swift:revision-efb67a324eaf1696b50e66bc471a53690e41fbf6"
+  purl: "pkg:swift/github.com%2Fgrpc%2Fgrpc-swift@revision-efb67a324eaf1696b50e66bc471a53690e41fbf6"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-lib.yml
+++ b/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-lib.yml
@@ -18,151 +18,151 @@ project:
   scopes:
   - name: "dependencies"
     dependencies:
-    - id: "SPM:apple:swift-crypto:2.6.0"
-    - id: "SPM:apple:swift-log:1.5.3"
-    - id: "SPM:apple:swift-metrics:2.4.1"
-    - id: "SPM:apple:swift-nio:2.62.0"
+    - id: "SPM::github.com/apple/swift-crypto:2.6.0"
+    - id: "SPM::github.com/apple/swift-log:1.5.3"
+    - id: "SPM::github.com/apple/swift-metrics:2.4.1"
+    - id: "SPM::github.com/apple/swift-nio:2.62.0"
       dependencies:
-      - id: "SPM:apple:swift-atomics:1.2.0"
-      - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:apple:swift-nio-extras:1.20.0"
+      - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+      - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/apple/swift-nio-extras:1.20.0"
       dependencies:
-      - id: "SPM:apple:swift-http-types:1.0.2"
-      - id: "SPM:apple:swift-nio:2.62.0"
+      - id: "SPM::github.com/apple/swift-http-types:1.0.2"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-http2:1.29.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-http2:1.29.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:apple:swift-nio-http2:1.29.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/apple/swift-nio-http2:1.29.0"
       dependencies:
-      - id: "SPM:apple:swift-atomics:1.2.0"
-      - id: "SPM:apple:swift-nio:2.62.0"
+      - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:apple:swift-nio-ssl:2.25.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/apple/swift-nio-ssl:2.25.0"
       dependencies:
-      - id: "SPM:apple:swift-nio:2.62.0"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:swift-server:async-http-client:1.20.1"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/swift-server/async-http-client:1.20.1"
       dependencies:
-      - id: "SPM:apple:swift-algorithms:1.2.0"
+      - id: "SPM::github.com/apple/swift-algorithms:1.2.0"
         dependencies:
-        - id: "SPM:apple:swift-numerics:1.0.2"
-      - id: "SPM:apple:swift-atomics:1.2.0"
-      - id: "SPM:apple:swift-log:1.5.3"
-      - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-numerics:1.0.2"
+      - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+      - id: "SPM::github.com/apple/swift-log:1.5.3"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-extras:1.20.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-extras:1.20.0"
         dependencies:
-        - id: "SPM:apple:swift-http-types:1.0.2"
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-http-types:1.0.2"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-        - id: "SPM:apple:swift-nio-http2:1.29.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+        - id: "SPM::github.com/apple/swift-nio-http2:1.29.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-nio:2.62.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-nio:2.62.0"
             dependencies:
-            - id: "SPM:apple:swift-atomics:1.2.0"
-            - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-http2:1.29.0"
+            - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+            - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-http2:1.29.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-ssl:2.25.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-ssl:2.25.0"
         dependencies:
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-transport-services:1.20.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-transport-services:1.20.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:swift-server:swift-backtrace:1.3.4"
-    - id: "SPM:vapor:async-kit:1.19.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/swift-server/swift-backtrace:1.3.4"
+    - id: "SPM::github.com/vapor/async-kit:1.19.0"
       dependencies:
-      - id: "SPM:apple:swift-algorithms:1.2.0"
+      - id: "SPM::github.com/apple/swift-algorithms:1.2.0"
         dependencies:
-        - id: "SPM:apple:swift-numerics:1.0.2"
-      - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-log:1.5.3"
-      - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-numerics:1.0.2"
+      - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-log:1.5.3"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:vapor:console-kit:4.14.1"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/vapor/console-kit:4.14.1"
       dependencies:
-      - id: "SPM:apple:swift-log:1.5.3"
-      - id: "SPM:apple:swift-nio:2.62.0"
+      - id: "SPM::github.com/apple/swift-log:1.5.3"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:vapor:multipart-kit:4.6.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/vapor/multipart-kit:4.6.0"
       dependencies:
-      - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio:2.62.0"
+      - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-    - id: "SPM:vapor:routing-kit:4.9.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+    - id: "SPM::github.com/vapor/routing-kit:4.9.0"
       dependencies:
-      - id: "SPM:apple:swift-log:1.5.3"
-    - id: "SPM:vapor:websocket-kit:2.14.0"
+      - id: "SPM::github.com/apple/swift-log:1.5.3"
+    - id: "SPM::github.com/vapor/websocket-kit:2.14.0"
       dependencies:
-      - id: "SPM:apple:swift-atomics:1.2.0"
-      - id: "SPM:apple:swift-nio:2.62.0"
+      - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+      - id: "SPM::github.com/apple/swift-nio:2.62.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-extras:1.20.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-extras:1.20.0"
         dependencies:
-        - id: "SPM:apple:swift-http-types:1.0.2"
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-http-types:1.0.2"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-        - id: "SPM:apple:swift-nio-http2:1.29.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+        - id: "SPM::github.com/apple/swift-nio-http2:1.29.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-nio:2.62.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-nio:2.62.0"
             dependencies:
-            - id: "SPM:apple:swift-atomics:1.2.0"
-            - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-ssl:2.25.0"
+            - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+            - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-ssl:2.25.0"
         dependencies:
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
-      - id: "SPM:apple:swift-nio-transport-services:1.20.0"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
+      - id: "SPM::github.com/apple/swift-nio-transport-services:1.20.0"
         dependencies:
-        - id: "SPM:apple:swift-atomics:1.2.0"
-        - id: "SPM:apple:swift-nio:2.62.0"
+        - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+        - id: "SPM::github.com/apple/swift-nio:2.62.0"
           dependencies:
-          - id: "SPM:apple:swift-atomics:1.2.0"
-          - id: "SPM:apple:swift-collections:1.0.6"
+          - id: "SPM::github.com/apple/swift-atomics:1.2.0"
+          - id: "SPM::github.com/apple/swift-collections:1.0.6"
 packages:
-- id: "SPM:apple:swift-algorithms:1.2.0"
-  purl: "pkg:swift/apple/swift-algorithms@1.2.0"
+- id: "SPM::github.com/apple/swift-algorithms:1.2.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-algorithms@1.2.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -187,8 +187,8 @@ packages:
     url: "https://github.com/apple/swift-algorithms.git"
     revision: "1.2.0"
     path: ""
-- id: "SPM:apple:swift-atomics:1.2.0"
-  purl: "pkg:swift/apple/swift-atomics@1.2.0"
+- id: "SPM::github.com/apple/swift-atomics:1.2.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-atomics@1.2.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -213,8 +213,8 @@ packages:
     url: "https://github.com/apple/swift-atomics.git"
     revision: "1.2.0"
     path: ""
-- id: "SPM:apple:swift-collections:1.0.6"
-  purl: "pkg:swift/apple/swift-collections@1.0.6"
+- id: "SPM::github.com/apple/swift-collections:1.0.6"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-collections@1.0.6"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -239,8 +239,8 @@ packages:
     url: "https://github.com/apple/swift-collections.git"
     revision: "1.0.6"
     path: ""
-- id: "SPM:apple:swift-crypto:2.6.0"
-  purl: "pkg:swift/apple/swift-crypto@2.6.0"
+- id: "SPM::github.com/apple/swift-crypto:2.6.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-crypto@2.6.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -265,8 +265,8 @@ packages:
     url: "https://github.com/apple/swift-crypto.git"
     revision: "2.6.0"
     path: ""
-- id: "SPM:apple:swift-http-types:1.0.2"
-  purl: "pkg:swift/apple/swift-http-types@1.0.2"
+- id: "SPM::github.com/apple/swift-http-types:1.0.2"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-http-types@1.0.2"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -291,8 +291,8 @@ packages:
     url: "https://github.com/apple/swift-http-types.git"
     revision: "1.0.2"
     path: ""
-- id: "SPM:apple:swift-log:1.5.3"
-  purl: "pkg:swift/apple/swift-log@1.5.3"
+- id: "SPM::github.com/apple/swift-log:1.5.3"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-log@1.5.3"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -317,8 +317,8 @@ packages:
     url: "https://github.com/apple/swift-log.git"
     revision: "1.5.3"
     path: ""
-- id: "SPM:apple:swift-metrics:2.4.1"
-  purl: "pkg:swift/apple/swift-metrics@2.4.1"
+- id: "SPM::github.com/apple/swift-metrics:2.4.1"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-metrics@2.4.1"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -343,8 +343,8 @@ packages:
     url: "https://github.com/apple/swift-metrics.git"
     revision: "2.4.1"
     path: ""
-- id: "SPM:apple:swift-nio:2.62.0"
-  purl: "pkg:swift/apple/swift-nio@2.62.0"
+- id: "SPM::github.com/apple/swift-nio:2.62.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-nio@2.62.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -369,8 +369,8 @@ packages:
     url: "https://github.com/apple/swift-nio.git"
     revision: "2.62.0"
     path: ""
-- id: "SPM:apple:swift-nio-extras:1.20.0"
-  purl: "pkg:swift/apple/swift-nio-extras@1.20.0"
+- id: "SPM::github.com/apple/swift-nio-extras:1.20.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-extras@1.20.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -395,8 +395,8 @@ packages:
     url: "https://github.com/apple/swift-nio-extras.git"
     revision: "1.20.0"
     path: ""
-- id: "SPM:apple:swift-nio-http2:1.29.0"
-  purl: "pkg:swift/apple/swift-nio-http2@1.29.0"
+- id: "SPM::github.com/apple/swift-nio-http2:1.29.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-http2@1.29.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -421,8 +421,8 @@ packages:
     url: "https://github.com/apple/swift-nio-http2.git"
     revision: "1.29.0"
     path: ""
-- id: "SPM:apple:swift-nio-ssl:2.25.0"
-  purl: "pkg:swift/apple/swift-nio-ssl@2.25.0"
+- id: "SPM::github.com/apple/swift-nio-ssl:2.25.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-ssl@2.25.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -447,8 +447,8 @@ packages:
     url: "https://github.com/apple/swift-nio-ssl.git"
     revision: "2.25.0"
     path: ""
-- id: "SPM:apple:swift-nio-transport-services:1.20.0"
-  purl: "pkg:swift/apple/swift-nio-transport-services@1.20.0"
+- id: "SPM::github.com/apple/swift-nio-transport-services:1.20.0"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-transport-services@1.20.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -473,8 +473,8 @@ packages:
     url: "https://github.com/apple/swift-nio-transport-services.git"
     revision: "1.20.0"
     path: ""
-- id: "SPM:apple:swift-numerics:1.0.2"
-  purl: "pkg:swift/apple/swift-numerics@1.0.2"
+- id: "SPM::github.com/apple/swift-numerics:1.0.2"
+  purl: "pkg:swift/github.com%2Fapple%2Fswift-numerics@1.0.2"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -499,8 +499,8 @@ packages:
     url: "https://github.com/apple/swift-numerics.git"
     revision: "1.0.2"
     path: ""
-- id: "SPM:swift-server:async-http-client:1.20.1"
-  purl: "pkg:swift/swift-server/async-http-client@1.20.1"
+- id: "SPM::github.com/swift-server/async-http-client:1.20.1"
+  purl: "pkg:swift/github.com%2Fswift-server%2Fasync-http-client@1.20.1"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -525,8 +525,8 @@ packages:
     url: "https://github.com/swift-server/async-http-client.git"
     revision: "1.20.1"
     path: ""
-- id: "SPM:swift-server:swift-backtrace:1.3.4"
-  purl: "pkg:swift/swift-server/swift-backtrace@1.3.4"
+- id: "SPM::github.com/swift-server/swift-backtrace:1.3.4"
+  purl: "pkg:swift/github.com%2Fswift-server%2Fswift-backtrace@1.3.4"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -551,8 +551,8 @@ packages:
     url: "https://github.com/swift-server/swift-backtrace.git"
     revision: "1.3.4"
     path: ""
-- id: "SPM:vapor:async-kit:1.19.0"
-  purl: "pkg:swift/vapor/async-kit@1.19.0"
+- id: "SPM::github.com/vapor/async-kit:1.19.0"
+  purl: "pkg:swift/github.com%2Fvapor%2Fasync-kit@1.19.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -577,8 +577,8 @@ packages:
     url: "https://github.com/vapor/async-kit.git"
     revision: "1.19.0"
     path: ""
-- id: "SPM:vapor:console-kit:4.14.1"
-  purl: "pkg:swift/vapor/console-kit@4.14.1"
+- id: "SPM::github.com/vapor/console-kit:4.14.1"
+  purl: "pkg:swift/github.com%2Fvapor%2Fconsole-kit@4.14.1"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -603,8 +603,8 @@ packages:
     url: "https://github.com/vapor/console-kit.git"
     revision: "4.14.1"
     path: ""
-- id: "SPM:vapor:multipart-kit:4.6.0"
-  purl: "pkg:swift/vapor/multipart-kit@4.6.0"
+- id: "SPM::github.com/vapor/multipart-kit:4.6.0"
+  purl: "pkg:swift/github.com%2Fvapor%2Fmultipart-kit@4.6.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -629,8 +629,8 @@ packages:
     url: "https://github.com/vapor/multipart-kit.git"
     revision: "4.6.0"
     path: ""
-- id: "SPM:vapor:routing-kit:4.9.0"
-  purl: "pkg:swift/vapor/routing-kit@4.9.0"
+- id: "SPM::github.com/vapor/routing-kit:4.9.0"
+  purl: "pkg:swift/github.com%2Fvapor%2Frouting-kit@4.9.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -655,8 +655,8 @@ packages:
     url: "https://github.com/vapor/routing-kit.git"
     revision: "4.9.0"
     path: ""
-- id: "SPM:vapor:websocket-kit:2.14.0"
-  purl: "pkg:swift/vapor/websocket-kit@2.14.0"
+- id: "SPM::github.com/vapor/websocket-kit:2.14.0"
+  purl: "pkg:swift/github.com%2Fvapor%2Fwebsocket-kit@2.14.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-lib.yml
+++ b/plugins/package-managers/spm/src/funTest/assets/projects/synthetic/spm-expected-output-lib.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "SPM:oss-review-toolkit:src/funTest/assets/projects/synthetic/spm-lib/Package.swift:<REPLACE_REVISION>"
+  id: "SPM::src/funTest/assets/projects/synthetic/spm-lib/Package.swift:<REPLACE_REVISION>"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/plugins/package-managers/spm/src/main/kotlin/Spm.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/Spm.kt
@@ -141,12 +141,11 @@ class Spm(
 
     private fun projectFromDefinitionFile(definitionFile: File): Project {
         val vcsInfo = VersionControlSystem.forDirectory(definitionFile.parentFile)?.getInfo().orEmpty()
-        val (author, _) = parseAuthorAndProjectFromRepo(repositoryURL = vcsInfo.url)
 
         val projectIdentifier = Identifier(
             type = managerName,
             version = vcsInfo.revision,
-            namespace = author.orEmpty(),
+            namespace = "",
             name = getFallbackProjectName(analysisRoot, definitionFile)
         )
 

--- a/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
@@ -19,20 +19,16 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.spm
 
-import java.lang.invoke.MethodHandles
-import java.net.URI
-
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-
-import org.apache.logging.log4j.kotlin.loggerOf
 
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 
 val json = Json { ignoreUnknownKeys = true }
@@ -83,11 +79,10 @@ data class LibraryDependency(
 
     override val id: Identifier
         get() {
-            val (author, _) = parseAuthorAndProjectFromRepo(repositoryUrl)
             return Identifier(
                 type = PACKAGE_TYPE,
-                namespace = author.orEmpty(),
-                name = name,
+                namespace = "",
+                name = getCanonicalName(repositoryUrl),
                 version = version
             )
         }
@@ -136,35 +131,25 @@ data class AppDependency(
 
     override val id: Identifier
         get() {
-            val (author, _) = parseAuthorAndProjectFromRepo(repositoryUrl)
             return Identifier(
                 type = PACKAGE_TYPE,
-                namespace = author.orEmpty(),
-                name = packageName,
+                namespace = "",
+                name = getCanonicalName(repositoryUrl),
                 version = state?.toString().orEmpty()
             )
         }
 }
 
-private val logger = loggerOf(MethodHandles.lookup().lookupClass())
-
-internal fun parseAuthorAndProjectFromRepo(repositoryURL: String): Pair<String?, String?> {
-    val normalizedURL = normalizeVcsUrl(repositoryURL)
-    val vcsHost = VcsHost.fromUrl(URI(normalizedURL))
-    val project = vcsHost?.getProject(normalizedURL)
-    val author = vcsHost?.getUserOrOrganization(normalizedURL)
-
-    if (author.isNullOrBlank()) {
-        logger.warn {
-            "Unable to parse the author from VCS URL $repositoryURL, results might be incomplete."
-        }
-    }
-
-    if (project.isNullOrBlank()) {
-        logger.warn {
-            "Unable to parse the project from VCS URL $repositoryURL, results might be incomplete."
-        }
-    }
-
-    return author to project
+/**
+ * Return the canonical name for a package based on the given [repositoryUrl].
+ * The algorithm assumes that the repository URL does not point to the local file
+ * system, as support for local dependencies is not implemented yet in ORT. Otherwise,
+ * the algorithm tries to effectively mimic the algorithm described in
+ * https://github.com/apple/swift-package-manager/blob/24bfdd180afdf78160e7a2f6f6deb2c8249d40d3/Sources/PackageModel/PackageIdentity.swift#L345-L415.
+ */
+internal fun getCanonicalName(repositoryUrl: String): String {
+    val normalizedUrl = normalizeVcsUrl(repositoryUrl)
+    return normalizedUrl.toUri {
+        "${it.host}${it.path.removeSuffix(".git")}"
+    }.getOrDefault(normalizedUrl).lowercase()
 }

--- a/plugins/package-managers/spm/src/test/kotlin/SpmTest.kt
+++ b/plugins/package-managers/spm/src/test/kotlin/SpmTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.spm
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+
+class SpmTest : WordSpec({
+    "getCanonicalName()" should {
+        "return the expected canonical name" {
+            listOf(
+                "git@github.com:oss-review-toolkit/ort.git",
+                "ssh://git@github.com:oss-review-toolkit/ort.git",
+                "https://github.com/oss-review-toolkit/ORT.git",
+                "https://github.com/oss-review-toolkit/ort/",
+                "https://github.com/oss-review-toolkit/ort.git",
+                "https://github.com/oss-review-toolkit/ort.git?foo=bar",
+                "https://github.com/oss-review-toolkit/ort.git#bar",
+                "https://github.com:1234/oss-review-toolkit/ort.git"
+            ).forAll {
+                getCanonicalName(it) shouldBe "github.com/oss-review-toolkit/ort"
+            }
+        }
+    }
+})


### PR DESCRIPTION
Ensure identifiers of dependencies are unique, stop using arbitrarily chosen organization name as namespace, and overall simplify the derivation of identifiers. The identifiers become pretty much aligned with the ones from `GoMod`.

Part of #8123.