### PR TITLE
chore: Generally do not quote URL as part of messages

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -242,8 +242,8 @@ class Downloader(private val config: DownloaderConfiguration) {
             applicableVcs = VersionControlSystem.forUrl(pkg.vcsProcessed.url)
             logger.info {
                 applicableVcs?.let {
-                    "Detected VCS type '${it.type}' from URL '${pkg.vcsProcessed.url}'."
-                } ?: "Could not detect VCS type from URL '${pkg.vcsProcessed.url}'."
+                    "Detected VCS type '${it.type}' from URL ${pkg.vcsProcessed.url}."
+                } ?: "Could not detect VCS type from URL ${pkg.vcsProcessed.url}."
             }
         }
 

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -239,7 +239,7 @@ abstract class VersionControlSystem(
         }
 
         val revisionCandidates = getRevisionCandidates(workingTree, pkg, allowMovingRevisions).getOrElse {
-            throw DownloadException("$type failed to get revisions from URL '${pkg.vcsProcessed.url}'.", it)
+            throw DownloadException("$type failed to get revisions from URL ${pkg.vcsProcessed.url}.", it)
         }
 
         val results = mutableListOf<Result<String>>()
@@ -251,7 +251,7 @@ abstract class VersionControlSystem(
         }
 
         val workingTreeRevision = results.last().getOrElse {
-            throw DownloadException("$type failed to download from URL '${pkg.vcsProcessed.url}'.", it)
+            throw DownloadException("$type failed to download from URL ${pkg.vcsProcessed.url}.", it)
         }
 
         pkg.vcsProcessed.path.let {

--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -160,7 +160,7 @@ internal class DeleteCommand : CliktCommand(
             ?: throw IllegalArgumentException("postgresStorage not configured.")
 
         logger.info {
-            "Using Postgres storage with URL '${storageConfig.connection.url}' and schema " +
+            "Using Postgres storage with URL ${storageConfig.connection.url} and schema " +
                 "'${storageConfig.connection.schema}'."
         }
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -150,11 +150,11 @@ class FossId internal constructor(
         fun convertGitUrlToProjectName(gitRepoUrl: String): String {
             val projectNameMatcher = PROJECT_NAME_REGEX.matchEntire(gitRepoUrl)
 
-            requireNotNull(projectNameMatcher) { "Git repository URL '$gitRepoUrl' does not contain a project name." }
+            requireNotNull(projectNameMatcher) { "Git repository URL $gitRepoUrl does not contain a project name." }
 
             val projectName = projectNameMatcher.groupValues[1]
 
-            logger.info { "Found project name '$projectName' in URL '$gitRepoUrl'." }
+            logger.info { "Found project name '$projectName' in URL $gitRepoUrl." }
 
             return projectName
         }

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -220,7 +220,7 @@ private fun urlToPackageType(url: String): PurlType =
         else -> {
             PurlType.GENERIC.also {
                 logger.warn {
-                    "Cannot determine PURL type for url '$url' and provider '$provider'. Falling back to '$it'."
+                    "Cannot determine PURL type for URL $url and provider '$provider'. Falling back to '$it'."
                 }
             }
         }

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
@@ -86,7 +86,7 @@ class FossIdUrlProvider private constructor(
          */
         private fun queryAuthenticator(repoUrl: String): PasswordAuthentication? {
             val repoUri = repoUrl.toUri().getOrElse {
-                logger.warn { "The repository URL '$repoUrl' is not valid." }
+                logger.warn { "The repository URL $repoUrl is not valid." }
                 return null
             }
 
@@ -154,7 +154,7 @@ class FossIdUrlProvider private constructor(
             }
         }
 
-        logger.info { "No matching URL mapping could be found for '$repoUrl'." }
+        logger.info { "No matching URL mapping could be found for $repoUrl." }
 
         return repoUrl
     }

--- a/plugins/version-control-systems/git/src/funTest/kotlin/GitDownloadFunTest.kt
+++ b/plugins/version-control-systems/git/src/funTest/kotlin/GitDownloadFunTest.kt
@@ -59,7 +59,7 @@ class GitDownloadFunTest : StringSpec() {
             val exception = shouldThrow<DownloadException> {
                 git.download(pkg, outputDir, allowMovingRevisions = true)
             }
-            exception.message shouldBe "Git failed to get revisions from URL '$url'."
+            exception.message shouldBe "Git failed to get revisions from URL $url."
         }
 
         "Git can download a given revision".config(tags = setOf(ExpensiveTag)) {

--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -174,7 +174,7 @@ class Git : VersionControlSystem(), CommandLineTool {
     ): Result<String> =
         (workingTree as GitWorkingTree).useRepo {
             Git(this).use { git ->
-                logger.info { "Updating working tree from '${workingTree.getRemoteUrl()}'." }
+                logger.info { "Updating working tree from ${workingTree.getRemoteUrl()}." }
 
                 updateWorkingTreeWithoutSubmodules(workingTree, git, revision).mapCatching {
                     // In case this throws the exception gets encapsulated as a failure.

--- a/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
@@ -115,7 +115,7 @@ val okHttpClient: OkHttpClient by lazy {
                 it.showStackTrace()
 
                 logger.error {
-                    "HTTP request to '${request.url}' failed with an exception: ${it.collectMessages()}"
+                    "HTTP request to ${request.url} failed with an exception: ${it.collectMessages()}"
                 }
             }.getOrThrow()
         }

--- a/utils/ort/src/main/kotlin/storage/HttpFileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/HttpFileStorage.kt
@@ -112,7 +112,7 @@ class HttpFileStorage(
         }
 
         response.close()
-        throw IOException("Could not read from '${request.url}': ${response.code} - ${response.message}")
+        throw IOException("Could not read from ${request.url}: ${response.code} - ${response.message}")
     }
 
     override fun write(path: String, inputStream: InputStream) {
@@ -128,7 +128,7 @@ class HttpFileStorage(
             return httpClient.execute(request).use { response ->
                 if (!response.isSuccessful) {
                     throw IOException(
-                        "Could not store file at '${request.url}': ${response.code} - ${response.message}"
+                        "Could not store file at ${request.url}: ${response.code} - ${response.message}"
                     )
                 }
             }


### PR DESCRIPTION
URLs cannot contain literal spaces, so there usually is no need to quote them for readability.