### PR TITLE
feat(scripting): Make the `logger` available by default

### DIFF
--- a/utils/scripting/src/main/kotlin/OrtScriptCompilationConfiguration.kt
+++ b/utils/scripting/src/main/kotlin/OrtScriptCompilationConfiguration.kt
@@ -45,6 +45,7 @@ class OrtScriptCompilationConfiguration : ScriptCompilationConfiguration({
     compilerOptions("-jvm-target", Environment().javaVersion.substringBefore('.'))
 
     defaultImports(
+        "org.apache.logging.log4j.kotlin.logger",
         "org.ossreviewtoolkit.utils.common.*",
         "org.ossreviewtoolkit.utils.ort.*",
         "java.util.*"


### PR DESCRIPTION
This allows to use e.g. `logger.debug { ... }` even from the top level of scripts.