### PR TITLE
fix(maven): return coordinates-only `Package` on `parsePackage` exception

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenDependencyHandler.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenDependencyHandler.kt
@@ -28,6 +28,8 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.Maven
@@ -112,7 +114,24 @@ class MavenDependencyHandler(
                 message = "Could not get package information for dependency '" +
                     "${dependency.artifact.identifier()}': ${e.collectMessages()}"
             )
-        }.getOrNull()
+        }.getOrElse {
+            Package(
+                id = dependency.artifact.run {
+                    Identifier(
+                        type = "Maven",
+                        namespace = groupId,
+                        name = artifactId,
+                        version = version
+                    )
+                },
+                binaryArtifact = RemoteArtifact.EMPTY,
+                declaredLicenses = emptySet(),
+                description = "",
+                homepageUrl = "",
+                sourceArtifact = RemoteArtifact.EMPTY,
+                vcs = VcsInfo.EMPTY
+            )
+        }
     }
 
     /**

--- a/plugins/package-managers/maven/src/test/kotlin/utils/MavenDependencyHandlerTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/utils/MavenDependencyHandlerTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.contain
@@ -46,7 +47,9 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.VcsInfo
 
 class MavenDependencyHandlerTest : WordSpec({
     beforeSpec {
@@ -204,7 +207,7 @@ class MavenDependencyHandlerTest : WordSpec({
             handler.linkageFor(dependency) shouldBe PackageLinkage.PROJECT_DYNAMIC
         }
 
-        "handle an exception from MavenSupport" {
+        "return coordinates-only Package when an exception is raised from MavenSupport" {
             val exception = ProjectBuildingException(
                 "BrokenProject", "Cannot parse pom.",
                 IOException("General failure when reading hard disk.")
@@ -219,7 +222,24 @@ class MavenDependencyHandlerTest : WordSpec({
             every { dependency.repositories } returns repos
             every { handler.support.parsePackage(artifact, repos) } throws exception
 
-            handler.createPackage(dependency, issues) should beNull()
+            val pkg = handler.createPackage(dependency, issues)
+            pkg.shouldNotBeNull()
+
+            with(pkg.id) {
+                type shouldBe "Maven"
+                namespace shouldBe artifact.groupId
+                name shouldBe artifact.artifactId
+                version shouldBe artifact.version
+            }
+
+            with(pkg) {
+                binaryArtifact shouldBe RemoteArtifact.EMPTY
+                declaredLicenses should beEmpty()
+                description shouldBe ""
+                homepageUrl shouldBe ""
+                sourceArtifact shouldBe RemoteArtifact.EMPTY
+                vcs shouldBe VcsInfo.EMPTY
+            }
 
             issues should haveSize(1)
             with(issues[0]) {


### PR DESCRIPTION
When analyzing a Maven project with a dependency on `opensymphony:quartz:1.6.0`, ORT does not include it in the packages list of the analyzer, but it is still present in the `dependency_graphs.Maven.packages`. The reason for it turned out to be a lack of POM for the dependency in the Central (see [1]) causing an exception in `MavenSupport.parsePackage` call.

This PR fixes the issue by returning a coordinates-only `Package` from `getOrElse` block instead of `null`. Another way to fix this would be to return that `Package` from the `MavenSupport.parsePackage` itself. However, `GradleDependencyHandler` seems to rely on the exception thrown by it, and other (potential) consumers might want to do that as well.

[1] https://repo.maven.apache.org/maven2/opensymphony/quartz/1.6.0/