### PR TITLE
fix(spdx): Accept "additional-terms" as part of LicenseRef exceptions

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -411,7 +411,7 @@ class SpdxLicenseWithExceptionExpression(
     val exception: String
 ) : SpdxSingleLicenseExpression() {
     companion object {
-        private val EXCEPTION_STRING_PATTERN = Regex("\\bexception\\b", RegexOption.IGNORE_CASE)
+        private val EXCEPTION_STRING_PATTERN = Regex("\\b(exception|additional-terms)\\b", RegexOption.IGNORE_CASE)
 
         /**
          * Parse a string into an [SpdxLicenseWithExceptionExpression]. Throws an [SpdxException] if the string cannot


### PR DESCRIPTION
This is a hotfix for not failing SPDX reports to get generated for ScanCode license expressions like

    AGPL-3.0-only WITH LicenseRef-scancode-agpl-generic-additional-terms

A proper future fix could be to introduce a license classification provider interface that can query whether a given string is an exception or not.