### PR TITLE
docs(website): Remove superfluous subdirectory

### DIFF
--- a/website/docs/getting-started/tutorial.md
+++ b/website/docs/getting-started/tutorial.md
@@ -306,7 +306,7 @@ cli/build/install/ort/bin/ort evaluate
   --rules-file evaluator.rules.kts
   --license-classifications-file license-classifications.yml
   -i [scanner-output-dir]/scan-result.yml
-  -o [evaluator-output-dir]/mime-types
+  -o [evaluator-output-dir]
 ```
 
 See the [curations.yml documentation](../configuration/package-curations.md) to learn more about using curations to correct invalid or missing package metadata and the [license-classifications.yml documentation](../configuration/license-classifications.md) on how you can classify licenses to simplify writing the policy rules.


### PR DESCRIPTION
Without this change, generating the report will fail during the next step as the file generated by the evaluator is expected to be stored directly in [evaluator-output-dir], not a subdirectory thereof.