### PR TITLE
fix(gradle): Unquote JVM args before forwarding them to Gradle

### DIFF
--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
@@ -59,6 +59,7 @@ import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.common.splitOnWhitespace
+import org.ossreviewtoolkit.utils.common.unquote
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.ort.downloadText
@@ -152,6 +153,7 @@ class GradleInspector(
             val jvmArgs = gradleProperties["org.gradle.jvmargs"].orEmpty()
                 .replace("MaxPermSize", "MaxMetaspaceSize") // Replace a deprecated JVM argument.
                 .splitOnWhitespace()
+                .map { it.unquote() }
 
             // In order to debug the plugin, pass the "-Dorg.gradle.debug=true" option to the JVM running ORT. This will
             // then block execution of the plugin until a remote debug session is attached to port 5005 (by default),

--- a/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
@@ -59,6 +59,7 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.temporaryProperties
+import org.ossreviewtoolkit.utils.common.unquote
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
 
 private val GRADLE_USER_HOME = Os.env["GRADLE_USER_HOME"]?.let { File(it) } ?: Os.userHomeDirectory.resolve(".gradle")
@@ -194,7 +195,7 @@ class Gradle(
         // Set the value to empirically determined 8 GiB if no value is set in "~/.gradle/gradle.properties".
         val jvmArgs = gradleProperties.find { (key, _) ->
             key == "org.gradle.jvmargs"
-        }?.second?.splitOnWhitespace().orEmpty().toMutableList()
+        }?.second?.splitOnWhitespace().orEmpty().mapTo(mutableListOf()) { it.unquote() }
 
         if (jvmArgs.none { it.contains(JAVA_MAX_HEAP_SIZE_OPTION, ignoreCase = true) }) {
             jvmArgs += "$JAVA_MAX_HEAP_SIZE_OPTION$JAVA_MAX_HEAP_SIZE_VALUE"


### PR DESCRIPTION
This fixes parsing JVM args like [1].

[1]: https://github.com/JetBrains/ideavim/blob/e443cb0/gradle.properties#L36