### PR TITLE
fix(fossid-webapp): Count snippets when enforcing the snippet limit

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -191,8 +191,12 @@ internal suspend fun mapSnippetFindings(
             snippetLicenseFindings
         )
 
-        runningSnippetCount += mappedSnippets.size
-        results += mappedSnippets
+        val snippetFindingIterator = mappedSnippets.iterator()
+        while (runningSnippetCount < snippetsLimit && snippetFindingIterator.hasNext()) {
+            val snippetFinding = snippetFindingIterator.next()
+            runningSnippetCount += snippetFinding.snippets.size
+            results += snippetFinding
+        }
     }
 
     if (runningSnippetCount >= snippetsLimit) {


### PR DESCRIPTION
The current logic is wrong: the snippet limit is applied to ORT snippet findings. However, a snippet finding refers to a single source code location and contains generally multiple snippets. Hence, those snippets must be counted when applying the limit. Please note that the new logic still garantees that all the snippets of a snippet finding are returned, for unity.

This is a fixup for 9223e90e.

