### PR TITLE
ci(github): Stop using the deprecated `arguments` of `setup-gradle`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,22 +19,24 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Build all classes
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
-        arguments: --scan classes -x :plugins:reporters:web-app-template:yarnBuild
+    - name: Build all classes
+      run: ./gradlew --scan classes -x :plugins:reporters:web-app-template:yarnBuild
   build-web-app-reporter:
     needs: build
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Build the web-app-reporter
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
-        arguments: --scan :plugins:reporters:web-app-template:yarnBuild
+    - name: Build the web-app-reporter
+      run: ./gradlew --scan :plugins:reporters:web-app-template:yarnBuild
   codeql-analysis:
     needs: build
     runs-on: ubuntu-22.04
@@ -48,11 +50,12 @@ jobs:
       with:
         languages: java
         tools: latest
-    - name: Build all classes
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
-        arguments: -Dorg.gradle.jvmargs=-Xmx1g classes -x :plugins:reporters:web-app-template:yarnBuild
+    - name: Build all classes
+      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx1g classes -x :plugins:reporters:web-app-template:yarnBuild
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
   test:
@@ -61,11 +64,12 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Run unit tests
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
-        arguments: --scan test jacocoTestReport -x :plugins:reporters:web-app-template:yarnBuild
+    - name: Run unit tests
+      run: ./gradlew --scan test jacocoTestReport -x :plugins:reporters:web-app-template:yarnBuild
     - name: Upload code coverage data
       uses: codecov/codecov-action@v4
       with:
@@ -106,11 +110,12 @@ jobs:
           # Install ScanCode for license texts.
           curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt
           pip install --no-cache-dir --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION
-    - name: Run functional tests that do not require external tools
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
-        arguments: --scan -Ptests.exclude=org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
+    - name: Run functional tests that do not require external tools
+      run: ./gradlew --scan -Ptests.exclude=org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
     - name: Upload code coverage data
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,26 +27,25 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Check copyrights, license headers, and .gitattributes
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
-        arguments: checkCopyrightsInNoticeFile checkLicenseHeaders checkGitAttributes
+    - name: Check copyrights, license headers, and .gitattributes
+      run: ./gradlew checkCopyrightsInNoticeFile checkLicenseHeaders checkGitAttributes
   detekt-issues:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-home-cache-cleanup: true
     - name: Check for Detekt Issues
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        gradle-home-cache-cleanup: true
-        arguments: detekt
+      run: ./gradlew detekt
     - name: Check for Detekt Issues with type resolution
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        gradle-home-cache-cleanup: true
-        arguments: detektMain detektTestFixtures detektTest detektFunTest
+      run: ./gradlew detektMain detektTestFixtures detektTest detektFunTest
     - name: Upload SARIF File
       uses: github/codeql-action/upload-sarif@v3
       if: ${{ always() }} # Upload even if the previous step failed.


### PR DESCRIPTION
The `arguments` parameter of the `setup-gradle` action is deprecated and will be removed in `setup-gradle@v4` [1].

[1]: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated