### PR TITLE
WebApp: Swap columns in summary views

### DIFF
--- a/plugins/reporters/web-app-template/src/components/IssuesTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/IssuesTable.jsx
@@ -58,76 +58,76 @@ class IssuesTable extends React.Component {
             return null;
         }
 
-        const columns = [
-            {
-                align: 'center',
-                dataIndex: 'severityIndex',
-                filters: [
-                    {
-                        text: 'Errors',
-                        value: 0
-                    },
-                    {
-                        text: 'Warnings',
-                        value: 1
-                    },
-                    {
-                        text: 'Hint',
-                        value: 2
-                    },
-                    {
-                        text: 'Resolved',
-                        value: 3
-                    }
-                ],
-                filteredValue: filteredInfo.severityIndex || null,
-                onFilter: (value, webAppOrtIssue) => webAppOrtIssue.severityIndex === Number(value),
-                render: (text, webAppOrtIssue) => (
-                    webAppOrtIssue.isResolved
-                        ? (
-                            <Tooltip
-                                placement="right"
-                                title={Array.from(webAppOrtIssue.resolutionReasons).join(', ')}
-                            >
-                                <IssuesCloseOutlined
-                                    className="ort-ok"
-                                />
-                            </Tooltip>
-                            )
-                        : (
-                            <span>
-                                {
-                                    webAppOrtIssue.severity === 'ERROR'
-                                    && (
-                                        <ExclamationCircleOutlined
-                                            className="ort-error"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppOrtIssue.severity === 'WARNING'
-                                    && (
-                                        <WarningOutlined
-                                            className="ort-warning"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppOrtIssue.severity === 'HINT'
-                                    && (
-                                        <InfoCircleOutlined
-                                            className="ort-hint"
-                                        />
-                                    )
-                                }
-                            </span>
-                            )
-                ),
-                sorter: (a, b) => a.severityIndex - b.severityIndex,
-                sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
-                width: '5em'
-            }
-        ];
+        const columns = [];
+
+        columns.push({
+            align: 'center',
+            dataIndex: 'severityIndex',
+            filters: [
+                {
+                    text: 'Errors',
+                    value: 0
+                },
+                {
+                    text: 'Warnings',
+                    value: 1
+                },
+                {
+                    text: 'Hint',
+                    value: 2
+                },
+                {
+                    text: 'Resolved',
+                    value: 3
+                }
+            ],
+            filteredValue: filteredInfo.severityIndex || null,
+            onFilter: (value, webAppOrtIssue) => webAppOrtIssue.severityIndex === Number(value),
+            render: (text, webAppOrtIssue) => (
+                webAppOrtIssue.isResolved
+                    ? (
+                        <Tooltip
+                            placement="right"
+                            title={Array.from(webAppOrtIssue.resolutionReasons).join(', ')}
+                        >
+                            <IssuesCloseOutlined
+                                className="ort-ok"
+                            />
+                        </Tooltip>
+                        )
+                    : (
+                        <span>
+                            {
+                                webAppOrtIssue.severity === 'ERROR'
+                                && (
+                                    <ExclamationCircleOutlined
+                                        className="ort-error"
+                                    />
+                                )
+                            }
+                            {
+                                webAppOrtIssue.severity === 'WARNING'
+                                && (
+                                    <WarningOutlined
+                                        className="ort-warning"
+                                    />
+                                )
+                            }
+                            {
+                                webAppOrtIssue.severity === 'HINT'
+                                && (
+                                    <InfoCircleOutlined
+                                        className="ort-hint"
+                                    />
+                                )
+                            }
+                        </span>
+                        )
+            ),
+            sorter: (a, b) => a.severityIndex - b.severityIndex,
+            sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
+            width: '5em'
+        });
 
         if (showExcludesColumn) {
             columns.push({

--- a/plugins/reporters/web-app-template/src/components/IssuesTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/IssuesTable.jsx
@@ -60,6 +60,68 @@ class IssuesTable extends React.Component {
 
         const columns = [];
 
+        if (showExcludesColumn) {
+            columns.push({
+                align: 'right',
+                filters: (() => [
+                    {
+                        text: (
+                            <span>
+                                <FileExcelOutlined className="ort-excluded" />
+                                {' '}
+                                Excluded
+                            </span>
+                        ),
+                        value: 'excluded'
+                    },
+                    {
+                        text: (
+                            <span>
+                                <FileAddOutlined />
+                                {' '}
+                                Included
+                            </span>
+                        ),
+                        value: 'included'
+                    }
+                ])(),
+                filteredValue: filteredInfo.excludes || null,
+                key: 'excludes',
+                onFilter: (value, webAppOrtIssue) => {
+                    const webAppPackage = webAppOrtIssue.package;
+
+                    if (value === 'excluded') {
+                        return webAppPackage.isExcluded;
+                    }
+
+                    if (value === 'included') {
+                        return !webAppPackage.isExcluded;
+                    }
+
+                    return false;
+                },
+                render: (webAppOrtIssue) => {
+                    const webAppPackage = webAppOrtIssue.package;
+
+                    return webAppPackage.isExcluded
+                        ? (
+                        <span className="ort-excludes">
+                            <Tooltip
+                                placement="right"
+                                title={Array.from(webAppPackage.excludeReasons).join(', ')}
+                            >
+                                <FileExcelOutlined className="ort-excluded" />
+                            </Tooltip>
+                        </span>
+                            )
+                        : (
+                        <FileAddOutlined />
+                            );
+                },
+                width: '2em'
+            });
+        }
+
         columns.push({
             align: 'center',
             dataIndex: 'severityIndex',
@@ -128,68 +190,6 @@ class IssuesTable extends React.Component {
             sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
             width: '5em'
         });
-
-        if (showExcludesColumn) {
-            columns.push({
-                align: 'right',
-                filters: (() => [
-                    {
-                        text: (
-                            <span>
-                                <FileExcelOutlined className="ort-excluded" />
-                                {' '}
-                                Excluded
-                            </span>
-                        ),
-                        value: 'excluded'
-                    },
-                    {
-                        text: (
-                            <span>
-                                <FileAddOutlined />
-                                {' '}
-                                Included
-                            </span>
-                        ),
-                        value: 'included'
-                    }
-                ])(),
-                filteredValue: filteredInfo.excludes || null,
-                key: 'excludes',
-                onFilter: (value, webAppOrtIssue) => {
-                    const webAppPackage = webAppOrtIssue.package;
-
-                    if (value === 'excluded') {
-                        return webAppPackage.isExcluded;
-                    }
-
-                    if (value === 'included') {
-                        return !webAppPackage.isExcluded;
-                    }
-
-                    return false;
-                },
-                render: (webAppOrtIssue) => {
-                    const webAppPackage = webAppOrtIssue.package;
-
-                    return webAppPackage.isExcluded
-                        ? (
-                        <span className="ort-excludes">
-                            <Tooltip
-                                placement="right"
-                                title={Array.from(webAppPackage.excludeReasons).join(', ')}
-                            >
-                                <FileExcelOutlined className="ort-excluded" />
-                            </Tooltip>
-                        </span>
-                            )
-                        : (
-                        <FileAddOutlined />
-                            );
-                },
-                width: '2em'
-            });
-        }
 
         columns.push(
             {

--- a/plugins/reporters/web-app-template/src/components/RuleViolationsTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/RuleViolationsTable.jsx
@@ -59,77 +59,76 @@ class RuleViolationsTable extends React.Component {
             return null;
         }
 
-        const columns = [
-            {
-                align: 'center',
-                dataIndex: 'severityIndex',
-                key: 'severityIndex',
-                filters: [
-                    {
-                        text: 'Errors',
-                        value: 0
-                    },
-                    {
-                        text: 'Warnings',
-                        value: 1
-                    },
-                    {
-                        text: 'Hint',
-                        value: 2
-                    },
-                    {
-                        text: 'Resolved',
-                        value: 3
-                    }
-                ],
-                filteredValue: filteredInfo.severityIndex || null,
-                onFilter: (value, webAppRuleViolation) => webAppRuleViolation.severityIndex === Number(value),
-                render: (text, webAppRuleViolation) => (
-                    webAppRuleViolation.isResolved
-                        ? (
-                            <Tooltip
-                                placement="right"
-                                title={Array.from(webAppRuleViolation.resolutionReasons).join(', ')}
-                            >
-                                <IssuesCloseOutlined
-                                    className="ort-ok"
-                                />
-                            </Tooltip>
-                            )
-                        : (
-                            <span>
-                                {
-                                    webAppRuleViolation.severity === 'ERROR'
-                                    && (
-                                        <ExclamationCircleOutlined
-                                            className="ort-error"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppRuleViolation.severity === 'WARNING'
-                                    && (
-                                        <WarningOutlined
-                                            className="ort-warning"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppRuleViolation.severity === 'HINT'
-                                    && (
-                                        <InfoCircleOutlined
-                                            className="ort-hint"
-                                        />
-                                    )
-                                }
-                            </span>
-                            )
-                ),
-                sorter: (a, b) => a.severityIndex - b.severityIndex,
-                sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
-                width: '5em'
-            }
-        ];
+        const columns = [];
+        columns.push({
+            align: 'center',
+            dataIndex: 'severityIndex',
+            key: 'severityIndex',
+            filters: [
+                {
+                    text: 'Errors',
+                    value: 0
+                },
+                {
+                    text: 'Warnings',
+                    value: 1
+                },
+                {
+                    text: 'Hint',
+                    value: 2
+                },
+                {
+                    text: 'Resolved',
+                    value: 3
+                }
+            ],
+            filteredValue: filteredInfo.severityIndex || null,
+            onFilter: (value, webAppRuleViolation) => webAppRuleViolation.severityIndex === Number(value),
+            render: (text, webAppRuleViolation) => (
+                webAppRuleViolation.isResolved
+                    ? (
+                        <Tooltip
+                            placement="right"
+                            title={Array.from(webAppRuleViolation.resolutionReasons).join(', ')}
+                        >
+                            <IssuesCloseOutlined
+                                className="ort-ok"
+                            />
+                        </Tooltip>
+                        )
+                    : (
+                        <span>
+                            {
+                                webAppRuleViolation.severity === 'ERROR'
+                                && (
+                                    <ExclamationCircleOutlined
+                                        className="ort-error"
+                                    />
+                                )
+                            }
+                            {
+                                webAppRuleViolation.severity === 'WARNING'
+                                && (
+                                    <WarningOutlined
+                                        className="ort-warning"
+                                    />
+                                )
+                            }
+                            {
+                                webAppRuleViolation.severity === 'HINT'
+                                && (
+                                    <InfoCircleOutlined
+                                        className="ort-hint"
+                                    />
+                                )
+                            }
+                        </span>
+                        )
+            ),
+            sorter: (a, b) => a.severityIndex - b.severityIndex,
+            sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
+            width: '5em'
+        });
 
         if (showExcludesColumn) {
             columns.push({

--- a/plugins/reporters/web-app-template/src/components/RuleViolationsTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/RuleViolationsTable.jsx
@@ -60,6 +60,68 @@ class RuleViolationsTable extends React.Component {
         }
 
         const columns = [];
+
+        if (showExcludesColumn) {
+            columns.push({
+                align: 'right',
+                filters: (() => [
+                    {
+                        text: (
+                            <span>
+                                <FileExcelOutlined className="ort-excluded" />
+                                {' '}
+                                Excluded
+                            </span>
+                        ),
+                        value: 'excluded'
+                    },
+                    {
+                        text: (
+                            <span>
+                                <FileAddOutlined />
+                                {' '}
+                                Included
+                            </span>
+                        ),
+                        value: 'included'
+                    }
+                ])(),
+                filteredValue: filteredInfo.excludes || null,
+                key: 'excludes',
+                onFilter: (value, webAppRuleViolation) => {
+                    if (!webAppRuleViolation.hasPackage()) return true;
+
+                    const { isExcluded } = webAppRuleViolation.package;
+
+                    return (isExcluded && value === 'excluded') || (!isExcluded && value === 'included');
+                },
+                render: (webAppRuleViolation) => {
+                    const webAppPackage = webAppRuleViolation.package;
+
+                    if (webAppPackage) {
+                        return webAppPackage.isExcluded
+                            ? (
+                            <span className="ort-excludes">
+                                <Tooltip
+                                    placement="right"
+                                    title={Array.from(webAppPackage.excludeReasons).join(', ')}
+                                >
+                                    <FileExcelOutlined className="ort-excluded" />
+                                </Tooltip>
+                            </span>
+                                )
+                            : (
+                            <FileAddOutlined />
+                                );
+                    }
+
+                    return null;
+                },
+                responsive: ['md'],
+                width: '2em'
+            });
+        }
+
         columns.push({
             align: 'center',
             dataIndex: 'severityIndex',
@@ -129,67 +191,6 @@ class RuleViolationsTable extends React.Component {
             sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
             width: '5em'
         });
-
-        if (showExcludesColumn) {
-            columns.push({
-                align: 'right',
-                filters: (() => [
-                    {
-                        text: (
-                            <span>
-                                <FileExcelOutlined className="ort-excluded" />
-                                {' '}
-                                Excluded
-                            </span>
-                        ),
-                        value: 'excluded'
-                    },
-                    {
-                        text: (
-                            <span>
-                                <FileAddOutlined />
-                                {' '}
-                                Included
-                            </span>
-                        ),
-                        value: 'included'
-                    }
-                ])(),
-                filteredValue: filteredInfo.excludes || null,
-                key: 'excludes',
-                onFilter: (value, webAppRuleViolation) => {
-                    if (!webAppRuleViolation.hasPackage()) return true;
-
-                    const { isExcluded } = webAppRuleViolation.package;
-
-                    return (isExcluded && value === 'excluded') || (!isExcluded && value === 'included');
-                },
-                render: (webAppRuleViolation) => {
-                    const webAppPackage = webAppRuleViolation.package;
-
-                    if (webAppPackage) {
-                        return webAppPackage.isExcluded
-                            ? (
-                            <span className="ort-excludes">
-                                <Tooltip
-                                    placement="right"
-                                    title={Array.from(webAppPackage.excludeReasons).join(', ')}
-                                >
-                                    <FileExcelOutlined className="ort-excluded" />
-                                </Tooltip>
-                            </span>
-                                )
-                            : (
-                            <FileAddOutlined />
-                                );
-                    }
-
-                    return null;
-                },
-                responsive: ['md'],
-                width: '2em'
-            });
-        }
 
         columns.push(
             {

--- a/plugins/reporters/web-app-template/src/components/VulnerabilitiesTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/VulnerabilitiesTable.jsx
@@ -70,101 +70,101 @@ class VulnerabilitiesTable extends React.Component {
             return null;
         }
 
-        const columns = [
-            {
-                align: 'center',
-                dataIndex: 'severityIndex',
-                key: 'severityIndex',
-                filters: [
-                    {
-                        text: 'Critical',
-                        value: 0
-                    },
-                    {
-                        text: 'High',
-                        value: 1
-                    },
-                    {
-                        text: 'Medium',
-                        value: 2
-                    },
-                    {
-                        text: 'Low',
-                        value: 3
-                    },
-                    {
-                        text: 'Resolved',
-                        value: 5
-                    },
-                    {
-                        text: 'Unknown',
-                        value: 4
-                    }
-                ],
-                filteredValue: filteredInfo.severityIndex || null,
-                onFilter: (value, webAppVulnerability) => webAppVulnerability.severityIndex === Number(value),
-                render: (text, webAppVulnerability) => (
-                    webAppVulnerability.isResolved
-                        ? (
-                            <Tooltip
-                                placement="right"
-                                title={Array.from(webAppVulnerability.resolutionReasons).join(', ')}
-                            >
-                                <IssuesCloseOutlined
-                                    className="ort-ok"
-                                />
-                            </Tooltip>
-                            )
-                        : (
-                            <span>
-                                {
-                                    webAppVulnerability.severityIndex === 0
-                                    && (
-                                        <CloseCircleOutlined
-                                            className="ort-critical"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppVulnerability.severityIndex === 1
-                                    && (
-                                        <ExclamationCircleOutlined
-                                            className="ort-high"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppVulnerability.severityIndex === 2
-                                    && (
-                                        <WarningOutlined
-                                            className="ort-medium"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppVulnerability.severityIndex === 3
-                                    && (
-                                        <InfoCircleOutlined
-                                            className="ort-low"
-                                        />
-                                    )
-                                }
-                                {
-                                    webAppVulnerability.severityIndex === 4
-                                    && (
-                                        <QuestionCircleOutlined
-                                            className="ort-unknown"
-                                        />
-                                    )
-                                }
-                            </span>
-                            )
-                ),
-                sorter: (a, b) => a.severityIndex - b.severityIndex,
-                sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
-                width: '5em'
-            }
-        ];
+        const columns = [];
+
+        columns.push({
+            align: 'center',
+            dataIndex: 'severityIndex',
+            key: 'severityIndex',
+            filters: [
+                {
+                    text: 'Critical',
+                    value: 0
+                },
+                {
+                    text: 'High',
+                    value: 1
+                },
+                {
+                    text: 'Medium',
+                    value: 2
+                },
+                {
+                    text: 'Low',
+                    value: 3
+                },
+                {
+                    text: 'Resolved',
+                    value: 5
+                },
+                {
+                    text: 'Unknown',
+                    value: 4
+                }
+            ],
+            filteredValue: filteredInfo.severityIndex || null,
+            onFilter: (value, webAppVulnerability) => webAppVulnerability.severityIndex === Number(value),
+            render: (text, webAppVulnerability) => (
+                webAppVulnerability.isResolved
+                    ? (
+                        <Tooltip
+                            placement="right"
+                            title={Array.from(webAppVulnerability.resolutionReasons).join(', ')}
+                        >
+                            <IssuesCloseOutlined
+                                className="ort-ok"
+                            />
+                        </Tooltip>
+                        )
+                    : (
+                        <span>
+                            {
+                                webAppVulnerability.severityIndex === 0
+                                && (
+                                    <CloseCircleOutlined
+                                        className="ort-critical"
+                                    />
+                                )
+                            }
+                            {
+                                webAppVulnerability.severityIndex === 1
+                                && (
+                                    <ExclamationCircleOutlined
+                                        className="ort-high"
+                                    />
+                                )
+                            }
+                            {
+                                webAppVulnerability.severityIndex === 2
+                                && (
+                                    <WarningOutlined
+                                        className="ort-medium"
+                                    />
+                                )
+                            }
+                            {
+                                webAppVulnerability.severityIndex === 3
+                                && (
+                                    <InfoCircleOutlined
+                                        className="ort-low"
+                                    />
+                                )
+                            }
+                            {
+                                webAppVulnerability.severityIndex === 4
+                                && (
+                                    <QuestionCircleOutlined
+                                        className="ort-unknown"
+                                    />
+                                )
+                            }
+                        </span>
+                        )
+            ),
+            sorter: (a, b) => a.severityIndex - b.severityIndex,
+            sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
+            width: '5em'
+        });
 
         if (showExcludesColumn) {
             columns.push({

--- a/plugins/reporters/web-app-template/src/components/VulnerabilitiesTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/VulnerabilitiesTable.jsx
@@ -72,6 +72,65 @@ class VulnerabilitiesTable extends React.Component {
 
         const columns = [];
 
+        if (showExcludesColumn) {
+            columns.push({
+                align: 'right',
+                filters: (() => [
+                    {
+                        text: (
+                            <span>
+                                <FileExcelOutlined className="ort-excluded" />
+                                {' '}
+                                Excluded
+                            </span>
+                        ),
+                        value: 'excluded'
+                    },
+                    {
+                        text: (
+                            <span>
+                                <FileAddOutlined />
+                                {' '}
+                                Included
+                            </span>
+                        ),
+                        value: 'included'
+                    }
+                ])(),
+                filteredValue: filteredInfo.excludes || null,
+                key: 'excludes',
+                onFilter: (value, webAppVulnerability) => {
+                    const { isExcluded } = webAppVulnerability.package;
+
+                    return (isExcluded && value === 'excluded') || (!isExcluded && value === 'included');
+                },
+                render: (webAppVulnerability) => {
+                    const webAppPackage = webAppVulnerability.package;
+
+                    if (webAppPackage) {
+                        return webAppPackage.isExcluded
+                            ? (
+                            <span className="ort-excludes">
+                                <Tooltip
+                                    placement="right"
+                                    title={Array.from(webAppPackage.excludeReasons).join(', ')}
+                                >
+                                    <FileExcelOutlined className="ort-excluded" />
+                                </Tooltip>
+                            </span>
+                                )
+                            : (
+                            <FileAddOutlined />
+                                );
+                    }
+
+                    return null;
+                },
+                responsive: ['md'],
+                width: '2em'
+            });
+        }
+
         columns.push({
             align: 'center',
             dataIndex: 'severityIndex',
@@ -165,65 +224,6 @@ class VulnerabilitiesTable extends React.Component {
             sortOrder: sortedInfo.field === 'severityIndex' && sortedInfo.order,
             width: '5em'
         });
-
-        if (showExcludesColumn) {
-            columns.push({
-                align: 'right',
-                filters: (() => [
-                    {
-                        text: (
-                            <span>
-                                <FileExcelOutlined className="ort-excluded" />
-                                {' '}
-                                Excluded
-                            </span>
-                        ),
-                        value: 'excluded'
-                    },
-                    {
-                        text: (
-                            <span>
-                                <FileAddOutlined />
-                                {' '}
-                                Included
-                            </span>
-                        ),
-                        value: 'included'
-                    }
-                ])(),
-                filteredValue: filteredInfo.excludes || null,
-                key: 'excludes',
-                onFilter: (value, webAppVulnerability) => {
-                    const { isExcluded } = webAppVulnerability.package;
-
-                    return (isExcluded && value === 'excluded') || (!isExcluded && value === 'included');
-                },
-                render: (webAppVulnerability) => {
-                    const webAppPackage = webAppVulnerability.package;
-
-                    if (webAppPackage) {
-                        return webAppPackage.isExcluded
-                            ? (
-                            <span className="ort-excludes">
-                                <Tooltip
-                                    placement="right"
-                                    title={Array.from(webAppPackage.excludeReasons).join(', ')}
-                                >
-                                    <FileExcelOutlined className="ort-excluded" />
-                                </Tooltip>
-                            </span>
-                                )
-                            : (
-                            <FileAddOutlined />
-                                );
-                    }
-
-                    return null;
-                },
-                responsive: ['md'],
-                width: '2em'
-            });
-        }
 
         columns.push(
             {


### PR DESCRIPTION
Having the excluded state visualized directly next to the package identifier can mis-lead the users into thinking that it means "package is excluded". However, it should mean "issue is excluded". Swap the columns to make this less likely to happen.

Part of: #7921.

### Before

![Screenshot from 2024-04-23 13-31-08](https://github.com/oss-review-toolkit/ort/assets/42963794/41fdec7c-cd42-4dfa-8d9d-71d9378eb4d8)

### After

![Screenshot from 2024-04-23 13-30-25](https://github.com/oss-review-toolkit/ort/assets/42963794/d0d0f0dd-49f7-494d-97c9-bd9b097f3ab6)

