### PR TITLE
docs(model): Use the new SCANOSS API endpoint also in `reference.yml`

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -277,7 +277,7 @@ ort:
 
       SCANOSS:
         options:
-          apiUrl: 'https://osskb.org/api/'
+          apiUrl: 'https://api.osskb.org/'
         secrets:
           apiKey: 'your API key'
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -291,7 +291,7 @@ class OrtConfigurationTest : WordSpec({
                     }
 
                     get("SCANOSS") shouldNotBeNull {
-                        options shouldContainExactly mapOf("apiUrl" to "https://osskb.org/api/")
+                        options shouldContainExactly mapOf("apiUrl" to "https://api.osskb.org/")
                         secrets shouldContainExactly mapOf("apiKey" to "your API key")
                     }
                 }


### PR DESCRIPTION
This is a fixup for 1f689aa.