### PR TITLE
ci(github): Set infinite fetch depth for `docker-build`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Free Disk Space
         uses: ./.github/actions/free-disk-space
       - name: Setup Gradle


### PR DESCRIPTION
Set infinite fetch depth for the `docker-build` workflow to be sure to get all tags for calculating the correct version.

This is a fixup for 94ef009.