### PR TITLE
Revert "refactor(scancode): Disregard the output format in scanner configuration

### DIFF
--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -76,6 +76,7 @@ class ScanCode internal constructor(
         const val SCANNER_NAME = "ScanCode"
 
         private const val LICENSE_REFERENCES_OPTION_VERSION = "32.0.0"
+        private const val OUTPUT_FORMAT_OPTION = "--json-pp"
     }
 
     class Factory : ScannerWrapperFactory<ScanCodeConfig>(SCANNER_NAME) {
@@ -101,6 +102,7 @@ class ScanCode internal constructor(
     override val configuration by lazy {
         buildList {
             addAll(config.commandLine)
+            add(OUTPUT_FORMAT_OPTION)
 
             // Add this in the style of a fake command line option for consistency with the above.
             if (config.preferFileLicense) add("--prefer-file-license")
@@ -165,7 +167,7 @@ class ScanCode internal constructor(
             command(),
             *commandLineOptions.toTypedArray(),
             // The output format option needs to directly precede the result file path.
-            "--json-pp", resultFile.absolutePath,
+            OUTPUT_FORMAT_OPTION, resultFile.absolutePath,
             path.absolutePath
         )
 }

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -43,7 +43,7 @@ class ScanCodeTest : WordSpec({
 
     "configuration" should {
         "return the default values if the scanner configuration is empty" {
-            scanner.configuration shouldBe "--copyright --license --info --strip-root --timeout 300"
+            scanner.configuration shouldBe "--copyright --license --info --strip-root --timeout 300 --json-pp"
         }
 
         "return the non-config values from the scanner configuration" {
@@ -56,7 +56,7 @@ class ScanCodeTest : WordSpec({
 
             val scannerWithConfig = ScanCode("ScanCode", config, ScannerWrapperConfig.EMPTY)
 
-            scannerWithConfig.configuration shouldBe "--command --line"
+            scannerWithConfig.configuration shouldBe "--command --line --json-pp"
         }
     }
 


### PR DESCRIPTION
This reverts commit a8d6171433ac0549ecf880cccb4f4c9be4036416.

While the change itself made sense, it breaks the matching with existing scan results that still contain the `--json-pp` option. This means that all stored `ScanCode` results cannot be used anymore.

As there is no way to fix this in the user configuration, revert the change until a better solution is found.

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
