### PR TITLE
fix(fossid-webapp): Remove unecessary call to `normalize`

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -221,7 +221,7 @@ internal fun mapSnippetFindings(
             val ortSnippetLocation = snippetLocation ?: TextLocation(snippet.file, TextLocation.UNKNOWN_LINE)
 
             val license = snippet.artifactLicense?.let { artifactLicense ->
-                mapLicense(artifactLicense, ortSnippetLocation, issues, detectedLicenseMapping)?.license?.normalize()
+                mapLicense(artifactLicense, ortSnippetLocation, issues, detectedLicenseMapping)?.license
             } ?: SpdxConstants.NOASSERTION.toSpdx()
 
             val ortSnippet = OrtSnippet(

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
@@ -69,6 +69,21 @@ class FossIdLicenseMappingTest : WordSpec({
             }
         }
 
+        "map deprecated SPDX FossId licenses in a snippet to snippet findings" {
+            val rawResults = createSnippet("GFDL-1.2")
+            val issues = mutableListOf<Issue>()
+
+            val findings = mapSnippetFindings(rawResults, issues, emptyMap(), emptyList(), mutableSetOf())
+
+            issues should beEmpty()
+            findings should haveSize(1)
+            findings.first() shouldNotBeNull {
+                snippets.first() shouldNotBeNull {
+                    licenses.toString() shouldBe "GFDL-1.2-only"
+                }
+            }
+        }
+
         "map SPDX compliant FossId licenses in a snippet to snippet findings" {
             val rawResults = createSnippet("Apache-2.0")
             val issues = mutableListOf<Issue>()


### PR DESCRIPTION
This call was needed because of the bug fixed by [1]. Therefore, it can now be removed. A test is also added that checks this behavior.

[1]: https://github.com/oss-review-toolkit/ort/pull/8447
