### PR TITLE
docs(evaluated-model): Fix a KDoc reference to `Excludes`

### DIFF
--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude


### PR DESCRIPTION
This is used in the `deduplicateResolutionsAndExcludes()` docs.