### PR TITLE
ci(github): Fix permissions to upload SARIF results

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,6 +35,8 @@ jobs:
       run: ./gradlew checkCopyrightsInNoticeFile checkLicenseHeaders checkGitAttributes
   detekt-issues:
     runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -79,6 +81,8 @@ jobs:
   qodana-scan:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4


### PR DESCRIPTION
See [1].

[1]: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository