### PR TITLE
chore(docker): Re-align `SWIFT_VERSION`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -356,7 +356,7 @@ COPY --from=scalabuild /opt/sbt /opt/sbt
 # SWIFT
 FROM base AS swiftbuild
 
-ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_VERSION=5.9.2
 
 ENV SWIFT_HOME=/opt/swift
 ENV PATH=$PATH:$SWIFT_HOME/bin


### PR DESCRIPTION
The Swift version is replicated in three file locations. The version became inconsistent by accident, see [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/8023
