### PR TITLE
build(Gradle): Improve enforcing terminal color

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -186,8 +186,12 @@ tasks.named<CreateStartScripts>("startScripts") {
 }
 
 tasks.named<JavaExec>("run") {
-    listOf("COLORTERM", "TERM").firstNotNullOfOrNull { System.getenv(it) }?.also {
-        val mode = it.substringAfter('-')
+    System.getenv("TERM")?.also {
+        val mode = it.substringAfter('-', "16color")
         environment("FORCE_COLOR" to mode)
+    }
+
+    System.getenv("COLORTERM")?.also {
+        environment("FORCE_COLOR" to it)
     }
 }


### PR DESCRIPTION
Fall back to 16 colors for plain "xterm", like Git Bash for Windows' "mintty".