### PR TITLE
fix(fossid-webapp): `creatScan` response can be polymorphic

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -149,7 +149,7 @@ suspend fun FossIdRestService.createScan(
     gitRepoUrl: String,
     gitBranch: String,
     comment: String = ""
-): MapResponseBody<String> =
+): PolymorphicResponseBody<String> =
     createScan(
         PostRequestBody(
             "create",

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -226,7 +226,7 @@ interface FossIdRestService {
     suspend fun createProject(@Body body: PostRequestBody): MapResponseBody<String>
 
     @POST("api.php")
-    suspend fun createScan(@Body body: PostRequestBody): MapResponseBody<String>
+    suspend fun createScan(@Body body: PostRequestBody): PolymorphicResponseBody<String>
 
     @POST("api.php")
     suspend fun runScan(@Body body: PostRequestBody): EntityResponseBody<Nothing>

--- a/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-create_scan.json
+++ b/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-create_scan.json
@@ -1,0 +1,26 @@
+{
+  "id" : "a1163704-9a3b-492c-bfd8-44593eeb9b25",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"action\":\"create\",\"group\":\"scans\",\"data\":{\"username\":\"\",\"key\":\"\",\"scan_code\":\"semver4j_20201203_090342\",\"project_code\":\"semver4j\",\"git_repo_url\":\"git_repo_url\",\"git_branch\":\"develop\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"operation\":\"scans_create\",  \"status\":\"0\",  \"data\":[{\"code\": \"RequestData.Base.issue_with_executing_command\",    \"message\":\"Field git_repo_url: there was an issue executing command: timeout 200 git ls-remote 'ssh git repo' 2>&1. Exit status: 128. Output: Repository not found The requested repository does not exist, or you do not have permission to access it. fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists.\",    \"message_parameters\":{\"fieldname\":\"git_repo_url\",      \"cmd\":\"timeout 200 git ls-remote 'ssh git repo' 2>&1\",      \"exitStatus\":128,      \"out\":\"Repository not found The requested repository does not exist, or you do not have permission to access it. fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists.\"}  }],  \"error\":\"RequestData.Base.issues_while_parsing_request\",  \"message\":\"These issues were found while parsing the request:\",  \"message_parameters\":[]}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 03 Dec 2020 08:03:42 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "a1163704-9a3b-492c-bfd8-44593eeb9b25",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -24,6 +24,8 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -95,7 +97,7 @@ class FossIdClientNewProjectTest : StringSpec({
             SCAN_CODE,
             "https://github.com/gundy/semver4j.git",
             "671aa533f7e33c773bf620b9f466650c3b9ab26e"
-        ).shouldNotBeNull().data.shouldNotBeNull() shouldContain("scan_id" to "4920")
+        ).shouldNotBeNull().data.shouldNotBeNull().shouldHaveSingleElement("4920")
     }
 
     "Download from Git can be triggered" {

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -256,6 +256,22 @@ class FossIdClientReturnTypeTest : StringSpec({
         }
     }
 
+    "When create scan returns an error, no exception is thrown" {
+        service.createScan(
+            "",
+            "",
+            PROJECT_CODE_1,
+            SCAN_CODE_1,
+            "git_repo_url",
+            "develop"
+        ).shouldNotBeNull().run {
+            error shouldBe "Field git_repo_url: there was an issue executing command: timeout 200 git ls-remote 'ssh " +
+                "git repo' 2>&1. Exit status: 128. Output: Repository not found The requested repository does not " +
+                "exist, or you do not have permission to access it. fatal: Could not read from remote repository.  " +
+                "Please make sure you have the correct access rights and the repository exists."
+        }
+    }
+
     "A file can be marked as identified" {
         service.markAsIdentified(
             "",

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -681,7 +681,7 @@ class FossId internal constructor(
             reference
         ).checkResponse("create scan")
 
-        val scanId = response.data?.get("scan_id")
+        val scanId = response.data?.firstOrNull()
 
         requireNotNull(scanId) { "Scan could not be created. The response was: ${response.message}." }
 

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -549,7 +549,7 @@ internal fun FossIdServiceWithVersion.expectCreateScan(
 ): FossIdServiceWithVersion {
     coEvery {
         createScan(USER, API_KEY, projectCode, scanCode, vcsInfo.url, vcsInfo.revision, comment)
-    } returns MapResponseBody(status = 1, data = mapOf("scan_id" to SCAN_ID.toString()))
+    } returns PolymorphicResponseBody(status = 1, data = PolymorphicList(listOf(SCAN_ID.toString())))
     return this
 }
 


### PR DESCRIPTION
Under some rare circumstances, `createScan` can return an error message as data payload instead of the scan id. This commit changes the function's signature to make it polymorphic.

Fixes #8462.
