### PR TITLE
chore(model): Remove the unused `createMissingArchives` scanner option

### DIFF
--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -198,9 +198,6 @@
                 "archive": {
                     "$ref": "#/definitions/Archive"
                 },
-                "createMissingArchives": {
-                    "type": "boolean"
-                },
                 "detectedLicenseMapping": {
                     "$ref": "#/definitions/DetectedLicenseMapping"
                 },

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -50,11 +50,6 @@ data class ScannerConfiguration(
     val archive: FileArchiverConfiguration? = null,
 
     /**
-     * Create archives for packages that have a stored scan result but no license archive yet.
-     */
-    val createMissingArchives: Boolean = false,
-
-    /**
      * Mappings from licenses returned by the scanner to valid SPDX licenses. Note that these mappings are only applied
      * in new scans, stored scan results are not affected.
      */

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -198,8 +198,6 @@ ort:
           maximumPoolSize: 10
           minimumIdle: 600000
 
-    createMissingArchives: false
-
     # Map scanner license findings to valid SPDX licenses. Note that these mappings are only applied in new scans,
     # stored scan results are not affected.
     detectedLicenseMapping:

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -221,8 +221,6 @@ class OrtConfigurationTest : WordSpec({
                     }
                 }
 
-                createMissingArchives shouldBe false
-
                 detectedLicenseMapping shouldContainExactly mapOf(
                     "BSD (Three Clause License)" to "BSD-3-clause",
                     "LicenseRef-scancode-generic-cla" to "NOASSERTION"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -387,7 +387,6 @@ scanner:
     tool_versions: {}
   config:
     skip_concluded: false
-    create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-generic-cla: "NOASSERTION"

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -387,7 +387,6 @@ scanner:
     tool_versions: {}
   config:
     skip_concluded: false
-    create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-generic-cla: "NOASSERTION"

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -387,7 +387,6 @@ scanner:
     tool_versions: {}
   config:
     skip_concluded: false
-    create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-generic-cla: "NOASSERTION"

--- a/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/scan-result-for-synthetic-gradle-lib.yml
@@ -198,7 +198,6 @@ scanner:
     tool_versions: {}
   config:
     skip_concluded: false
-    create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-generic-cla: "NOASSERTION"

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -197,7 +197,6 @@ scanner:
   config:
     skip_concluded: false
     skip_excluded: false
-    create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-free-unknown: "NOASSERTION"

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -116,7 +116,6 @@ scanner:
   config:
     skip_concluded: false
     skip_excluded: false
-    create_missing_archives: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-free-unknown: "NOASSERTION"


### PR DESCRIPTION
The condition that used that option was removed in c71628d, and there is no plan to reintroduce it as the current provenance-based scanner logic works differently.