### PR TITLE
fix(fossid-webapp): Add a version check in `waitDownloadComplete`

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -739,7 +739,9 @@ class FossId internal constructor(
                     // stays in state "NOT FINISHED". Therefore, we check the output of the Git fetch to find out
                     // whether the download is actually done.
                     val message = response.message
-                    if (message == null || !GIT_FETCH_DONE_REGEX.containsMatchIn(message)) return@wait false
+                    if (version >= "20.2" || message == null || !GIT_FETCH_DONE_REGEX.containsMatchIn(message)) {
+                        return@wait false
+                    }
 
                     logger.warn { "The download is not finished but Git Fetch has completed. Carrying on..." }
 


### PR DESCRIPTION
Previous versions of FossID could stay blocked in the state NOT_FINISHED while downloading the repository.  Therefore, during the call to `waitDownloadComplete`, a workaround that checks Git output was put in place.
However, with the newest version of FossID (23.3.0), trying to call "trigger scan" when the download is not finished could lead to an error "Downloading scan files from the git repository is NOT FINISHED. Please wait a little and click rescan button.".
Therefore, this commit adds a version check to the workaround.

