### PR TITLE
fix(python): Support ZIP archives for source artifacts

### DIFF
--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
@@ -241,10 +241,10 @@ packages:
       value: "f34088c08be2ec16279dfa9c3b4ff3d1453c5c67597a33e2819b000e18d4c546"
       algorithm: "SHA-256"
   source_artifact:
-    url: ""
+    url: "https://files.pythonhosted.org/packages/f6/14/aa3ec10e4ab1524ba69f4742ef9cfa01fd668d0840afe5d5e6f708a95031/graphviz-0.19.1.zip"
     hash:
-      value: ""
-      algorithm: ""
+      value: "09ed0cde452d015fe77c4845a210eb642f28d245f5bc250d4b97808cb8f49078"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-no-dev-group-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-no-dev-group-expected-output.yml
@@ -42,10 +42,10 @@ packages:
       value: "f34088c08be2ec16279dfa9c3b4ff3d1453c5c67597a33e2819b000e18d4c546"
       algorithm: "SHA-256"
   source_artifact:
-    url: ""
+    url: "https://files.pythonhosted.org/packages/f6/14/aa3ec10e4ab1524ba69f4742ef9cfa01fd668d0840afe5d5e6f708a95031/graphviz-0.19.1.zip"
     hash:
-      value: ""
-      algorithm: ""
+      value: "09ed0cde452d015fe77c4845a210eb642f28d245f5bc250d4b97808cb8f49078"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
@@ -126,8 +126,8 @@ internal fun List<PythonInspector.Package>.toOrtPackages(): Set<Package> =
         @Suppress("UseOrEmpty")
         fun PythonInspector.Package.getHash(): Hash = Hash.create(sha512 ?: sha256 ?: sha1 ?: md5 ?: "")
 
-        fun getArtifact(fileExtension: String) =
-            packages.find { it.downloadUrl.endsWith(fileExtension) }?.let {
+        fun getArtifact(vararg fileExtensions: String) =
+            packages.find { pkg -> fileExtensions.any { pkg.downloadUrl.endsWith(it) } }?.let {
                 RemoteArtifact(
                     url = it.downloadUrl,
                     hash = it.getHash()
@@ -151,7 +151,7 @@ internal fun List<PythonInspector.Package>.toOrtPackages(): Set<Package> =
             description = pkg.description.lineSequence().firstOrNull { it.isNotBlank() }.orEmpty(),
             homepageUrl = pkg.homepageUrl.orEmpty(),
             binaryArtifact = getArtifact(".whl"),
-            sourceArtifact = getArtifact(".tar.gz"),
+            sourceArtifact = getArtifact(".tar.gz", ".zip"),
             vcs = VcsInfo.EMPTY.copy(url = pkg.vcsUrl.orEmpty()),
             vcsProcessed = PackageManager.processPackageVcs(
                 VcsInfo(VcsType.UNKNOWN, pkg.vcsUrl.orEmpty(), revision = ""),


### PR DESCRIPTION
See e.g. [1] which has `wget-3.2.zip`.

[1]: https://pypi.org/project/wget/#files