### PR TITLE
refactor(model): Make an `associateLicensesWithExceptions` overload public

### DIFF
--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -287,7 +287,7 @@ fun associateLicensesWithExceptions(
  * licenses. Orphan license exceptions will get associated by [SpdxConstants.NOASSERTION]. Return a new expression that
  * does not contain stand-alone license exceptions anymore.
  */
-internal fun associateLicensesWithExceptions(license: SpdxExpression): SpdxExpression {
+fun associateLicensesWithExceptions(license: SpdxExpression): SpdxExpression {
     // If this is not a compound expression, there can be no stand-alone license exceptions with belonging licenses.
     if (license !is SpdxCompoundExpression) return license
 


### PR DESCRIPTION
Allow this to be called from plugins, like package configuration providers that need to fixup the declared license of a license finding curation.