### PR TITLE
Implement a Gradle 8.2 work-around for repository ids

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -172,6 +172,9 @@ internal class OrtModelBuilder : ToolingModelBuilder {
                                 }.recoverCatching {
                                     @Suppress("DEPRECATION")
                                     selectedComponent.repositoryName
+                                }.map {
+                                    // Work around https://github.com/gradle/gradle/issues/25674.
+                                    if (it == "26c913274550a0b2221f47a0fe2d2358") "MavenRepo" else it
                                 }.getOrNull()
 
                                 repositories[repositoryId]?.let { repositoryUrl ->

--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -167,11 +167,12 @@ internal class OrtModelBuilder : ToolingModelBuilder {
                     when (val id = selectedComponent.id) {
                         is ModuleComponentIdentifier -> {
                             val pomFile = if (selectedComponent is ResolvedComponentResultInternal) {
-                                val repositoryId = runCatching { selectedComponent.repositoryId }
-                                    .recoverCatching {
-                                        @Suppress("DEPRECATION")
-                                        selectedComponent.repositoryName
-                                    }.getOrNull()
+                                val repositoryId = runCatching {
+                                    selectedComponent.repositoryId
+                                }.recoverCatching {
+                                    @Suppress("DEPRECATION")
+                                    selectedComponent.repositoryName
+                                }.getOrNull()
 
                                 repositories[repositoryId]?.let { repositoryUrl ->
                                     // Note: Only Maven-style layout is supported for now.


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 