### PR TITLE
refactor: Use Kotest's own `tempdir()` in tests

### DIFF
--- a/helper-cli/src/funTest/kotlin/commands/CreateAnalyzerResultFromPackageListCommandFunTest.kt
+++ b/helper-cli/src/funTest/kotlin/commands/CreateAnalyzerResultFromPackageListCommandFunTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.helper.commands
 import com.github.ajalt.clikt.testing.test
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.helper.HelperMain
@@ -29,14 +30,13 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ResolvedConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.ort.Environment
-import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class CreateAnalyzerResultFromPackageListCommandFunTest : WordSpec({
     "The command" should {
         "generate the expected analyzer result file" {
             val inputFile = getAssetFile("package-list.yml")
-            val outputFile = createOrtTempDir().resolve("analyzer-result.yml")
+            val outputFile = tempdir().resolve("analyzer-result.yml")
             val expectedOutputFile = getAssetFile("create-analyzer-result-from-pkg-list-expected-output.yml")
 
             HelperMain().test(

--- a/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
+++ b/plugins/scanners/scancode/src/funTest/kotlin/ScanCodeScannerFunTest.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.scanners.scancode
 
+import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.endWith
@@ -28,7 +29,6 @@ import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.scanner.AbstractPathScannerWrapperFunTest
 import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
-import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.getLicenseText
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
@@ -66,7 +66,7 @@ class ScanCodeScannerFunTest : AbstractPathScannerWrapperFunTest(setOf(Expensive
             val id = "LicenseRef-scancode-here-proprietary"
             val text = "x\ny\n"
 
-            val outputDir = createOrtTempDir().apply { resolve(id).writeText(text) }
+            val outputDir = tempdir().apply { resolve(id).writeText(text) }
 
             getLicenseText(id, true, listOf(outputDir)) shouldBe getLicenseText(id, true)
         }

--- a/scanner/src/test/kotlin/utils/FileListResolverTest.kt
+++ b/scanner/src/test/kotlin/utils/FileListResolverTest.kt
@@ -37,7 +37,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.utils.FileProvenanceFileStorage
 import org.ossreviewtoolkit.model.utils.ProvenanceFileStorage
-import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
 
 class FileListResolverTest : StringSpec({
@@ -81,7 +80,7 @@ class FileListResolverTest : StringSpec({
 })
 
 private fun Spec.createTempDirWithFiles(vararg paths: String) =
-    createOrtTempDir().apply {
+    tempdir().apply {
         paths.forEachIndexed { index, path ->
             resolve(path).apply {
                 parentFile.mkdirs()


### PR DESCRIPTION
These are cleaned up automatically.