### PR TITLE
build(github): Migrate to the new Gradle actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Build all classes
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: --scan classes -x :plugins:reporters:web-app-template:yarnBuild
@@ -29,7 +29,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Build the web-app-reporter
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: --scan :plugins:reporters:web-app-template:yarnBuild
@@ -47,7 +47,7 @@ jobs:
         languages: java
         tools: latest
     - name: Build all classes
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: -Dorg.gradle.jvmargs=-Xmx1g classes -x :plugins:reporters:web-app-template:yarnBuild
@@ -60,7 +60,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Run unit tests
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: --scan test jacocoTestReport -x :plugins:reporters:web-app-template:yarnBuild
@@ -105,7 +105,7 @@ jobs:
           curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt
           pip install --no-cache-dir --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION
     - name: Run functional tests that do not require external tools
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: --scan -Ptests.exclude=org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
@@ -125,7 +125,7 @@ jobs:
       with:
         submodules: recursive
     - name: Run functional tests that do require external tools
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: --scan -Ptests.include=org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ env.ORT_VERSION }}
           fetch-depth: 0
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
       - name: Publish to OSSRH

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Check copyrights, license headers, and .gitattributes
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: checkCopyrightsInNoticeFile checkLicenseHeaders checkGitAttributes
@@ -38,12 +38,12 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Check for Detekt Issues
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: detekt
     - name: Check for Detekt Issues with type resolution
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
         arguments: detektMain detektTestFixtures detektTest detektFunTest

--- a/.github/workflows/wrapper-validation.yml
+++ b/.github/workflows/wrapper-validation.yml
@@ -15,4 +15,4 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Validate Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
See [1]. Still validate the wrapper only once instead of using (every) `setup-gradle` with `validate-wrappers: true` [2].

[1]: https://github.com/gradle/actions/releases/tag/v3.3.0
[2]: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation