### PR TITLE
feat(scancode): Support reading `matched_text` fields

### DIFF
--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModel.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModel.kt
@@ -139,6 +139,7 @@ sealed interface LicenseEntry {
     val startLine: Int
     val endLine: Int
     val score: Float
+    val matchedText: String?
 
     @Serializable
     data class Version1(
@@ -147,7 +148,8 @@ sealed interface LicenseEntry {
         val spdxLicenseKey: String? = null, // This might be explicitly set to null in JSON.
         override val startLine: Int,
         override val endLine: Int,
-        val matchedRule: LicenseRule
+        val matchedRule: LicenseRule,
+        override val matchedText: String? = null
     ) : LicenseEntry {
         override val licenseExpression = matchedRule.licenseExpression
     }
@@ -159,7 +161,8 @@ sealed interface LicenseEntry {
         override val endLine: Int,
         override val licenseExpression: String,
         val spdxLicenseExpression: String? = null, // This might be missing in JSON.
-        val fromFile: String? = null // This might be missing in JSON.
+        val fromFile: String? = null, // This might be missing in JSON.
+        override val matchedText: String? = null
     ) : LicenseEntry
 }
 


### PR DESCRIPTION
When ScanCode is run with `--license-text`, `matched_text` fields are added to license findings that contain the matched license text. Support reading those fields even if they are not used yet. This enables programmatic use of those fields and / or future use e.g. when deserializing ScanCode results from ClearlyDefined (which runs ScanCode with `--license-text`).