### PR TITLE
build(Gradle): Use the new way to opt-in to build scan terms

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,9 +67,11 @@ idea {
     }
 }
 
-extensions.findByName("buildScan")?.withGroovyBuilder {
-    setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
-    setProperty("termsOfServiceAgree", "yes")
+extensions.findByName("develocity")?.withGroovyBuilder {
+    getProperty("buildScan")?.withGroovyBuilder {
+        setProperty("termsOfUseUrl", "https://gradle.com/terms-of-service")
+        setProperty("termsOfUseAgree", "yes")
+    }
 }
 
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {


### PR DESCRIPTION
This gets rid of the

    The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has
    been replaced by "develocity.buildScan.termsOfUseUrl"

deprecation warning when running a Gradle build scan.