### PR TITLE
feat(clients/osv): Align model with latest OSV schema version 1.6.3

### DIFF
--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -193,7 +193,8 @@ data class Severity(
 ) {
     enum class Type {
         CVSS_V2,
-        CVSS_V3
+        CVSS_V3,
+        CVSS_V4
     }
 }
 


### PR DESCRIPTION
Previously, ORT's OSV model was aligned with schema version 1.6.0 [1], see also [2].

[1]: 868b1a243dfee36afb4d829d33b4755bcd0af579
[2]: https://github.com/ossf/osv-schema/blob/v1.6.3/validation/schema.json
