### PR TITLE
Add statistics for the effective licenses to the evaluated model's license stats

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -409,15 +409,11 @@ data class OrtResult(
      * [includeSubProjects].
      */
     @JsonIgnore
-    fun getProjectsAndPackages(includeSubProjects: Boolean = true): Set<Identifier> {
-        val projectsAndPackages = mutableSetOf<Identifier>()
-        val projects = getProjects(includeSubProjects = includeSubProjects)
-
-        projects.mapTo(projectsAndPackages) { it.id }
-        getPackages().mapTo(projectsAndPackages) { it.metadata.id }
-
-        return projectsAndPackages
-    }
+    fun getProjectsAndPackages(includeSubProjects: Boolean = true): Set<Identifier> =
+        buildSet {
+            getProjects(includeSubProjects = includeSubProjects).mapTo(this) { it.id }
+            getPackages().mapTo(this) { it.metadata.id }
+        }
 
     /**
      * Return all [SpdxLicenseChoice]s applicable for the scope of the whole [repository].

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -406,13 +406,13 @@ data class OrtResult(
 
     /**
      * Return the set of all project or package identifiers in the result, optionally [including those of subprojects]
-     * [includeSubProjects].
+     * [includeSubProjects] and optionally limited to only non-excluded ones if [omitExcluded] is true.
      */
     @JsonIgnore
-    fun getProjectsAndPackages(includeSubProjects: Boolean = true): Set<Identifier> =
+    fun getProjectsAndPackages(includeSubProjects: Boolean = true, omitExcluded: Boolean = false): Set<Identifier> =
         buildSet {
-            getProjects(includeSubProjects = includeSubProjects).mapTo(this) { it.id }
-            getPackages().mapTo(this) { it.metadata.id }
+            getProjects(includeSubProjects = includeSubProjects, omitExcluded = omitExcluded).mapTo(this) { it.id }
+            getPackages(omitExcluded = omitExcluded).mapTo(this) { it.metadata.id }
         }
 
     /**

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -1089,6 +1089,13 @@ statistics:
       LicenseRef-test-Apache-2.0-multi-line: 1
       LicenseRef-test-Apache-2.0-single-line: 1
       MIT: 2
+    effective:
+      Apache-2.0: 2
+      BSD-3-Clause: 1
+      GPL-2.0-only WITH Classpath-exception-2.0: 1
+      LicenseRef-test-Apache-2.0-multi-line: 1
+      LicenseRef-test-Apache-2.0-single-line: 1
+      MIT: 1
   execution_duration_in_seconds: 3125
 repository:
   vcs:

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -1181,6 +1181,14 @@
         "LicenseRef-test-Apache-2.0-multi-line" : 1,
         "LicenseRef-test-Apache-2.0-single-line" : 1,
         "MIT" : 2
+      },
+      "effective" : {
+        "Apache-2.0" : 2,
+        "BSD-3-Clause" : 1,
+        "GPL-2.0-only WITH Classpath-exception-2.0" : 1,
+        "LicenseRef-test-Apache-2.0-multi-line" : 1,
+        "LicenseRef-test-Apache-2.0-single-line" : 1,
+        "MIT" : 1
       }
     },
     "execution_duration_in_seconds" : 3125

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -1093,6 +1093,13 @@ statistics:
       LicenseRef-test-Apache-2.0-multi-line: 1
       LicenseRef-test-Apache-2.0-single-line: 1
       MIT: 2
+    effective:
+      Apache-2.0: 2
+      BSD-3-Clause: 1
+      GPL-2.0-only WITH Classpath-exception-2.0: 1
+      LicenseRef-test-Apache-2.0-multi-line: 1
+      LicenseRef-test-Apache-2.0-single-line: 1
+      MIT: 1
   execution_duration_in_seconds: 3125
 repository:
   vcs:

--- a/reporter/src/main/kotlin/Statistics.kt
+++ b/reporter/src/main/kotlin/Statistics.kt
@@ -165,7 +165,13 @@ data class LicenseStatistics(
      * All detected licenses, mapped to the number of [Project]s and [Package]s they were detected in.
      */
     @JsonPropertyOrder(alphabetic = true)
-    val detected: Map<String, Int>
+    val detected: Map<String, Int>,
+
+    /**
+     * All effective licenses, mapped to the number of non-excluded [Project]s and [Package]s they apply to.
+     */
+    @JsonPropertyOrder(alphabetic = true)
+    val effective: Map<String, Int>
 )
 
 /**

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -130,7 +130,13 @@ object StatisticsCalculator {
 
         return LicenseStatistics(
             declared = ids.countLicenses { filter(LicenseView.ONLY_DECLARED) },
-            detected = ids.countLicenses { filter(LicenseView.ONLY_DETECTED) }
+            detected = ids.countLicenses { filter(LicenseView.ONLY_DETECTED) },
+            effective = ortResult.getProjectsAndPackages(omitExcluded = true).countLicenses {
+                filterExcluded()
+                    .filter(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
+                    .applyChoices(ortResult.getPackageLicenseChoices(id))
+                    .applyChoices(ortResult.getRepositoryLicenseChoices())
+            }
         )
     }
 

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -118,8 +118,6 @@ object StatisticsCalculator {
         ortResult: OrtResult,
         licenseInfoResolver: LicenseInfoResolver
     ): LicenseStatistics {
-        val ids = ortResult.getProjectsAndPackages()
-
         fun Collection<Identifier>.countLicenses(
             transform: ResolvedLicenseInfo.() -> ResolvedLicenseInfo = { this }
         ): Map<String, Int> =
@@ -128,12 +126,11 @@ object StatisticsCalculator {
                 transform(resolvedLicenseInfo).map { it.license.toString() }
             }.groupingBy { it }.eachCount().toMap()
 
-        val declaredLicenses = ids.countLicenses { filter(LicenseView.ONLY_DECLARED) }
-        val detectedLicenses = ids.countLicenses { filter(LicenseView.ONLY_DETECTED) }
+        val ids = ortResult.getProjectsAndPackages()
 
         return LicenseStatistics(
-            declared = declaredLicenses,
-            detected = detectedLicenses
+            declared = ids.countLicenses { filter(LicenseView.ONLY_DECLARED) },
+            detected = ids.countLicenses { filter(LicenseView.ONLY_DETECTED) }
         )
     }
 


### PR DESCRIPTION
See individual commits.

Part of: #8038.