### PR TITLE
feat(reporter): Sort license finding paths with localeCompare

### DIFF
--- a/plugins/reporters/web-app-template/src/components/PackageFindingsTable.js
+++ b/plugins/reporters/web-app-template/src/components/PackageFindingsTable.js
@@ -204,7 +204,7 @@ const PackageFindingsTable = (props) => {
             dataIndex: 'path',
             defaultSortOrder: 'ascend',
             key: 'path',
-            sorter: (a, b) => a.path.length - b.path.length,
+            sorter: (a, b) => a.path.localeCompare(b.path),
             textWrap: 'word-break',
             title: 'Path'
         },


### PR DESCRIPTION
Use localeCompare to sort paths textually.

Currently paths are sorted by their length, which produces an output that is hard to use. It seems much more natural to sort paths textually.

Old behaviour:
![image](https://github.com/oss-review-toolkit/ort/assets/763880/a867938d-45d5-4f46-be14-4a654803d4da)

New behaviour:
![image](https://github.com/oss-review-toolkit/ort/assets/763880/2387e9fc-7d10-4f69-9dd3-ce4df9b4b653)
