### PR TITLE
fix(cargo): Treat projects outside the analyer root as packages

### DIFF
--- a/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
@@ -225,7 +225,7 @@ private fun CargoMetadata.Package.toPackage(hashes: Map<String, String>): Packag
         binaryArtifact = RemoteArtifact.EMPTY,
         sourceArtifact = parseSourceArtifact(hashes).orEmpty(),
         homepageUrl = homepage.orEmpty(),
-        vcs = VcsHost.parseUrl(repository.orEmpty())
+        vcs = repository?.let { VcsHost.parseUrl(it) }.orEmpty()
     )
 }
 

--- a/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
@@ -250,7 +250,7 @@ private fun CargoMetadata.Package.parseDeclaredLicenses(): Set<String> {
 // to.
 // See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories
 // for the specification for this kind of dependency.
-private val GIT_DEPENDENCY_REGEX = Regex("git\\+(https://.*)\\?(?:rev|tag|branch)=.+#([0-9a-zA-Z]+)")
+private val GIT_DEPENDENCY_REGEX = Regex("git\\+(https://.*)\\?(?:rev|tag|branch)=.+#([0-9a-fA-F]{7,40})")
 
 private fun CargoMetadata.Package.parseSourceArtifact(hashes: Map<String, String>): RemoteArtifact? {
     val source = source ?: return null


### PR DESCRIPTION
E.g. when analyzing a single Cargo project in a sub-directory with a `cargo.toml` file that points to "path dependencies" in a parent directory, these dependencies should not be seen as projects but as packages. This restores the behavior from before 7522a0c.

Resolves #8571.