### PR TITLE
Allow to set the `sourceCodeOrigins` priority on package granularity

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -74,7 +74,9 @@ class Downloader(private val config: DownloaderConfiguration) {
 
         val exception = DownloadException("Download failed for '${pkg.id.toCoordinates()}'.")
 
-        config.sourceCodeOrigins.forEach { origin ->
+        val sourceCodeOrigins = pkg.sourceCodeOrigins ?: config.sourceCodeOrigins
+
+        sourceCodeOrigins.forEach { origin ->
             val provenance = when (origin) {
                 SourceCodeOrigin.VCS -> handleVcsDownload(pkg, outputDirectory, dryRun, exception)
                 SourceCodeOrigin.ARTIFACT -> handleSourceArtifactDownload(pkg, outputDirectory, dryRun, exception)

--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -70,3 +70,8 @@
     comment: "A copyright statement was used to declare the license."
     declared_license_mapping:
       "Copyright (C) 2013, Martin Journois": "NONE"
+
+- id: "Maven:androidx.collection:collection:"
+  curations:
+    comment: "Scan the source artifact, because the VCS revision and path are hard to figure out."
+    source_code_origins: [ARTIFACT]

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -182,7 +182,8 @@ data class Package(
             sourceArtifact = sourceArtifact.takeIf { it != other.sourceArtifact },
             vcs = vcsProcessed.takeIf { it != other.vcsProcessed }?.toCuration(),
             isMetadataOnly = isMetadataOnly.takeIf { it != other.isMetadataOnly },
-            isModified = isModified.takeIf { it != other.isModified }
+            isModified = isModified.takeIf { it != other.isModified },
+            sourceCodeOrigins = sourceCodeOrigins.takeIf { it != other.sourceCodeOrigins }
         )
     }
 

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
+import org.ossreviewtoolkit.model.utils.requireNotEmptyNoDuplicates
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.common.StringSortedSetConverter
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -129,7 +130,14 @@ data class Package(
      * e.g., in case of a fork of an upstream Open Source project.
      */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    val isModified: Boolean = false
+    val isModified: Boolean = false,
+
+    /**
+     * The considered source code origins and their priority order to use for this package. If null, the configured
+     * default is used. If not null, this must not be empty and not contain any duplicates.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val sourceCodeOrigins: List<SourceCodeOrigin>? = null
 ) {
     companion object {
         /**
@@ -150,6 +158,10 @@ data class Package(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = VcsInfo.EMPTY
         )
+    }
+
+    init {
+        sourceCodeOrigins?.requireNotEmptyNoDuplicates()
     }
 
     /**

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -99,7 +99,14 @@ data class PackageCurationData(
      * applied by [DeclaredLicenseProcessor.process].
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val declaredLicenseMapping: Map<String, SpdxExpression> = emptyMap()
+    val declaredLicenseMapping: Map<String, SpdxExpression> = emptyMap(),
+
+    /**
+     * The considered source code origins in order of priority. If not null, this must not be empty and not contain any
+     * duplicates.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val sourceCodeOrigins: List<SourceCodeOrigin>? = null
 ) {
     /**
      * Apply this [PackageCuration] to [targetPackage] by overriding all values of [targetPackage] with non-null values
@@ -139,7 +146,8 @@ data class PackageCurationData(
             vcs = original.vcs,
             vcsProcessed = vcsProcessed,
             isMetadataOnly = isMetadataOnly ?: original.isMetadataOnly,
-            isModified = isModified ?: original.isModified
+            isModified = isModified ?: original.isModified,
+            sourceCodeOrigins = sourceCodeOrigins ?: original.sourceCodeOrigins
         )
 
         val declaredLicenseMappingDiff = buildMap {
@@ -179,6 +187,7 @@ data class PackageCurationData(
             declaredLicenseMapping = declaredLicenseMapping.zip(other.declaredLicenseMapping) { value, otherValue ->
                 @Suppress("UnsafeCallOnNullableType")
                 (value ?: otherValue)!!
-            }
+            },
+            sourceCodeOrigins = sourceCodeOrigins ?: other.sourceCodeOrigins
         )
 }

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -41,7 +41,8 @@ data class DownloaderConfiguration(
     val skipExcluded: Boolean = false,
 
     /**
-     * Configuration of the considered source code origins and their priority order.
+     * Configuration of the considered source code origins and their priority order. This must not be empty and not
+     * contain any duplicates.
      */
     val sourceCodeOrigins: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
 ) {

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.licenses.LicenseCategory
-import org.ossreviewtoolkit.utils.common.getDuplicates
+import org.ossreviewtoolkit.model.utils.requireNotEmptyNoDuplicates
 
 data class DownloaderConfiguration(
     /**
@@ -47,13 +47,6 @@ data class DownloaderConfiguration(
     val sourceCodeOrigins: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
 ) {
     init {
-        require(sourceCodeOrigins.isNotEmpty()) {
-            "'sourceCodeOrigins' must not be empty."
-        }
-
-        val duplicates = sourceCodeOrigins.getDuplicates()
-        require(duplicates.isEmpty()) {
-            "'sourceCodeOrigins' must not contain duplicates. Duplicates: $duplicates"
-        }
+        sourceCodeOrigins.requireNotEmptyNoDuplicates()
     }
 }

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -26,8 +26,10 @@ import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
 import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.utils.common.getDuplicates
 
 fun String.prependPath(prefix: String): String = if (prefix.isBlank()) this else "${prefix.removeSuffix("/")}/$this"
 
@@ -86,3 +88,14 @@ fun String.parseRepoManifestPath() =
             ?.get(1)
             ?.takeUnless { it.isEmpty() }
     }.getOrNull()
+
+internal fun List<SourceCodeOrigin>.requireNotEmptyNoDuplicates() {
+    require(isNotEmpty()) {
+        "'sourceCodeOrigins' must not be empty."
+    }
+
+    val duplicates = getDuplicates()
+    require(duplicates.isEmpty()) {
+        "'sourceCodeOrigins' must not contain duplicates. Duplicates: $duplicates"
+    }
+}

--- a/model/src/test/kotlin/PackageCurationDataTest.kt
+++ b/model/src/test/kotlin/PackageCurationDataTest.kt
@@ -49,7 +49,8 @@ class PackageCurationDataTest : WordSpec({
         ),
         isMetadataOnly = true,
         isModified = true,
-        declaredLicenseMapping = mapOf("original" to "original".toSpdx())
+        declaredLicenseMapping = mapOf("original" to "original".toSpdx()),
+        sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
     )
 
     val other = PackageCurationData(
@@ -76,7 +77,8 @@ class PackageCurationDataTest : WordSpec({
         ),
         isMetadataOnly = false,
         isModified = false,
-        declaredLicenseMapping = mapOf("other" to "other".toSpdx())
+        declaredLicenseMapping = mapOf("other" to "other".toSpdx()),
+        sourceCodeOrigins = listOf(SourceCodeOrigin.VCS)
     )
 
     "Merging" should {
@@ -92,7 +94,8 @@ class PackageCurationDataTest : WordSpec({
                 binaryArtifact = null,
                 vcs = null,
                 isMetadataOnly = null,
-                declaredLicenseMapping = emptyMap()
+                declaredLicenseMapping = emptyMap(),
+                sourceCodeOrigins = null
             )
 
             originalWithSomeUnsetData.merge(other) shouldBe originalWithSomeUnsetData.copy(
@@ -102,7 +105,8 @@ class PackageCurationDataTest : WordSpec({
                 binaryArtifact = other.binaryArtifact,
                 vcs = other.vcs,
                 isMetadataOnly = other.isMetadataOnly,
-                declaredLicenseMapping = other.declaredLicenseMapping
+                declaredLicenseMapping = other.declaredLicenseMapping,
+                sourceCodeOrigins = other.sourceCodeOrigins
             )
         }
 
@@ -123,7 +127,8 @@ class PackageCurationDataTest : WordSpec({
                 comment = original.comment,
                 authors = original.authors,
                 concludedLicense = original.concludedLicense,
-                declaredLicenseMapping = original.declaredLicenseMapping
+                declaredLicenseMapping = original.declaredLicenseMapping,
+                sourceCodeOrigins = original.sourceCodeOrigins
             )
 
             val mergedData = original.merge(otherWithSomeOriginalData)

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -51,7 +51,8 @@ class PackageTest : StringSpec({
             sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
             vcs = VcsInfo(VcsType.forName("type"), "url", "revision"),
             isMetadataOnly = false,
-            isModified = false
+            isModified = false,
+            sourceCodeOrigins = null
         )
 
         val other = Package(
@@ -83,6 +84,7 @@ class PackageTest : StringSpec({
         diff.vcs shouldBe pkg.vcsProcessed.toCuration()
         diff.isMetadataOnly shouldBe pkg.isMetadataOnly
         diff.isModified shouldBe pkg.isModified
+        diff.sourceCodeOrigins shouldBe pkg.sourceCodeOrigins
     }
 
     "diff result does not contain unchanged values" {
@@ -112,5 +114,6 @@ class PackageTest : StringSpec({
         diff.sourceArtifact should beNull()
         diff.vcs should beNull()
         diff.isMetadataOnly should beNull()
+        diff.sourceCodeOrigins should beNull()
     }
 })

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -69,7 +69,8 @@ class PackageTest : StringSpec({
             sourceArtifact = RemoteArtifact("other url", Hash.create("other hash")),
             vcs = VcsInfo(VcsType.forName("other type"), "other url", "other revision"),
             isMetadataOnly = true,
-            isModified = true
+            isModified = true,
+            sourceCodeOrigins = listOf(SourceCodeOrigin.VCS)
         )
 
         val diff = pkg.diff(other)
@@ -98,7 +99,8 @@ class PackageTest : StringSpec({
             homepageUrl = "homepageUrl",
             binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
             sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
-            vcs = VcsInfo(VcsType.forName("type"), "url", "revision")
+            vcs = VcsInfo(VcsType.forName("type"), "url", "revision"),
+            sourceCodeOrigins = listOf(SourceCodeOrigin.VCS)
         )
 
         val diff = pkg.diff(pkg)

--- a/scanner/src/funTest/kotlin/provenance/DefaultPackageProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/DefaultPackageProvenanceResolverFunTest.kt
@@ -22,7 +22,9 @@ package org.ossreviewtoolkit.scanner.provenance
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
 
 import java.io.IOException
 
@@ -189,6 +191,32 @@ class DefaultPackageProvenanceResolverFunTest : WordSpec() {
 
                 resolver.resolveProvenance(pkg, listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)) shouldBe
                     ArtifactProvenance(pkg.sourceArtifact)
+            }
+        }
+
+        "source code origins from package" should {
+            "override the default" {
+                val pkg = Package.EMPTY.copy(
+                    sourceArtifact = RemoteArtifact(
+                        url = sourceArtifactUrl,
+                        hash = Hash.NONE
+                    ),
+                    vcsProcessed = VcsInfo(
+                        type = VcsType.GIT,
+                        url = repositoryUrl,
+                        revision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
+                    )
+                )
+
+                resolver.resolveProvenance(
+                    pkg.copy(sourceCodeOrigins = listOf(SourceCodeOrigin.VCS)),
+                    listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
+                ) should beInstanceOf<RepositoryProvenance>()
+
+                resolver.resolveProvenance(
+                    pkg.copy(sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT)),
+                    listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
+                ) should beInstanceOf<ArtifactProvenance>()
             }
         }
     }

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -952,8 +952,11 @@ private class FakeProvenanceDownloader(val filename: String = "fake.txt") : Prov
  * validation.
  */
 private class FakePackageProvenanceResolver : PackageProvenanceResolver {
-    override fun resolveProvenance(pkg: Package, sourceCodeOriginPriority: List<SourceCodeOrigin>): KnownProvenance {
-        sourceCodeOriginPriority.forEach { sourceCodeOrigin ->
+    override fun resolveProvenance(
+        pkg: Package,
+        defaultSourceCodeOriginsPriority: List<SourceCodeOrigin>
+    ): KnownProvenance {
+        defaultSourceCodeOriginsPriority.forEach { sourceCodeOrigin ->
             when (sourceCodeOrigin) {
                 SourceCodeOrigin.ARTIFACT -> {
                     if (pkg.sourceArtifact != RemoteArtifact.EMPTY) {

--- a/website/docs/configuration/package-curations.md
+++ b/website/docs/configuration/package-curations.md
@@ -28,6 +28,9 @@ Curations can be used to:
     If multiple curations declare license mappings, they get combined into a single mapping.
     Thus, multiple curations can contribute to the declared license mapping for the package.
     The effect of its application can be seen in the *declared_license_processed* property of the respective curated package.
+* set the *source_code_origins* property:
+  * Override the source code origins priority configured in the downloader configuration by the given one.
+    Possible values: VCS, ARTIFACT.
 
 The sections below explain how to create curations in the `curations.yml` file which, if passed to the *analyzer*, is applied to all package metadata found in the analysis.
 If a license detected in the source code of a package needs to be corrected, add a license finding curation in the [.ort.yml](ort-yml.md#curations) file for the project.
@@ -80,6 +83,7 @@ A curation file consists of one or more `id` entries:
       path: "subdirectory"
     is_metadata_only: true
     is_modified: true
+    source_code_origins: "ARTIFACT, VCS"
 ```
 
 Where the list of available options for curations is defined in [PackageCurationData.kt](https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/PackageCurationData.kt).


### PR DESCRIPTION
If one wants to scan a certain package with a different source code origin priority, the only work around to make ORT do so was to nullify the "other" provenance. This PR introduces a dedicated, machine readable property which allows to write clean fixes / curations for this use case. This in turn enables to share such curations, e.g. potentially in 'ort-config', and removes the need for this rather ugly work-around.

Fixes #8402.