### PR TITLE
Re-enable the Gradle configuration cache when not publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew publishAndReleaseToMavenCentral
+        run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
       - name: Build ORT Distributions
         run: ./gradlew :cli:distZip :helper-cli:distZip
       - name: Generate Release Notes

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@
 # License-Filename: LICENSE
 
 org.gradle.caching = true
+org.gradle.configuration-cache = true
 org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 