### PR TITLE
ci(github): Make host users and groups available in the container

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -149,6 +149,8 @@ jobs:
         # Run the functional tests in the Docker container.
         docker run \
           -u $(id -u):$(id -g) \
+          -v /etc/group:/etc/group:ro \
+          -v /etc/passwd:/etc/passwd:ro \
           -v /home/runner:/home/runner \
           -v ${{ github.workspace }}:/workspace \
           -w /workspace \


### PR DESCRIPTION
This fixes proper Gradle caching of builds in the Docker container, i.e.
the Gradle wrapper is not downloaded again. This is a fixup for 69bdfd9.
    
