### PR TITLE
fix(pub): Do not use the revision from the pubspec.yaml of dependencies

### DIFF
--- a/plugins/package-managers/pub/src/funTest/assets/projects/external/dart-http-expected-output.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/external/dart-http-expected-output.yml
@@ -904,12 +904,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/_fe_analyzer_shared"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/_fe_analyzer_shared"
 - id: "Pub::analyzer:6.4.0"
   purl: "pkg:pub/analyzer@6.4.0"
@@ -931,12 +931,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/analyzer"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/analyzer"
 - id: "Pub::args:2.4.2"
   purl: "pkg:pub/args@2.4.2"
@@ -1144,12 +1144,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/google/file.dart.git"
-    revision: "master"
+    revision: ""
     path: "packages/file"
   vcs_processed:
     type: "Git"
     url: "https://github.com/google/file.dart.git"
-    revision: "master"
+    revision: ""
     path: "packages/file"
 - id: "Pub::frontend_server_client:3.2.0"
   purl: "pkg:pub/frontend_server_client@3.2.0"
@@ -1171,12 +1171,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/webdev.git"
-    revision: "master"
+    revision: ""
     path: "frontend_server_client"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/webdev.git"
-    revision: "master"
+    revision: ""
     path: "frontend_server_client"
 - id: "Pub::glob:2.1.2"
   purl: "pkg:pub/glob@2.1.2"
@@ -1302,12 +1302,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/js"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/js"
 - id: "Pub::logging:1.2.0"
   purl: "pkg:pub/logging@1.2.0"
@@ -1384,12 +1384,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/meta"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/meta"
 - id: "Pub::mime:1.0.4"
   purl: "pkg:pub/mime@1.0.4"
@@ -1600,12 +1600,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf"
 - id: "Pub::shelf_packages_handler:3.0.2"
   purl: "pkg:pub/shelf_packages_handler@3.0.2"
@@ -1626,12 +1626,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_packages_handler"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_packages_handler"
 - id: "Pub::shelf_static:1.1.2"
   purl: "pkg:pub/shelf_static@1.1.2"
@@ -1652,12 +1652,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_static"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_static"
 - id: "Pub::shelf_web_socket:1.0.4"
   purl: "pkg:pub/shelf_web_socket@1.0.4"
@@ -1678,12 +1678,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_web_socket"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_web_socket"
 - id: "Pub::source_map_stack_trace:2.1.1"
   purl: "pkg:pub/source_map_stack_trace@2.1.1"
@@ -1888,12 +1888,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test"
 - id: "Pub::test_api:0.7.0"
   purl: "pkg:pub/test_api@0.7.0"
@@ -1914,12 +1914,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_api"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_api"
 - id: "Pub::test_core:0.6.0"
   purl: "pkg:pub/test_core@0.6.0"
@@ -1940,12 +1940,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_core"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_core"
 - id: "Pub::typed_data:1.3.2"
   purl: "pkg:pub/typed_data@1.3.2"
@@ -1993,12 +1993,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/vm_service"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/vm_service"
 - id: "Pub::watcher:1.1.0"
   purl: "pkg:pub/watcher@1.1.0"

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
@@ -862,12 +862,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/_fe_analyzer_shared"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/_fe_analyzer_shared"
 - id: "Pub::analyzer:5.13.0"
   purl: "pkg:pub/analyzer@5.13.0"
@@ -889,12 +889,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/analyzer"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/analyzer"
 - id: "Pub::args:2.4.2"
   purl: "pkg:pub/args@2.4.2"
@@ -1102,12 +1102,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/google/file.dart.git"
-    revision: "master"
+    revision: ""
     path: "packages/file"
   vcs_processed:
     type: "Git"
     url: "https://github.com/google/file.dart.git"
-    revision: "master"
+    revision: ""
     path: "packages/file"
 - id: "Pub::fixnum:1.1.0"
   purl: "pkg:pub/fixnum@1.1.0"
@@ -1156,12 +1156,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/webdev.git"
-    revision: "master"
+    revision: ""
     path: "frontend_server_client"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/webdev.git"
-    revision: "master"
+    revision: ""
     path: "frontend_server_client"
 - id: "Pub::glob:2.1.2"
   purl: "pkg:pub/glob@2.1.2"
@@ -1287,12 +1287,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/js"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/js"
 - id: "Pub::logging:1.2.0"
   purl: "pkg:pub/logging@1.2.0"
@@ -1369,12 +1369,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/meta"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/meta"
 - id: "Pub::mime:1.0.4"
   purl: "pkg:pub/mime@1.0.4"
@@ -1532,12 +1532,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/google/protobuf.dart.git"
-    revision: "master"
+    revision: ""
     path: "protobuf"
   vcs_processed:
     type: "Git"
     url: "https://github.com/google/protobuf.dart.git"
-    revision: "master"
+    revision: ""
     path: "protobuf"
 - id: "Pub::pub_semver:2.1.4"
   purl: "pkg:pub/pub_semver@2.1.4"
@@ -1586,12 +1586,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf"
 - id: "Pub::shelf_packages_handler:3.0.2"
   purl: "pkg:pub/shelf_packages_handler@3.0.2"
@@ -1612,12 +1612,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_packages_handler"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_packages_handler"
 - id: "Pub::shelf_static:1.1.2"
   purl: "pkg:pub/shelf_static@1.1.2"
@@ -1638,12 +1638,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_static"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_static"
 - id: "Pub::shelf_web_socket:1.0.4"
   purl: "pkg:pub/shelf_web_socket@1.0.4"
@@ -1664,12 +1664,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_web_socket"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/shelf.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/shelf_web_socket"
 - id: "Pub::source_map_stack_trace:2.1.1"
   purl: "pkg:pub/source_map_stack_trace@2.1.1"
@@ -1874,12 +1874,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test"
 - id: "Pub::test_api:0.6.0"
   purl: "pkg:pub/test_api@0.6.0"
@@ -1900,12 +1900,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_api"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_api"
 - id: "Pub::test_core:0.5.3"
   purl: "pkg:pub/test_core@0.5.3"
@@ -1926,12 +1926,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_core"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/test.git"
-    revision: "master"
+    revision: ""
     path: "pkgs/test_core"
 - id: "Pub::typed_data:1.3.2"
   purl: "pkg:pub/typed_data@1.3.2"
@@ -1979,12 +1979,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/vm_service"
   vcs_processed:
     type: "Git"
     url: "https://github.com/dart-lang/sdk.git"
-    revision: "main"
+    revision: ""
     path: "pkg/vm_service"
 - id: "Pub::watcher:1.1.0"
   purl: "pkg:pub/watcher@1.1.0"

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-with-flutter-android-and-cocoapods.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-with-flutter-android-and-cocoapods.yml
@@ -1440,12 +1440,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/flutter/packages.git"
-    revision: "master"
+    revision: ""
     path: "packages/flutter_lints"
   vcs_processed:
     type: "Git"
     url: "https://github.com/flutter/packages.git"
-    revision: "master"
+    revision: ""
     path: "packages/flutter_lints"
 - id: "Pub::lints:1.0.1"
   purl: "pkg:pub/lints@1.0.1"

--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -574,7 +574,11 @@ class Pub(
                             authors = parseAuthors(pkgInfoFromYamlFile)
 
                             val repositoryUrl = pkgInfoFromYamlFile["repository"].textValueOrEmpty()
-                            vcs = VcsHost.parseUrl(repositoryUrl)
+
+                            // Ignore the revision parsed from the repositoryUrl because the URL often points to the
+                            // main or master branch of the repository but never to the correct revision that matches
+                            // the version of the package.
+                            vcs = VcsHost.parseUrl(repositoryUrl).copy(revision = "")
                         }
 
                         pkgInfoFromLockFile["description"].textValueOrEmpty() == "flutter" -> {


### PR DESCRIPTION
The repository URLs taken from the pubspec.yaml in the local Pub cache often point to the main or master branch of the repository, for example:

https://github.com/dart-lang/sdk/tree/main/pkg/_fe_analyzer_shared

As there was not a single example where the URL pointed to the correct revision that matches the release of the package, simply ignore the revision.

Fixes #5542.