### PR TITLE
fix(scanner): Revert the merge of read functions in scan storages

### DIFF
--- a/scanner/src/main/kotlin/ScanStorage.kt
+++ b/scanner/src/main/kotlin/ScanStorage.kt
@@ -39,9 +39,16 @@ sealed interface ScanStorageReader
  */
 interface PackageBasedScanStorageReader : ScanStorageReader {
     /**
-     * Read all [ScanResult]s for the provided [package][pkg]. The results have to match the
-     * [provenance][KnownProvenance.matches] of the package and can optionally be filtered by the provided
-     * [scannerMatcher]. The results are converted to a [NestedProvenanceScanResult] using the provided
+     * Read all [ScanResult]s for the provided [package][pkg]. The package scan results are converted to a
+     * [NestedProvenanceScanResult] using the provided [nestedProvenance].
+     *
+     * Throws a [ScanStorageException] if an error occurs while reading from the storage.
+     */
+    fun read(pkg: Package, nestedProvenance: NestedProvenance): List<NestedProvenanceScanResult>
+
+    /**
+     * Read all [ScanResult]s for the provided [package][pkg] matching the [provenance][KnownProvenance.matches] and the
+     * [scannerMatcher]. The package scan results are converted to a [NestedProvenanceScanResult] using the provided
      * [nestedProvenance].
      *
      * Throws a [ScanStorageException] if an error occurs while reading from the storage.
@@ -49,7 +56,7 @@ interface PackageBasedScanStorageReader : ScanStorageReader {
     fun read(
         pkg: Package,
         nestedProvenance: NestedProvenance,
-        scannerMatcher: ScannerMatcher? = null
+        scannerMatcher: ScannerMatcher
     ): List<NestedProvenanceScanResult>
 }
 

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -51,7 +51,6 @@ import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScanStorageException
-import org.ossreviewtoolkit.scanner.ScannerMatcher
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.storages.utils.getScanCodeDetails
 import org.ossreviewtoolkit.utils.common.AlphaNumericComparator
@@ -82,7 +81,7 @@ class ClearlyDefinedStorage(
         ClearlyDefinedService.create(config.serverUrl, client ?: OkHttpClientHelper.buildClient())
     }
 
-    override fun readInternal(pkg: Package, scannerMatcher: ScannerMatcher?): Result<List<ScanResult>> =
+    override fun readInternal(pkg: Package): Result<List<ScanResult>> =
         runBlocking(Dispatchers.IO) { readFromClearlyDefined(pkg) }
 
     override fun addInternal(id: Identifier, scanResult: ScanResult): Result<Unit> =

--- a/scanner/src/main/kotlin/storages/Sw360Storage.kt
+++ b/scanner/src/main/kotlin/storages/Sw360Storage.kt
@@ -44,7 +44,6 @@ import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.scanner.ScanStorageException
-import org.ossreviewtoolkit.scanner.ScannerMatcher
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -86,7 +85,7 @@ class Sw360Storage(
     private val connectionFactory = createConnection(configuration)
     private val releaseClient = connectionFactory.releaseAdapter
 
-    override fun readInternal(pkg: Package, scannerMatcher: ScannerMatcher?): Result<List<ScanResult>> {
+    override fun readInternal(pkg: Package): Result<List<ScanResult>> {
         val tempScanResultFile = createTempFileForUpload(pkg.id)
 
         val result = runCatching {

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -356,7 +356,7 @@ class ScannerTest : WordSpec({
             val pkgWithArtifact = Package.new(name = "artifact").withValidSourceArtifact()
             val scannerWrapper = spyk(FakePackageScannerWrapper())
             val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details)) {
-                every { read(any(), any(), any()) } returns emptyList()
+                every { read(any(), any()) } returns emptyList()
             }
 
             val scanner = createScanner(
@@ -376,7 +376,7 @@ class ScannerTest : WordSpec({
             )
 
             verify(exactly = 1) {
-                reader.read(pkgWithArtifact, any(), any())
+                reader.read(pkgWithArtifact, any())
                 scannerWrapper.scanPackage(any(), createContext().copy(coveredPackages = listOf(pkgWithArtifact)))
             }
         }
@@ -433,7 +433,7 @@ class ScannerTest : WordSpec({
             }
 
             val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details)) {
-                every { read(pkgCompletelyScanned, any(), any()) } returns listOf(nestedScanResultCompletelyScanned)
+                every { read(pkgCompletelyScanned, any()) } returns listOf(nestedScanResultCompletelyScanned)
             }
 
             val scanner = createScanner(
@@ -985,11 +985,14 @@ private class FakeNestedProvenanceResolver : NestedProvenanceResolver {
  * with a single license finding for the provided [scannerDetails].
  */
 private class FakePackageBasedStorageReader(val scannerDetails: ScannerDetails) : PackageBasedScanStorageReader {
+    override fun read(pkg: Package, nestedProvenance: NestedProvenance): List<NestedProvenanceScanResult> =
+        listOf(createStoredNestedScanResult(nestedProvenance.root, scannerDetails))
+
     override fun read(
         pkg: Package,
         nestedProvenance: NestedProvenance,
-        scannerMatcher: ScannerMatcher?
-    ): List<NestedProvenanceScanResult> = listOf(createStoredNestedScanResult(nestedProvenance.root, scannerDetails))
+        scannerMatcher: ScannerMatcher
+    ): List<NestedProvenanceScanResult> = read(pkg, nestedProvenance)
 }
 
 private class FakeProvenanceBasedStorageReader(val scannerDetails: ScannerDetails) : ProvenanceBasedScanStorageReader {


### PR DESCRIPTION
With this change it is no more possible to obtain scan results by identifiers, without provenance. In particular, this breaks `helper-cli`'s `Create` command which always passes an empty provenance, see [1].

This reverts commit 70b1b869815ae1ff4fbdf53828939e25ad98d829.

[1]: https://github.com/oss-review-toolkit/ort/blob/9b34a7b1f21237d01a29e3eb64fa2c767bee120c/helper-cli/src/main/kotlin/commands/packageconfig/CreateCommand.kt#L123

