### PR TITLE
refactor(clearly-defined): Get enums for serial names directly

### DIFF
--- a/clients/clearly-defined/src/main/kotlin/Enums.kt
+++ b/clients/clearly-defined/src/main/kotlin/Enums.kt
@@ -43,7 +43,8 @@ enum class ComponentType(val defaultProvider: Provider? = null) {
 
     companion object {
         @JvmStatic
-        fun fromString(value: String) = ComponentType.entries.single { it.toString() == value }
+        fun fromString(value: String) =
+            ComponentType.entries[ComponentType.serializer().descriptor.getElementIndex(value)]
     }
 
     // Align the string representation with the serial name to make Retrofit's GET request work. Also see:
@@ -73,7 +74,7 @@ enum class Provider {
 
     companion object {
         @JvmStatic
-        fun fromString(value: String) = Provider.entries.single { it.toString() == value }
+        fun fromString(value: String) = Provider.entries[Provider.serializer().descriptor.getElementIndex(value)]
     }
 
     // Align the string representation with the serial name to make Retrofit's GET request work. Also see:


### PR DESCRIPTION
Look up enums for serial names directly instead of searching for them by string representation.