### PR TITLE
Clarify supported Conan versions

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -123,7 +123,7 @@ class Conan(
         // Conan version 1.18.0
         output.removePrefix("Conan version ")
 
-    override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.18.0")
+    override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.18.0 <2.0")
 
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion()
 

--- a/website/docs/tools/analyzer.md
+++ b/website/docs/tools/analyzer.md
@@ -14,7 +14,7 @@ Currently, the following package managers (grouped by the programming language t
 
 * C / C++
   * [Bazel](https://bazel.build/) (**experimental**) (limitations: see [open tasks](https://github.com/oss-review-toolkit/ort/issues/264))
-  * [Conan](https://conan.io/)
+  * [Conan 1.x](https://conan.io/)
   * Also see: [SPDX documents](#analyzer-for-spdx-documents)
 * Dart / Flutter
   * [Pub](https://pub.dev/)


### PR DESCRIPTION
Conan 2 is not yet supported by ORT. Stating this clearly avoids misunderstandings.