### PR TITLE
fix(swiftpm): Ignore "unspecified" versions

### DIFF
--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -190,7 +190,7 @@ private fun SwiftPackage.toId(pinsByIdentity: Map<String, PinV2>): Identifier =
         type = PACKAGE_TYPE,
         namespace = "",
         name = getCanonicalName(url),
-        version = version
+        version = version.takeUnless { it == "unspecified" }.orEmpty()
     )
 
 private fun SwiftPackage.toVcsInfo(pinsByIdentity: Map<String, PinV2>): VcsInfo =


### PR DESCRIPTION
When a dependency is specified using a branch, running [^1] yields "unspecified" as the version. Use an empty string in this case for consistency.

[^1]: `swift package show-dependencies`
