### PR TITLE
docs(osv): Remove an obsolete code comment

### DIFF
--- a/plugins/advisors/osv/src/main/kotlin/Osv.kt
+++ b/plugins/advisors/osv/src/main/kotlin/Osv.kt
@@ -192,7 +192,6 @@ private fun Vulnerability.toOrtVulnerability(): org.ossreviewtoolkit.model.vulne
         }
 
         Cvss.fromVector(it.score)?.let { cvss ->
-            // Work around for https://github.com/stevespringett/cvss-calculator/issues/56.
             it.score.substringBefore("/") to "${cvss.calculateScore().baseScore}"
         } ?: run {
             logger.debug { "Could not parse CVSS vector '${it.score}'." }

--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -28,7 +28,7 @@ project:
     dependencies:
     - id: "Conan::libcurl:7.85.0"
       dependencies:
-      - id: "Conan::openssl:3.2.1"
+      - id: "Conan::openssl:3.2.2"
         dependencies:
         - id: "Conan::zlib:1.2.13"
       - id: "Conan::zlib:1.2.13"
@@ -148,8 +148,8 @@ packages:
     revision: ""
     path: ""
   is_modified: true
-- id: "Conan::openssl:3.2.1"
-  purl: "pkg:conan/openssl@3.2.1"
+- id: "Conan::openssl:3.2.2"
+  purl: "pkg:conan/openssl@3.2.2"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -163,9 +163,9 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://www.openssl.org/source/openssl-3.2.1.tar.gz"
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.2.2/openssl-3.2.2.tar.gz"
     hash:
-      value: "83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"
+      value: "197149c18d9e9f292c43f0400acaba12e5f52cacfe050f3d199277ea738ec2e7"
       algorithm: "SHA-256"
   vcs:
     type: "Git"


### PR DESCRIPTION
The actual work-around code involving `it.score.startsWith("CVSS:")` was removed in 0546d45, but the comment was left over, so remove it now.

As a side note, the issue has been fixed with release 1.4.3 of the cvss-calculator library, which is what ORT already uses.