### PR TITLE
fix(fossid-webapp): Replace version comparison with Semver

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -87,6 +87,8 @@ import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
+import org.semver4j.Semver
+
 /**
  * A wrapper for [FossID](https://fossid.com/).
  *
@@ -700,7 +702,9 @@ class FossId internal constructor(
             // Scans that were added to the queue are interpreted as an error by FossID before version 2021.2.
             // For older versions, `waitScanComplete()` is able to deal with queued scans. Therefore, not checking the
             // response of queued scans.
-            if (version >= "2021.2" || scanResult.error != "Scan was added to queue.") {
+            val currentVersion = checkNotNull(Semver.coerce(version))
+            val minVersion = checkNotNull(Semver.coerce("2021.2"))
+            if (currentVersion >= minVersion || scanResult.error != "Scan was added to queue.") {
                 scanResult.checkResponse("trigger scan", false)
             }
 
@@ -739,7 +743,11 @@ class FossId internal constructor(
                     // stays in state "NOT FINISHED". Therefore, we check the output of the Git fetch to find out
                     // whether the download is actually done.
                     val message = response.message
-                    if (version >= "20.2" || message == null || !GIT_FETCH_DONE_REGEX.containsMatchIn(message)) {
+                    val currentVersion = checkNotNull(Semver.coerce(version))
+                    val minVersion = checkNotNull(Semver.coerce("20.2"))
+                    if (currentVersion >= minVersion || message == null
+                        || !GIT_FETCH_DONE_REGEX.containsMatchIn(message)
+                    ) {
                         return@wait false
                     }
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -68,6 +68,8 @@ import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SCAN_ID_KEY
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.SERVER_URL_KEY
 import org.ossreviewtoolkit.plugins.scanners.fossid.FossId.Companion.convertGitUrlToProjectName
 
+import org.semver4j.Semver
+
 @Suppress("LargeClass")
 class FossIdTest : WordSpec({
     beforeSpec {
@@ -94,6 +96,16 @@ class FossIdTest : WordSpec({
             val fossId = createFossId(createConfig())
 
             fossId.version shouldBe FOSSID_VERSION
+        }
+
+        "return a comparable version" {
+            val fossId = createFossId(createConfig())
+
+            val currentVersion = checkNotNull(Semver.coerce(fossId.version))
+            val minVersion = checkNotNull(Semver.coerce("2020.2"))
+            (currentVersion >= minVersion) shouldBe true
+            val minVersion2 = checkNotNull(Semver.coerce("2023.3"))
+            (currentVersion <= minVersion2) shouldBe true
         }
     }
 


### PR DESCRIPTION
`coerce` needs to be used because FossID versions are not valid semantic versions e.g. "23.3".

This follows discussion on https://github.com/oss-review-toolkit/ort/pull/8352.