### PR TITLE
refactor(scanner)!: Align provenance storages on `write` instead of `put`

### DIFF
--- a/scanner/src/funTest/kotlin/provenance/AbstractNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/AbstractNestedProvenanceStorageFunTest.kt
@@ -45,7 +45,7 @@ abstract class AbstractNestedProvenanceStorageFunTest(vararg listeners: TestList
                 val root = createRepositoryProvenance()
                 val result = NestedProvenanceResolutionResult(createNestedProvenance(root), true)
 
-                storage.putNestedProvenance(root, result)
+                storage.writeNestedProvenance(root, result)
 
                 storage.readNestedProvenance(root) shouldBe result
             }
@@ -57,8 +57,8 @@ abstract class AbstractNestedProvenanceStorageFunTest(vararg listeners: TestList
                 )
                 val result2 = NestedProvenanceResolutionResult(createNestedProvenance(root), true)
 
-                storage.putNestedProvenance(root, result1)
-                storage.putNestedProvenance(root, result2)
+                storage.writeNestedProvenance(root, result1)
+                storage.writeNestedProvenance(root, result2)
 
                 storage.readNestedProvenance(root) shouldBe result2
             }

--- a/scanner/src/funTest/kotlin/provenance/AbstractPackageProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/AbstractPackageProvenanceStorageFunTest.kt
@@ -52,7 +52,7 @@ abstract class AbstractPackageProvenanceStorageFunTest(vararg listeners: TestLis
                 val sourceArtifact = createRemoteArtifact()
                 val result = ResolvedArtifactProvenance(createArtifactProvenance(sourceArtifact))
 
-                storage.putProvenance(id, sourceArtifact, result)
+                storage.writeProvenance(id, sourceArtifact, result)
 
                 storage.readProvenance(id, sourceArtifact) shouldBe result
             }
@@ -62,7 +62,7 @@ abstract class AbstractPackageProvenanceStorageFunTest(vararg listeners: TestLis
                 val vcs = createVcsInfo()
                 val result = ResolvedRepositoryProvenance(createRepositoryProvenance(vcs), vcs.revision, true)
 
-                storage.putProvenance(id, vcs, result)
+                storage.writeProvenance(id, vcs, result)
 
                 storage.readProvenance(id, vcs) shouldBe result
             }
@@ -72,7 +72,7 @@ abstract class AbstractPackageProvenanceStorageFunTest(vararg listeners: TestLis
                 val vcs = createVcsInfo()
                 val result = UnresolvedPackageProvenance("message")
 
-                storage.putProvenance(id, vcs, result)
+                storage.writeProvenance(id, vcs, result)
 
                 storage.readProvenance(id, vcs) shouldBe result
             }
@@ -83,8 +83,8 @@ abstract class AbstractPackageProvenanceStorageFunTest(vararg listeners: TestLis
                 val result1 = UnresolvedPackageProvenance("message")
                 val result2 = ResolvedRepositoryProvenance(createRepositoryProvenance(vcs), vcs.revision, true)
 
-                storage.putProvenance(id, vcs, result1)
-                storage.putProvenance(id, vcs, result2)
+                storage.writeProvenance(id, vcs, result1)
+                storage.writeProvenance(id, vcs, result2)
 
                 storage.readProvenance(id, vcs) shouldBe result2
             }
@@ -96,11 +96,11 @@ abstract class AbstractPackageProvenanceStorageFunTest(vararg listeners: TestLis
 
                 val sourceArtifact = createRemoteArtifact()
                 val artifactResult = ResolvedArtifactProvenance(createArtifactProvenance(sourceArtifact))
-                storage.putProvenance(id, sourceArtifact, artifactResult)
+                storage.writeProvenance(id, sourceArtifact, artifactResult)
 
                 val vcs = createVcsInfo()
                 val vcsResult = ResolvedRepositoryProvenance(createRepositoryProvenance(vcs), vcs.revision, true)
-                storage.putProvenance(id, vcs, vcsResult)
+                storage.writeProvenance(id, vcs, vcsResult)
 
                 storage.readProvenances(id) should containExactlyInAnyOrder(artifactResult, vcsResult)
             }

--- a/scanner/src/funTest/kotlin/provenance/DefaultNestedProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/DefaultNestedProvenanceResolverFunTest.kt
@@ -223,7 +223,7 @@ class DefaultNestedProvenanceResolverFunTest : WordSpec() {
 
 internal class DummyNestedProvenanceStorage : NestedProvenanceStorage {
     override fun readNestedProvenance(root: RepositoryProvenance): NestedProvenanceResolutionResult? = null
-    override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
+    override fun writeNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
         /** no-op */
     }
 }

--- a/scanner/src/funTest/kotlin/provenance/DefaultPackageProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/DefaultPackageProvenanceResolverFunTest.kt
@@ -202,9 +202,11 @@ internal class DummyProvenanceStorage : PackageProvenanceStorage {
 
     override fun readProvenances(id: Identifier): List<PackageProvenanceResolutionResult> = emptyList()
 
-    override fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) { /* no-op */ }
+    override fun writeProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) {
+        /* no-op */
+    }
 
-    override fun putProvenance(
+    override fun writeProvenance(
         id: Identifier,
         sourceArtifact: RemoteArtifact,
         result: PackageProvenanceResolutionResult

--- a/scanner/src/main/kotlin/provenance/FileBasedNestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/provenance/FileBasedNestedProvenanceStorage.kt
@@ -63,7 +63,7 @@ class FileBasedNestedProvenanceStorage(private val backend: FileStorage) : Neste
         }
     }
 
-    override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
+    override fun writeNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
         val results = readResults(root).toMutableList()
         results.removeAll { it.nestedProvenance.root == root }
         results += result

--- a/scanner/src/main/kotlin/provenance/FileBasedPackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/provenance/FileBasedPackageProvenanceStorage.kt
@@ -71,16 +71,16 @@ class FileBasedPackageProvenanceStorage(val backend: FileStorage) : PackageProve
         }
     }
 
-    override fun putProvenance(
+    override fun writeProvenance(
         id: Identifier,
         sourceArtifact: RemoteArtifact,
         result: PackageProvenanceResolutionResult
-    ) = putProvenance(id, sourceArtifact, null, result)
+    ) = writeProvenance(id, sourceArtifact, null, result)
 
-    override fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) =
-        putProvenance(id, null, vcs, result)
+    override fun writeProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) =
+        writeProvenance(id, null, vcs, result)
 
-    private fun putProvenance(
+    private fun writeProvenance(
         id: Identifier,
         sourceArtifact: RemoteArtifact?,
         vcs: VcsInfo?,

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceResolver.kt
@@ -93,7 +93,7 @@ class DefaultNestedProvenanceResolver(
                 // TODO: Find a way to figure out if the nested repository is configured with a fixed revision to
                 //       correctly set `hasOnlyFixedRevisions`. For now always assume that they are fixed because that
                 //       should be correct for most cases and otherwise the storage would have no effect.
-                storage.putNestedProvenance(
+                storage.writeNestedProvenance(
                     provenance,
                     NestedProvenanceResolutionResult(nestedProvenance, hasOnlyFixedRevisions = true)
                 )

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceStorage.kt
@@ -58,10 +58,10 @@ interface NestedProvenanceStorage {
     fun readNestedProvenance(root: RepositoryProvenance): NestedProvenanceResolutionResult?
 
     /**
-     * Put the resolution [result] for the [root] provenance into the storage. If the storage already contains an entry
-     * for [root] it is overwritten.
+     * Write the resolution [result] for the [root] provenance into the storage. If the storage already contains an
+     * entry for [root] it is overwritten.
      */
-    fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult)
+    fun writeNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult)
 }
 
 /**

--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -142,7 +142,7 @@ class DefaultPackageProvenanceResolver(
 
         if (responseCode == HttpURLConnection.HTTP_OK) {
             val artifactProvenance = ArtifactProvenance(pkg.sourceArtifact)
-            storage.putProvenance(pkg.id, pkg.sourceArtifact, ResolvedArtifactProvenance(artifactProvenance))
+            storage.writeProvenance(pkg.id, pkg.sourceArtifact, ResolvedArtifactProvenance(artifactProvenance))
             return artifactProvenance
         }
 
@@ -252,7 +252,7 @@ class DefaultPackageProvenanceResolver(
                 val repositoryProvenance = RepositoryProvenance(pkg.vcsProcessed, workingTree.getRevision())
 
                 vcs.isFixedRevision(workingTree, revision).onSuccess { isFixedRevision ->
-                    storage.putProvenance(
+                    storage.writeProvenance(
                         pkg.id,
                         pkg.vcsProcessed,
                         ResolvedRepositoryProvenance(repositoryProvenance, revision, isFixedRevision)
@@ -265,7 +265,7 @@ class DefaultPackageProvenanceResolver(
             val message = "Could not resolve revision for package '${pkg.id.toCoordinates()}' with " +
                 "${pkg.vcsProcessed}:\n${messages.joinToString("\n") { "\t$it" }}"
 
-            storage.putProvenance(pkg.id, pkg.vcsProcessed, UnresolvedPackageProvenance(message))
+            storage.writeProvenance(pkg.id, pkg.vcsProcessed, UnresolvedPackageProvenance(message))
 
             throw IOException(message)
         }

--- a/scanner/src/main/kotlin/provenance/PackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceStorage.kt
@@ -77,16 +77,16 @@ interface PackageProvenanceStorage {
     fun readProvenances(id: Identifier): List<PackageProvenanceResolutionResult>
 
     /**
-     * Put the resolution [result] for the [id] and [sourceArtifact] into the storage. If the storage already contains
+     * Write the resolution [result] for the [id] and [sourceArtifact] into the storage. If the storage already contains
      * an entry for [id] and [sourceArtifact] it is overwritten.
      */
-    fun putProvenance(id: Identifier, sourceArtifact: RemoteArtifact, result: PackageProvenanceResolutionResult)
+    fun writeProvenance(id: Identifier, sourceArtifact: RemoteArtifact, result: PackageProvenanceResolutionResult)
 
     /**
-     * Put the resolution [result] for the [id] and [vcs] into the storage. If the storage already contains an entry
+     * Write the resolution [result] for the [id] and [vcs] into the storage. If the storage already contains an entry
      * for [id] and [vcs] it is overwritten.
      */
-    fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult)
+    fun writeProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult)
 }
 
 /**

--- a/scanner/src/main/kotlin/provenance/PostgresNestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/provenance/PostgresNestedProvenanceStorage.kt
@@ -73,7 +73,7 @@ class PostgresNestedProvenanceStorage(
             }.map { it[table.result] }.find { it.nestedProvenance.root == root }
         }
 
-    override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
+    override fun writeNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
         database.transaction {
             val idsToRemove = table.selectAll().where {
                 table.vcsType eq root.vcsInfo.type.toString() and

--- a/scanner/src/main/kotlin/provenance/PostgresPackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/provenance/PostgresPackageProvenanceStorage.kt
@@ -93,7 +93,7 @@ class PostgresPackageProvenanceStorage(
             }.map { it[table.result] }
         }
 
-    override fun putProvenance(
+    override fun writeProvenance(
         id: Identifier,
         sourceArtifact: RemoteArtifact,
         result: PackageProvenanceResolutionResult
@@ -114,7 +114,7 @@ class PostgresPackageProvenanceStorage(
         }
     }
 
-    override fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) {
+    override fun writeProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) {
         database.transaction {
             table.deleteWhere {
                 table.identifier eq id.toCoordinates() and


### PR DESCRIPTION
Say `write` instead of `put` to match `read` functions and to align with the `ScanStorage` interfaces.