### PR TITLE
ci(github): Use a non-deprecated value to configure CodeQL tools

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: java
-        tools: latest
+        tools: linked
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:


### PR DESCRIPTION
See [1].

[1]: https://github.com/github/codeql-action/pull/2281