### PR TITLE
build: Only sign when making official releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew publishAndReleaseToMavenCentral

--- a/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
@@ -30,7 +30,6 @@ mavenPublishing {
 
     coordinates(groupId = "org${getGroupId(parent)}")
     publishToMavenCentral(SonatypeHost.DEFAULT)
-    signAllPublications()
 
     pom {
         name = project.name


### PR DESCRIPTION
Signing is not set up for JitPack, so simply disable it as these are just snapshot builds.