### PR TITLE
feat(model): Allow configuring further PostgreSQL connection parameters

### DIFF
--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -384,6 +384,24 @@
                 },
                 "parallelTransactions": {
                     "type": "integer"
+                },
+                "connectionTimeout": {
+                    "type": "integer"
+                },
+                "idleTimeout": {
+                    "type": "integer"
+                },
+                "keepaliveTime": {
+                    "type": "integer"
+                },
+                "maxLifetime": {
+                    "type": "integer"
+                },
+                "maximumPoolSize": {
+                    "type": "integer"
+                },
+                "minimumIdle": {
+                    "type": "integer"
                 }
             },
             "required": [

--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -382,9 +382,6 @@
                 "sslrootcert": {
                     "type": "string"
                 },
-                "parallelTransactions": {
-                    "type": "integer"
-                },
                 "connectionTimeout": {
                     "type": "integer"
                 },

--- a/model/src/main/kotlin/config/PostgresConnection.kt
+++ b/model/src/main/kotlin/config/PostgresConnection.kt
@@ -117,9 +117,4 @@ data class PostgresConnection(
      */
     @JsonInclude(Include.NON_NULL)
     val minimumIdle: Int? = null
-
-    /**
-     * TODO: Make additional parameters configurable, see:
-     *       https://jdbc.postgresql.org/documentation/head/connect.html
-     */
 )

--- a/model/src/main/kotlin/config/PostgresConnection.kt
+++ b/model/src/main/kotlin/config/PostgresConnection.kt
@@ -19,10 +19,12 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonIgnoreProperties("parallel_transactions")
 data class PostgresConnection(
     /**
      * The database URL in JDBC format.
@@ -71,11 +73,6 @@ data class PostgresConnection(
      */
     @JsonInclude(Include.NON_NULL)
     val sslrootcert: String? = null,
-
-    /**
-     * The number of parallel transactions to use for the storage dispatcher.
-     */
-    val parallelTransactions: Int = 5,
 
     /**
      * The maximum number of milliseconds to wait for connections from the pool. For details see the

--- a/model/src/main/kotlin/config/PostgresConnection.kt
+++ b/model/src/main/kotlin/config/PostgresConnection.kt
@@ -75,7 +75,51 @@ data class PostgresConnection(
     /**
      * The number of parallel transactions to use for the storage dispatcher.
      */
-    val parallelTransactions: Int = 5
+    val parallelTransactions: Int = 5,
+
+    /**
+     * The maximum number of milliseconds to wait for connections from the pool. For details see the
+     * [Hikari documentation](https://github.com/brettwooldridge/HikariCP#frequently-used).
+     */
+    @JsonInclude(Include.NON_NULL)
+    val connectionTimeout: Long? = null,
+
+    /**
+     * The maximum number of milliseconds a connection is allowed to sit idle in the pool. This requires that
+     * [minimumIdle] is set to a value lower than [maximumPoolSize]. For details see the
+     * [Hikari documentation](https://github.com/brettwooldridge/HikariCP#frequently-used).
+     */
+    @JsonInclude(Include.NON_NULL)
+    val idleTimeout: Long? = null,
+
+    /**
+     * The frequency in milliseconds that the pool will attempt to keep an idle connection alive. Must be set to a value
+     * lower than [maxLifetime]. For details see the
+     * [Hikari documentation](https://github.com/brettwooldridge/HikariCP#frequently-used).
+     */
+    @JsonInclude(Include.NON_NULL)
+    val keepaliveTime: Long? = null,
+
+    /**
+     * The maximum lifetime of a connection in milliseconds. For details see the
+     * [Hikari documentation](https://github.com/brettwooldridge/HikariCP#frequently-used).
+     */
+    @JsonInclude(Include.NON_NULL)
+    val maxLifetime: Long? = null,
+
+    /**
+     * The maximum size of the connection pool. For details see the
+     * [Hikari documentation](https://github.com/brettwooldridge/HikariCP#frequently-used).
+     */
+    @JsonInclude(Include.NON_NULL)
+    val maximumPoolSize: Int? = null,
+
+    /**
+     * The minimum number of idle connections that the pool tries to maintain. For details see the
+     * [Hikari documentation](https://github.com/brettwooldridge/HikariCP#frequently-used).
+     */
+    @JsonInclude(Include.NON_NULL)
+    val minimumIdle: Int? = null
 
     /**
      * TODO: Make additional parameters configurable, see:

--- a/model/src/main/kotlin/utils/DatabaseUtils.kt
+++ b/model/src/main/kotlin/utils/DatabaseUtils.kt
@@ -73,6 +73,13 @@ object DatabaseUtils {
                 schema = config.schema
                 maximumPoolSize = maxPoolSize
 
+                config.connectionTimeout?.also { connectionTimeout = it }
+                config.idleTimeout?.also { idleTimeout = it }
+                config.keepaliveTime?.also { keepaliveTime = it }
+                config.maxLifetime?.also { maxLifetime = it }
+                config.maximumPoolSize?.also { maximumPoolSize = it }
+                config.minimumIdle?.also { minimumIdle = it }
+
                 val suffix = " - $applicationNameSuffix".takeIf { applicationNameSuffix.isNotEmpty() }.orEmpty()
                 addDataSourceProperty("ApplicationName", "$ORT_FULL_NAME$suffix")
 


### PR DESCRIPTION
The implementation has been done based on [1].

Fixes #8543.

[1]: https://github.com/eclipse-apoapsis/ort-server/commit/f0f601e1c20d0e6f94d9e9c0240ea33098410ab8

