### PR TITLE
fix(analyzer): Re-align the version requirement for pnpm

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/Pnpm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Pnpm.kt
@@ -63,7 +63,7 @@ class Pnpm(
 
     override fun command(workingDir: File?) = if (Os.isWindows) "pnpm.cmd" else "pnpm"
 
-    override fun getVersionRequirement(): RangesList = RangesListFactory.create("5.* - 8.*")
+    override fun getVersionRequirement(): RangesList = RangesListFactory.create("5.* - 9.*")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>) =
         NpmDetection(definitionFiles).filterApplicable(NodePackageManager.PNPM)


### PR DESCRIPTION
Pnpm has been upgrade to version 9.x without updating the version requirement, see [1].

[1] afdd4fa09b5cd7da7606b6b6980000457391dd65

