### PR TITLE
build(github): Pass a token to Codecov

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Upload code coverage data
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: test
   funTest-non-docker:
     needs: build-web-app-reporter
@@ -136,6 +137,7 @@ jobs:
     - name: Upload code coverage data
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: funTest-non-docker
   funTest-docker:
     runs-on: ubuntu-22.04
@@ -160,4 +162,5 @@ jobs:
     - name: Upload code coverage data
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: funTest-docker


### PR DESCRIPTION
Since version 4 the token is no longer optional [1], so forward it from a configured GitHub secret.

[1]: https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes