### PR TITLE
feat(jenkins): Allow to specify an input path within the repository

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -130,6 +130,12 @@ pipeline {
             description: 'An optional existing analyzer result file to use instead of running the analyzer.'
         )
 
+        string(
+            name: 'ANALYZER_INPUT_PATH',
+            description: 'The path to analyze, relative to the repository root. May point to a definition file if only a single package manager is enabled.',
+            defaultValue: ''
+        )
+
         booleanParam(
             name: 'ALLOW_DYNAMIC_VERSIONS',
             description: 'Allow dynamic versions of dependencies (support projects without lock files).',
@@ -494,7 +500,7 @@ pipeline {
                     /opt/ort/bin/set_gradle_proxy.sh
 
                     rm -fr out/results
-                    /opt/ort/bin/ort $ORT_OPTIONS analyze -i "$PROJECT_DIR/source" -o out/results/analyzer -l JENKINS_BUILD_URL=$BUILD_URL
+                    /opt/ort/bin/ort $ORT_OPTIONS analyze -i "$PROJECT_DIR/source/$ANALYZER_INPUT_PATH" -o out/results/analyzer -l JENKINS_BUILD_URL=$BUILD_URL
                     '''.stripIndent().trim()
 
                     if (status >= ORT_FAILURE_STATUS_CODE) unstable('Analyzer issues found.')

--- a/plugins/commands/analyzer/src/main/kotlin/AnalyzerCommand.kt
+++ b/plugins/commands/analyzer/src/main/kotlin/AnalyzerCommand.kt
@@ -67,8 +67,8 @@ class AnalyzerCommand : OrtCommand(
 ) {
     private val inputDir by option(
         "--input-dir", "-i",
-        help = "The project directory to analyze. As a special case, if only one package manager is enabled, this " +
-            "may point to a definition file for that package manager to only analyze that single project."
+        help = "The project directory to analyze. May point to a definition file if only a single package manager is " +
+            "enabled."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
         .convert { it.absoluteFile.normalize() }


### PR DESCRIPTION
This can be useful when enabling only a single package manager and pointing the analyzer to a single file for testing analysis of a single project.