### PR TITLE
fix(sw360): Do not use a path as the temp dir infix

### DIFF
--- a/plugins/commands/upload-result-to-sw360/src/main/kotlin/UploadResultToSw360Command.kt
+++ b/plugins/commands/upload-result-to-sw360/src/main/kotlin/UploadResultToSw360Command.kt
@@ -94,7 +94,7 @@ class UploadResultToSw360Command : OrtCommand(
                     .orElseGet { createSw360Release(pkg, sw360ReleaseClient) }
 
                 if (attachSources) {
-                    val tempDirectory = createOrtTempDir(pkg.id.toPath())
+                    val tempDirectory = createOrtTempDir()
                     try {
                         // First, download the sources of the package into a source directory, whose parent directory
                         // is temporary.


### PR DESCRIPTION
The optional infix should be a string without path separators, so simply omit it for simplicity.