### PR TITLE
chore(conan): Update test fixture

### DIFF
--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -1,17 +1,14 @@
 ---
 project:
-  id: "Conan::Poco:1.9.3"
+  id: "Conan::poco:null"
   definition_file_path: "plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-py/conanfile.py"
-  authors:
-  - "The Author"
   declared_licenses:
-  - "The Boost Software License 1.0"
+  - "BSL-1.0"
   declared_licenses_processed:
-    unmapped:
-    - "The Boost Software License 1.0"
+    spdx_expression: "BSL-1.0"
   vcs:
     type: "Git"
-    url: "http://github.com/pocoproject/conan-poco.git"
+    url: "https://github.com/conan-io/conan-center-index.git"
     revision: ""
     path: ""
   vcs_processed:
@@ -19,18 +16,182 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
-  homepage_url: ""
+  homepage_url: "https://pocoproject.org"
   scopes:
   - name: "build_requires"
     dependencies: []
   - name: "requires"
     dependencies:
-    - id: "Conan::openssl:3.0.0"
+    - id: "Conan::expat:2.6.2"
+    - id: "Conan::libmysqlclient:8.1.0"
       dependencies:
-      - id: "Conan::zlib:1.2.12"
+      - id: "Conan::lz4:1.9.4"
+      - id: "Conan::openssl:3.3.1"
+        dependencies:
+        - id: "Conan::zlib:1.3.1"
+      - id: "Conan::zlib:1.3.1"
+      - id: "Conan::zstd:1.5.5"
+    - id: "Conan::libpq:15.4"
+    - id: "Conan::openssl:3.3.1"
+      dependencies:
+      - id: "Conan::zlib:1.3.1"
+    - id: "Conan::pcre2:10.42"
+      dependencies:
+      - id: "Conan::bzip2:1.0.8"
+      - id: "Conan::zlib:1.3.1"
+    - id: "Conan::sqlite3:3.45.0"
+    - id: "Conan::zlib:1.3.1"
 packages:
-- id: "Conan::openssl:3.0.0"
-  purl: "pkg:conan/openssl@3.0.0"
+- id: "Conan::bzip2:1.0.8"
+  purl: "pkg:conan/bzip2@1.0.8"
+  declared_licenses:
+  - "bzip2-1.0.8"
+  declared_licenses_processed:
+    unmapped:
+    - "bzip2-1.0.8"
+  description: "bzip2 is a free and open-source file compression program that uses\
+    \ the Burrows Wheeler algorithm."
+  homepage_url: "https://sourceware.org/bzip2"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+    hash:
+      value: "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+      algorithm: "SHA-256"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "Conan::expat:2.6.2"
+  purl: "pkg:conan/expat@2.6.2"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fast streaming XML parser written in C."
+  homepage_url: "https://github.com/libexpat/libexpat"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_2/expat-2.6.2.tar.xz"
+    hash:
+      value: "ee14b4c5d8908b1bec37ad937607eab183d4d9806a08adee472c3c3121d27364"
+      algorithm: "SHA-256"
+  vcs:
+    type: "Git"
+    url: "https://github.com/libexpat/libexpat.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/libexpat/libexpat.git"
+    revision: ""
+    path: ""
+- id: "Conan::libmysqlclient:8.1.0"
+  purl: "pkg:conan/libmysqlclient@8.1.0"
+  declared_licenses:
+  - "GPL-2.0"
+  declared_licenses_processed:
+    spdx_expression: "GPL-2.0-only"
+    mapped:
+      GPL-2.0: "GPL-2.0-only"
+  description: "A MySQL client library for C development."
+  homepage_url: "https://dev.mysql.com/downloads/mysql/"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://dev.mysql.com/get/Downloads/MySQL-8.1/mysql-8.1.0.tar.gz"
+    hash:
+      value: "3dd017a940734aa90796a4c65e125e6712f64bbbbe3388d36469deaa87b599eb"
+      algorithm: "SHA-256"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  is_modified: true
+- id: "Conan::libpq:15.4"
+  purl: "pkg:conan/libpq@15.4"
+  declared_licenses:
+  - "PostgreSQL"
+  declared_licenses_processed:
+    spdx_expression: "PostgreSQL"
+  description: "The library used by all the standard PostgreSQL tools."
+  homepage_url: "https://www.postgresql.org/docs/current/static/libpq.html"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://ftp.postgresql.org/pub/source/v15.4/postgresql-15.4.tar.bz2"
+    hash:
+      value: "baec5a4bdc4437336653b6cb5d9ed89be5bd5c0c58b94e0becee0a999e63c8f9"
+      algorithm: "SHA-256"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  is_modified: true
+- id: "Conan::lz4:1.9.4"
+  purl: "pkg:conan/lz4@1.9.4"
+  declared_licenses:
+  - "BSD-2-Clause"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause AND BSD-3-Clause"
+  description: "Extremely Fast Compression algorithm"
+  homepage_url: "https://github.com/lz4/lz4"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://github.com/lz4/lz4/archive/v1.9.4.tar.gz"
+    hash:
+      value: "0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b"
+      algorithm: "SHA-256"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lz4/lz4.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lz4/lz4.git"
+    revision: ""
+    path: ""
+  is_modified: true
+- id: "Conan::openssl:3.3.1"
+  purl: "pkg:conan/openssl@3.3.1"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -44,9 +205,9 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://www.openssl.org/source/openssl-3.0.0.tar.gz"
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"
     hash:
-      value: "59eedfcb46c25214c9bd37ed6078297b4df01d012267fe9e9eee31f61bc70536"
+      value: "777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
       algorithm: "SHA-256"
   vcs:
     type: "Git"
@@ -58,8 +219,64 @@ packages:
     url: "https://github.com/openssl/openssl.git"
     revision: ""
     path: ""
-- id: "Conan::zlib:1.2.12"
-  purl: "pkg:conan/zlib@1.2.12"
+- id: "Conan::pcre2:10.42"
+  purl: "pkg:conan/pcre2@10.42"
+  declared_licenses:
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+  description: "Perl Compatible Regular Expressions"
+  homepage_url: "https://www.pcre.org/"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2"
+    hash:
+      value: "8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840"
+      algorithm: "SHA-256"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "Conan::sqlite3:3.45.0"
+  purl: "pkg:conan/sqlite3@3.45.0"
+  declared_licenses:
+  - "Unlicense"
+  declared_licenses_processed:
+    spdx_expression: "Unlicense"
+  description: "Self-contained, serverless, in-process SQL database engine."
+  homepage_url: "https://www.sqlite.org"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://sqlite.org/2024/sqlite-amalgamation-3450000.zip"
+    hash:
+      value: "bde30d13ebdf84926ddd5e8b6df145be03a577a48fd075a087a5dd815bcdf740"
+      algorithm: "SHA-256"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "Conan::zlib:1.3.1"
+  purl: "pkg:conan/zlib@1.3.1"
   declared_licenses:
   - "Zlib"
   declared_licenses_processed:
@@ -73,9 +290,9 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://zlib.net/fossils/zlib-1.2.12.tar.gz"
+    url: "https://zlib.net/fossils/zlib-1.3.1.tar.gz"
     hash:
-      value: "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
+      value: "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
       algorithm: "SHA-256"
   vcs:
     type: ""
@@ -85,6 +302,35 @@ packages:
   vcs_processed:
     type: ""
     url: ""
+    revision: ""
+    path: ""
+  is_modified: true
+- id: "Conan::zstd:1.5.5"
+  purl: "pkg:conan/zstd@1.5.5"
+  declared_licenses:
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+  description: "Zstandard - Fast real-time compression algorithm"
+  homepage_url: "https://github.com/facebook/zstd"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"
+    hash:
+      value: "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4"
+      algorithm: "SHA-256"
+  vcs:
+    type: "Git"
+    url: "https://github.com/facebook/zstd.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/facebook/zstd.git"
     revision: ""
     path: ""
   is_modified: true

--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Conan::poco:null"
+  id: "Conan::poco:"
   definition_file_path: "plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-py/conanfile.py"
   declared_licenses:
   - "BSL-1.0"

--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-py/conanfile.py.license
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-py/conanfile.py.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019 Conan.io

--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-py/lockfile.lock
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-py/lockfile.lock
@@ -2,32 +2,96 @@
  "graph_lock": {
   "nodes": {
    "0": {
-    "ref": "Poco/1.9.3",
-    "options": "cxx_14=False\nenable_apacheconnector=False\nenable_cppparser=False\nenable_crypto=True\nenable_data=True\nenable_data_mysql=False\nenable_data_odbc=False\nenable_data_sqlite=True\nenable_json=True\nenable_mongodb=True\nenable_net=True\nenable_netssl=True\nenable_netssl_win=True\nenable_pagecompiler=False\nenable_pagecompiler_file2page=False\nenable_pdf=False\nenable_pocodoc=False\nenable_redis=True\nenable_sevenzip=False\nenable_tests=False\nenable_util=True\nenable_xml=True\nenable_zip=True\nforce_openssl=True\npoco_unbundled=False\nshared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:enable_capieng=False\nopenssl:enable_weak_ssl_ciphers=False\nopenssl:no_aria=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_blake2=False\nopenssl:no_camellia=False\nopenssl:no_cast=False\nopenssl:no_chacha=False\nopenssl:no_cms=False\nopenssl:no_comp=False\nopenssl:no_ct=False\nopenssl:no_deprecated=False\nopenssl:no_des=False\nopenssl:no_dgram=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_ec=False\nopenssl:no_ecdh=False\nopenssl:no_ecdsa=False\nopenssl:no_engine=False\nopenssl:no_filenames=False\nopenssl:no_fips=False\nopenssl:no_gost=False\nopenssl:no_idea=False\nopenssl:no_legacy=False\nopenssl:no_md2=True\nopenssl:no_md4=False\nopenssl:no_mdc2=False\nopenssl:no_ocsp=False\nopenssl:no_pinshared=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rfc3779=False\nopenssl:no_rmd160=False\nopenssl:no_seed=False\nopenssl:no_sm2=False\nopenssl:no_sm3=False\nopenssl:no_sm4=False\nopenssl:no_sock=False\nopenssl:no_srp=False\nopenssl:no_srtp=False\nopenssl:no_sse2=False\nopenssl:no_ssl=False\nopenssl:no_ssl3=False\nopenssl:no_stdio=False\nopenssl:no_threads=False\nopenssl:no_tls1=False\nopenssl:no_ts=False\nopenssl:no_whirlpool=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nzlib:shared=False",
+    "ref": "poco/None",
+    "options": "enable_active_record=deprecated\nenable_activerecord=True\nenable_activerecord_compiler=False\nenable_apacheconnector=False\nenable_cppparser=False\nenable_crypto=True\nenable_data=True\nenable_data_mysql=True\nenable_data_odbc=False\nenable_data_postgresql=True\nenable_data_sqlite=True\nenable_encodings=True\nenable_fork=True\nenable_json=True\nenable_jwt=True\nenable_mongodb=True\nenable_net=True\nenable_netssl=True\nenable_pagecompiler=False\nenable_pagecompiler_file2page=False\nenable_pdf=False\nenable_pocodoc=False\nenable_prometheus=False\nenable_redis=True\nenable_sevenzip=False\nenable_util=True\nenable_xml=True\nenable_zip=True\nfPIC=True\nlog_debug=False\nshared=False\nwith_sql_parser=True\nbzip2:build_executable=True\nbzip2:fPIC=True\nbzip2:shared=False\nexpat:char_type=char\nexpat:fPIC=True\nexpat:large_size=False\nexpat:shared=False\nlibmysqlclient:fPIC=True\nlibmysqlclient:shared=False\nlibpq:disable_rpath=False\nlibpq:fPIC=True\nlibpq:shared=False\nlibpq:with_openssl=False\nlz4:fPIC=True\nlz4:shared=False\nopenssl:386=False\nopenssl:enable_trace=False\nopenssl:enable_weak_ssl_ciphers=False\nopenssl:fPIC=True\nopenssl:no_apps=False\nopenssl:no_aria=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_autoload_config=False\nopenssl:no_bf=False\nopenssl:no_blake2=False\nopenssl:no_camellia=False\nopenssl:no_cast=False\nopenssl:no_chacha=False\nopenssl:no_cms=False\nopenssl:no_comp=False\nopenssl:no_ct=False\nopenssl:no_deprecated=False\nopenssl:no_des=False\nopenssl:no_dgram=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_ec=False\nopenssl:no_ecdh=False\nopenssl:no_ecdsa=False\nopenssl:no_engine=False\nopenssl:no_filenames=False\nopenssl:no_fips=False\nopenssl:no_gost=False\nopenssl:no_idea=False\nopenssl:no_legacy=False\nopenssl:no_md2=True\nopenssl:no_md4=False\nopenssl:no_mdc2=False\nopenssl:no_module=False\nopenssl:no_ocsp=False\nopenssl:no_pinshared=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rfc3779=False\nopenssl:no_rmd160=False\nopenssl:no_seed=False\nopenssl:no_sm2=False\nopenssl:no_sm3=False\nopenssl:no_sm4=False\nopenssl:no_sock=False\nopenssl:no_srp=False\nopenssl:no_srtp=False\nopenssl:no_sse2=False\nopenssl:no_ssl=False\nopenssl:no_ssl3=False\nopenssl:no_stdio=False\nopenssl:no_threads=False\nopenssl:no_tls1=False\nopenssl:no_ts=False\nopenssl:no_whirlpool=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nopenssl:tls_security_level=None\npcre2:build_pcre2_16=True\npcre2:build_pcre2_32=True\npcre2:build_pcre2_8=True\npcre2:build_pcre2grep=True\npcre2:fPIC=True\npcre2:grep_support_callout_fork=True\npcre2:link_size=2\npcre2:shared=False\npcre2:support_jit=False\npcre2:with_bzip2=True\npcre2:with_zlib=True\nsqlite3:build_executable=True\nsqlite3:disable_gethostuuid=False\nsqlite3:enable_column_metadata=True\nsqlite3:enable_dbpage_vtab=False\nsqlite3:enable_dbstat_vtab=False\nsqlite3:enable_default_secure_delete=False\nsqlite3:enable_default_vfs=True\nsqlite3:enable_explain_comments=False\nsqlite3:enable_fts3=False\nsqlite3:enable_fts3_parenthesis=False\nsqlite3:enable_fts4=False\nsqlite3:enable_fts5=False\nsqlite3:enable_json1=False\nsqlite3:enable_math_functions=True\nsqlite3:enable_preupdate_hook=False\nsqlite3:enable_rtree=True\nsqlite3:enable_soundex=False\nsqlite3:enable_unlock_notify=True\nsqlite3:fPIC=True\nsqlite3:max_blob_size=None\nsqlite3:max_column=None\nsqlite3:max_variable_number=None\nsqlite3:omit_deprecated=False\nsqlite3:omit_load_extension=False\nsqlite3:shared=False\nsqlite3:threadsafe=1\nsqlite3:use_alloca=False\nsqlite3:use_uri=False\nzlib:fPIC=True\nzlib:shared=False\nzstd:build_programs=True\nzstd:fPIC=True\nzstd:shared=False\nzstd:threading=True",
     "requires": [
-     "1"
+     "1",
+     "2",
+     "4",
+     "5",
+     "6",
+     "7",
+     "8"
     ],
     "path": "conanfile.py",
     "context": "host"
    },
    "1": {
-    "ref": "openssl/3.0.0",
-    "options": "386=False\ncapieng_dialog=False\nenable_capieng=False\nenable_weak_ssl_ciphers=False\nno_aria=False\nno_asm=False\nno_async=False\nno_bf=False\nno_blake2=False\nno_camellia=False\nno_cast=False\nno_chacha=False\nno_cms=False\nno_comp=False\nno_ct=False\nno_deprecated=False\nno_des=False\nno_dgram=False\nno_dh=False\nno_dsa=False\nno_dso=False\nno_ec=False\nno_ecdh=False\nno_ecdsa=False\nno_engine=False\nno_filenames=False\nno_fips=False\nno_gost=False\nno_idea=False\nno_legacy=False\nno_md2=True\nno_md4=False\nno_mdc2=False\nno_ocsp=False\nno_pinshared=False\nno_rc2=False\nno_rc4=False\nno_rc5=False\nno_rfc3779=False\nno_rmd160=False\nno_seed=False\nno_sm2=False\nno_sm3=False\nno_sm4=False\nno_sock=False\nno_srp=False\nno_srtp=False\nno_sse2=False\nno_ssl=False\nno_ssl3=False\nno_stdio=False\nno_threads=False\nno_tls1=False\nno_ts=False\nno_whirlpool=False\nno_zlib=False\nopenssldir=None\nshared=False\nzlib:shared=False",
-    "package_id": "73fc7f3ed0faf0fd80110346c52171985a5794b4",
+    "ref": "pcre2/10.42",
+    "options": "build_pcre2_16=True\nbuild_pcre2_32=True\nbuild_pcre2_8=True\nbuild_pcre2grep=True\nfPIC=True\ngrep_support_callout_fork=True\nlink_size=2\nshared=False\nsupport_jit=False\nwith_bzip2=True\nwith_zlib=True\nbzip2:build_executable=True\nbzip2:fPIC=True\nbzip2:shared=False\nzlib:fPIC=True\nzlib:shared=False",
+    "package_id": "89b1a341654fffa9a2b737e1b6e52b42acec7462",
+    "requires": [
+     "2",
+     "3"
+    ],
+    "context": "host"
+   },
+   "2": {
+    "ref": "zlib/1.3.1",
+    "options": "fPIC=True\nshared=False",
+    "package_id": "2a19826344ff00be1c04403f2f8e7008ed3a7cc6",
+    "context": "host"
+   },
+   "3": {
+    "ref": "bzip2/1.0.8",
+    "options": "build_executable=True\nfPIC=True\nshared=False",
+    "package_id": "3cfc45772763dad1237052f26c1fe8b2bae3f7d2",
+    "context": "host"
+   },
+   "4": {
+    "ref": "expat/2.6.2",
+    "options": "char_type=char\nfPIC=True\nlarge_size=False\nshared=False",
+    "package_id": "a1ba772dbe13186199f7ecf8dde362ba9613ecf7",
+    "context": "host"
+   },
+   "5": {
+    "ref": "sqlite3/3.45.0",
+    "options": "build_executable=True\ndisable_gethostuuid=False\nenable_column_metadata=True\nenable_dbpage_vtab=False\nenable_dbstat_vtab=False\nenable_default_secure_delete=False\nenable_default_vfs=True\nenable_explain_comments=False\nenable_fts3=False\nenable_fts3_parenthesis=False\nenable_fts4=False\nenable_fts5=False\nenable_json1=False\nenable_math_functions=True\nenable_preupdate_hook=False\nenable_rtree=True\nenable_soundex=False\nenable_unlock_notify=True\nfPIC=True\nmax_blob_size=None\nmax_column=None\nmax_variable_number=None\nomit_deprecated=False\nomit_load_extension=False\nshared=False\nthreadsafe=1\nuse_alloca=False\nuse_uri=False",
+    "package_id": "668a23a956a1ae835b578205ecc8274cfd29ae40",
+    "context": "host"
+   },
+   "6": {
+    "ref": "openssl/3.3.1",
+    "options": "386=False\nenable_trace=False\nenable_weak_ssl_ciphers=False\nfPIC=True\nno_apps=False\nno_aria=False\nno_asm=False\nno_async=False\nno_autoload_config=False\nno_bf=False\nno_blake2=False\nno_camellia=False\nno_cast=False\nno_chacha=False\nno_cms=False\nno_comp=False\nno_ct=False\nno_deprecated=False\nno_des=False\nno_dgram=False\nno_dh=False\nno_dsa=False\nno_dso=False\nno_ec=False\nno_ecdh=False\nno_ecdsa=False\nno_engine=False\nno_filenames=False\nno_fips=False\nno_gost=False\nno_idea=False\nno_legacy=False\nno_md2=True\nno_md4=False\nno_mdc2=False\nno_module=False\nno_ocsp=False\nno_pinshared=False\nno_rc2=False\nno_rc4=False\nno_rc5=False\nno_rfc3779=False\nno_rmd160=False\nno_seed=False\nno_sm2=False\nno_sm3=False\nno_sm4=False\nno_sock=False\nno_srp=False\nno_srtp=False\nno_sse2=False\nno_ssl=False\nno_ssl3=False\nno_stdio=False\nno_threads=False\nno_tls1=False\nno_ts=False\nno_whirlpool=False\nno_zlib=False\nopenssldir=None\nshared=False\ntls_security_level=None\nzlib:fPIC=True\nzlib:shared=False",
+    "package_id": "772675ace4978e609416253f5f352cadffbfbb53",
     "requires": [
      "2"
     ],
     "context": "host"
    },
-   "2": {
-    "ref": "zlib/1.2.12",
-    "options": "shared=False",
-    "package_id": "7bc8c2c85db7a618e5320dc997f27fc33e1df074",
+   "7": {
+    "ref": "libpq/15.4",
+    "options": "disable_rpath=False\nfPIC=True\nshared=False\nwith_openssl=False",
+    "package_id": "2a19826344ff00be1c04403f2f8e7008ed3a7cc6",
+    "context": "host"
+   },
+   "8": {
+    "ref": "libmysqlclient/8.1.0",
+    "options": "fPIC=True\nshared=False\nlz4:fPIC=True\nlz4:shared=False\nopenssl:386=False\nopenssl:enable_trace=False\nopenssl:enable_weak_ssl_ciphers=False\nopenssl:fPIC=True\nopenssl:no_apps=False\nopenssl:no_aria=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_autoload_config=False\nopenssl:no_bf=False\nopenssl:no_blake2=False\nopenssl:no_camellia=False\nopenssl:no_cast=False\nopenssl:no_chacha=False\nopenssl:no_cms=False\nopenssl:no_comp=False\nopenssl:no_ct=False\nopenssl:no_deprecated=False\nopenssl:no_des=False\nopenssl:no_dgram=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_ec=False\nopenssl:no_ecdh=False\nopenssl:no_ecdsa=False\nopenssl:no_engine=False\nopenssl:no_filenames=False\nopenssl:no_fips=False\nopenssl:no_gost=False\nopenssl:no_idea=False\nopenssl:no_legacy=False\nopenssl:no_md2=True\nopenssl:no_md4=False\nopenssl:no_mdc2=False\nopenssl:no_module=False\nopenssl:no_ocsp=False\nopenssl:no_pinshared=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rfc3779=False\nopenssl:no_rmd160=False\nopenssl:no_seed=False\nopenssl:no_sm2=False\nopenssl:no_sm3=False\nopenssl:no_sm4=False\nopenssl:no_sock=False\nopenssl:no_srp=False\nopenssl:no_srtp=False\nopenssl:no_sse2=False\nopenssl:no_ssl=False\nopenssl:no_ssl3=False\nopenssl:no_stdio=False\nopenssl:no_threads=False\nopenssl:no_tls1=False\nopenssl:no_ts=False\nopenssl:no_whirlpool=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nopenssl:tls_security_level=None\nzlib:fPIC=True\nzlib:shared=False\nzstd:build_programs=True\nzstd:fPIC=True\nzstd:shared=False\nzstd:threading=True",
+    "package_id": "fa72dd8aafc989c2eefcb1d5933a7a6f312c1c1a",
+    "requires": [
+     "6",
+     "2",
+     "9",
+     "10"
+    ],
+    "context": "host"
+   },
+   "9": {
+    "ref": "zstd/1.5.5",
+    "options": "build_programs=True\nfPIC=True\nshared=False\nthreading=True",
+    "package_id": "1b177e416597e90db2922415c5ce0fe8e7df6e75",
+    "context": "host"
+   },
+   "10": {
+    "ref": "lz4/1.9.4",
+    "options": "fPIC=True\nshared=False",
+    "package_id": "2a19826344ff00be1c04403f2f8e7008ed3a7cc6",
     "context": "host"
    }
   },
   "revisions_enabled": false
  },
  "version": "0.4",
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=gcc\ncompiler.libcxx=libstdc++\ncompiler.version=6.3\nos=Windows\nos_build=Windows\n[options]\n[build_requires]\n[env]\n"
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=gcc\ncompiler.libcxx=libstdc++\ncompiler.version=12\nos=Linux\nos_build=Linux\n[options]\n[build_requires]\n[env]\n"
 }

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -32,6 +32,7 @@ import java.io.File
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -334,7 +335,9 @@ class Conan(
             }
         }
 
-        return results[field]?.jsonPrimitive?.content
+        // Note that while the console output of "conan inspect" uses "None" for absent values, the JSON output actually
+        // uses null values.
+        return results[field]?.jsonPrimitive?.contentOrNull
     }
 
     /**


### PR DESCRIPTION
This change is a (not strictly needed) preparation for Conan 2.x support in ORT.

Updating the Poco recipe to the current version offered by the Conan Center Index allows it to work with both, version 1.x and 2.x of Conan.

The lock file has been created using Conan version 1.64.1:

```shell
rm -rf ~/.conan/data
conan lock create --lockfile-out lockfile.lock conanfile.py
```

Conan Center Index: https://github.com/conan-io/conan-center-index
Commit: f78dc3729f97c1554eae5f3843cabb2e2198c09a