### PR TITLE
docs(spdx): Consistently refer to patch-level version 2 of SPDX 2.2

### DIFF
--- a/utils/spdx/src/main/kotlin/model/SpdxDocument.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxDocument.kt
@@ -33,8 +33,7 @@ private const val SPDX_VERSION_MAJOR_MINOR = "SPDX-2.2"
 private val DATA_LICENSE = SpdxLicense.CC0_1_0.id
 
 /**
- * An SPDX document as specified by https://github.com/spdx/spdx-spec/tree/development/v2.2.1/chapters and
- * https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/ in revision 947271b.
+ * An SPDX document as specified by https://spdx.github.io/spdx-spec/v2.2.2/.
  */
 data class SpdxDocument(
     /**

--- a/utils/spdx/src/test/kotlin/model/SpdxDocumentTest.kt
+++ b/utils/spdx/src/test/kotlin/model/SpdxDocumentTest.kt
@@ -33,10 +33,10 @@ import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper
 import org.ossreviewtoolkit.utils.spdx.yamlMapper
 
 /**
- * This test uses the following test assets copied from the SPDX 2.2.1 specification examples.
+ * This test uses the following test assets copied from the SPDX 2.2.2 specification examples.
  *
- * 1. https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/SPDXYAMLExample-2.2.spdx.yaml
- * 2. https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/SPDXJSONExample-v2.2.spdx.json
+ * 1. https://github.com/spdx/spdx-spec/blob/development/v2.2.2/examples/SPDXYAMLExample-2.2.spdx.yaml
+ * 2. https://github.com/spdx/spdx-spec/blob/development/v2.2.2/examples/SPDXJSONExample-v2.2.spdx.json
  *
  * The "*-no-ranges.spdx.*" resource files have the "ranges" property removed, which is actually broken in the
  * specification and impossible to implement.


### PR DESCRIPTION
While at it, simplify the `SpdxDocument` docs to just point at the Markdown specification for version 2.2.2.