### PR TITLE
fix(github): Be explicit about artifact paths to attest for

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,5 +59,7 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: |
-            ./cli/build/distributions/ort-$ORT_VERSION.{tgz,zip}*
-            ./helper-cli/build/distributions/orth-$ORT_VERSION.{tgz,zip}*
+            ./cli/build/distributions/ort-$ORT_VERSION.tgz
+            ./cli/build/distributions/ort-$ORT_VERSION.zip
+            ./helper-cli/build/distributions/orth-$ORT_VERSION.tgz
+            ./helper-cli/build/distributions/orth-$ORT_VERSION.zip


### PR DESCRIPTION
Work-around [1] and only attest the main artifacts, not the signature files.

[1]: https://github.com/actions/attest-build-provenance/issues/133