### PR TITLE
refactor(clearly-defined): Get enum serial names more efficiently

### DIFF
--- a/clients/clearly-defined/src/main/kotlin/Enums.kt
+++ b/clients/clearly-defined/src/main/kotlin/Enums.kt
@@ -21,8 +21,6 @@ package org.ossreviewtoolkit.clients.clearlydefined
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * See https://github.com/clearlydefined/service/blob/48f2c97/schemas/definition-1.0.json#L32-L48.
@@ -50,7 +48,7 @@ enum class ComponentType(val defaultProvider: Provider? = null) {
 
     // Align the string representation with the serial name to make Retrofit's GET request work. Also see:
     // https://github.com/JakeWharton/retrofit2-kotlinx-serialization-converter/issues/39
-    override fun toString() = ClearlyDefinedService.JSON.encodeToJsonElement(this).jsonPrimitive.content
+    override fun toString() = serializer().descriptor.getElementName(ordinal)
 }
 
 /**
@@ -80,7 +78,7 @@ enum class Provider {
 
     // Align the string representation with the serial name to make Retrofit's GET request work. Also see:
     // https://github.com/JakeWharton/retrofit2-kotlinx-serialization-converter/issues/39
-    override fun toString() = ClearlyDefinedService.JSON.encodeToJsonElement(this).jsonPrimitive.content
+    override fun toString() = serializer().descriptor.getElementName(ordinal)
 }
 
 /**


### PR DESCRIPTION
Based on the hint at [1] and the code at [2], leverage the serializer's descriptor to get the serial name of the element, without doing any "dummy serialization".

[1]: https://github.com/Kotlin/kotlinx.serialization/issues/1482#issuecomment-841308774
[2]: https://github.com/andregasser/bigbone/pull/332/files#diff-8d64fdf06ceb51ff99e649f64c911cf787b07aff678d5d7efd7bf13322db4983R90