### PR TITLE
chore(Gradle): Remove a work-around for the SemVersioning plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ semver {
 
 // Only override a default version (which usually is "unspecified"), but not a custom version.
 if (version == Project.DEFAULT_VERSION) {
-    version = semver.semVersion.takeIf { it.preRelease.isPreRelease }
+    version = semver.semVersion.takeIf { it.isPreRelease }
         // To get rid of a build part's "+" prefix because Docker tags do not support it, use only the original "build"
         // part as the "pre-release" part.
         ?.toString()?.replace("${semver.defaultPreRelease}+", "")


### PR DESCRIPTION
This was required for version 0.12.0 by accident, see [1].

[1]: https://github.com/jmongard/Git.SemVersioning.Gradle/issues/51