### PR TITLE
test: Disable scanning for Kotest project config in third-party JARs

### DIFF
--- a/utils/test/src/main/resources/kotest.properties
+++ b/utils/test/src/main/resources/kotest.properties
@@ -18,3 +18,4 @@
 kotest.framework.classpath.scanning.autoscan.disable = true
 kotest.framework.classpath.scanning.config.disable = true
 kotest.framework.config.fqn = org.ossreviewtoolkit.utils.test.ProjectConfig
+kotest.framework.discovery.jar.scan.disable = true


### PR DESCRIPTION
This should reduce test startup times yet more, see [1].

[1]: https://kantis.github.io/posts/Faster-Kotest-startup/