### PR TITLE
build(Gradle): Force color for the `run` task if the terminal supports it

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -184,3 +184,10 @@ tasks.named<CreateStartScripts>("startScripts") {
         )
     }
 }
+
+tasks.named<JavaExec>("run") {
+    listOf("COLORTERM", "TERM").firstNotNullOfOrNull { System.getenv(it) }?.also {
+        val mode = it.substringAfter('-')
+        environment("FORCE_COLOR" to mode)
+    }
+}


### PR DESCRIPTION
When running through Gradle, the app's output is redirected to terminal detection does not work. Force color in this case if the host's terminal actually supports color. This way e.g.

    ./gradlew :cli:run --args="--help"

shows colorful help output.