### PR TITLE
Further `Spm` improvements

### DIFF
--- a/plugins/package-managers/spm/src/main/kotlin/Spm.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/Spm.kt
@@ -89,8 +89,8 @@ class Spm(
     }
 
     /**
-     * Resolves dependencies when the final build target is an app and no Package.swift is available.
-     * This method parses dependencies from the Package.resolved file.
+     * Resolves dependencies when only a lockfile aka `Package.Resolved` is available. This commonly applies to e.g.
+     * Xcode projects which only have a lockfile, but no `Package.swift` file.
      */
     private fun resolveAppDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val resolved = definitionFile.inputStream().use { json.decodeFromStream<PackageResolved>(it) }

--- a/plugins/package-managers/spm/src/main/kotlin/Spm.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/Spm.kt
@@ -83,7 +83,7 @@ class Spm(
         requireLockfile(definitionFile.parentFile) { definitionFile.name != PACKAGE_SWIFT_NAME }
 
         return when (definitionFile.name) {
-            PACKAGE_SWIFT_NAME -> resolveLibraryDependencies(definitionFile)
+            PACKAGE_SWIFT_NAME -> resolveDefinitionFileDependencies(definitionFile)
             else -> resolveLockfileDependencies(definitionFile)
         }
     }
@@ -108,11 +108,11 @@ class Spm(
      * This method parses dependencies from `swift package show-dependencies --format json` output.
      * Also, this method provides parent-child associations for parsed dependencies.
      */
-    private fun resolveLibraryDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
-        val project = projectFromDefinitionFile(definitionFile)
+    private fun resolveDefinitionFileDependencies(packageSwiftFile: File): List<ProjectAnalyzerResult> {
+        val project = projectFromDefinitionFile(packageSwiftFile)
 
         val result = run(
-            definitionFile.parentFile,
+            packageSwiftFile.parentFile,
             "package",
             "show-dependencies",
             "--format",

--- a/plugins/package-managers/spm/src/main/kotlin/Spm.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/Spm.kt
@@ -104,11 +104,9 @@ class Spm(
     }
 
     /**
-     * Resolves dependencies when the final build target is a library and Package.swift is available.
+     * Resolves dependencies of a `Package.swift` file.
      * This method parses dependencies from `swift package show-dependencies --format json` output.
      * Also, this method provides parent-child associations for parsed dependencies.
-     *
-     * Only used when analyzerConfig.allowDynamicVersions is set to true.
      */
     private fun resolveLibraryDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val project = projectFromDefinitionFile(definitionFile)

--- a/plugins/package-managers/spm/src/main/kotlin/Spm.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/Spm.kt
@@ -84,7 +84,7 @@ class Spm(
 
         return when (definitionFile.name) {
             PACKAGE_SWIFT_NAME -> resolveLibraryDependencies(definitionFile)
-            else -> resolveAppDependencies(definitionFile)
+            else -> resolveLockfileDependencies(definitionFile)
         }
     }
 
@@ -92,12 +92,12 @@ class Spm(
      * Resolves dependencies when only a lockfile aka `Package.Resolved` is available. This commonly applies to e.g.
      * Xcode projects which only have a lockfile, but no `Package.swift` file.
      */
-    private fun resolveAppDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
-        val resolved = definitionFile.inputStream().use { json.decodeFromStream<PackageResolved>(it) }
+    private fun resolveLockfileDependencies(packageResolvedFile: File): List<ProjectAnalyzerResult> {
+        val resolved = packageResolvedFile.inputStream().use { json.decodeFromStream<PackageResolved>(it) }
 
         return listOf(
             ProjectAnalyzerResult(
-                project = projectFromDefinitionFile(definitionFile),
+                project = projectFromDefinitionFile(packageResolvedFile),
                 packages = resolved.objects["pins"].orEmpty().mapTo(mutableSetOf()) { it.toPackage() }
             )
         )

--- a/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
@@ -74,25 +74,25 @@ data class LibraryDependency(
 
 @Serializable
 data class PackageResolved(
-    @SerialName("object") val objects: Map<String, List<AppDependency>>,
+    @SerialName("object") val objects: Map<String, List<Pin>>,
     val version: Int
 )
 
 @Serializable
-data class AppDependency(
+data class Pin(
     @SerialName("package") val packageName: String,
-    val state: AppDependencyState?,
+    val state: State?,
     @SerialName("repositoryURL") val repositoryUrl: String
 ) {
     @Serializable
-    data class AppDependencyState(
+    data class State(
         val version: String? = null,
         val revision: String? = null,
         val branch: String? = null
     )
 }
 
-internal fun AppDependency.toPackage(): Package {
+internal fun Pin.toPackage(): Package {
     val id = Identifier(
         type = PACKAGE_TYPE,
         namespace = "",

--- a/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
@@ -90,35 +90,35 @@ data class AppDependency(
         val revision: String? = null,
         val branch: String? = null
     )
+}
 
-    fun toPackage(): Package {
-        val id = Identifier(
-            type = PACKAGE_TYPE,
-            namespace = "",
-            name = getCanonicalName(repositoryUrl),
-            version = state?.run {
-                when {
-                    !version.isNullOrBlank() -> version
-                    !revision.isNullOrBlank() -> "revision-$revision"
-                    !branch.isNullOrBlank() -> "branch-$branch"
-                    else -> ""
-                }
-            }.orEmpty()
-        )
-
-        val vcsInfoFromUrl = VcsHost.parseUrl(repositoryUrl)
-        val vcsInfo = if (vcsInfoFromUrl.revision.isBlank() && state != null) {
+internal fun AppDependency.toPackage(): Package {
+    val id = Identifier(
+        type = PACKAGE_TYPE,
+        namespace = "",
+        name = getCanonicalName(repositoryUrl),
+        version = state?.run {
             when {
-                !state.revision.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.revision)
-                !state.version.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.version)
-                else -> vcsInfoFromUrl
+                !version.isNullOrBlank() -> version
+                !revision.isNullOrBlank() -> "revision-$revision"
+                !branch.isNullOrBlank() -> "branch-$branch"
+                else -> ""
             }
-        } else {
-            vcsInfoFromUrl
-        }
+        }.orEmpty()
+    )
 
-        return createPackage(id, vcsInfo)
+    val vcsInfoFromUrl = VcsHost.parseUrl(repositoryUrl)
+    val vcsInfo = if (vcsInfoFromUrl.revision.isBlank() && state != null) {
+        when {
+            !state.revision.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.revision)
+            !state.version.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.version)
+            else -> vcsInfoFromUrl
+        }
+    } else {
+        vcsInfoFromUrl
     }
+
+    return createPackage(id, vcsInfo)
 }
 
 private fun createPackage(id: Identifier, vcsInfo: VcsInfo) =

--- a/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
@@ -38,17 +38,7 @@ abstract class SpmDependency {
     abstract val vcs: VcsInfo
     abstract val id: Identifier
 
-    fun toPackage(): Package {
-        return Package(
-            vcs = vcs,
-            description = "",
-            id = id,
-            binaryArtifact = RemoteArtifact.EMPTY,
-            sourceArtifact = RemoteArtifact.EMPTY,
-            declaredLicenses = emptySet(), // SPM files do not declare any licenses.
-            homepageUrl = ""
-        )
-    }
+    fun toPackage(): Package = createPackage(id, vcs)
 }
 
 /**
@@ -139,6 +129,17 @@ data class AppDependency(
             )
         }
 }
+
+private fun createPackage(id: Identifier, vcsInfo: VcsInfo) =
+    Package(
+        vcs = vcsInfo,
+        description = "",
+        id = id,
+        binaryArtifact = RemoteArtifact.EMPTY,
+        sourceArtifact = RemoteArtifact.EMPTY,
+        declaredLicenses = emptySet(), // SPM files do not declare any licenses.
+        homepageUrl = ""
+    )
 
 /**
  * Return the canonical name for a package based on the given [repositoryUrl].

--- a/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
@@ -88,23 +88,22 @@ data class AppDependency(
     data class AppDependencyState(
         val version: String? = null,
         val revision: String? = null,
-        private val branch: String? = null
-    ) {
-        override fun toString(): String =
-            when {
-                !version.isNullOrBlank() -> version
-                !revision.isNullOrBlank() -> "revision-$revision"
-                !branch.isNullOrBlank() -> "branch-$branch"
-                else -> ""
-            }
-    }
+        val branch: String? = null
+    )
 
     fun toPackage(): Package {
         val id = Identifier(
             type = PACKAGE_TYPE,
             namespace = "",
             name = getCanonicalName(repositoryUrl),
-            version = state?.toString().orEmpty()
+            version = state?.run {
+                when {
+                    !version.isNullOrBlank() -> version
+                    !revision.isNullOrBlank() -> "revision-$revision"
+                    !branch.isNullOrBlank() -> "branch-$branch"
+                    else -> ""
+                }
+            }.orEmpty()
         )
 
         val vcsInfoFromUrl = VcsHost.parseUrl(repositoryUrl)

--- a/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
+++ b/plugins/package-managers/spm/src/main/kotlin/SpmModel.kt
@@ -99,31 +99,27 @@ data class AppDependency(
             }
     }
 
-    val vcs: VcsInfo
-        get() {
-            val vcsInfoFromUrl = VcsHost.parseUrl(repositoryUrl)
+    fun toPackage(): Package {
+        val id = Identifier(
+            type = PACKAGE_TYPE,
+            namespace = "",
+            name = getCanonicalName(repositoryUrl),
+            version = state?.toString().orEmpty()
+        )
 
-            if (vcsInfoFromUrl.revision.isBlank() && state != null) {
-                when {
-                    !state.revision.isNullOrBlank() -> return vcsInfoFromUrl.copy(revision = state.revision)
-                    !state.version.isNullOrBlank() -> return vcsInfoFromUrl.copy(revision = state.version)
-                }
+        val vcsInfoFromUrl = VcsHost.parseUrl(repositoryUrl)
+        val vcsInfo = if (vcsInfoFromUrl.revision.isBlank() && state != null) {
+            when {
+                !state.revision.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.revision)
+                !state.version.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.version)
+                else -> vcsInfoFromUrl
             }
-
-            return vcsInfoFromUrl
+        } else {
+            vcsInfoFromUrl
         }
 
-    val id: Identifier
-        get() {
-            return Identifier(
-                type = PACKAGE_TYPE,
-                namespace = "",
-                name = getCanonicalName(repositoryUrl),
-                version = state?.toString().orEmpty()
-            )
-        }
-
-    fun toPackage(): Package = createPackage(id, vcs)
+        return createPackage(id, vcsInfo)
+    }
 }
 
 private fun createPackage(id: Identifier, vcsInfo: VcsInfo) =


### PR DESCRIPTION
Primarily separate the models for `Package.resolved` (lockfile) and `Package.swift` (definitionFile) in order to prepare for
handling multiple file format versions of `Package.resolved`. Furthermore, clarify miscellaneous related things a bit.

Part of #8123.  
