### PR TITLE
ci(renovate): Extend from `config:recommended`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "docker:disable",
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)"


### PR DESCRIPTION
`config:base` was renamed to `config:recommended` in release 36.0.0 [1].

[1]: https://github.com/renovatebot/renovate/releases/tag/36.0.0