### PR TITLE
fix(reporter): Prevent `null` in snippet report template

### DIFF
--- a/plugins/reporters/fossid/src/main/resources/templates/asciidoc/fossid_snippet.ftl
+++ b/plugins/reporters/fossid/src/main/resources/templates/asciidoc/fossid_snippet.ftl
@@ -33,7 +33,7 @@ List of all the provenances with their files and snippets.
 
 [#assign snippetsLimitIssue = helper.getSnippetsLimitIssue()]
 
-[#if snippetsLimitIssue??]
+[#if snippetsLimitIssue?has_content]
 [WARNING]
 ====
 ${snippetsLimitIssue}

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -279,8 +279,8 @@ class FreemarkerTemplateProcessor(
             input.ortResult.getOpenIssues(minSeverity = threshold).isNotEmpty()
 
         /**
-         * If there are any issue caused by reaching the snippets limit, return the text of the issue. Otherwise reuturn
-         * 'null'.
+         * If there are any issue caused by reaching the snippets limit, return the text of the issue. Otherwise return
+         * the empty string.
          */
         @Suppress("UNUSED") // This function is used in the templates.
         fun getSnippetsLimitIssue() =
@@ -288,7 +288,7 @@ class FreemarkerTemplateProcessor(
                 result.summary.issues
             }?.firstOrNull {
                 it.message.contains("snippets limit")
-            }?.message
+            }?.message.orEmpty()
 
         /**
          * Return `true` if there are any unresolved and non-excluded [RuleViolation]s whose severity is equal to or


### PR DESCRIPTION
Freemarker does not support `null`. Hence, use the empty string instead when there is no snippet limit issue.
