### PR TITLE
fix(scanner): Catch a `DownloadException` instead of `IOException`

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.scanner
 
 import java.io.File
-import java.io.IOException
 import java.time.Instant
 
 import kotlin.time.measureTime
@@ -705,7 +704,7 @@ class Scanner(
                 try {
                     dir = provenanceDownloader.downloadRecursively(nestedProvenance)
                     archiver.archive(dir, nestedProvenance.root)
-                } catch (e: IOException) {
+                } catch (e: DownloadException) {
                     controller.addIssue(
                         pkg.id,
                         Issue(

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -709,8 +709,8 @@ class Scanner(
                         pkg.id,
                         Issue(
                             source = "Scanner",
-                            message = "Could not create file archive for " +
-                                "'${pkg.id.toCoordinates()}': ${e.collectMessages()}"
+                            message = "Could not create file archive for '${pkg.id.toCoordinates()}': "
+                                + e.collectMessages()
                         )
                     )
                 } finally {


### PR DESCRIPTION
The `downloadRecursively()` function rethrows `IOException` as `DownloadException`, so the latter needs to be catched here.