### PR TITLE
fix(github): Do not use variables as part of attestation subject paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: |
-            ./cli/build/distributions/ort-$ORT_VERSION.tgz
-            ./cli/build/distributions/ort-$ORT_VERSION.zip
-            ./helper-cli/build/distributions/orth-$ORT_VERSION.tgz
-            ./helper-cli/build/distributions/orth-$ORT_VERSION.zip
+            ./cli/build/distributions/ort-*.tgz
+            ./cli/build/distributions/ort-*.zip
+            ./helper-cli/build/distributions/orth-*.tgz
+            ./helper-cli/build/distributions/orth-*.zip


### PR DESCRIPTION
Work around another restriction of the build attestation action, see [1].

[1]: https://github.com/actions/attest-build-provenance/issues/146