### PR TITLE
chore(model): Drop some unnecessary sorting

### DIFF
--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -127,7 +127,7 @@ data class AdvisorRecord(
  * references. Other [Vulnerability] properties are taken from the first object which has any such property set.
  */
 private fun Collection<Vulnerability>.mergeVulnerabilities(): List<Vulnerability> {
-    val vulnerabilitiesById = groupByTo(sortedMapOf()) { it.id }
+    val vulnerabilitiesById = groupBy { it.id }
     return vulnerabilitiesById.map { it.value.mergeReferences() }
 }
 


### PR DESCRIPTION
The callers do not make any assumption about the ordering, so the sorting is not needed.
