### PR TITLE
chore(package-managers): Do not log all Gradle `stderr` output as warnings

### DIFF
--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
@@ -188,7 +188,7 @@ class GradleInspector(
             }
 
             if (stderr.size() > 0) {
-                logger.warn {
+                logger.debug {
                     "Analyzing the project in '$projectDir' produced the following error output:\n" +
                         stderr.toString().prependIndent("\t")
                 }

--- a/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
@@ -241,7 +241,7 @@ class Gradle(
                 }
 
                 if (stderr.size() > 0) {
-                    logger.warn {
+                    logger.debug {
                         "Analyzing the project in '$projectDir' produced the following error output:\n" +
                             stderr.toString().prependIndent("\t")
                     }


### PR DESCRIPTION
Not everything that Gradle outputs to `stderr` is a warning in the sense that results are wrong or something needs to be done. Avoid some potential confusion by only logging `stderr` output at `debug` level, which aligns with logging of `stdout` output.