### PR TITLE
build: Disable Kotest's classpath scanning for faster test startup

### DIFF
--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
 
     api(libs.kotest.assertions.core)
     api(libs.kotest.framework.api)
+    api(libs.logbackClassic) {
+        because("Transitively export this to consumers so they do not have to declare a logger implementation.")
+    }
 
     implementation(projects.downloader)
     implementation(projects.utils.ortUtils)
@@ -39,5 +42,4 @@ dependencies {
     implementation(libs.postgresEmbedded)
 
     runtimeOnly(libs.log4j.api.slf4j)
-    runtimeOnly(libs.logbackClassic)
 }

--- a/utils/test/src/main/resources/kotest.properties
+++ b/utils/test/src/main/resources/kotest.properties
@@ -1,0 +1,20 @@
+# Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+kotest.framework.classpath.scanning.autoscan.disable = true
+kotest.framework.classpath.scanning.config.disable = true
+kotest.framework.config.fqn = org.ossreviewtoolkit.utils.test.ProjectConfig


### PR DESCRIPTION
See [1] for details.

[1]: https://kotest.io/docs/next/framework/project-config.html#runtime-detection