### PR TITLE
build(Docker): Remove explicit Cargo version

### DIFF
--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -72,7 +72,6 @@ ARG SCANCODE_VERSION
 ENV \
     # Package manager versions.
     BOWER_VERSION=1.8.12 \
-    CARGO_VERSION=1.74.1+dfsg0ubuntu1~bpo0-0ubuntu0.22.04 \
     COCOAPODS_VERSION=1.14.2 \
     COMPOSER_VERSION=2.2.6-2ubuntu4 \
     CONAN_VERSION=1.61.0 \
@@ -128,7 +127,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
         mercurial \
         subversion \
         # Install package managers (in versions known to work).
-        cargo=$CARGO_VERSION \
+        cargo \
         composer=$COMPOSER_VERSION \
         nodejs \
         python-is-python3 \


### PR DESCRIPTION
Since Cargo package manager has no version requirement, always use the version of Cargo available in Ubuntu.
