### PR TITLE
fix(advisors): Use potentially customized PURLs in advisor queries

### DIFF
--- a/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
+++ b/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
@@ -42,7 +42,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.utils.PurlType
 import org.ossreviewtoolkit.model.utils.getPurlType
-import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.utils.common.Options
@@ -149,7 +148,7 @@ class NexusIq(name: String, private val config: NexusIqConfiguration) : AdvicePr
         val endTime = Instant.now()
 
         return packages.mapNotNullTo(mutableListOf()) { pkg ->
-            componentDetails[pkg.id.toPurl()]?.let { pkgDetails ->
+            componentDetails[pkg.purl]?.let { pkgDetails ->
                 pkg to AdvisorResult(
                     details,
                     AdvisorSummary(startTime, endTime, issues),

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
@@ -36,7 +36,6 @@ import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.PluginConfiguration
-import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.utils.common.Options
@@ -126,7 +125,7 @@ class OssIndex(name: String, config: OssIndexConfiguration) : AdviceProvider(nam
         val endTime = Instant.now()
 
         return packages.mapNotNullTo(mutableListOf()) { pkg ->
-            componentReports[pkg.id.toPurl()]?.let { report ->
+            componentReports[pkg.purl]?.let { report ->
                 pkg to AdvisorResult(
                     details,
                     AdvisorSummary(startTime, endTime, issues),

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -38,7 +38,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.utils.common.Options
@@ -130,7 +129,7 @@ class VulnerableCode(name: String, config: VulnerableCodeConfiguration) : Advice
         val endTime = Instant.now()
 
         return packages.mapNotNullTo(mutableListOf()) { pkg ->
-            allVulnerabilities[pkg.id.toPurl()]?.let { packageVulnerabilities ->
+            allVulnerabilities[pkg.purl]?.let { packageVulnerabilities ->
                 val vulnerabilities = packageVulnerabilities.map { it.toModel(issues) }
                 val summary = AdvisorSummary(startTime, endTime, issues)
                 pkg to AdvisorResult(details, summary, vulnerabilities = vulnerabilities)


### PR DESCRIPTION
Do not regenerate the PURL from the package ID, but use the PURL that is already stored as part of the package as that might be a custom PURL, e.g. coming from a curation.

For VulnerableCode, this fixes a regression introduced the the refactoring in 70916bf.

Fixes #8385.