### PR TITLE
static-html: Re-design the issues summary table

### DIFF
--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -26,7 +26,6 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.getScanIssues
 import org.ossreviewtoolkit.helper.utils.readOrtResult
 import org.ossreviewtoolkit.helper.utils.replaceConfig
 import org.ossreviewtoolkit.model.config.IssueResolution
@@ -70,11 +69,9 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
 
         val resolutionProvider = DefaultResolutionProvider.create(ortResult, resolutionsFile)
 
-        val timeoutIssues = ortResult
-            .getScanIssues(omitExcluded)
-            .filter {
-                it.message.startsWith("ERROR: Timeout") && !resolutionProvider.isResolved(it)
-            }
+        val timeoutIssues = ortResult.getScannerIssues(omitExcluded).flatMapTo(mutableSetOf()) { it.value }.filter {
+            it.message.startsWith("ERROR: Timeout") && !resolutionProvider.isResolved(it)
+        }
 
         val generatedResolutions = timeoutIssues.mapTo(mutableSetOf()) {
             IssueResolution(

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -36,10 +36,8 @@ import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.downloader.Downloader
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Provenance
@@ -235,24 +233,6 @@ internal fun KnownProvenance?.getSourceCodeOrigin(): SourceCodeOrigin? =
         is RepositoryProvenance -> SourceCodeOrigin.VCS
         else -> null
     }
-
-/**
- * Return all issues from scan results. Issues for excludes [Project]s or [Package]s are not returned if and only if
- * the given [omitExcluded] is true.
- */
-internal fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<Issue> {
-    val result = mutableListOf<Issue>()
-
-    getScanResults().forEach { (id, results) ->
-        if (!omitExcluded || !isExcluded(id)) {
-            results.forEach { scanResult ->
-                result += scanResult.summary.issues
-            }
-        }
-    }
-
-    return result
-}
 
 /**
  * Return all path excludes from this [OrtResult] represented as [RepositoryPathExcludes].

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -276,15 +276,47 @@ data class OrtResult(
         omitExcluded: Boolean = false,
         omitResolved: Boolean = false,
         minSeverity: Severity = Severity.entries.min()
-    ): Map<Identifier, Set<Issue>> {
-        val analyzerIssues = analyzer?.result?.getAllIssues().orEmpty()
-        val scannerIssues = scanner?.getAllIssues().orEmpty()
-        val advisorIssues = advisor?.results?.getIssues().orEmpty()
+    ): Map<Identifier, Set<Issue>> =
+        getAnalyzerIssues()
+            .zipWithCollections(getScannerIssues())
+            .zipWithCollections(getAdvisorIssues())
+            .filterIssues(omitExcluded, omitResolved, minSeverity)
 
-        val allIssues = analyzerIssues.zipWithCollections(scannerIssues).zipWithCollections(advisorIssues)
+    /**
+     * Return a map of all de-duplicated analyzer [Issue]s associated by [Identifier]. If [omitExcluded] is set to true,
+     * excluded issues are omitted from the result. If [omitResolved] is set to true, resolved issues are omitted from
+     * the result. Issues with [severity][Issue.severity] below [minSeverity] are omitted from the result.
+     */
+    fun getAnalyzerIssues(
+        omitExcluded: Boolean = false,
+        omitResolved: Boolean = false,
+        minSeverity: Severity = Severity.entries.min()
+    ): Map<Identifier, Set<Issue>> =
+        analyzer?.result?.getAllIssues().orEmpty().filterIssues(omitExcluded, omitResolved, minSeverity)
 
-        return allIssues.filterIssues(omitExcluded, omitResolved, minSeverity)
-    }
+    /**
+     * Return a map of all de-duplicated scanner [Issue]s associated by [Identifier]. If [omitExcluded] is set to true,
+     * excluded issues are omitted from the result. If [omitResolved] is set to true, resolved issues are omitted from
+     * the result. Issues with [severity][Issue.severity] below [minSeverity] are omitted from the result.
+     */
+    fun getScannerIssues(
+        omitExcluded: Boolean = false,
+        omitResolved: Boolean = false,
+        minSeverity: Severity = Severity.entries.min()
+    ): Map<Identifier, Set<Issue>> =
+        scanner?.getAllIssues().orEmpty().filterIssues(omitExcluded, omitResolved, minSeverity)
+
+    /**
+     * Return a map of all de-duplicated advisor [Issue]s associated by [Identifier]. If [omitExcluded] is set to true,
+     * excluded issues are omitted from the result. If [omitResolved] is set to true, resolved issues are omitted from
+     * the result. Issues with [severity][Issue.severity] below [minSeverity] are omitted from the result.
+     */
+    fun getAdvisorIssues(
+        omitExcluded: Boolean = false,
+        omitResolved: Boolean = false,
+        minSeverity: Severity = Severity.entries.min()
+    ): Map<Identifier, Set<Issue>> =
+        advisor?.results?.getIssues().orEmpty().filterIssues(omitExcluded, omitResolved, minSeverity)
 
     private fun Map<Identifier, Set<Issue>>.filterIssues(
         omitExcluded: Boolean = false,

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -283,7 +283,15 @@ data class OrtResult(
 
         val allIssues = analyzerIssues.zipWithCollections(scannerIssues).zipWithCollections(advisorIssues)
 
-        return allIssues.mapNotNull { (id, issues) ->
+        return allIssues.filterIssues(omitExcluded, omitResolved, minSeverity)
+    }
+
+    private fun Map<Identifier, Set<Issue>>.filterIssues(
+        omitExcluded: Boolean = false,
+        omitResolved: Boolean = false,
+        minSeverity: Severity = Severity.entries.min()
+    ): Map<Identifier, Set<Issue>> =
+        mapNotNull { (id, issues) ->
             if (omitExcluded && isExcluded(id)) return@mapNotNull null
 
             val filteredIssues = issues.filterTo(mutableSetOf()) {
@@ -294,7 +302,6 @@ data class OrtResult(
 
             filteredIssues.takeUnless { it.isEmpty() }?.let { id to it }
         }.toMap()
-    }
 
     /**
      * Return the label values corresponding to the given [key] split at the delimiter ',', or an empty set if the label

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -235,6 +235,25 @@ issues:
   - 1
   pkg: 2
   how_to_fix: "Some how to fix text."
+- _id: 17
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in included package."
+  severity: "WARNING"
+  pkg: 2
+  path: 0
+  how_to_fix: "Some how to fix text."
+- _id: 18
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in excluded package."
+  severity: "WARNING"
+  is_excluded: true
+  pkg: 3
+  path: 1
+  how_to_fix: "Some how to fix text."
 scan_results:
 - _id: 0
   provenance:
@@ -555,8 +574,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 5
-  - 6
+  - 7
+  - 8
   levels:
   - 0
   - 1
@@ -602,7 +621,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 0
+  - 2
   levels:
   - 0
   scopes:
@@ -654,7 +673,7 @@ packages:
       comment: "Foobar is an imaginary dependency and offers a license choice"
       concluded_license: "GPL-2.0-only OR MIT"
   paths:
-  - 1
+  - 3
   levels:
   - 1
   scopes:
@@ -706,7 +725,7 @@ packages:
       comment: "H2 database offers a license choice"
       concluded_license: "MPL-2.0 OR EPL-1.0"
   paths:
-  - 2
+  - 4
   levels:
   - 1
   scopes:
@@ -753,8 +772,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 3
-  - 4
+  - 5
+  - 6
   levels:
   - 1
   - 2
@@ -837,7 +856,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 7
+  - 9
   levels:
   - 1
   scopes:
@@ -873,8 +892,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 8
-  - 9
+  - 10
+  - 11
   levels:
   - 0
   scopes:
@@ -883,58 +902,68 @@ packages:
   is_excluded: false
 paths:
 - _id: 0
+  pkg: 2
+  project: 1
+  scope: 0
+  path: []
+- _id: 1
   pkg: 3
   project: 1
   scope: 1
   path: []
-- _id: 1
+- _id: 2
+  pkg: 3
+  project: 1
+  scope: 1
+  path: []
+- _id: 3
   pkg: 4
   project: 1
   scope: 1
   path:
   - 3
-- _id: 2
+- _id: 4
   pkg: 5
   project: 1
   scope: 1
   path:
   - 3
-- _id: 3
+- _id: 5
   pkg: 6
   project: 1
   scope: 0
   path:
   - 2
-- _id: 4
+- _id: 6
   pkg: 6
   project: 1
   scope: 1
   path:
   - 9
   - 2
-- _id: 5
+- _id: 7
   pkg: 2
   project: 1
   scope: 0
   path: []
-- _id: 6
+- _id: 8
   pkg: 2
   project: 1
   scope: 1
   path:
   - 9
-- _id: 7
+- _id: 9
   pkg: 8
   project: 1
   scope: 1
   path:
   - 3
-- _id: 8
+- _id: 10
   pkg: 9
   project: 1
   scope: 0
   path: []
-- _id: 9
+- _id: 11
   pkg: 9
   project: 1
   scope: 1
@@ -953,6 +982,8 @@ dependency_trees:
     - key: 3
       linkage: "DYNAMIC"
       pkg: 2
+      issues:
+      - 17
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -964,33 +995,39 @@ dependency_trees:
       - key: 6
         linkage: "DYNAMIC"
         pkg: 2
-  - key: 7
+        children:
+        - key: 7
+          linkage: "DYNAMIC"
+          pkg: 6
+  - key: 8
     scope: 1
     scope_excludes:
     - 0
     children:
-    - key: 8
+    - key: 9
       linkage: "DYNAMIC"
       pkg: 3
+      issues:
+      - 18
       children:
-      - key: 9
-        linkage: "DYNAMIC"
-        pkg: 4
       - key: 10
         linkage: "DYNAMIC"
-        pkg: 5
+        pkg: 4
       - key: 11
         linkage: "DYNAMIC"
+        pkg: 5
+      - key: 12
+        linkage: "DYNAMIC"
         pkg: 8
-    - key: 12
+    - key: 13
       linkage: "DYNAMIC"
       pkg: 9
       children:
-      - key: 13
+      - key: 14
         linkage: "DYNAMIC"
         pkg: 2
         children:
-        - key: 14
+        - key: 15
           linkage: "DYNAMIC"
           pkg: 6
 rule_violation_resolutions:
@@ -1052,9 +1089,9 @@ statistics:
     vulnerability_resolutions: 0
   open_issues:
     errors: 4
-    warnings: 2
+    warnings: 3
     hints: 2
-    severe: 6
+    severe: 7
   open_rule_violations:
     errors: 1
     warnings: 1

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -67,7 +67,7 @@ issue_resolutions:
   reason: "CANT_FIX_ISSUE"
   comment: "Resolved for illustration."
 - _id: 1
-  message: "A test issue\\."
+  message: "Example advisor error, resolved."
   reason: "CANT_FIX_ISSUE"
   comment: "A comment explaining why the issue can be ignored."
 issues:
@@ -229,13 +229,37 @@ issues:
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
-  message: "A test issue."
+  message: "Example advisor error, resolved."
   severity: "ERROR"
   resolutions:
   - 1
   pkg: 2
   how_to_fix: "Some how to fix text."
 - _id: 17
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor error."
+  severity: "ERROR"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 18
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor warning."
+  severity: "WARNING"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 19
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor hint."
+  severity: "HINT"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 20
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -244,7 +268,7 @@ issues:
   pkg: 2
   path: 0
   how_to_fix: "Some how to fix text."
-- _id: 18
+- _id: 21
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -983,7 +1007,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 2
       issues:
-      - 17
+      - 20
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -1008,7 +1032,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 3
       issues:
-      - 18
+      - 21
       children:
       - key: 10
         linkage: "DYNAMIC"
@@ -1088,10 +1112,10 @@ statistics:
     rule_violation_resolutions: 1
     vulnerability_resolutions: 0
   open_issues:
-    errors: 4
-    warnings: 3
-    hints: 2
-    severe: 7
+    errors: 5
+    warnings: 4
+    hints: 3
+    severe: 9
   open_rule_violations:
     errors: 1
     warnings: 1
@@ -1182,15 +1206,15 @@ repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/p
   \n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\
   \n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason:\
   \ \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\
-  \nresolutions:\n  issues:\n  - message: \"A test issue\\\\.\"\n    reason: \"CANT_FIX_ISSUE\"\
-  \n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message:\
-  \ \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"\
-  Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\
-  \n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\
-  \nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR\
-  \ MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\
-  \n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\
-  \n"
+  \nresolutions:\n  issues:\n  - message: \"Example advisor error, resolved.\"\n \
+  \   reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue\
+  \ can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\
+  \n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message:\
+  \ \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2\
+  \ is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given:\
+  \ \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  -\
+  \ package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given:\
+  \ \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n"
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -91,7 +91,7 @@
     "comment" : "Resolved for illustration."
   }, {
     "_id" : 1,
-    "message" : "A test issue\\.",
+    "message" : "Example advisor error, resolved.",
     "reason" : "CANT_FIX_ISSUE",
     "comment" : "A comment explaining why the issue can be ignored."
   } ],
@@ -265,13 +265,40 @@
     "timestamp" : "1970-01-01T00:00:00Z",
     "type" : "ADVISOR",
     "source" : "VulnerableCode",
-    "message" : "A test issue.",
+    "message" : "Example advisor error, resolved.",
     "severity" : "ERROR",
     "resolutions" : [ 1 ],
     "pkg" : 2,
     "how_to_fix" : "Some how to fix text."
   }, {
     "_id" : 17,
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "type" : "ADVISOR",
+    "source" : "VulnerableCode",
+    "message" : "Example advisor error.",
+    "severity" : "ERROR",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 18,
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "type" : "ADVISOR",
+    "source" : "VulnerableCode",
+    "message" : "Example advisor warning.",
+    "severity" : "WARNING",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 19,
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "type" : "ADVISOR",
+    "source" : "VulnerableCode",
+    "message" : "Example advisor hint.",
+    "severity" : "HINT",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 20,
     "timestamp" : "2024-04-25T07:44:20.725613974Z",
     "type" : "ANALYZER",
     "source" : "Gradle",
@@ -281,7 +308,7 @@
     "path" : 0,
     "how_to_fix" : "Some how to fix text."
   }, {
-    "_id" : 18,
+    "_id" : 21,
     "timestamp" : "2024-04-25T07:44:20.725613974Z",
     "type" : "ANALYZER",
     "source" : "Gradle",
@@ -1055,7 +1082,7 @@
         "key" : 3,
         "linkage" : "DYNAMIC",
         "pkg" : 2,
-        "issues" : [ 17 ],
+        "issues" : [ 20 ],
         "children" : [ {
           "key" : 4,
           "linkage" : "DYNAMIC",
@@ -1084,7 +1111,7 @@
         "key" : 9,
         "linkage" : "DYNAMIC",
         "pkg" : 3,
-        "issues" : [ 18 ],
+        "issues" : [ 21 ],
         "children" : [ {
           "key" : 10,
           "linkage" : "DYNAMIC",
@@ -1176,10 +1203,10 @@
       "vulnerability_resolutions" : 0
     },
     "open_issues" : {
-      "errors" : 4,
-      "warnings" : 3,
-      "hints" : 2,
-      "severe" : 7
+      "errors" : 5,
+      "warnings" : 4,
+      "hints" : 3,
+      "severe" : 9
     },
     "open_rule_violations" : {
       "errors" : 1,
@@ -1275,7 +1302,7 @@
   },
   "severe_issue_threshold" : "WARNING",
   "severe_rule_violation_threshold" : "WARNING",
-  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  issues:\n  - message: \"A test issue\\\\.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
+  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  issues:\n  - message: \"Example advisor error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
   "labels" : {
     "job_parameters.JOB_PARAM_1" : "label job param 1",
     "job_parameters.JOB_PARAM_2" : "label job param 2",

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -270,6 +270,27 @@
     "resolutions" : [ 1 ],
     "pkg" : 2,
     "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 17,
+    "timestamp" : "2024-04-25T07:44:20.725613974Z",
+    "type" : "ANALYZER",
+    "source" : "Gradle",
+    "message" : "Example analyzer warning in included package.",
+    "severity" : "WARNING",
+    "pkg" : 2,
+    "path" : 0,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 18,
+    "timestamp" : "2024-04-25T07:44:20.725613974Z",
+    "type" : "ANALYZER",
+    "source" : "Gradle",
+    "message" : "Example analyzer warning in excluded package.",
+    "severity" : "WARNING",
+    "is_excluded" : true,
+    "pkg" : 3,
+    "path" : 1,
+    "how_to_fix" : "Some how to fix text."
   } ],
   "scan_results" : [ {
     "_id" : 0,
@@ -619,7 +640,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 5, 6 ],
+    "paths" : [ 7, 8 ],
     "levels" : [ 0, 1 ],
     "scopes" : [ 0, 1 ],
     "scan_results" : [ 5 ],
@@ -664,7 +685,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 0 ],
+    "paths" : [ 2 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
     "scan_results" : [ 2 ],
@@ -717,7 +738,7 @@
         "concluded_license" : "GPL-2.0-only OR MIT"
       }
     } ],
-    "paths" : [ 1 ],
+    "paths" : [ 3 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
     "is_excluded" : true,
@@ -771,7 +792,7 @@
         "concluded_license" : "MPL-2.0 OR EPL-1.0"
       }
     } ],
-    "paths" : [ 2 ],
+    "paths" : [ 4 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
     "scan_results" : [ 3 ],
@@ -817,7 +838,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 3, 4 ],
+    "paths" : [ 5, 6 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 0, 1 ],
     "scan_results" : [ 4 ],
@@ -904,7 +925,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 7 ],
+    "paths" : [ 9 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
     "scan_results" : [ 6 ],
@@ -942,67 +963,79 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 8, 9 ],
+    "paths" : [ 10, 11 ],
     "levels" : [ 0 ],
     "scopes" : [ 0, 1 ],
     "is_excluded" : false
   } ],
   "paths" : [ {
     "_id" : 0,
+    "pkg" : 2,
+    "project" : 1,
+    "scope" : 0,
+    "path" : [ ]
+  }, {
+    "_id" : 1,
     "pkg" : 3,
     "project" : 1,
     "scope" : 1,
     "path" : [ ]
   }, {
-    "_id" : 1,
+    "_id" : 2,
+    "pkg" : 3,
+    "project" : 1,
+    "scope" : 1,
+    "path" : [ ]
+  }, {
+    "_id" : 3,
     "pkg" : 4,
     "project" : 1,
     "scope" : 1,
     "path" : [ 3 ]
   }, {
-    "_id" : 2,
+    "_id" : 4,
     "pkg" : 5,
     "project" : 1,
     "scope" : 1,
     "path" : [ 3 ]
   }, {
-    "_id" : 3,
+    "_id" : 5,
     "pkg" : 6,
     "project" : 1,
     "scope" : 0,
     "path" : [ 2 ]
   }, {
-    "_id" : 4,
+    "_id" : 6,
     "pkg" : 6,
     "project" : 1,
     "scope" : 1,
     "path" : [ 9, 2 ]
   }, {
-    "_id" : 5,
+    "_id" : 7,
     "pkg" : 2,
     "project" : 1,
     "scope" : 0,
     "path" : [ ]
   }, {
-    "_id" : 6,
+    "_id" : 8,
     "pkg" : 2,
     "project" : 1,
     "scope" : 1,
     "path" : [ 9 ]
   }, {
-    "_id" : 7,
+    "_id" : 9,
     "pkg" : 8,
     "project" : 1,
     "scope" : 1,
     "path" : [ 3 ]
   }, {
-    "_id" : 8,
+    "_id" : 10,
     "pkg" : 9,
     "project" : 1,
     "scope" : 0,
     "path" : [ ]
   }, {
-    "_id" : 9,
+    "_id" : 11,
     "pkg" : 9,
     "project" : 1,
     "scope" : 1,
@@ -1022,6 +1055,7 @@
         "key" : 3,
         "linkage" : "DYNAMIC",
         "pkg" : 2,
+        "issues" : [ 17 ],
         "children" : [ {
           "key" : 4,
           "linkage" : "DYNAMIC",
@@ -1050,6 +1084,7 @@
         "key" : 9,
         "linkage" : "DYNAMIC",
         "pkg" : 3,
+        "issues" : [ 18 ],
         "children" : [ {
           "key" : 10,
           "linkage" : "DYNAMIC",
@@ -1142,9 +1177,9 @@
     },
     "open_issues" : {
       "errors" : 4,
-      "warnings" : 2,
+      "warnings" : 3,
       "hints" : 2,
-      "severe" : 6
+      "severe" : 7
     },
     "open_rule_violations" : {
       "errors" : 1,

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -235,6 +235,25 @@ issues:
   - 1
   pkg: 2
   how_to_fix: "Some how to fix text."
+- _id: 17
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in included package."
+  severity: "WARNING"
+  pkg: 2
+  path: 0
+  how_to_fix: "Some how to fix text."
+- _id: 18
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in excluded package."
+  severity: "WARNING"
+  is_excluded: true
+  pkg: 3
+  path: 1
+  how_to_fix: "Some how to fix text."
 scan_results:
 - _id: 0
   provenance:
@@ -555,8 +574,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 5
-  - 6
+  - 7
+  - 8
   levels:
   - 0
   - 1
@@ -602,7 +621,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 0
+  - 2
   levels:
   - 0
   scopes:
@@ -654,7 +673,7 @@ packages:
       comment: "Foobar is an imaginary dependency and offers a license choice"
       concluded_license: "GPL-2.0-only OR MIT"
   paths:
-  - 1
+  - 3
   levels:
   - 1
   scopes:
@@ -706,7 +725,7 @@ packages:
       comment: "H2 database offers a license choice"
       concluded_license: "MPL-2.0 OR EPL-1.0"
   paths:
-  - 2
+  - 4
   levels:
   - 1
   scopes:
@@ -753,8 +772,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 3
-  - 4
+  - 5
+  - 6
   levels:
   - 1
   - 2
@@ -837,7 +856,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 7
+  - 9
   levels:
   - 1
   scopes:
@@ -873,8 +892,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 8
-  - 9
+  - 10
+  - 11
   levels:
   - 0
   scopes:
@@ -883,58 +902,68 @@ packages:
   is_excluded: false
 paths:
 - _id: 0
+  pkg: 2
+  project: 1
+  scope: 0
+  path: []
+- _id: 1
   pkg: 3
   project: 1
   scope: 1
   path: []
-- _id: 1
+- _id: 2
+  pkg: 3
+  project: 1
+  scope: 1
+  path: []
+- _id: 3
   pkg: 4
   project: 1
   scope: 1
   path:
   - 3
-- _id: 2
+- _id: 4
   pkg: 5
   project: 1
   scope: 1
   path:
   - 3
-- _id: 3
+- _id: 5
   pkg: 6
   project: 1
   scope: 0
   path:
   - 2
-- _id: 4
+- _id: 6
   pkg: 6
   project: 1
   scope: 1
   path:
   - 9
   - 2
-- _id: 5
+- _id: 7
   pkg: 2
   project: 1
   scope: 0
   path: []
-- _id: 6
+- _id: 8
   pkg: 2
   project: 1
   scope: 1
   path:
   - 9
-- _id: 7
+- _id: 9
   pkg: 8
   project: 1
   scope: 1
   path:
   - 3
-- _id: 8
+- _id: 10
   pkg: 9
   project: 1
   scope: 0
   path: []
-- _id: 9
+- _id: 11
   pkg: 9
   project: 1
   scope: 1
@@ -953,6 +982,8 @@ dependency_trees:
     - key: 3
       linkage: "DYNAMIC"
       pkg: 2
+      issues:
+      - 17
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -976,6 +1007,8 @@ dependency_trees:
     - key: 9
       linkage: "DYNAMIC"
       pkg: 3
+      issues:
+      - 18
       children:
       - key: 10
         linkage: "DYNAMIC"
@@ -1056,9 +1089,9 @@ statistics:
     vulnerability_resolutions: 0
   open_issues:
     errors: 4
-    warnings: 2
+    warnings: 3
     hints: 2
-    severe: 6
+    severe: 7
   open_rule_violations:
     errors: 1
     warnings: 1

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -67,7 +67,7 @@ issue_resolutions:
   reason: "CANT_FIX_ISSUE"
   comment: "Resolved for illustration."
 - _id: 1
-  message: "A test issue\\."
+  message: "Example advisor error, resolved."
   reason: "CANT_FIX_ISSUE"
   comment: "A comment explaining why the issue can be ignored."
 issues:
@@ -229,13 +229,37 @@ issues:
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
-  message: "A test issue."
+  message: "Example advisor error, resolved."
   severity: "ERROR"
   resolutions:
   - 1
   pkg: 2
   how_to_fix: "Some how to fix text."
 - _id: 17
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor error."
+  severity: "ERROR"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 18
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor warning."
+  severity: "WARNING"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 19
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor hint."
+  severity: "HINT"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 20
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -244,7 +268,7 @@ issues:
   pkg: 2
   path: 0
   how_to_fix: "Some how to fix text."
-- _id: 18
+- _id: 21
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -983,7 +1007,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 2
       issues:
-      - 17
+      - 20
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -1008,7 +1032,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 3
       issues:
-      - 18
+      - 21
       children:
       - key: 10
         linkage: "DYNAMIC"
@@ -1088,10 +1112,10 @@ statistics:
     rule_violation_resolutions: 1
     vulnerability_resolutions: 0
   open_issues:
-    errors: 4
-    warnings: 3
-    hints: 2
-    severe: 7
+    errors: 5
+    warnings: 4
+    hints: 3
+    severe: 9
   open_rule_violations:
     errors: 1
     warnings: 1
@@ -1182,15 +1206,15 @@ repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/p
   \n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\
   \n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason:\
   \ \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\
-  \nresolutions:\n  issues:\n  - message: \"A test issue\\\\.\"\n    reason: \"CANT_FIX_ISSUE\"\
-  \n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message:\
-  \ \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"\
-  Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\
-  \n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\
-  \nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR\
-  \ MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\
-  \n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\
-  \n"
+  \nresolutions:\n  issues:\n  - message: \"Example advisor error, resolved.\"\n \
+  \   reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue\
+  \ can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\
+  \n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message:\
+  \ \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2\
+  \ is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given:\
+  \ \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  -\
+  \ package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given:\
+  \ \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n"
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -104,6 +104,11 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in included package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.example.test:component:1.11"
@@ -114,6 +119,11 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Ant:junit:junit:4.12"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in excluded package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:com.foobar:foobar:1.0"
           - id: "Maven:com.h2database:h2:1.4.200"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -33,7 +33,7 @@ repository:
         comment: "The scope only contains test dependencies."
     resolutions:
       issues:
-      - message: "A test issue\\."
+      - message: "Example advisor error, resolved."
         reason: "CANT_FIX_ISSUE"
         comment: "A comment explaining why the issue can be ignored."
       - message: "Example error, resolved."
@@ -791,8 +791,20 @@ advisor:
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "VulnerableCode"
-            message: "A test issue."
+            message: "Example advisor error, resolved."
             severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor error."
+            severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor warning."
+            severity: "WARNING"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor hint."
+            severity: "HINT"
         defects: []
         vulnerabilities:
         - id: "VULCOID-VULNERABILITY_ID"
@@ -845,7 +857,7 @@ resolved_configuration:
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
     issues:
-    - message: "A test issue\\."
+    - message: "Example advisor error, resolved."
       reason: "CANT_FIX_ISSUE"
       comment: "A comment explaining why the issue can be ignored."
     - message: "Example error, resolved."

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -104,6 +104,11 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in included package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.example.test:component:1.11"
@@ -114,6 +119,11 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Ant:junit:junit:4.12"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in excluded package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:com.foobar:foobar:1.0"
           - id: "Maven:com.h2database:h2:1.4.200"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -33,7 +33,7 @@ repository:
         comment: "The scope only contains test dependencies."
     resolutions:
       issues:
-      - message: "A test issue\\."
+      - message: "Example advisor error, resolved."
         reason: "CANT_FIX_ISSUE"
         comment: "A comment explaining why the issue can be ignored."
       - message: "Example error, resolved."
@@ -791,8 +791,20 @@ advisor:
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "VulnerableCode"
-            message: "A test issue."
+            message: "Example advisor error, resolved."
             severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor error."
+            severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor warning."
+            severity: "WARNING"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor hint."
+            severity: "HINT"
         defects: []
         vulnerabilities:
         - id: "VULCOID-VULNERABILITY_ID"
@@ -845,7 +857,7 @@ resolved_configuration:
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
     issues:
-    - message: "A test issue\\."
+    - message: "Example advisor error, resolved."
       reason: "CANT_FIX_ISSUE"
       comment: "A comment explaining why the issue can be ignored."
     - message: "Example error, resolved."

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -104,6 +104,11 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in included package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.example.test:component:1.11"
@@ -114,6 +119,11 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Ant:junit:junit:4.12"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in excluded package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:com.foobar:foobar:1.0"
           - id: "Maven:com.h2database:h2:1.4.200"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -33,7 +33,7 @@ repository:
         comment: "The scope only contains test dependencies."
     resolutions:
       issues:
-      - message: "A test issue\\."
+      - message: "Example advisor error, resolved."
         reason: "CANT_FIX_ISSUE"
         comment: "A comment explaining why the issue can be ignored."
       - message: "Example error, resolved."
@@ -791,8 +791,20 @@ advisor:
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "VulnerableCode"
-            message: "A test issue."
+            message: "Example advisor error, resolved."
             severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor error."
+            severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor warning."
+            severity: "WARNING"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor hint."
+            severity: "HINT"
         defects: []
         vulnerabilities:
         - id: "VULCOID-VULNERABILITY_ID"
@@ -845,7 +857,7 @@ resolved_configuration:
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
     issues:
-    - message: "A test issue\\."
+    - message: "Example advisor error, resolved."
       reason: "CANT_FIX_ISSUE"
       comment: "A comment explaining why the issue can be ignored."
     - message: "Example error, resolved."

--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -454,7 +454,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
          <h2>Index</h2>
          <ul>
             <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a></li>
-            <li><a href="#issue-summary">Issue Summary (5 errors, 2 warnings, 2 hints to resolve)</a></li>
+            <li><a href="#issue-summary">Issue Summary (5 errors, 3 warnings, 2 hints to resolve)</a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 
                   <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div></a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a></li>
@@ -531,7 +531,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                </tr>
             </tbody>
          </table>
-         <h2 id="issue-summary">Issue Summary (5 errors, 2 warnings, 2 hints to resolve)</h2>
+         <h2 id="issue-summary">Issue Summary (5 errors, 3 warnings, 2 hints to resolve)</h2>
          <p>Issues from excluded components are not shown in this summary.</p>
          <h3>Packages</h3>
          <table class="ort-report-table">
@@ -701,6 +701,31 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                            </details>
                      </ul>
                   </td>
+               </tr>
+               <tr class="ort-warning" id="issue-2">
+                  <td><a href="#issue-2">2</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
+                        <li>
+                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
+                              package.</p>
+                           <p></p>
+                        </li>
+                        <details>
+                           <summary>How to fix</summary>
+                           <ul>
+                              
+                              <li><em>Step 1</em></li>
+                              
+                              <li><strong>Step 2</strong></li>
+                              
+                              <li><em><strong>Step 3</strong></em>
+                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                              </ul>
+                           </details>
+                     </ul>
+                  </td>
+                  <td></td>
                </tr>
             </tbody>
          </table>
@@ -895,7 +920,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      </ul>
                   </td>
                </tr>
-               <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">
+               <tr class="ort-error ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">
                   <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">2</a></td>
                   <td>Ant:junit:junit:4.12</td>
                   <td>
@@ -916,7 +941,12 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      </dl>
                   </td>
                   <td>
-                     <ul></ul>
+                     <ul>
+                        <li>
+                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in excluded
+                              package.</p>
+                        </li>
+                     </ul>
                   </td>
                   <td>
                      <ul></ul>
@@ -1014,7 +1044,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      <ul></ul>
                   </td>
                </tr>
-               <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
+               <tr class="ort-error " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
                   <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">6</a></td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>
@@ -1036,7 +1066,12 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      </dl>
                   </td>
                   <td>
-                     <ul></ul>
+                     <ul>
+                        <li>
+                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
+                              package.</p>
+                        </li>
+                     </ul>
                   </td>
                   <td>
                      <ul></ul>

--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -456,6 +456,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
             <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a></li>
             <li><a href="#analyzer-issue-summary">Analyzer Issue Summary (1 errors, 2 warnings, 1 hints to resolve)</a></li>
             <li><a href="#scanner-issue-summary">Scanner Issue Summary (3 errors, 1 warnings, 1 hints to resolve)</a></li>
+            <li><a href="#advisor-issue-summary">Advisor Issue Summary (1 errors, 1 warnings, 1 hints to resolve)</a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 
                   <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div></a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a></li>
@@ -717,6 +718,76 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
                      <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="advisor-issue-summary">Advisor Issue Summary (1 errors, 1 warnings, 1 hints to resolve)</h2>
+         <p>Issues from excluded components are not shown in this summary.</p>
+         <table class="ort-report-table">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Message</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error" id="advisor-issue-summary-1">
+                  <td><a href="#advisor-issue-summary-1">1</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>Unknown time [ERROR]: VulnerableCode - Example advisor error.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-warning" id="advisor-issue-summary-2">
+                  <td><a href="#advisor-issue-summary-2">2</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>Unknown time [WARNING]: VulnerableCode - Example advisor warning.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-hint" id="advisor-issue-summary-3">
+                  <td><a href="#advisor-issue-summary-3">3</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>Unknown time [HINT]: VulnerableCode - Example advisor hint.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>

--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -1148,7 +1148,7 @@ excludes:
     comment: "The scope only contains test dependencies."
 resolutions:
   issues:
-  - message: "A test issue\\."
+  - message: "Example advisor error, resolved."
     reason: "CANT_FIX_ISSUE"
     comment: "A comment explaining why the issue can be ignored."
   - message: "Example error, resolved."

--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -454,7 +454,8 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
          <h2>Index</h2>
          <ul>
             <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a></li>
-            <li><a href="#issue-summary">Issue Summary (5 errors, 3 warnings, 2 hints to resolve)</a></li>
+            <li><a href="#analyzer-issue-summary">Analyzer Issue Summary (1 errors, 2 warnings, 1 hints to resolve)</a></li>
+            <li><a href="#scanner-issue-summary">Scanner Issue Summary (3 errors, 1 warnings, 1 hints to resolve)</a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 
                   <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div></a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a></li>
@@ -531,201 +532,204 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                </tr>
             </tbody>
          </table>
-         <h2 id="issue-summary">Issue Summary (5 errors, 3 warnings, 2 hints to resolve)</h2>
+         <h2 id="analyzer-issue-summary">Analyzer Issue Summary (1 errors, 2 warnings, 1 hints to resolve)</h2>
          <p>Issues from excluded components are not shown in this summary.</p>
-         <h3>Packages</h3>
          <table class="ort-report-table">
             <thead>
                <tr>
                   <th>#</th>
                   <th>Package</th>
-                  <th>Analyzer Issues</th>
-                  <th>Scanner Issues</th>
+                  <th>Message</th>
                </tr>
             </thead>
             <tbody>
-               <tr class="ort-error" id="issue-1">
-                  <td><a href="#issue-1">1</a></td>
+               <tr class="ort-error" id="analyzer-issue-summary-1">
+                  <td><a href="#analyzer-issue-summary-1">1</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
-                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example warning.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [HINT]: Gradle - Example hint.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                     </ul>
-                  </td>
-                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
-                        <li>
-                           <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
-                              'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
-                              Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                              while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                              while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                     </ul>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
                   </td>
                </tr>
-               <tr class="ort-warning" id="issue-2">
-                  <td><a href="#issue-2">2</a></td>
-                  <td>Maven:org.apache.commons:commons-text:1.1</td>
-                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
-                              package.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                     </ul>
+               <tr class="ort-warning" id="analyzer-issue-summary-2">
+                  <td><a href="#analyzer-issue-summary-2">2</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example warning.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
                   </td>
-                  <td></td>
+               </tr>
+               <tr class="ort-warning" id="analyzer-issue-summary-3">
+                  <td><a href="#analyzer-issue-summary-3">3</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
+                        package.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-hint" id="analyzer-issue-summary-4">
+                  <td><a href="#analyzer-issue-summary-4">4</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [HINT]: Gradle - Example hint.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="scanner-issue-summary">Scanner Issue Summary (3 errors, 1 warnings, 1 hints to resolve)</h2>
+         <p>Issues from excluded components are not shown in this summary.</p>
+         <table class="ort-report-table">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Message</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error" id="scanner-issue-summary-1">
+                  <td><a href="#scanner-issue-summary-1">1</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
+                        'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
+                        Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-error" id="scanner-issue-summary-2">
+                  <td><a href="#scanner-issue-summary-2">2</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
+                        while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-error" id="scanner-issue-summary-3">
+                  <td><a href="#scanner-issue-summary-3">3</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-warning" id="scanner-issue-summary-4">
+                  <td><a href="#scanner-issue-summary-4">4</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-hint" id="scanner-issue-summary-5">
+                  <td><a href="#scanner-issue-summary-5">5</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
                </tr>
             </tbody>
          </table>

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
@@ -64,6 +64,11 @@ internal data class ReportTableModel(
     val scannerIssueSummary: IssueTable,
 
     /**
+     * A [IssueTable] containing all advisor issues.
+     */
+    val advisorIssueSummary: IssueTable,
+
+    /**
      * The [ProjectTable]s containing the dependencies for each [Project].
      */
     val projectDependencies: SortedMap<Project, ProjectTable>,
@@ -156,7 +161,8 @@ internal data class ReportTableModel(
 
         enum class Type {
             ANALYZER,
-            SCANNER
+            SCANNER,
+            ADVISOR
         }
     }
 

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -116,6 +116,7 @@ internal object ReportTableModelMapper {
             ruleViolations,
             getAnalyzerIssueSummaryTable(input),
             getScannerIssueSummaryTable(input),
+            getAdvisorIssueSummaryTable(input),
             projectTables,
             labels
         )
@@ -190,6 +191,10 @@ private fun getAnalyzerIssueSummaryTable(input: ReporterInput): IssueTable =
 private fun getScannerIssueSummaryTable(input: ReporterInput): IssueTable =
     input.ortResult.getScannerIssues(omitExcluded = true, omitResolved = true)
         .toIssueSummaryTable(IssueTable.Type.SCANNER, input)
+
+private fun getAdvisorIssueSummaryTable(input: ReporterInput): IssueTable =
+    input.ortResult.getAdvisorIssues(omitExcluded = true, omitResolved = true)
+        .toIssueSummaryTable(IssueTable.Type.ADVISOR, input)
 
 private fun Map<Identifier, Set<Issue>>.toIssueSummaryTable(type: IssueTable.Type, input: ReporterInput): IssueTable {
     val rows = flatMap { (id, issues) ->

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -348,7 +348,7 @@ class StaticHtmlReporter : Reporter {
                 ul {
                     issues.forEach { issue ->
                         li {
-                            issueDescription(issue)
+                            p { issueDescription(issue) }
                             p { +issue.resolutionDescription }
                         }
 
@@ -583,7 +583,7 @@ class StaticHtmlReporter : Reporter {
         ul {
             issues.forEach {
                 li {
-                    issueDescription(it)
+                    p { issueDescription(it) }
 
                     if (it.isResolved) {
                         classes = setOf("ort-resolved")
@@ -594,13 +594,11 @@ class StaticHtmlReporter : Reporter {
         }
     }
 
-    private fun LI.issueDescription(issue: ResolvableIssue) {
-        p {
-            var first = true
-            issue.description.lines().forEach {
-                if (first) first = false else br
-                +it
-            }
+    private fun P.issueDescription(issue: ResolvableIssue) {
+        var first = true
+        issue.description.lines().forEach {
+            if (first) first = false else br
+            +it
         }
     }
 

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -161,6 +161,10 @@ class StaticHtmlReporter : Reporter {
                         issueTable(reportTableModel.scannerIssueSummary)
                     }
 
+                    if (reportTableModel.advisorIssueSummary.rows.isNotEmpty()) {
+                        issueTable(reportTableModel.advisorIssueSummary)
+                    }
+
                     reportTableModel.projectDependencies.forEach { (project, table) ->
                         projectTable(project, table)
                     }
@@ -220,6 +224,14 @@ class StaticHtmlReporter : Reporter {
                 li {
                     a("#${reportTableModel.scannerIssueSummary.id()}") {
                         +reportTableModel.scannerIssueSummary.title()
+                    }
+                }
+            }
+
+            if (reportTableModel.advisorIssueSummary.rows.isNotEmpty()) {
+                li {
+                    a("#${reportTableModel.advisorIssueSummary.id()}") {
+                        +reportTableModel.advisorIssueSummary.title()
                     }
                 }
             }

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -150,7 +150,7 @@ class StaticHtmlReporter : Reporter {
                     index(reportTableModel)
 
                     reportTableModel.ruleViolations?.let {
-                        evaluatorTable(it)
+                        ruleViolationTable(it)
                     }
 
                     if (reportTableModel.issueSummary.rows.isNotEmpty()) {
@@ -237,7 +237,7 @@ class StaticHtmlReporter : Reporter {
         }
     }
 
-    private fun DIV.evaluatorTable(ruleViolations: List<ReportTableModel.ResolvableViolation>) {
+    private fun DIV.ruleViolationTable(ruleViolations: List<ReportTableModel.ResolvableViolation>) {
         h2 {
             id = RULE_VIOLATION_TABLE_ID
             +getRuleViolationSummaryString(ruleViolations)
@@ -259,14 +259,14 @@ class StaticHtmlReporter : Reporter {
 
                 tbody {
                     ruleViolations.forEachIndexed { rowIndex, ruleViolation ->
-                        evaluatorRow(rowIndex + 1, ruleViolation)
+                        ruleViolationRow(rowIndex + 1, ruleViolation)
                     }
                 }
             }
         }
     }
 
-    private fun TBODY.evaluatorRow(rowIndex: Int, ruleViolation: ReportTableModel.ResolvableViolation) {
+    private fun TBODY.ruleViolationRow(rowIndex: Int, ruleViolation: ReportTableModel.ResolvableViolation) {
         val cssClass = if (ruleViolation.isResolved) {
             "ort-resolved"
         } else {

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -64,6 +64,8 @@ import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
 
+private const val RULE_VIOLATION_TABLE_ID = "rule-violation-summary"
+
 @Suppress("LargeClass", "TooManyFunctions")
 class StaticHtmlReporter : Reporter {
     override val type = "StaticHtml"
@@ -196,7 +198,7 @@ class StaticHtmlReporter : Reporter {
         ul {
             reportTableModel.ruleViolations?.let { ruleViolations ->
                 li {
-                    a("#rule-violation-summary") {
+                    a("#$RULE_VIOLATION_TABLE_ID") {
                         +getRuleViolationSummaryString(ruleViolations)
                     }
                 }
@@ -237,7 +239,7 @@ class StaticHtmlReporter : Reporter {
 
     private fun DIV.evaluatorTable(ruleViolations: List<ReportTableModel.ResolvableViolation>) {
         h2 {
-            id = "rule-violation-summary"
+            id = RULE_VIOLATION_TABLE_ID
             +getRuleViolationSummaryString(ruleViolations)
         }
 


### PR DESCRIPTION
This PR simplifies the issues summary view, by showing one table per stage (analyzer, scanner, ...) and (only) one issue per table row. The ability to show advisor issues is added as well in a dedicated table. Finally, issue summaries
do filter issues by excluded affected path WRT. path excludes.

Please see individual commit messages for the details.

### Before

![Screenshot from 2024-04-30 10-23-44](https://github.com/oss-review-toolkit/ort/assets/42963794/1ee09e87-9382-43ff-ab9f-8faa63e17442)

### After

![Screenshot from 2024-04-30 10-22-33](https://github.com/oss-review-toolkit/ort/assets/42963794/05d89f7f-20e9-479c-b43f-7f31bd555bc9)

