### PR TITLE
feat(cli): Use the resolved resolutions in `NotifierCommand`

### DIFF
--- a/plugins/commands/notifier/src/main/kotlin/NotifierCommand.kt
+++ b/plugins/commands/notifier/src/main/kotlin/NotifierCommand.kt
@@ -77,11 +77,14 @@ class NotifierCommand : OrtCommand(
 
     override fun run() {
         val ortResult = readOrtResult(ortFile).mergeLabels(labels)
-        val notifier = Notifier(
-            ortResult,
-            ortConfig.notifier,
-            DefaultResolutionProvider.create(ortResult, resolutionsFile)
-        )
+
+        // If available, use only the resolved resolutions.
+        val resolutionProvider = when (ortResult.resolvedConfiguration.resolutions) {
+            null -> DefaultResolutionProvider.create(ortResult, resolutionsFile)
+            else -> ortResult
+        }
+
+        val notifier = Notifier(ortResult, ortConfig.notifier, resolutionProvider)
 
         val script = notificationsFile?.readText() ?: readDefaultNotificationsFile()
         notifier.run(script)


### PR DESCRIPTION
If available, use only the resolved resolutions in the `NotifierCommand` instead of resolving them again. This increases consistency with previously executed ORT commands.