### PR TITLE
model: Serialize dependency graph edges in some explicit order

### DIFF
--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -99,10 +99,10 @@ data class DependencyGraph(
     val nodes: List<DependencyGraphNode>? = null,
 
     /**
-     * A list with the edges of this dependency graph. By traversing the edges, the dependencies of packages can be
+     * A set with the edges of this dependency graph. By traversing the edges, the dependencies of packages can be
      * determined.
      */
-    val edges: List<DependencyGraphEdge>? = null
+    val edges: Set<DependencyGraphEdge>? = null
 ) {
     companion object {
         /**
@@ -419,7 +419,7 @@ private fun constructNodeDependenciesFromScopeRoots(roots: SortedSet<DependencyR
  */
 private fun constructNodeDependenciesFromGraph(
     nodes: List<DependencyGraphNode>,
-    edges: List<DependencyGraphEdge>
+    edges: Set<DependencyGraphEdge>
 ): NodeDependencies {
     val mapping = mutableMapOf<DependencyGraphNode, MutableList<DependencyGraphNode>>()
 

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -21,9 +21,11 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 import java.util.SortedSet
 
+import org.ossreviewtoolkit.model.utils.DependencyGraphEdgeSortedSetConverter
 import org.ossreviewtoolkit.model.utils.PackageLinkageValueFilter
 
 /**
@@ -102,6 +104,7 @@ data class DependencyGraph(
      * A set with the edges of this dependency graph. By traversing the edges, the dependencies of packages can be
      * determined.
      */
+    @JsonSerialize(converter = DependencyGraphEdgeSortedSetConverter::class)
     val edges: Set<DependencyGraphEdge>? = null
 ) {
     companion object {

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -179,7 +179,7 @@ class DependencyGraphBuilder<D>(
         )
     }
 
-    private fun Collection<DependencyGraphEdge>.removeCycles(): List<DependencyGraphEdge> {
+    private fun Set<DependencyGraphEdge>.removeCycles(): Set<DependencyGraphEdge> {
         val edges = toMutableSet()
         val edgesToKeep = breakCycles(edges)
         val edgesToRemove = edges - edgesToKeep
@@ -188,7 +188,7 @@ class DependencyGraphBuilder<D>(
             logger.warn { "Removing edge '${it.from} -> ${it.to}' to break a cycle." }
         }
 
-        return filter { it in edgesToKeep }
+        return filterTo(mutableSetOf()) { it in edgesToKeep }
     }
 
     private fun checkReferences() {
@@ -436,9 +436,9 @@ class DependencyGraphBuilder<D>(
  */
 private fun Collection<DependencyReference>.toGraph(
     indexMapping: IntArray
-): Pair<List<DependencyGraphNode>, List<DependencyGraphEdge>> {
+): Pair<List<DependencyGraphNode>, Set<DependencyGraphEdge>> {
     val nodes = mutableSetOf<DependencyGraphNode>()
-    val edges = mutableListOf<DependencyGraphEdge>()
+    val edges = mutableSetOf<DependencyGraphEdge>()
     val nodeIndices = mutableMapOf<NodeKey, Int>()
 
     fun getOrAddNodeIndex(ref: DependencyReference): Int =

--- a/model/src/main/kotlin/utils/SortedSetConverters.kt
+++ b/model/src/main/kotlin/utils/SortedSetConverters.kt
@@ -27,6 +27,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.DependencyGraphEdge
 import org.ossreviewtoolkit.model.FileList
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
@@ -42,6 +43,10 @@ import org.ossreviewtoolkit.model.SnippetFinding
 
 class CopyrightFindingSortedSetConverter : StdConverter<Set<CopyrightFinding>, SortedSet<CopyrightFinding>>() {
     override fun convert(value: Set<CopyrightFinding>) = value.toSortedSet(CopyrightFinding.COMPARATOR)
+}
+
+class DependencyGraphEdgeSortedSetConverter : StdConverter<Set<DependencyGraphEdge>, Set<DependencyGraphEdge>>() {
+    override fun convert(value: Set<DependencyGraphEdge>) = value.toSortedSet(compareBy({ it.from }, { it.to }))
 }
 
 /** Do not convert to SortedSet in order to not require a comparator consistent with equals */

--- a/model/src/test/assets/result-with-issues-graph.yml
+++ b/model/src/test/assets/result-with-issues-graph.yml
@@ -1300,22 +1300,22 @@ analyzer:
           to: 1
         - from: 0
           to: 2
-        - from: 6
-          to: 7
         - from: 4
           to: 5
         - from: 4
           to: 6
         - from: 4
           to: 8
+        - from: 6
+          to: 7
         - from: 9
           to: 10
+        - from: 11
+          to: 12
         - from: 12
           to: 13
         - from: 12
           to: 14
-        - from: 11
-          to: 12
         - from: 17
           to: 18
         - from: 19
@@ -1328,14 +1328,14 @@ analyzer:
           to: 24
         - from: 25
           to: 26
-        - from: 30
-          to: 26
-        - from: 30
-          to: 31
         - from: 28
           to: 29
         - from: 28
           to: 30
+        - from: 30
+          to: 26
+        - from: 30
+          to: 31
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/sbt-multi-project-example-graph.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph.yml
@@ -1290,22 +1290,22 @@ analyzer:
           to: 1
         - from: 0
           to: 2
-        - from: 6
-          to: 7
         - from: 4
           to: 5
         - from: 4
           to: 6
         - from: 4
           to: 8
+        - from: 6
+          to: 7
         - from: 9
           to: 10
+        - from: 11
+          to: 12
         - from: 12
           to: 13
         - from: 12
           to: 14
-        - from: 11
-          to: 12
         - from: 17
           to: 18
         - from: 19
@@ -1318,14 +1318,14 @@ analyzer:
           to: 24
         - from: 25
           to: 26
-        - from: 30
-          to: 26
-        - from: 30
-          to: 31
         - from: 28
           to: 29
         - from: 28
           to: 30
+        - from: 30
+          to: 26
+        - from: 30
+          to: 31
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -144,7 +144,7 @@ class DependencyGraphTest : WordSpec({
             val nodeConfig1 = DependencyGraphNode(2)
             val nodeConfig2 = DependencyGraphNode(2, fragment = 1)
             val nodes = listOf(nodeLogging, nodeLang, nodeCollections1, nodeCollections2, nodeConfig1, nodeConfig2)
-            val edges = listOf(
+            val edges = setOf(
                 DependencyGraphEdge(3, 0),
                 DependencyGraphEdge(4, 1),
                 DependencyGraphEdge(4, 2),

--- a/plugins/package-managers/gradle-inspector/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
+++ b/plugins/package-managers/gradle-inspector/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
@@ -522,15 +522,15 @@ dependency_graph:
   - from: 18
     to: 17
   - from: 19
-    to: 18
-  - from: 19
     to: 16
+  - from: 19
+    to: 18
   - from: 20
     to: 0
   - from: 20
-    to: 11
-  - from: 20
     to: 10
+  - from: 20
+    to: 11
   - from: 20
     to: 12
   - from: 20
@@ -542,23 +542,23 @@ dependency_graph:
   - from: 21
     to: 0
   - from: 21
-    to: 7
-  - from: 21
     to: 4
   - from: 21
-    to: 11
+    to: 7
   - from: 21
     to: 10
   - from: 21
-    to: 20
+    to: 11
   - from: 21
     to: 14
+  - from: 21
+    to: 20
   - from: 22
     to: 0
   - from: 22
-    to: 7
-  - from: 22
     to: 5
+  - from: 22
+    to: 7
   - from: 23
     to: 0
   - from: 24
@@ -612,35 +612,35 @@ dependency_graph:
   - from: 32
     to: 31
   - from: 33
-    to: 21
-  - from: 33
     to: 0
-  - from: 33
-    to: 7
   - from: 33
     to: 1
   - from: 33
     to: 5
   - from: 33
-    to: 11
+    to: 7
   - from: 33
-    to: 20
+    to: 11
   - from: 33
     to: 13
   - from: 33
     to: 14
   - from: 33
+    to: 20
+  - from: 33
+    to: 21
+  - from: 33
     to: 29
   - from: 33
     to: 32
-  - from: 34
-    to: 21
   - from: 34
     to: 0
   - from: 34
     to: 7
   - from: 34
     to: 14
+  - from: 34
+    to: 21
   - from: 34
     to: 25
   - from: 34
@@ -654,15 +654,15 @@ dependency_graph:
   - from: 36
     to: 0
   - from: 36
-    to: 7
-  - from: 36
     to: 5
+  - from: 36
+    to: 7
   - from: 36
     to: 27
   - from: 38
-    to: 34
-  - from: 38
     to: 7
+  - from: 38
+    to: 34
   - from: 38
     to: 37
   - from: 39
@@ -684,9 +684,9 @@ dependency_graph:
   - from: 42
     to: 41
   - from: 43
-    to: 7
-  - from: 43
     to: 5
+  - from: 43
+    to: 7
   - from: 43
     to: 42
   - from: 44
@@ -698,35 +698,35 @@ dependency_graph:
   - from: 45
     to: 0
   - from: 45
-    to: 7
-  - from: 45
     to: 5
+  - from: 45
+    to: 7
   - from: 46
     to: 0
   - from: 46
-    to: 7
-  - from: 46
     to: 5
+  - from: 46
+    to: 7
   - from: 46
     to: 33
   - from: 46
     to: 44
   - from: 47
-    to: 34
-  - from: 47
     to: 0
-  - from: 47
-    to: 7
   - from: 47
     to: 1
   - from: 47
     to: 4
+  - from: 47
+    to: 7
   - from: 47
     to: 22
   - from: 47
     to: 28
   - from: 47
     to: 33
+  - from: 47
+    to: 34
   - from: 47
     to: 35
   - from: 47
@@ -758,19 +758,19 @@ dependency_graph:
   - from: 51
     to: 1
   - from: 51
-    to: 50
+    to: 5
   - from: 51
     to: 6
   - from: 51
-    to: 5
-  - from: 51
     to: 49
+  - from: 51
+    to: 50
   - from: 52
     to: 0
   - from: 52
-    to: 51
-  - from: 52
     to: 10
+  - from: 52
+    to: 51
   - from: 53
     to: 2
   - from: 53
@@ -788,55 +788,55 @@ dependency_graph:
   - from: 55
     to: 0
   - from: 55
+    to: 10
+  - from: 55
     to: 11
   - from: 55
-    to: 10
+    to: 19
   - from: 55
     to: 52
   - from: 55
     to: 53
   - from: 55
     to: 54
-  - from: 55
-    to: 19
   - from: 56
     to: 0
   - from: 57
     to: 0
   - from: 57
-    to: 51
-  - from: 57
-    to: 50
-  - from: 57
     to: 5
-  - from: 57
-    to: 11
   - from: 57
     to: 10
   - from: 57
-    to: 55
+    to: 11
+  - from: 57
+    to: 50
+  - from: 57
+    to: 51
   - from: 57
     to: 54
+  - from: 57
+    to: 55
   - from: 57
     to: 56
   - from: 58
     to: 0
   - from: 58
-    to: 51
+    to: 5
   - from: 58
-    to: 5
+    to: 51
   - from: 59
     to: 5
-  - from: 59
-    to: 58
   - from: 59
     to: 23
+  - from: 59
+    to: 58
   - from: 60
     to: 0
   - from: 60
-    to: 51
-  - from: 60
     to: 5
+  - from: 60
+    to: 51
   - from: 60
     to: 58
   - from: 60
@@ -844,9 +844,9 @@ dependency_graph:
   - from: 61
     to: 0
   - from: 61
-    to: 51
-  - from: 61
     to: 5
+  - from: 61
+    to: 51
   - from: 62
     to: 0
   - from: 62
@@ -866,17 +866,17 @@ dependency_graph:
   - from: 65
     to: 0
   - from: 65
-    to: 51
-  - from: 65
     to: 5
   - from: 65
-    to: 64
+    to: 51
   - from: 65
     to: 63
-  - from: 66
-    to: 51
+  - from: 65
+    to: 64
   - from: 66
     to: 5
+  - from: 66
+    to: 51
   - from: 66
     to: 65
   - from: 67
@@ -888,23 +888,19 @@ dependency_graph:
   - from: 68
     to: 2
   - from: 68
-    to: 53
-  - from: 68
     to: 30
+  - from: 68
+    to: 53
   - from: 69
     to: 0
-  - from: 69
-    to: 51
   - from: 69
     to: 11
   - from: 69
+    to: 51
+  - from: 69
     to: 68
   - from: 70
-    to: 57
-  - from: 70
     to: 0
-  - from: 70
-    to: 51
   - from: 70
     to: 1
   - from: 70
@@ -912,11 +908,15 @@ dependency_graph:
   - from: 70
     to: 11
   - from: 70
-    to: 55
+    to: 51
   - from: 70
     to: 53
   - from: 70
     to: 54
+  - from: 70
+    to: 55
+  - from: 70
+    to: 57
   - from: 70
     to: 67
   - from: 70
@@ -924,103 +924,103 @@ dependency_graph:
   - from: 71
     to: 0
   - from: 72
-    to: 57
-  - from: 72
     to: 0
-  - from: 72
-    to: 51
-  - from: 72
-    to: 50
   - from: 72
     to: 5
   - from: 72
+    to: 10
+  - from: 72
     to: 11
   - from: 72
-    to: 10
+    to: 26
+  - from: 72
+    to: 50
+  - from: 72
+    to: 51
   - from: 72
     to: 52
   - from: 72
     to: 54
   - from: 72
+    to: 57
+  - from: 72
     to: 60
   - from: 72
-    to: 26
-  - from: 72
     to: 62
-  - from: 72
-    to: 70
   - from: 72
     to: 65
   - from: 72
     to: 66
   - from: 72
+    to: 70
+  - from: 72
     to: 71
   - from: 73
     to: 0
   - from: 73
-    to: 51
-  - from: 73
     to: 5
+  - from: 73
+    to: 51
   - from: 73
     to: 61
   - from: 74
-    to: 72
+    to: 37
   - from: 74
     to: 51
   - from: 74
-    to: 37
+    to: 72
   - from: 75
     to: 0
-  - from: 75
-    to: 51
-  - from: 75
-    to: 69
   - from: 75
     to: 39
   - from: 75
     to: 40
   - from: 75
     to: 41
-  - from: 76
+  - from: 75
     to: 51
+  - from: 75
+    to: 69
   - from: 76
     to: 5
+  - from: 76
+    to: 51
   - from: 76
     to: 75
   - from: 77
     to: 0
   - from: 77
-    to: 51
-  - from: 77
     to: 5
+  - from: 77
+    to: 51
   - from: 77
     to: 61
   - from: 78
     to: 0
   - from: 78
-    to: 51
-  - from: 78
     to: 5
+  - from: 78
+    to: 51
   - from: 79
     to: 0
   - from: 79
-    to: 51
-  - from: 79
     to: 5
+  - from: 79
+    to: 51
   - from: 79
     to: 70
   - from: 79
     to: 77
   - from: 80
-    to: 72
-  - from: 80
     to: 0
-  - from: 80
-    to: 51
   - from: 80
     to: 1
   - from: 80
+    to: 35
+  - from: 80
     to: 50
+  - from: 80
+    to: 51
   - from: 80
     to: 58
   - from: 80
@@ -1028,7 +1028,7 @@ dependency_graph:
   - from: 80
     to: 70
   - from: 80
-    to: 35
+    to: 72
   - from: 80
     to: 73
   - from: 80

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
@@ -522,15 +522,15 @@ dependency_graph:
   - from: 18
     to: 17
   - from: 19
-    to: 18
-  - from: 19
     to: 16
+  - from: 19
+    to: 18
   - from: 20
     to: 0
   - from: 20
-    to: 11
-  - from: 20
     to: 10
+  - from: 20
+    to: 11
   - from: 20
     to: 12
   - from: 20
@@ -542,23 +542,23 @@ dependency_graph:
   - from: 21
     to: 0
   - from: 21
-    to: 7
-  - from: 21
     to: 4
   - from: 21
-    to: 11
+    to: 7
   - from: 21
     to: 10
   - from: 21
-    to: 20
+    to: 11
   - from: 21
     to: 14
+  - from: 21
+    to: 20
   - from: 22
     to: 0
   - from: 22
-    to: 7
-  - from: 22
     to: 5
+  - from: 22
+    to: 7
   - from: 23
     to: 0
   - from: 24
@@ -612,35 +612,35 @@ dependency_graph:
   - from: 32
     to: 31
   - from: 33
-    to: 21
-  - from: 33
     to: 0
-  - from: 33
-    to: 7
   - from: 33
     to: 1
   - from: 33
     to: 5
   - from: 33
-    to: 11
+    to: 7
   - from: 33
-    to: 20
+    to: 11
   - from: 33
     to: 13
   - from: 33
     to: 14
   - from: 33
+    to: 20
+  - from: 33
+    to: 21
+  - from: 33
     to: 29
   - from: 33
     to: 32
-  - from: 34
-    to: 21
   - from: 34
     to: 0
   - from: 34
     to: 7
   - from: 34
     to: 14
+  - from: 34
+    to: 21
   - from: 34
     to: 25
   - from: 34
@@ -654,15 +654,15 @@ dependency_graph:
   - from: 36
     to: 0
   - from: 36
-    to: 7
-  - from: 36
     to: 5
+  - from: 36
+    to: 7
   - from: 36
     to: 27
   - from: 38
-    to: 34
-  - from: 38
     to: 7
+  - from: 38
+    to: 34
   - from: 38
     to: 37
   - from: 39
@@ -684,9 +684,9 @@ dependency_graph:
   - from: 42
     to: 41
   - from: 43
-    to: 7
-  - from: 43
     to: 5
+  - from: 43
+    to: 7
   - from: 43
     to: 42
   - from: 44
@@ -698,35 +698,35 @@ dependency_graph:
   - from: 45
     to: 0
   - from: 45
-    to: 7
-  - from: 45
     to: 5
+  - from: 45
+    to: 7
   - from: 46
     to: 0
   - from: 46
-    to: 7
-  - from: 46
     to: 5
+  - from: 46
+    to: 7
   - from: 46
     to: 33
   - from: 46
     to: 44
   - from: 47
-    to: 34
-  - from: 47
     to: 0
-  - from: 47
-    to: 7
   - from: 47
     to: 1
   - from: 47
     to: 4
+  - from: 47
+    to: 7
   - from: 47
     to: 22
   - from: 47
     to: 28
   - from: 47
     to: 33
+  - from: 47
+    to: 34
   - from: 47
     to: 35
   - from: 47
@@ -758,19 +758,19 @@ dependency_graph:
   - from: 51
     to: 1
   - from: 51
-    to: 50
+    to: 5
   - from: 51
     to: 6
   - from: 51
-    to: 5
-  - from: 51
     to: 49
+  - from: 51
+    to: 50
   - from: 52
     to: 0
   - from: 52
-    to: 51
-  - from: 52
     to: 10
+  - from: 52
+    to: 51
   - from: 53
     to: 2
   - from: 53
@@ -788,55 +788,55 @@ dependency_graph:
   - from: 55
     to: 0
   - from: 55
+    to: 10
+  - from: 55
     to: 11
   - from: 55
-    to: 10
+    to: 19
   - from: 55
     to: 52
   - from: 55
     to: 53
   - from: 55
     to: 54
-  - from: 55
-    to: 19
   - from: 56
     to: 0
   - from: 57
     to: 0
   - from: 57
-    to: 51
-  - from: 57
-    to: 50
-  - from: 57
     to: 5
-  - from: 57
-    to: 11
   - from: 57
     to: 10
   - from: 57
-    to: 55
+    to: 11
+  - from: 57
+    to: 50
+  - from: 57
+    to: 51
   - from: 57
     to: 54
+  - from: 57
+    to: 55
   - from: 57
     to: 56
   - from: 58
     to: 0
   - from: 58
-    to: 51
+    to: 5
   - from: 58
-    to: 5
+    to: 51
   - from: 59
     to: 5
-  - from: 59
-    to: 58
   - from: 59
     to: 23
+  - from: 59
+    to: 58
   - from: 60
     to: 0
   - from: 60
-    to: 51
-  - from: 60
     to: 5
+  - from: 60
+    to: 51
   - from: 60
     to: 58
   - from: 60
@@ -844,9 +844,9 @@ dependency_graph:
   - from: 61
     to: 0
   - from: 61
-    to: 51
-  - from: 61
     to: 5
+  - from: 61
+    to: 51
   - from: 62
     to: 0
   - from: 62
@@ -866,17 +866,17 @@ dependency_graph:
   - from: 65
     to: 0
   - from: 65
-    to: 51
-  - from: 65
     to: 5
   - from: 65
-    to: 64
+    to: 51
   - from: 65
     to: 63
-  - from: 66
-    to: 51
+  - from: 65
+    to: 64
   - from: 66
     to: 5
+  - from: 66
+    to: 51
   - from: 66
     to: 65
   - from: 67
@@ -888,23 +888,19 @@ dependency_graph:
   - from: 68
     to: 2
   - from: 68
-    to: 53
-  - from: 68
     to: 30
+  - from: 68
+    to: 53
   - from: 69
     to: 0
-  - from: 69
-    to: 51
   - from: 69
     to: 11
   - from: 69
+    to: 51
+  - from: 69
     to: 68
   - from: 70
-    to: 57
-  - from: 70
     to: 0
-  - from: 70
-    to: 51
   - from: 70
     to: 1
   - from: 70
@@ -912,11 +908,15 @@ dependency_graph:
   - from: 70
     to: 11
   - from: 70
-    to: 55
+    to: 51
   - from: 70
     to: 53
   - from: 70
     to: 54
+  - from: 70
+    to: 55
+  - from: 70
+    to: 57
   - from: 70
     to: 67
   - from: 70
@@ -924,103 +924,103 @@ dependency_graph:
   - from: 71
     to: 0
   - from: 72
-    to: 57
-  - from: 72
     to: 0
-  - from: 72
-    to: 51
-  - from: 72
-    to: 50
   - from: 72
     to: 5
   - from: 72
+    to: 10
+  - from: 72
     to: 11
   - from: 72
-    to: 10
+    to: 26
+  - from: 72
+    to: 50
+  - from: 72
+    to: 51
   - from: 72
     to: 52
   - from: 72
     to: 54
   - from: 72
+    to: 57
+  - from: 72
     to: 60
   - from: 72
-    to: 26
-  - from: 72
     to: 62
-  - from: 72
-    to: 70
   - from: 72
     to: 65
   - from: 72
     to: 66
   - from: 72
+    to: 70
+  - from: 72
     to: 71
   - from: 73
     to: 0
   - from: 73
-    to: 51
-  - from: 73
     to: 5
+  - from: 73
+    to: 51
   - from: 73
     to: 61
   - from: 74
-    to: 72
+    to: 37
   - from: 74
     to: 51
   - from: 74
-    to: 37
+    to: 72
   - from: 75
     to: 0
-  - from: 75
-    to: 51
-  - from: 75
-    to: 69
   - from: 75
     to: 39
   - from: 75
     to: 40
   - from: 75
     to: 41
-  - from: 76
+  - from: 75
     to: 51
+  - from: 75
+    to: 69
   - from: 76
     to: 5
+  - from: 76
+    to: 51
   - from: 76
     to: 75
   - from: 77
     to: 0
   - from: 77
-    to: 51
-  - from: 77
     to: 5
+  - from: 77
+    to: 51
   - from: 77
     to: 61
   - from: 78
     to: 0
   - from: 78
-    to: 51
-  - from: 78
     to: 5
+  - from: 78
+    to: 51
   - from: 79
     to: 0
   - from: 79
-    to: 51
-  - from: 79
     to: 5
+  - from: 79
+    to: 51
   - from: 79
     to: 70
   - from: 79
     to: 77
   - from: 80
-    to: 72
-  - from: 80
     to: 0
-  - from: 80
-    to: 51
   - from: 80
     to: 1
   - from: 80
+    to: 35
+  - from: 80
     to: 50
+  - from: 80
+    to: 51
   - from: 80
     to: 58
   - from: 80
@@ -1028,7 +1028,7 @@ dependency_graph:
   - from: 80
     to: 70
   - from: 80
-    to: 35
+    to: 72
   - from: 80
     to: 73
   - from: 80


### PR DESCRIPTION
Make serialized order independent of insertion order in order to remove the need to update the tests when changing insertion order in upcoming changes.

Part of https://github.com/oss-review-toolkit/ort/issues/6235.

