### PR TITLE
test(swiftpm): Avoid a hard-coded path in test results

### DIFF
--- a/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "1.6.0",
     "id": "GHSA-xvch-5gv4-984h",
-    "modified": "2023-02-27T14:47:14Z",
+    "modified": "2023-11-08T04:07:19.028993Z",
     "published": "2022-03-18T00:01:09Z",
     "aliases": [
         "CVE-2021-44906"
@@ -57,8 +57,6 @@
                     ]
                 }
             ],
-            "ecosystem_specific": {
-            },
             "database_specific": {
                 "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2022/03/GHSA-xvch-5gv4-984h/GHSA-xvch-5gv4-984h.json"
             }

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-lockfile-v3.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-lockfile-v3.yml
@@ -19,6 +19,6 @@ packages: []
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "SwiftPM"
-  message: "Could not parse lockfile '/workspace/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/lockfile-v3/Package.resolved'.\
+  message: "Could not parse lockfile '<REPLACE_ABSOLUTE_DEFINITION_FILE_PATH>'.\
     \ Unknown file format version '3'."
   severity: "ERROR"

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -102,7 +102,7 @@ fun patchExpectedResult(
             val path = vcsDir.getPathToRoot(projectDir)
 
             put("<REPLACE_DEFINITION_FILE_PATH>", "$path/${definitionFile.name}")
-            put("<REPLACE_ABSOLUTE_DEFINITION_FILE_PATH>", definitionFile.absolutePath)
+            put("<REPLACE_ABSOLUTE_DEFINITION_FILE_PATH>", definitionFile.absoluteFile.invariantSeparatorsPath)
             put("<REPLACE_URL>", url)
             put("<REPLACE_REVISION>", vcsDir.getRevision())
             put("<REPLACE_PATH>", path)


### PR DESCRIPTION
Also fix the `REPLACE_ABSOLUTE_DEFINITION_FILE_PATH` placeholder to be invariant, just like `REPLACE_DEFINITION_FILE_PATH` is.