### PR TITLE
fix(Bazel): Fix local registry modules path

### DIFF
--- a/clients/bazel-module-registry/src/main/kotlin/LocalBazelModuleRegistryService.kt
+++ b/clients/bazel-module-registry/src/main/kotlin/LocalBazelModuleRegistryService.kt
@@ -24,11 +24,14 @@ import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.decodeFromStream
 
+private const val BAZEL_MODULES_DIR = "modules"
+
 /**
  * A Bazel registry which is located on the local file system.
  */
 class LocalBazelModuleRegistryService(directory: File) : BazelModuleRegistryService {
     private val moduleDirectory: File
+    private val bazelRegistry: BazelRegistry
 
     init {
         val registryFile = directory.resolve("bazel_registry.json")
@@ -37,11 +40,11 @@ class LocalBazelModuleRegistryService(directory: File) : BazelModuleRegistryServ
             "The Bazel registry file bazel_registry.json does not exist in '${directory.canonicalPath}'."
         }
 
-        val bazelRegistry = registryFile.inputStream().use {
+        bazelRegistry = registryFile.inputStream().use {
             JSON.decodeFromStream<BazelRegistry>(it)
         }
 
-        moduleDirectory = registryFile.resolve(bazelRegistry.moduleBasePath)
+        moduleDirectory = registryFile.resolveSibling(BAZEL_MODULES_DIR)
     }
 
     override suspend fun getModuleMetadata(name: String): ModuleMetadata {


### PR DESCRIPTION
Bazel modules are always in a 'modules' directory alongside the `bazel_registry.json` file. See [1].

The latter is still parsed and will be used in a future commit to handle modules with type 'local_path'.

This is a fixup for 59681807ea5c4ab9f468e783f2bdb7fa1de5dd30.

[1]: https://bazel.build/external/registry#index_registry