### PR TITLE
fix(fossid-webapp): Align license mapping for snippets

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -913,7 +913,13 @@ class FossId internal constructor(
         )
 
         val snippetLicenseFindings = mutableSetOf<LicenseFinding>()
-        val snippetFindings = mapSnippetFindings(rawResults, issues, snippetChoices, snippetLicenseFindings)
+        val snippetFindings = mapSnippetFindings(
+            rawResults,
+            issues,
+            detectedLicenseMapping,
+            snippetChoices,
+            snippetLicenseFindings
+        )
         markFilesWithChosenSnippetsAsIdentified(
             scanCode,
             snippetChoices,

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
@@ -57,7 +57,8 @@ class FossIdLicenseMappingTest : WordSpec({
             val rawResults = createSnippet("Apache 2.0")
             val issues = mutableListOf<Issue>()
 
-            val findings = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
+            val mapping = mapOf("Apache 2.0" to "Apache-2.0")
+            val findings = mapSnippetFindings(rawResults, issues, mapping, emptyList(), mutableSetOf())
 
             issues should beEmpty()
             findings should haveSize(1)
@@ -72,7 +73,7 @@ class FossIdLicenseMappingTest : WordSpec({
             val rawResults = createSnippet("Apache-2.0")
             val issues = mutableListOf<Issue>()
 
-            val findings = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
+            val findings = mapSnippetFindings(rawResults, issues, emptyMap(), emptyList(), mutableSetOf())
 
             issues should beEmpty()
             findings should haveSize(1)
@@ -87,13 +88,13 @@ class FossIdLicenseMappingTest : WordSpec({
             val rawResults = createSnippet("invalid license")
             val issues = mutableListOf<Issue>()
 
-            val findings = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
+            val findings = mapSnippetFindings(rawResults, issues, emptyMap(), emptyList(), mutableSetOf())
 
             issues should haveSize(1)
             issues.first() shouldNotBeNull {
                 message shouldStartWith
-                    "Failed to map license 'invalid license' as an SPDX expression."
-                severity shouldBe Severity.HINT
+                    "Failed to parse license 'invalid license' as an SPDX expression"
+                severity shouldBe Severity.ERROR
             }
             findings should haveSize(1)
             findings.first() shouldNotBeNull {

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
@@ -78,7 +78,7 @@ class FossIdSnippetMappingTest : WordSpec({
                 snippetMatchedLines
             )
 
-            val mappedSnippets = mapSnippetFindings(rawResults, issues, emptyList(), mutableSetOf())
+            val mappedSnippets = mapSnippetFindings(rawResults, issues, emptyMap(), emptyList(), mutableSetOf())
 
             issues should beEmpty()
             mappedSnippets shouldHaveSize 3


### PR DESCRIPTION
Currently, the licenses of the files marked as identified in FossID are mapped to SPDX using the detected license mapping. The licenses of the snippet however is mapped using the declared license mapping. This commit aligns these behaviors to always use the detected license mapping.
