### PR TITLE
refactor(scanner): Rename `sourceCodeOriginsPriority`

### DIFF
--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -952,11 +952,8 @@ private class FakeProvenanceDownloader(val filename: String = "fake.txt") : Prov
  * validation.
  */
 private class FakePackageProvenanceResolver : PackageProvenanceResolver {
-    override fun resolveProvenance(
-        pkg: Package,
-        defaultSourceCodeOriginsPriority: List<SourceCodeOrigin>
-    ): KnownProvenance {
-        defaultSourceCodeOriginsPriority.forEach { sourceCodeOrigin ->
+    override fun resolveProvenance(pkg: Package, defaultSourceCodeOrigins: List<SourceCodeOrigin>): KnownProvenance {
+        defaultSourceCodeOrigins.forEach { sourceCodeOrigin ->
             when (sourceCodeOrigin) {
                 SourceCodeOrigin.ARTIFACT -> {
                     if (pkg.sourceArtifact != RemoteArtifact.EMPTY) {


### PR DESCRIPTION
Drop the `Priority`-suffix to align with the `sourceCodeOriginsProperty` in other places, e.g. in `Package`. Adjust the KDoc to make clear that the given list of source code origins is in order of priority.

While at it, re-word the comment a bit further, and re-align the analog part of the comment in the `PackageProvenanceResolver` interface with the one in the `DefaultPackageProvenanceResolver` class.
