### PR TITLE
SwiftPM enhancements

### DIFF
--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v1.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v1.yml
@@ -15,6 +15,14 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "Swift::github.com/apple/swift-argument-parser:0.2.0"
+    - id: "Swift::github.com/apple/swift-crypto:"
+    - id: "Swift::github.com/apple/swift-llbuild:9.0.8"
+    - id: "Swift::github.com/braze-inc/braze-ios-sdk:branch-master"
+    - id: "Swift::github.com/grpc/grpc-swift:revision-efb67a324eaf1696b50e66bc471a53690e41fbf6"
 packages:
 - id: "Swift::github.com/apple/swift-argument-parser:0.2.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-argument-parser@0.2.0"

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v1.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v1.yml
@@ -95,12 +95,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-llbuild.git"
-    revision: "9.0.8"
+    revision: ""
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-llbuild.git"
-    revision: "9.0.8"
+    revision: ""
     path: ""
 - id: "Swift::github.com/braze-inc/braze-ios-sdk:branch-master"
   purl: "pkg:swift/github.com%2Fbraze-inc%2Fbraze-ios-sdk@branch-master"

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v2.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v2.yml
@@ -15,6 +15,10 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "Swift::github.com/alamofire/alamofire:5.4.4"
 packages:
 - id: "Swift::github.com/alamofire/alamofire:5.4.4"
   purl: "pkg:swift/github.com%2Falamofire%2Falamofire@5.4.4"

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v3.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v3.yml
@@ -15,6 +15,7 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""
+  scopes: []
 packages: []
 issues:
 - timestamp: "1970-01-01T00:00:00Z"

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-project-with-lockfile.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-project-with-lockfile.yml
@@ -121,7 +121,7 @@ project:
         - id: "Swift::github.com/apple/swift-atomics:1.2.0"
         - id: "Swift::github.com/apple/swift-collections:1.0.6"
         - id: "Swift::github.com/apple/swift-system:1.2.1"
-    - id: "Swift::github.com/vapor/console-kit:unspecified"
+    - id: "Swift::github.com/vapor/console-kit:revision-a31f44ebfbd15a2cc0fda705279676773ac16355"
       dependencies:
       - id: "Swift::github.com/apple/swift-log:1.5.4"
       - id: "Swift::github.com/apple/swift-nio:2.63.0"
@@ -199,12 +199,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-algorithms.git"
-    revision: "1.2.0"
+    revision: "f6919dfc309e7f1b56224378b11e28bab5bccc42"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-algorithms.git"
-    revision: "1.2.0"
+    revision: "f6919dfc309e7f1b56224378b11e28bab5bccc42"
     path: ""
 - id: "Swift::github.com/apple/swift-atomics:1.2.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-atomics@1.2.0"
@@ -225,12 +225,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-atomics.git"
-    revision: "1.2.0"
+    revision: "cd142fd2f64be2100422d658e7411e39489da985"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-atomics.git"
-    revision: "1.2.0"
+    revision: "cd142fd2f64be2100422d658e7411e39489da985"
     path: ""
 - id: "Swift::github.com/apple/swift-collections:1.0.6"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-collections@1.0.6"
@@ -251,12 +251,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-collections.git"
-    revision: "1.0.6"
+    revision: "d029d9d39c87bed85b1c50adee7c41795261a192"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-collections.git"
-    revision: "1.0.6"
+    revision: "d029d9d39c87bed85b1c50adee7c41795261a192"
     path: ""
 - id: "Swift::github.com/apple/swift-crypto:2.6.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-crypto@2.6.0"
@@ -277,12 +277,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-crypto.git"
-    revision: "2.6.0"
+    revision: "60f13f60c4d093691934dc6cfdf5f508ada1f894"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-crypto.git"
-    revision: "2.6.0"
+    revision: "60f13f60c4d093691934dc6cfdf5f508ada1f894"
     path: ""
 - id: "Swift::github.com/apple/swift-http-types:1.0.3"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-http-types@1.0.3"
@@ -303,12 +303,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-http-types.git"
-    revision: "1.0.3"
+    revision: "12358d55a3824bd5fed310b999ea8cf83a9a1a65"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-http-types.git"
-    revision: "1.0.3"
+    revision: "12358d55a3824bd5fed310b999ea8cf83a9a1a65"
     path: ""
 - id: "Swift::github.com/apple/swift-log:1.5.4"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-log@1.5.4"
@@ -329,12 +329,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-log.git"
-    revision: "1.5.4"
+    revision: "e97a6fcb1ab07462881ac165fdbb37f067e205d5"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-log.git"
-    revision: "1.5.4"
+    revision: "e97a6fcb1ab07462881ac165fdbb37f067e205d5"
     path: ""
 - id: "Swift::github.com/apple/swift-metrics:2.4.1"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-metrics@2.4.1"
@@ -355,12 +355,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-metrics.git"
-    revision: "2.4.1"
+    revision: "971ba26378ab69c43737ee7ba967a896cb74c0d1"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-metrics.git"
-    revision: "2.4.1"
+    revision: "971ba26378ab69c43737ee7ba967a896cb74c0d1"
     path: ""
 - id: "Swift::github.com/apple/swift-nio:2.63.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-nio@2.63.0"
@@ -381,12 +381,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-nio.git"
-    revision: "2.63.0"
+    revision: "635b2589494c97e48c62514bc8b37ced762e0a62"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-nio.git"
-    revision: "2.63.0"
+    revision: "635b2589494c97e48c62514bc8b37ced762e0a62"
     path: ""
 - id: "Swift::github.com/apple/swift-nio-extras:1.21.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-extras@1.21.0"
@@ -407,12 +407,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-nio-extras.git"
-    revision: "1.21.0"
+    revision: "363da63c1966405764f380c627409b2f9d9e710b"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-nio-extras.git"
-    revision: "1.21.0"
+    revision: "363da63c1966405764f380c627409b2f9d9e710b"
     path: ""
 - id: "Swift::github.com/apple/swift-nio-http2:1.30.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-http2@1.30.0"
@@ -433,12 +433,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-nio-http2.git"
-    revision: "1.30.0"
+    revision: "0904bf0feb5122b7e5c3f15db7df0eabe623dd87"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-nio-http2.git"
-    revision: "1.30.0"
+    revision: "0904bf0feb5122b7e5c3f15db7df0eabe623dd87"
     path: ""
 - id: "Swift::github.com/apple/swift-nio-ssl:2.26.0"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-ssl@2.26.0"
@@ -459,12 +459,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-nio-ssl.git"
-    revision: "2.26.0"
+    revision: "7c381eb6083542b124a6c18fae742f55001dc2b5"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-nio-ssl.git"
-    revision: "2.26.0"
+    revision: "7c381eb6083542b124a6c18fae742f55001dc2b5"
     path: ""
 - id: "Swift::github.com/apple/swift-nio-transport-services:1.20.1"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-nio-transport-services@1.20.1"
@@ -485,12 +485,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-nio-transport-services.git"
-    revision: "1.20.1"
+    revision: "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-nio-transport-services.git"
-    revision: "1.20.1"
+    revision: "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce"
     path: ""
 - id: "Swift::github.com/apple/swift-numerics:1.0.2"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-numerics@1.0.2"
@@ -511,12 +511,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-numerics.git"
-    revision: "1.0.2"
+    revision: "0a5bc04095a675662cf24757cc0640aa2204253b"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-numerics.git"
-    revision: "1.0.2"
+    revision: "0a5bc04095a675662cf24757cc0640aa2204253b"
     path: ""
 - id: "Swift::github.com/apple/swift-system:1.2.1"
   purl: "pkg:swift/github.com%2Fapple%2Fswift-system@1.2.1"
@@ -537,12 +537,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/apple/swift-system.git"
-    revision: "1.2.1"
+    revision: "025bcb1165deab2e20d4eaba79967ce73013f496"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/apple/swift-system.git"
-    revision: "1.2.1"
+    revision: "025bcb1165deab2e20d4eaba79967ce73013f496"
     path: ""
 - id: "Swift::github.com/swift-server/async-http-client:1.20.1"
   purl: "pkg:swift/github.com%2Fswift-server%2Fasync-http-client@1.20.1"
@@ -563,12 +563,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/swift-server/async-http-client.git"
-    revision: "1.20.1"
+    revision: "291438696abdd48d2a83b52465c176efbd94512b"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/swift-server/async-http-client.git"
-    revision: "1.20.1"
+    revision: "291438696abdd48d2a83b52465c176efbd94512b"
     path: ""
 - id: "Swift::github.com/swift-server/swift-backtrace:1.3.4"
   purl: "pkg:swift/github.com%2Fswift-server%2Fswift-backtrace@1.3.4"
@@ -589,12 +589,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/swift-server/swift-backtrace.git"
-    revision: "1.3.4"
+    revision: "80746bdd0ac8a7d83aad5d89dac3cbf15de652e6"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/swift-server/swift-backtrace.git"
-    revision: "1.3.4"
+    revision: "80746bdd0ac8a7d83aad5d89dac3cbf15de652e6"
     path: ""
 - id: "Swift::github.com/vapor/async-kit:1.19.0"
   purl: "pkg:swift/github.com%2Fvapor%2Fasync-kit@1.19.0"
@@ -615,15 +615,15 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/vapor/async-kit.git"
-    revision: "1.19.0"
+    revision: "7ece208cd401687641c88367a00e3ea2b04311f1"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/vapor/async-kit.git"
-    revision: "1.19.0"
+    revision: "7ece208cd401687641c88367a00e3ea2b04311f1"
     path: ""
-- id: "Swift::github.com/vapor/console-kit:unspecified"
-  purl: "pkg:swift/github.com%2Fvapor%2Fconsole-kit@unspecified"
+- id: "Swift::github.com/vapor/console-kit:revision-a31f44ebfbd15a2cc0fda705279676773ac16355"
+  purl: "pkg:swift/github.com%2Fvapor%2Fconsole-kit@revision-a31f44ebfbd15a2cc0fda705279676773ac16355"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -641,12 +641,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/vapor/console-kit.git"
-    revision: "unspecified"
+    revision: "a31f44ebfbd15a2cc0fda705279676773ac16355"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/vapor/console-kit.git"
-    revision: "unspecified"
+    revision: "a31f44ebfbd15a2cc0fda705279676773ac16355"
     path: ""
 - id: "Swift::github.com/vapor/multipart-kit:4.6.0"
   purl: "pkg:swift/github.com%2Fvapor%2Fmultipart-kit@4.6.0"
@@ -667,12 +667,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/vapor/multipart-kit.git"
-    revision: "4.6.0"
+    revision: "12ee56f25bd3fc4c2d09c2aa16e69de61dc786e8"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/vapor/multipart-kit.git"
-    revision: "4.6.0"
+    revision: "12ee56f25bd3fc4c2d09c2aa16e69de61dc786e8"
     path: ""
 - id: "Swift::github.com/vapor/routing-kit:4.9.0"
   purl: "pkg:swift/github.com%2Fvapor%2Frouting-kit@4.9.0"
@@ -693,12 +693,12 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/vapor/routing-kit.git"
-    revision: "4.9.0"
+    revision: "2a92a7eac411a82fb3a03731be5e76773ebe1b3e"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/vapor/routing-kit.git"
-    revision: "4.9.0"
+    revision: "2a92a7eac411a82fb3a03731be5e76773ebe1b3e"
     path: ""
 - id: "Swift::github.com/vapor/websocket-kit:2.14.0"
   purl: "pkg:swift/github.com%2Fvapor%2Fwebsocket-kit@2.14.0"
@@ -719,10 +719,10 @@ packages:
   vcs:
     type: "Git"
     url: "https://github.com/vapor/websocket-kit.git"
-    revision: "2.14.0"
+    revision: "53fe0639a98903858d0196b699720decb42aee7b"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/vapor/websocket-kit.git"
-    revision: "2.14.0"
+    revision: "53fe0639a98903858d0196b699720decb42aee7b"
     path: ""

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -173,12 +173,12 @@ private val SwiftPackage.id: Identifier
         version = version
     )
 
-private fun SwiftPackage.toPackage(): Package {
+private fun SwiftPackage.toVcsInfo(): VcsInfo {
     val vcsInfoFromUrl = VcsHost.parseUrl(url)
-    val vcsInfo = vcsInfoFromUrl.takeUnless { it.revision.isBlank() } ?: vcsInfoFromUrl.copy(revision = version)
-
-    return createPackage(id, vcsInfo)
+    return vcsInfoFromUrl.takeUnless { it.revision.isBlank() } ?: vcsInfoFromUrl.copy(revision = version)
 }
+
+private fun SwiftPackage.toPackage(): Package = createPackage(id, toVcsInfo())
 
 private fun SwiftPackage.toPackageReference(): PackageReference =
     PackageReference(

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -101,7 +101,7 @@ class SwiftPm(
 
         return listOf(
             ProjectAnalyzerResult(
-                project = projectFromDefinitionFile(packageResolvedFile),
+                project = projectFromDefinitionFile(packageResolvedFile, emptySet()),
                 packages = pins.mapTo(mutableSetOf()) { it.toPackage() },
                 issues = issues
             )
@@ -114,7 +114,6 @@ class SwiftPm(
      * Also, this method provides parent-child associations for parsed dependencies.
      */
     private fun resolveDefinitionFileDependencies(packageSwiftFile: File): List<ProjectAnalyzerResult> {
-        val project = projectFromDefinitionFile(packageSwiftFile)
         val swiftPackage = getSwiftPackage(packageSwiftFile)
 
         val issues = mutableListOf<Issue>()
@@ -135,7 +134,7 @@ class SwiftPm(
 
         return listOf(
             ProjectAnalyzerResult(
-                project = project.copy(scopeDependencies = scopeDependencies),
+                project = projectFromDefinitionFile(packageSwiftFile, scopeDependencies),
                 packages = packages,
                 issues = issues
             )
@@ -155,7 +154,7 @@ class SwiftPm(
         return parseSwiftPackage(result)
     }
 
-    private fun projectFromDefinitionFile(definitionFile: File): Project {
+    private fun projectFromDefinitionFile(definitionFile: File, scopeDependencies: Set<Scope>): Project {
         val vcsInfo = VersionControlSystem.forDirectory(definitionFile.parentFile)?.getInfo().orEmpty()
 
         val projectIdentifier = Identifier(
@@ -170,6 +169,7 @@ class SwiftPm(
             id = projectIdentifier,
             declaredLicenses = emptySet(),
             homepageUrl = "",
+            scopeDependencies = scopeDependencies,
             vcsProcessed = processProjectVcs(definitionFile.parentFile),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path
         )

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -194,10 +194,7 @@ private fun SwiftPackage.toId(pinsByIdentity: Map<String, PinV2>): Identifier =
     )
 
 private fun SwiftPackage.toVcsInfo(pinsByIdentity: Map<String, PinV2>): VcsInfo =
-    pinsByIdentity[identity]?.toVcsInfo() ?: run {
-        val vcsInfoFromUrl = VcsHost.parseUrl(url)
-        return vcsInfoFromUrl.takeUnless { it.revision.isBlank() } ?: vcsInfoFromUrl.copy(revision = version)
-    }
+    pinsByIdentity[identity]?.toVcsInfo() ?: VcsHost.parseUrl(url)
 
 private fun SwiftPackage.toPackage(pinsByIdentity: Map<String, PinV2>): Package =
     createPackage(toId(pinsByIdentity), toVcsInfo(pinsByIdentity))
@@ -241,7 +238,6 @@ private fun PinV2.toVcsInfo(): VcsInfo {
     return if (vcsInfoFromUrl.revision.isBlank() && state != null) {
         when {
             !state.revision.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.revision)
-            !state.version.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.version)
             else -> vcsInfoFromUrl
         }
     } else {

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -199,8 +199,8 @@ private fun SwiftPackage.getTransitiveDependencies(): Set<SwiftPackage> {
     return result
 }
 
-private fun PinV2.toPackage(): Package {
-    val id = Identifier(
+private fun PinV2.toId(): Identifier =
+    Identifier(
         type = PACKAGE_TYPE,
         namespace = "",
         name = getCanonicalName(location),
@@ -214,8 +214,9 @@ private fun PinV2.toPackage(): Package {
         }.orEmpty()
     )
 
+private fun PinV2.toVcsInfo(): VcsInfo {
     val vcsInfoFromUrl = VcsHost.parseUrl(location)
-    val vcsInfo = if (vcsInfoFromUrl.revision.isBlank() && state != null) {
+    return if (vcsInfoFromUrl.revision.isBlank() && state != null) {
         when {
             !state.revision.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.revision)
             !state.version.isNullOrBlank() -> vcsInfoFromUrl.copy(revision = state.version)
@@ -224,9 +225,9 @@ private fun PinV2.toPackage(): Package {
     } else {
         vcsInfoFromUrl
     }
-
-    return createPackage(id, vcsInfo)
 }
+
+private fun PinV2.toPackage(): Package = createPackage(toId(), toVcsInfo())
 
 private fun createPackage(id: Identifier, vcsInfo: VcsInfo) =
     Package(

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -165,8 +165,8 @@ class SwiftPm(
     }
 }
 
-private val SwiftPackage.id: Identifier
-    get() = Identifier(
+private fun SwiftPackage.toId(): Identifier =
+    Identifier(
         type = PACKAGE_TYPE,
         namespace = "",
         name = getCanonicalName(url),
@@ -178,11 +178,11 @@ private fun SwiftPackage.toVcsInfo(): VcsInfo {
     return vcsInfoFromUrl.takeUnless { it.revision.isBlank() } ?: vcsInfoFromUrl.copy(revision = version)
 }
 
-private fun SwiftPackage.toPackage(): Package = createPackage(id, toVcsInfo())
+private fun SwiftPackage.toPackage(): Package = createPackage(toId(), toVcsInfo())
 
 private fun SwiftPackage.toPackageReference(): PackageReference =
     PackageReference(
-        id = id,
+        id = toId(),
         dependencies = dependencies.mapTo(mutableSetOf()) { it.toPackageReference() }
     )
 


### PR DESCRIPTION
As a first step, this PR moves from the dependency graph builder to the old way of constructing things, to simplify the following steps. Then, the implementation is enhanced by:

1. Properly set the version strings and revision for the `Package.swift` analysis by creating 
    the result based on the lockfile entries, while using the previously used `swift package show-dependencies` entries
    only as a fallback.
2. Properly assign all packages to a scope for the lockfile-only analysis. Previously, no links between packages
    and projects have been created.
3. Remove the invalid fallback to the `version` for `vcs.revision`.

Note: This PR should be merged after #8233.