### PR TITLE
refactor(utils): Slightly re-write a function

### DIFF
--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -553,8 +553,8 @@ private fun constructSortedScopeMappings(
 ): Map<String, List<RootDependencyIndex>> {
     val orderedMappings = mutableMapOf<String, List<RootDependencyIndex>>()
 
-    scopeMappings.keys.toSortedSet().forEach { scope ->
-        orderedMappings[scope] = scopeMappings.getValue(scope)
+    scopeMappings.entries.sortedBy { it.key }.forEach { (scope, rootDependencyIndices) ->
+        orderedMappings[scope] = rootDependencyIndices
             .map { it.mapIndex(indexMapping) }
             .sortedWith(rootDependencyIndexComparator)
     }


### PR DESCRIPTION
Avoid a conversion to a `SortedSet` and the `getValue()` made in each iteration.
