### PR TITLE
feat(model)!: Stop silently ignoring invalid declared license mappings

### DIFF
--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import org.ossreviewtoolkit.utils.common.zip
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression.Strictness.ALLOW_LICENSEREF_EXCEPTIONS
 
 /**
  * This class contains curation data for a package. It is used to amend the automatically detected metadata for a
@@ -108,6 +109,14 @@ data class PackageCurationData(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val sourceCodeOrigins: List<SourceCodeOrigin>? = null
 ) {
+    init {
+        declaredLicenseMapping.forEach { (key, value) ->
+            require(value.isValid(ALLOW_LICENSEREF_EXCEPTIONS)) {
+                "The declared license '$key' is configured to map to '$value' which is not a valid SPDX expression."
+            }
+        }
+    }
+
     /**
      * Apply this [PackageCuration] to [targetPackage] by overriding all values of [targetPackage] with non-null values
      * of this [PackageCurationData], and return the resulting [CuratedPackage].

--- a/model/src/test/kotlin/PackageCurationDataTest.kt
+++ b/model/src/test/kotlin/PackageCurationDataTest.kt
@@ -49,7 +49,7 @@ class PackageCurationDataTest : WordSpec({
         ),
         isMetadataOnly = true,
         isModified = true,
-        declaredLicenseMapping = mapOf("original" to "original".toSpdx()),
+        declaredLicenseMapping = mapOf("original" to "LicenseRef-original".toSpdx()),
         sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
     )
 
@@ -77,7 +77,7 @@ class PackageCurationDataTest : WordSpec({
         ),
         isMetadataOnly = false,
         isModified = false,
-        declaredLicenseMapping = mapOf("other" to "other".toSpdx()),
+        declaredLicenseMapping = mapOf("other" to "LicenseRef-other".toSpdx()),
         sourceCodeOrigins = listOf(SourceCodeOrigin.VCS)
     )
 
@@ -116,8 +116,8 @@ class PackageCurationDataTest : WordSpec({
                 authors = setOf("original", "other"),
                 concludedLicense = "original AND other".toSpdx(),
                 declaredLicenseMapping = mapOf(
-                    "original" to "original".toSpdx(),
-                    "other" to "other".toSpdx()
+                    "original" to "LicenseRef-original".toSpdx(),
+                    "other" to "LicenseRef-other".toSpdx()
                 )
             )
         }


### PR DESCRIPTION
Previously, `PackageCuration.apply()` silently ignored declared license mapping entries with invalid SPDX expressions. For example, if one accidentally omits the `LicenseRef-` prefix, the mapping is just silently ignored.

Add a check that all values in the `Map` are valid SPDX expression into the constructor, to fail as early as possible. When used via a `FilePackageCurationProvider`, ORT now fails with the error message pointing to the problematic curation file path.

Fixes: #7828.

