### PR TITLE
fix(github): Use correct syntax for environment variable expansion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: |
-            ./cli/build/distributions/ort-*.tgz
-            ./cli/build/distributions/ort-*.zip
-            ./helper-cli/build/distributions/orth-*.tgz
-            ./helper-cli/build/distributions/orth-*.zip
+            ./cli/build/distributions/ort-${{ env.ORT_VERSION }}.tgz
+            ./cli/build/distributions/ort-${{ env.ORT_VERSION }}.zip
+            ./helper-cli/build/distributions/orth-${{ env.ORT_VERSION }}.tgz
+            ./helper-cli/build/distributions/orth-${{ env.ORT_VERSION }}.zip


### PR DESCRIPTION
This is a fixup for 3f8f078.