### PR TITLE
fix(node): Do not follow cyclic directory links

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -247,7 +247,8 @@ open class Npm(
         logger.info { "Searching for 'package.json' files in '$nodeModulesDir'..." }
 
         val nodeModulesFiles = nodeModulesDir.walk().maxDepth(modulesSearchDepth).filter {
-            it.name == "package.json" && isValidNodeModulesDirectory(nodeModulesDir, nodeModulesDirForPackageJson(it))
+            it.isFile && it.name == "package.json" &&
+                isValidNodeModulesDirectory(nodeModulesDir, nodeModulesDirForPackageJson(it))
         }
 
         return runBlocking(Dispatchers.IO) {

--- a/plugins/package-managers/node/src/main/kotlin/Pnpm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Pnpm.kt
@@ -51,13 +51,6 @@ class Pnpm(
         ) = Pnpm(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    /**
-     * PNPM symlinks workspace modules in the `node_modules` directory, which will result in cyclic symlinks of
-     * `node_module` directories. Limit the search depth to '2' in this case as all packages are in a direct
-     * subdirectory of the `node_modules` directory, thanks to the `--shamefully-hoist` install option.
-     */
-    override val modulesSearchDepth = 2
-
     override fun hasLockFile(projectDir: File) = NodePackageManager.PNPM.hasLockFile(projectDir)
 
     override fun File.isWorkspaceDir() = realFile() in findWorkspaceSubmodules(analysisRoot)


### PR DESCRIPTION
This generalizes the `maxDepth`-related work-around done for PNPM to fix a similar issue for Yarn if the `node_modules` directory hierarchy contains cyclic links. This is done by maintaining a temporary set of visited "real" directories.

The issue was interesting to debug as the infinite loop caused by circular links was only triggered when actually evaluating the lazy sequence created by `File.walk()`.

While at it, make the filtering for `package.json` a bit more strict by requiring it to be a file.

Fixes #6531.