### PR TITLE
Fix CodeCov calls after which to comment

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 comment:
   # Keep this in sync with the number of codecov-action calls.
-  after_n_builds: 4
+  after_n_builds: 3
 coverage:
   status:
     project:


### PR DESCRIPTION
See [1].

[1]: https://docs.codecov.com/docs/pull-request-comments#after_n_builds