### PR TITLE
Adding IconScout simple license

### DIFF
--- a/plugins/reporters/web-app-template/public/index.html
+++ b/plugins/reporters/web-app-template/public/index.html
@@ -1782,6 +1782,9 @@
             }, {
               "_id" : 260,
               "id" : "ZPL-2.1"
+            }, {
+              "_id" : 261,
+              "id" : "IconScoutSimple"
             } ],
             "scopes" : [ {
               "_id" : 0,

--- a/utils/spdx/src/main/kotlin/SpdxLicense.kt
+++ b/utils/spdx/src/main/kotlin/SpdxLicense.kt
@@ -340,6 +340,7 @@ enum class SpdxLicense(
     HP_1989("HP-1989", "Hewlett-Packard 1989 License"),
     HTMLTIDY("HTMLTIDY", "HTML Tidy License"),
     IBM_PIBS("IBM-pibs", "IBM PowerPC Initialization and Boot Software"),
+    ICON_SCOUT_SIMPLE("IconScoutSimple", "IconScout Simple License"),
     ICU("ICU", "ICU License"),
     IEC_CODE_COMPONENTS_EULA("IEC-Code-Components-EULA", "IEC    Code Components End-user licence agreement"),
     IJG("IJG", "Independent JPEG Group License"),

--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -338,6 +338,7 @@
 "HSQLDB License, a BSD open source license": BSD-3-Clause
 "Historical Permission Notice and Disclaimer (HPND)": HPND
 "IBM Public License": IPL-1.0
+"IconScout Simple License": IconScoutSimple
 "ISC License (ISCL)": ISC
 "ISC/BSD License": ISC OR BSD-2-Clause
 "Indiana University Extreme! Lab Software License 1.1.1": LicenseRef-scancode-indiana-extreme

--- a/utils/spdx/src/main/resources/licenses/IconScoutSimple
+++ b/utils/spdx/src/main/resources/licenses/IconScoutSimple
@@ -1,0 +1,12 @@
+IconScout Simple License
+
+Copyright © 2022 Design Barn Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the asset files available for download at the IconScout site (“Files”). To download, modify, and use digitally such Files, for commercial purposes, provided that any display, publication, or performance of Files must contain (and be subject to) the same terms and conditions of this license. Modifications to Files are deemed derivative works and can be used for commercial as well as personal projects but are not allowed to resell or republish( as a separate entity under any other profile) to any platform. You may not purport to impose any additional or different terms or conditions on or apply any technical measures that restrict the exercise of, the rights granted under this license.
+
+This license does not include the right to collect or compile Files from IconScout to replicate or develop a similar or competing service.
+
+Use of Files in your product or project without attributing the creator(s) of the Files is permitted under this license, though attribution is strongly encouraged. If attributions are included, such attributions should be visible to the end-user. However, Any assets uploaded or published by you of which you are **not the original designer** but you have edited in some way must have the original creator attributed and a link provided to the original animation in the description. If you fail to do this, the upload falls under the category of plagiarised content can be reported and may be removed from IconScout.
+
+FILES ARE PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL THE CREATOR(S) OF FILES OR DESIGN BARN, INC. BE LIABLE ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF SUCH FILES.
+


### PR DESCRIPTION
Adding the IconScout Simple License, which is granted for using the Unicons icon library.

See https://github.com/Iconscout/unicons for details and the original license.
