### PR TITLE
feat(fossid-webapp): Add license findings from snippet choice

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -66,6 +66,7 @@ import org.ossreviewtoolkit.clients.fossid.model.status.ScanStatus
 import org.ossreviewtoolkit.clients.fossid.runScan
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
@@ -902,7 +903,8 @@ class FossId internal constructor(
             )
         )
 
-        val snippetFindings = mapSnippetFindings(rawResults, issues, snippetChoices)
+        val snippetLicenseFindings = mutableSetOf<LicenseFinding>()
+        val snippetFindings = mapSnippetFindings(rawResults, issues, snippetChoices, snippetLicenseFindings)
         markFilesWithChosenSnippetsAsIdentified(scanCode, snippetChoices, snippetFindings, rawResults.listPendingFiles)
 
         val ignoredFiles = rawResults.listIgnoredFiles.associateBy { it.path }
@@ -914,7 +916,7 @@ class FossId internal constructor(
         val summary = ScanSummary(
             startTime = startTime,
             endTime = Instant.now(),
-            licenseFindings = licenseFindings,
+            licenseFindings = licenseFindings + snippetLicenseFindings,
             copyrightFindings = copyrightFindings,
             snippetFindings = snippetFindings,
             issues = issues + additionalIssues

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
@@ -62,7 +62,7 @@ class FossIdLicenseMappingTest : WordSpec({
             val rawResults = createSnippet("Apache 2.0")
             val issues = mutableListOf<Issue>()
 
-            val findings = mapSnippetFindings(rawResults, issues, emptyList())
+            val findings = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
 
             issues should beEmpty()
             findings should haveSize(1)
@@ -77,7 +77,7 @@ class FossIdLicenseMappingTest : WordSpec({
             val rawResults = createSnippet("Apache-2.0")
             val issues = mutableListOf<Issue>()
 
-            val findings = mapSnippetFindings(rawResults, issues, emptyList())
+            val findings = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
 
             issues should beEmpty()
             findings should haveSize(1)
@@ -92,7 +92,7 @@ class FossIdLicenseMappingTest : WordSpec({
             val rawResults = createSnippet("invalid license")
             val issues = mutableListOf<Issue>()
 
-            val findings = mapSnippetFindings(rawResults, issues, emptyList())
+            val findings = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
 
             issues should haveSize(1)
             issues.first() shouldNotBeNull {

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
@@ -78,7 +78,7 @@ class FossIdSnippetMappingTest : WordSpec({
                 snippetMatchedLines
             )
 
-            val mappedSnippets = mapSnippetFindings(rawResults, issues, emptyList())
+            val mappedSnippets = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
 
             issues should beEmpty()
             mappedSnippets shouldHaveSize 3


### PR DESCRIPTION
License findings from marked as identified files contain only the path, with a missing line range since FossID does not return this information. On the other hand, license findings from chosen snippets  contain the full source location.
If a snippet is chosen but is not present in the snippet results, an issue is added to the ORT scan results.

