### PR TITLE
model: Improve and align `OrtResult.getIssues()`

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -293,7 +293,7 @@ data class OrtResult(
      */
     @JsonIgnore
     fun getOpenIssues(minSeverity: Severity = Severity.WARNING) =
-        getIssues(omitExcluded = true, omitResolved = true, minSeverity = minSeverity).values.flatten()
+        getIssues(omitExcluded = true, omitResolved = true, minSeverity = minSeverity).values.flatten().distinct()
 
     /**
      * Return a list of [PackageConfiguration]s for the given [packageId] and [provenance].

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -252,8 +252,7 @@ data class OrtResult(
         val scannerIssues = scanner?.getAllIssues().orEmpty()
         val advisorIssues = advisor?.results?.getIssues().orEmpty()
 
-        val analyzerAndScannerIssues = analyzerIssues.zipWithCollections(scannerIssues)
-        return analyzerAndScannerIssues.zipWithCollections(advisorIssues)
+        return analyzerIssues.zipWithCollections(scannerIssues).zipWithCollections(advisorIssues)
     }
 
     /**

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -448,11 +448,14 @@ data class OrtResult(
      * [omitResolved] and remove violations below the [minSeverity].
      */
     @JsonIgnore
-    fun getRuleViolations(omitResolved: Boolean = false, minSeverity: Severity? = null): List<RuleViolation> {
+    fun getRuleViolations(
+        omitResolved: Boolean = false,
+        minSeverity: Severity = Severity.entries.min()
+    ): List<RuleViolation> {
         val allViolations = evaluator?.violations.orEmpty()
 
         val severeViolations = when (minSeverity) {
-            null -> allViolations
+            Severity.entries.min() -> allViolations
             else -> allViolations.filter { it.severity >= minSeverity }
         }
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -451,20 +451,10 @@ data class OrtResult(
     fun getRuleViolations(
         omitResolved: Boolean = false,
         minSeverity: Severity = Severity.entries.min()
-    ): List<RuleViolation> {
-        val allViolations = evaluator?.violations.orEmpty()
-
-        val severeViolations = when (minSeverity) {
-            Severity.entries.min() -> allViolations
-            else -> allViolations.filter { it.severity >= minSeverity }
+    ): List<RuleViolation> =
+        evaluator?.violations.orEmpty().filter {
+            (!omitResolved || !isResolved(it)) && it.severity >= minSeverity
         }
-
-        return if (omitResolved) {
-            severeViolations.filter { !isResolved(it) }
-        } else {
-            severeViolations
-        }
-    }
 
     /**
      * Return the list of [ScanResult]s for the given [id].

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.model.config.RuleViolationResolutionReason
 import org.ossreviewtoolkit.utils.test.readOrtResult
 
 class OrtResultTest : WordSpec({
-    "collectDependencies" should {
+    "collectDependencies()" should {
         "be able to get all direct dependencies of a package" {
             val ortResult = readOrtResult("src/test/assets/sbt-multi-project-example-expected-output.yml")
             val id = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
@@ -59,7 +59,7 @@ class OrtResultTest : WordSpec({
         }
     }
 
-    "collectProjectsAndPackages" should {
+    "collectProjectsAndPackages()" should {
         "be able to get all ids except for ones for sub-projects" {
             val ortResult = readOrtResult("src/test/assets/gradle-all-dependencies-expected-result.yml")
             val ids = ortResult.getProjectsAndPackages()
@@ -72,7 +72,7 @@ class OrtResultTest : WordSpec({
         }
     }
 
-    "getDefinitionFilePathRelativeToAnalyzerRoot" should {
+    "getDefinitionFilePathRelativeToAnalyzerRoot()" should {
         "use the correct vcs" {
             val vcs = VcsInfo(type = VcsType.GIT, url = "https://example.com/git", revision = "")
             val nestedVcs1 = VcsInfo(type = VcsType.GIT, url = "https://example.com/git1", revision = "")
@@ -143,7 +143,7 @@ class OrtResultTest : WordSpec({
         }
     }
 
-    "getOpenIssues" should {
+    "getOpenIssues()" should {
         "omit resolved issues" {
             val ortResult = OrtResult.EMPTY.copy(
                 analyzer = AnalyzerRun.EMPTY.copy(
@@ -269,7 +269,7 @@ class OrtResultTest : WordSpec({
         }
     }
 
-    "getRuleViolations" should {
+    "getRuleViolations()" should {
         "return unfiltered rule violations if omitResolved is false" {
             val ortResult = OrtResult.EMPTY.copy(
                 repository = Repository.EMPTY.copy(

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -300,7 +300,7 @@ class OrtResultTest : WordSpec({
                 )
             )
 
-            ortResult.getRuleViolations(omitResolved = false, minSeverity = null).map { it.rule }
+            ortResult.getRuleViolations(omitResolved = false, minSeverity = Severity.entries.min()).map { it.rule }
                 .shouldContainExactly("rule id")
         }
 

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -270,7 +270,7 @@ class OrtResultTest : WordSpec({
     }
 
     "getRuleViolations()" should {
-        "return unfiltered rule violations if omitResolved is false" {
+        "return unfiltered rule violations if omitResolved is false and minSeverity is HINT" {
             val ortResult = OrtResult.EMPTY.copy(
                 repository = Repository.EMPTY.copy(
                     config = RepositoryConfiguration(
@@ -304,7 +304,7 @@ class OrtResultTest : WordSpec({
                 .shouldContainExactly("rule id")
         }
 
-        "drop resolved rule violations if omitResolved is true" {
+        "drop violations which are resolved or below minSeverity if omitResolved is true and minSeverity is WARNING" {
             val ortResult = OrtResult.EMPTY.copy(
                 evaluator = EvaluatorRun.EMPTY.copy(
                     violations = listOf(


### PR DESCRIPTION
Align with `getRuleViolations()` and `getVulnerabilities()` and make the API more flexible.
This prepares for filtering the issues by their affected path in a following change.

Context: #7921.