### PR TITLE
Migrate from custom kotlinx-serializers for Java types to ks3

### DIFF
--- a/clients/clearly-defined/build.gradle.kts
+++ b/clients/clearly-defined/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
+    implementation(libs.bundles.ks3)
     implementation(libs.kotlinx.coroutines)
     implementation(libs.retrofit.converter.kotlinxSerialization)
     implementation(libs.retrofit.converter.scalars)

--- a/clients/clearly-defined/src/main/kotlin/CoordinatesSerializer.kt
+++ b/clients/clearly-defined/src/main/kotlin/CoordinatesSerializer.kt
@@ -19,14 +19,10 @@
 
 package org.ossreviewtoolkit.clients.clearlydefined
 
-import java.io.File
-import java.net.URI
+import io.ks3.standard.stringSerializer
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -35,7 +31,7 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * A (de-)serializer for ClearlyDefined [Coordinates] instances from / to strings, or from a nested structure.
  */
-object CoordinatesSerializer : KSerializer<Coordinates> by toStringSerializer(::Coordinates) {
+object CoordinatesSerializer : KSerializer<Coordinates> by stringSerializer(::Coordinates) {
     override fun deserialize(decoder: Decoder): Coordinates {
         require(decoder is JsonDecoder)
         return when (val element = decoder.decodeJsonElement()) {
@@ -50,30 +46,4 @@ object CoordinatesSerializer : KSerializer<Coordinates> by toStringSerializer(::
             else -> throw IllegalArgumentException("Unsupported JSON element $element.")
         }
     }
-}
-
-/**
- * A (de-)serializer for Java [File] instances from / to strings.
- */
-object FileSerializer : KSerializer<File> by toStringSerializer(::File)
-
-/**
- * A (de-)serializer for Java [URI] instances class from / to strings.
- */
-object URISerializer : KSerializer<URI> by toStringSerializer(::URI)
-
-/**
- * A convenience function for creating a [ToStringSerializer] whose name is derived from the class name.
- */
-inline fun <reified T : Any> toStringSerializer(noinline create: (String) -> T): ToStringSerializer<T> =
-    ToStringSerializer(T::class.java.name, create)
-
-/**
- * A serializer with the given serial name that uses [Any] instance's [toString] function for serialization and the
- * given [create] function for deserialization.
- */
-class ToStringSerializer<T : Any>(serialName: String, private val create: (String) -> T) : KSerializer<T> {
-    override val descriptor = PrimitiveSerialDescriptor(serialName, PrimitiveKind.STRING)
-    override fun serialize(encoder: Encoder, value: T) = encoder.encodeString(value.toString())
-    override fun deserialize(decoder: Decoder) = create(decoder.decodeString())
 }

--- a/clients/clearly-defined/src/main/kotlin/Curation.kt
+++ b/clients/clearly-defined/src/main/kotlin/Curation.kt
@@ -17,15 +17,12 @@
  * License-Filename: LICENSE
  */
 
-@file:UseSerializers(FileSerializer::class, URISerializer::class)
-
 package org.ossreviewtoolkit.clients.clearlydefined
 
-import java.io.File
-import java.net.URI
+import io.ks3.java.`typealias`.FileAsString
+import io.ks3.java.`typealias`.UriAsString
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonElement
 
 @Serializable
@@ -51,8 +48,8 @@ data class Curation(
 data class CurationDescribed(
     val facets: CurationFacets? = null,
     val sourceLocation: SourceLocation? = null,
-    val projectWebsite: URI? = null,
-    val issueTracker: URI? = null,
+    val projectWebsite: UriAsString? = null,
+    val issueTracker: UriAsString? = null,
     val releaseDate: String? = null
 )
 
@@ -81,7 +78,7 @@ data class CurationLicensed(
  */
 @Serializable
 data class CurationFileEntry(
-    val path: File,
+    val path: FileAsString,
     val license: String? = null,
     val attributions: List<String>? = null
 )

--- a/clients/clearly-defined/src/main/kotlin/Definition.kt
+++ b/clients/clearly-defined/src/main/kotlin/Definition.kt
@@ -17,15 +17,12 @@
  * License-Filename: LICENSE
  */
 
-@file:UseSerializers(FileSerializer::class, URISerializer::class)
-
 package org.ossreviewtoolkit.clients.clearlydefined
 
-import java.io.File
-import java.net.URI
+import io.ks3.java.`typealias`.FileAsString
+import io.ks3.java.`typealias`.UriAsString
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 
 /**
  * See https://github.com/clearlydefined/service/blob/b339cb7/schemas/definition-1.0.json#L48-L61.
@@ -50,7 +47,7 @@ data class FinalScore(
  */
 @Serializable
 data class FileEntry(
-    val path: File,
+    val path: FileAsString,
     val license: String? = null,
     val attributions: List<String>? = null,
     val facets: List<String>? = null,
@@ -80,8 +77,8 @@ data class Described(
     val facets: CurationFacets? = null,
     val sourceLocation: SourceLocation? = null,
     val urls: URLs? = null,
-    val projectWebsite: URI? = null,
-    val issueTracker: URI? = null,
+    val projectWebsite: UriAsString? = null,
+    val issueTracker: UriAsString? = null,
     val releaseDate: String? = null,
     val hashes: Hashes? = null,
     val files: Int? = null,
@@ -116,9 +113,9 @@ data class LicensedScore(
  */
 @Serializable
 data class URLs(
-    val registry: URI? = null,
-    val version: URI? = null,
-    val download: URI? = null
+    val registry: UriAsString? = null,
+    val version: UriAsString? = null,
+    val download: UriAsString? = null
 )
 
 /**

--- a/clients/nexus-iq/build.gradle.kts
+++ b/clients/nexus-iq/build.gradle.kts
@@ -30,5 +30,6 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
+    implementation(libs.bundles.ks3)
     implementation(libs.retrofit.converter.kotlinxSerialization)
 }

--- a/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
+++ b/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
@@ -21,14 +21,11 @@ package org.ossreviewtoolkit.clients.nexusiq
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 
-import java.net.URI
+import io.ks3.java.`typealias`.UriAsString
+
 import java.util.UUID
 
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 
 import okhttp3.Credentials
@@ -40,12 +37,6 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
-
-@Serializer(URI::class)
-object URISerializer : KSerializer<URI> {
-    override fun serialize(encoder: Encoder, value: URI) = encoder.encodeString(value.toString())
-    override fun deserialize(decoder: Decoder) = URI(decoder.decodeString())
-}
 
 /**
  * Interface for the NexusIQ REST API, based on the documentation from
@@ -120,7 +111,7 @@ interface NexusIqService {
         val source: String,
         val reference: String,
         val severity: Float,
-        @Serializable(URISerializer::class) val url: URI?,
+        val url: UriAsString?,
         val threatCategory: String
     ) {
         // See https://guides.sonatype.com/iqserver/technical-guides/sonatype-vuln-data/#how-is-a-vulnerability-score-severity-calculated.

--- a/clients/osv/build.gradle.kts
+++ b/clients/osv/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api(libs.retrofit)
 
     implementation(libs.bundles.kotlinxSerialization)
+    implementation(libs.bundles.ks3)
     implementation(libs.retrofit.converter.kotlinxSerialization)
     implementation(libs.retrofit.converter.scalars)
 

--- a/clients/osv/src/main/kotlin/EventSerializer.kt
+++ b/clients/osv/src/main/kotlin/EventSerializer.kt
@@ -19,15 +19,9 @@
 
 package org.ossreviewtoolkit.clients.osv
 
-import java.time.Instant
-import java.time.format.DateTimeFormatter
-
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
@@ -62,20 +56,5 @@ internal object EventSerializer : KSerializer<Event> {
         val tree = JsonObject(mapOf(value.type.name.lowercase() to JsonPrimitive(value.value)))
 
         output.encodeJsonElement(tree)
-    }
-}
-
-/**
- * Handle RFC3339 formatted strings with a 'Z' as suffix.
- */
-internal object InstantSerializer : KSerializer<Instant> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(javaClass.canonicalName, PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: Instant) {
-        encoder.encodeString(value.toString())
-    }
-
-    override fun deserialize(decoder: Decoder): Instant {
-        return DateTimeFormatter.ISO_ZONED_DATE_TIME.parse(decoder.decodeString(), Instant::from)
     }
 }

--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.clients.osv
 
-import java.time.Instant
+import io.ks3.java.`typealias`.InstantAsString
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -46,12 +46,9 @@ import kotlinx.serialization.json.JsonObject
 data class Vulnerability(
     val schemaVersion: String = "1.0.0",
     val id: String,
-    @Serializable(InstantSerializer::class)
-    val modified: Instant,
-    @Serializable(InstantSerializer::class)
-    val published: Instant? = null,
-    @Serializable(InstantSerializer::class)
-    val withdrawn: Instant? = null,
+    val modified: InstantAsString,
+    val published: InstantAsString? = null,
+    val withdrawn: InstantAsString? = null,
     val aliases: Set<String> = emptySet(),
     val related: Set<String> = emptySet(),
     val summary: String? = null,

--- a/clients/osv/src/main/kotlin/OsvApiClient.kt
+++ b/clients/osv/src/main/kotlin/OsvApiClient.kt
@@ -21,7 +21,8 @@ package org.ossreviewtoolkit.clients.osv
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 
-import java.time.Instant
+import io.ks3.java.`typealias`.InstantAsString
+
 import java.util.concurrent.Executors
 
 import kotlinx.serialization.SerialName
@@ -138,8 +139,7 @@ data class VulnerabilitiesForPackageBatchResponse(
     @Serializable
     data class Id(
         val id: String,
-        @Serializable(InstantSerializer::class)
-        val modified: Instant
+        val modified: InstantAsString
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -129,7 +129,6 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinxHtml" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version.ref = "tomlkt" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4jApi" }
@@ -162,6 +161,7 @@ slf4j = { module = "org.slf4j:slf4j-api ", version.ref = "slf4j" }
 springCore = { module = "org.springframework:spring-core", version.ref = "springCore" }
 svnkit = { module = "org.tmatesoft.svnkit:svnkit", version.ref = "svnkit" }
 sw360Client = { module = "org.eclipse.sw360:client", version.ref = "sw360Client" }
+tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version.ref = "tomlkt" }
 wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 xz = { module = "org.tukaani:xz", version.ref = "xz" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ kotest = "5.8.0"
 kotlinxCoroutines = "1.8.0"
 kotlinxHtml = "0.11.0"
 kotlinxSerialization = "1.6.3"
+ks3 = "0.5.0"
 tomlkt = "0.3.7"
 ktor = "2.3.8"
 log4jApi = "2.23.0"
@@ -129,6 +130,8 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinxHtml" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+ks3-jdk = { module = "io.ks3:ks3-jdk", version.ref = "ks3" }
+ks3-standard = { module = "io.ks3:ks3-standard", version.ref = "ks3" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4jApi" }
@@ -169,4 +172,5 @@ xz = { module = "org.tukaani:xz", version.ref = "xz" }
 exposed = ["exposed-core", "exposed-dao", "exposed-jdbc", "exposed-javaTime", "exposed-json"]
 hoplite = ["hoplite-core", "hoplite-yaml"]
 kotlinxSerialization = ["kotlinx-serialization-core", "kotlinx-serialization-json"]
+ks3 = ["ks3-jdk", "ks3-standard"]
 mavenResolver = ["maven-resolver-connector-basic", "maven-resolver-transport-file", "maven-resolver-transport-http", "maven-resolver-transport-wagon"]


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 