### PR TITLE
fix(gradle): Bump the SPDX license list version to 3.23

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ kotlin.code.style = official
 
 # The version of the SPDX license list which is used to import license texts and generate SPDX enums. Must be a valid
 # tag, see https://github.com/spdx/license-list-data/tags.
-spdxLicenseListVersion = 3.22
+spdxLicenseListVersion = 3.23


### PR DESCRIPTION
This is a fixup ba46f52.