### PR TITLE
ci(github): Do not push Docker images for pull requests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-ort.outputs.tags }}
           labels: ${{ steps.meta-ort.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort:cache
@@ -80,7 +80,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-ort-minimal.outputs.tags }}
           labels: ${{ steps.meta-ort-minimal.outputs.labels }}
           target: minimal


### PR DESCRIPTION
Disable pushing of Docker images for the `docker-build` workflow if it was triggered by a pull request. For pull requests the workflow should only verify that the Docker build works, but not publish any images.