### PR TITLE
feat(static-html): Make the descriptions of issues more compact

### DIFF
--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -577,7 +577,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#analyzer-issue-summary-1">1</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error.</p>
+                     <p>Example error.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -596,7 +596,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#analyzer-issue-summary-2">2</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example warning.</p>
+                     <p>Example warning.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -615,8 +615,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#analyzer-issue-summary-3">3</a></td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
-                        package.</p>
+                     <p>Example analyzer warning in included package.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -635,7 +634,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#analyzer-issue-summary-4">4</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [HINT]: Gradle - Example hint.</p>
+                     <p>Example hint.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -667,8 +666,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#scanner-issue-summary-1">1</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
-                        'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
+                     <p>DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
                         Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
                      <details>
                         <summary>How to fix</summary>
@@ -688,8 +686,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#scanner-issue-summary-2">2</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                        while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
+                     <p>ERROR: Timeout after 300 seconds while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -708,7 +705,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#scanner-issue-summary-3">3</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
+                     <p>Example error.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -727,7 +724,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#scanner-issue-summary-4">4</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
+                     <p>Example warning.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -746,7 +743,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#scanner-issue-summary-5">5</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
                   <td>
-                     <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
+                     <p>Example hint.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -778,7 +775,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#advisor-issue-summary-1">1</a></td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>
-                     <p>Unknown time [ERROR]: VulnerableCode - Example advisor error.</p>
+                     <p>Example advisor error.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -797,7 +794,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#advisor-issue-summary-2">2</a></td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>
-                     <p>Unknown time [WARNING]: VulnerableCode - Example advisor warning.</p>
+                     <p>Example advisor warning.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -816,7 +813,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                   <td><a href="#advisor-issue-summary-3">3</a></td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>
-                     <p>Unknown time [HINT]: VulnerableCode - Example advisor hint.</p>
+                     <p>Example advisor hint.</p>
                      <details>
                         <summary>How to fix</summary>
                         <ul>
@@ -899,30 +896,29 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         <table class="report-table package-issue-table">
                            <tr class="resolved">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error, resolved.</p>
+                                 <p>Example error, resolved.</p>
                                  <p>
                                     Resolved by: CANT_FIX_ISSUE - Resolved for illustration.</p>
                               </td>
                            </tr>
                            <tr class="excluded">
                               <td>
-                                 <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                                    while scanning file 'project/file-within-excluded-project.dat'.</p>
+                                 <p>ERROR: Timeout after 300 seconds while scanning file 'project/file-within-excluded-project.dat'.</p>
                               </td>
                            </tr>
                            <tr class="excluded">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
+                                 <p>Example hint.</p>
                               </td>
                            </tr>
                            <tr class="excluded">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
+                                 <p>Example warning.</p>
                               </td>
                            </tr>
                            <tr class="excluded">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
+                                 <p>Example error.</p>
                               </td>
                            </tr>
                         </table>
@@ -989,45 +985,43 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         <table class="report-table package-issue-table">
                            <tr class="error">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error.</p>
+                                 <p>Example error.</p>
                               </td>
                            </tr>
                            <tr class="error">
                               <td>
-                                 <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
-                                    'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
+                                 <p>DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
                                     Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
                               </td>
                            </tr>
                            <tr class="error">
                               <td>
-                                 <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                                    while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
+                                 <p>ERROR: Timeout after 300 seconds while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
                               </td>
                            </tr>
                            <tr class="error">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
+                                 <p>Example error.</p>
                               </td>
                            </tr>
                            <tr class="warning">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example warning.</p>
+                                 <p>Example warning.</p>
                               </td>
                            </tr>
                            <tr class="warning">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
+                                 <p>Example warning.</p>
                               </td>
                            </tr>
                            <tr class="hint">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [HINT]: Gradle - Example hint.</p>
+                                 <p>Example hint.</p>
                               </td>
                            </tr>
                            <tr class="hint">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
+                                 <p>Example hint.</p>
                               </td>
                            </tr>
                         </table>
@@ -1036,22 +1030,21 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         <table class="report-table package-issue-table">
                            <tr class="resolved">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error, resolved.</p>
+                                 <p>Example error, resolved.</p>
                                  <p>
                                     Resolved by: CANT_FIX_ISSUE - Resolved for illustration.</p>
                               </td>
                            </tr>
                            <tr class="resolved">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error, resolved.</p>
+                                 <p>Example error, resolved.</p>
                                  <p>
                                     Resolved by: CANT_FIX_ISSUE - Resolved for illustration.</p>
                               </td>
                            </tr>
                            <tr class="excluded">
                               <td>
-                                 <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                                    while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'.</p>
+                                 <p>ERROR: Timeout after 300 seconds while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'.</p>
                               </td>
                            </tr>
                         </table>
@@ -1082,8 +1075,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         <table class="report-table package-issue-table">
                            <tr class="excluded">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in excluded
-                                    package.</p>
+                                 <p>Example analyzer warning in excluded package.</p>
                               </td>
                            </tr>
                         </table>
@@ -1194,23 +1186,22 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         <table class="report-table package-issue-table">
                            <tr class="error">
                               <td>
-                                 <p>Unknown time [ERROR]: VulnerableCode - Example advisor error.</p>
+                                 <p>Example advisor error.</p>
                               </td>
                            </tr>
                            <tr class="warning">
                               <td>
-                                 <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
-                                    package.</p>
+                                 <p>Example analyzer warning in included package.</p>
                               </td>
                            </tr>
                            <tr class="warning">
                               <td>
-                                 <p>Unknown time [WARNING]: VulnerableCode - Example advisor warning.</p>
+                                 <p>Example advisor warning.</p>
                               </td>
                            </tr>
                            <tr class="hint">
                               <td>
-                                 <p>Unknown time [HINT]: VulnerableCode - Example advisor hint.</p>
+                                 <p>Example advisor hint.</p>
                               </td>
                            </tr>
                         </table>
@@ -1219,7 +1210,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         <table class="report-table package-issue-table">
                            <tr class="resolved">
                               <td>
-                                 <p>Unknown time [ERROR]: VulnerableCode - Example advisor error, resolved.</p>
+                                 <p>Example advisor error, resolved.</p>
                                  <p>
                                     Resolved by: CANT_FIX_ISSUE - A comment explaining why the issue can be ignored.</p>
                               </td>

--- a/plugins/reporters/static-html/src/main/kotlin/TablesReportModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/TablesReportModelMapper.kt
@@ -90,7 +90,7 @@ private fun Issue.toTableReportIssue(
     val resolutions = ortResult.getResolutionsFor(this)
     return TablesReportIssue(
         source = source,
-        description = toString(),
+        description = message,
         resolutionDescription = buildString {
             if (resolutions.isNotEmpty()) {
                 append(


### PR DESCRIPTION
Only show the `Issue.message`, but stop showing `Issue.timestamp` and `Issue.severity`, to make the representation more compact and to align with the WebApp report. Note that the timestamp is rarely relevant and the severity is represented by a dedicated styling anyway.
