### PR TITLE
feat(osv): Enable querying vulnerabilities for the SwiftURL ecosystem

### DIFF
--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -119,6 +119,7 @@ object Ecosystem {
     const val PUB = "Pub"
     const val PYPI = "PyPI"
     const val RUBY_GEMS = "RubyGems"
+    const val SWIFT_URL = "SwiftURL"
 }
 
 @Serializable(EventSerializer::class)

--- a/plugins/advisors/osv/src/funTest/kotlin/OsvFunTest.kt
+++ b/plugins/advisors/osv/src/funTest/kotlin/OsvFunTest.kt
@@ -48,7 +48,8 @@ class OsvFunTest : StringSpec({
             "NPM::rebber:1.0.0",
             "NuGet::Bunkum:4.0.0",
             "Pub::http:0.13.1",
-            "PyPI::django:3.2"
+            "PyPI::django:3.2",
+            "Swift::github.com/apple/swift-nio:2.41.0"
         ).mapTo(mutableSetOf()) {
             identifierToPackage(it)
         }

--- a/plugins/advisors/osv/src/main/kotlin/Osv.kt
+++ b/plugins/advisors/osv/src/main/kotlin/Osv.kt
@@ -159,6 +159,7 @@ private fun createRequest(pkg: Package): VulnerabilitiesForPackageRequest? {
         "Maven" -> Ecosystem.MAVEN
         "Pub" -> Ecosystem.PUB
         "PyPI" -> Ecosystem.PYPI
+        "Swift" -> Ecosystem.SWIFT_URL
         else -> null
     }
 


### PR DESCRIPTION
Since the package identifiers in OSV's vulnerability data for the SwiftURL ecosystem have become consistent [1], it is now clear how to construct the requests. Simply add the missing mapping and a test to enable retrieving vulnerabilities for Swift packages.

Fixes #7841.

[1] https://github.com/google/osv.dev/issues/1923#issuecomment-2099711017

