### PR TITLE
docs(README): Rename Swift package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ supported:
     [no `cartfile.private`](https://github.com/oss-review-toolkit/ort/issues/3774))
   * [CocoaPods](https://github.com/CocoaPods/CocoaPods) (limitations:
     [no custom source repositories](https://github.com/oss-review-toolkit/ort/issues/4188))
-  * [Swift Package Manager](https://www.swift.org/package-manager)
+  * [SwiftPM](https://www.swift.org/package-manager)
 * PHP
   * [Composer](https://getcomposer.org/)
 * Python


### PR DESCRIPTION
Use official project name as listed on project website[1] to improve inclusion of ORT in GitHub/Google search results.

[1]: https://www.swift.org/package-manager
