### PR TITLE
fix(spdx): Avoid serializing the document into a string

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -94,10 +94,10 @@ class SpdxDocumentReporter : Reporter {
         }
 
         return outputFileFormats.map { fileFormat ->
-            val serializedDocument = fileFormat.mapper.writeValueAsString(spdxDocument)
-
             outputDir.resolve("$REPORT_BASE_FILENAME.${fileFormat.fileExtension}").apply {
-                bufferedWriter().use { it.write(serializedDocument) }
+                bufferedWriter().use { writer ->
+                    fileFormat.mapper.writeValue(writer, spdxDocument)
+                }
             }
         }
     }


### PR DESCRIPTION
For large documents this can result in an out of memory error, such as [1].

Fixes: #8829.

[1]: `UTF16 String size is [..], should be less than 1073741823`
