### PR TITLE
ci(github): Make signing properties available to the distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
       - name: Build ORT Distributions
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew :cli:signDistTar :cli:signDistZip :helper-cli:signDistTar :helper-cli:signDistZip
       - name: Generate Release Notes
         run: ./gradlew -q printChangeLog > RELEASE_NOTES.md


### PR DESCRIPTION
Without these, signing is not configured and the respective tasks are not available. This is a fixup for 37ec96b.