### PR TITLE
WebApp: Reflect excluded affected paths of issues in the UI

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -77,6 +77,7 @@ issues:
   source: "FakeScanner"
   message: "ERROR: Timeout after 300 seconds while scanning file 'project/file-within-excluded-project.dat'."
   severity: "ERROR"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -86,6 +87,7 @@ issues:
   source: "FakeScanner"
   message: "Example hint."
   severity: "HINT"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -95,6 +97,7 @@ issues:
   source: "FakeScanner"
   message: "Example warning."
   severity: "WARNING"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -104,6 +107,7 @@ issues:
   source: "FakeScanner"
   message: "Example error."
   severity: "ERROR"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -115,6 +119,7 @@ issues:
   severity: "ERROR"
   resolutions:
   - 0
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -178,6 +183,7 @@ issues:
   source: "FakeScanner"
   message: "ERROR: Timeout after 300 seconds while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'."
   severity: "ERROR"
+  is_excluded: true
   pkg: 1
   scan_result: 1
   how_to_fix: "Some how to fix text."

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -102,6 +102,7 @@
     "source" : "FakeScanner",
     "message" : "ERROR: Timeout after 300 seconds while scanning file 'project/file-within-excluded-project.dat'.",
     "severity" : "ERROR",
+    "is_excluded" : true,
     "pkg" : 0,
     "scan_result" : 0,
     "how_to_fix" : "Some how to fix text."
@@ -112,6 +113,7 @@
     "source" : "FakeScanner",
     "message" : "Example hint.",
     "severity" : "HINT",
+    "is_excluded" : true,
     "pkg" : 0,
     "scan_result" : 0,
     "how_to_fix" : "Some how to fix text."
@@ -122,6 +124,7 @@
     "source" : "FakeScanner",
     "message" : "Example warning.",
     "severity" : "WARNING",
+    "is_excluded" : true,
     "pkg" : 0,
     "scan_result" : 0,
     "how_to_fix" : "Some how to fix text."
@@ -132,6 +135,7 @@
     "source" : "FakeScanner",
     "message" : "Example error.",
     "severity" : "ERROR",
+    "is_excluded" : true,
     "pkg" : 0,
     "scan_result" : 0,
     "how_to_fix" : "Some how to fix text."
@@ -143,6 +147,7 @@
     "message" : "Example error, resolved.",
     "severity" : "ERROR",
     "resolutions" : [ 0 ],
+    "is_excluded" : true,
     "pkg" : 0,
     "scan_result" : 0,
     "how_to_fix" : "Some how to fix text."
@@ -210,6 +215,7 @@
     "source" : "FakeScanner",
     "message" : "ERROR: Timeout after 300 seconds while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'.",
     "severity" : "ERROR",
+    "is_excluded" : true,
     "pkg" : 1,
     "scan_result" : 1,
     "how_to_fix" : "Some how to fix text."

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -77,6 +77,7 @@ issues:
   source: "FakeScanner"
   message: "ERROR: Timeout after 300 seconds while scanning file 'project/file-within-excluded-project.dat'."
   severity: "ERROR"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -86,6 +87,7 @@ issues:
   source: "FakeScanner"
   message: "Example hint."
   severity: "HINT"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -95,6 +97,7 @@ issues:
   source: "FakeScanner"
   message: "Example warning."
   severity: "WARNING"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -104,6 +107,7 @@ issues:
   source: "FakeScanner"
   message: "Example error."
   severity: "ERROR"
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -115,6 +119,7 @@ issues:
   severity: "ERROR"
   resolutions:
   - 0
+  is_excluded: true
   pkg: 0
   scan_result: 0
   how_to_fix: "Some how to fix text."
@@ -178,6 +183,7 @@ issues:
   source: "FakeScanner"
   message: "ERROR: Timeout after 300 seconds while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'."
   severity: "ERROR"
+  is_excluded: true
   pkg: 1
   scan_result: 1
   how_to_fix: "Some how to fix text."

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedIssue.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedIssue.kt
@@ -41,6 +41,8 @@ data class EvaluatedIssue(
     val severity: Severity = Severity.ERROR,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val resolutions: List<IssueResolution>,
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val isExcluded: Boolean = false,
     @JsonIdentityReference(alwaysAsId = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val pkg: EvaluatedPackage?,

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -595,6 +595,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                 message = issue.message,
                 severity = issue.severity,
                 resolutions = resolutions,
+                isExcluded = input.ortResult.isExcluded(issue, pkg.id),
                 pkg = pkg,
                 scanResult = scanResult,
                 path = path,

--- a/plugins/reporters/web-app-template/src/components/IssuesTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/IssuesTable.jsx
@@ -157,14 +157,12 @@ class IssuesTable extends React.Component {
                 filteredValue: filteredInfo.excludes || null,
                 key: 'excludes',
                 onFilter: (value, webAppOrtIssue) => {
-                    const webAppPackage = webAppOrtIssue.package;
-
                     if (value === 'excluded') {
-                        return webAppPackage.isExcluded;
+                        return webAppOrtIssue.isExcluded;
                     }
 
                     if (value === 'included') {
-                        return !webAppPackage.isExcluded;
+                        return !webAppOrtIssue.isExcluded;
                     }
 
                     return false;
@@ -172,7 +170,7 @@ class IssuesTable extends React.Component {
                 render: (webAppOrtIssue) => {
                     const webAppPackage = webAppOrtIssue.package;
 
-                    return webAppPackage.isExcluded
+                    return webAppOrtIssue.isExcluded
                         ? (
                         <span className="ort-excludes">
                             <Tooltip

--- a/plugins/reporters/web-app-template/src/models/WebAppOrtIssue.js
+++ b/plugins/reporters/web-app-template/src/models/WebAppOrtIssue.js
@@ -22,6 +22,8 @@ import { randomStringGenerator } from '../utils';
 class WebAppOrtIssue {
     #_id;
 
+    #isExcluded
+
     #howToFix
 
     #message;
@@ -57,6 +59,8 @@ class WebAppOrtIssue {
             if (Number.isInteger(obj._id)) {
                 this.#_id = obj._id;
             }
+
+            this.#isExcluded = obj.is_excluded === true || obj.isExcluded === true;
 
             if (obj.how_to_fix || obj.howToFix) {
                 this.#howToFix = obj.how_to_fix
@@ -123,6 +127,10 @@ class WebAppOrtIssue {
 
     get howToFix() {
         return this.#howToFix;
+    }
+
+    get isExcluded() {
+        return this.#isExcluded;
     }
 
     get isResolved() {


### PR DESCRIPTION
The effect on the UI is visible only under the issues summary view and is as follows:

1. The excluded state icon of issues now reflects excluded affected paths
2. The filtering of excluded issues now filters out issues with excluded affected paths

Note: This PR can be easily verified by creating a WebApp report from `./plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml`.

Part of: #7921.

### UI Changes

1. Excluded scan timeout issue for non-excluded package `Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0` now grayed out: 
![Screenshot from 2024-04-25 13-11-58](https://github.com/oss-review-toolkit/ort/assets/42963794/35bdf3eb-8334-41a8-9621-de38f38a05dc)
2. After adjusting the filter for excluded issues, the issue is properly hidden:
![Screenshot from 2024-04-25 13-12-20](https://github.com/oss-review-toolkit/ort/assets/42963794/d69ebddb-fcb1-4fdb-b2c8-fe8255d82b05)


