### PR TITLE
fix(go): Disable the GOPATH mode to fix the fun tests

### DIFF
--- a/plugins/package-managers/go/src/main/kotlin/GoDep.kt
+++ b/plugins/package-managers/go/src/main/kotlin/GoDep.kt
@@ -266,7 +266,7 @@ private fun resolveProjectRoot(definitionFile: File) =
 private fun resolveVcsInfo(importPath: String, revision: String, gopath: File): VcsInfo {
     val pc = ProcessCapture(
         "go", "get", "-d", importPath,
-        environment = mapOf("GOPATH" to gopath.path, "GO111MODULE" to "off")
+        environment = mapOf("GOPATH" to gopath.path)
     )
 
     // HACK Some failure modes from "go get" can be ignored:


### PR DESCRIPTION
Recently, the fun tests for `GoDep` started failing which was roughly the same time as the major version upgrade to 1.22.0 in ORT's docker images. As the GOPATH mode will eventually be remoed ^[1], just disable it now to fix the tests. In particular, do so even though the root cause of the failing tests is unkown, as `GoDep` is rather outdated and thus cannot satisfy putting in further efforts.

[1]: https://github.com/golang/go/issues/41330#issuecomment-690807092

