### PR TITLE
fix(askalono): Correctly handle errors in results

### DIFF
--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -97,13 +97,13 @@ class Askalono internal constructor(name: String, private val wrapperConfig: Sca
         )
 
         results.forEach {
-            if (it.error == null) {
+            if (it.result != null) {
                 licenseFindings += LicenseFinding(
                     license = it.result.license.name,
                     location = TextLocation(it.path, TextLocation.UNKNOWN_LINE),
                     score = it.result.score
                 )
-            } else {
+            } else if (it.error != null) {
                 issues += Issue(
                     source = name,
                     message = it.error,

--- a/plugins/scanners/askalono/src/main/kotlin/AskalonoResultModel.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/AskalonoResultModel.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AskalonoResult(
     val path: String,
-    val result: PathResult,
+    val result: PathResult? = null,
     val error: String? = null
 )
 


### PR DESCRIPTION
When working on unrelated changes, I noticed that the Askalono wrapper assumes the "result" key is always present. Maybe that used to be the case, but the version I'm using (0.4.6) produces the following structure:

```
{"path":"./COPYING","error":"Confidence threshold not high enough for any known license"}
```
