### PR TITLE
refactor(downloader)!: Make `getDefaultBranchName()` non-nullable

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -179,9 +179,10 @@ abstract class VersionControlSystem(
     abstract fun getVersion(): String
 
     /**
-     * Return the name of the default branch for the repository at [url], or null if there is no default remote branch.
+     * Return the name of the default branch for the repository at [url]. It is expected that there always is a default
+     * branch name that implementations can fall back to, and that the returned name is non-empty.
      */
-    abstract fun getDefaultBranchName(url: String): String?
+    abstract fun getDefaultBranchName(url: String): String
 
     /**
      * Return a working tree instance for this VCS.

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -156,7 +156,7 @@ private class VersionControlSystemTestImpl(
 ) : VersionControlSystem(tool) {
     override fun getVersion(): String = "0"
 
-    override fun getDefaultBranchName(url: String): String? = null
+    override fun getDefaultBranchName(url: String): String = ""
 
     override fun getWorkingTree(vcsDirectory: File): WorkingTree = mockk()
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -508,9 +508,7 @@ class FossId internal constructor(
         val vcs = requireNotNull(VersionControlSystem.forUrl(url))
 
         val defaultBranch = vcs.getDefaultBranchName(url)
-        logger.info {
-            if (defaultBranch != null) "Default branch is '$defaultBranch'." else "There is no default remote branch."
-        }
+        logger.info { "Default branch is '$defaultBranch'." }
 
         // If a scan for the default branch is created, put the default branch name in the scan code (the
         // FossIdNamingProvider must also have a scan pattern that makes use of it).


### PR DESCRIPTION
All current (non-test) implementations return a non-null name already as they fall back to a hard-coded name eventually.