### PR TITLE
ci(github): Move Scorecard analysis to a separate workflow

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -1,0 +1,35 @@
+name: Scorecard Analysis
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  scorecard-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for SARIF scanning upload.
+      security-events: write
+      # Needed for GitHub OIDC token if `publish_results` is true.
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Run Analysis
+        uses: ossf/scorecard-action@v2.3.3
+        with:
+          results_file: ossf-results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload Code Scanning Results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ossf-results.sarif

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -114,25 +114,3 @@ jobs:
       run: |
         pip install --user reuse
         ~/.local/bin/reuse lint
-  scorecard-analysis:
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed for SARIF scanning upload.
-      security-events: write
-      # Needed for GitHub OIDC token if `publish_results` is true.
-      id-token: write
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - name: Run Analysis
-      uses: ossf/scorecard-action@v2.3.3
-      with:
-        results_file: ossf-results.sarif
-        results_format: sarif
-        publish_results: true
-    - name: Upload Code Scanning Results
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: ossf-results.sarif


### PR DESCRIPTION
The Scorecard action does not work properly with workflows that define global environment variables [1], so move the job to its own workflow.

[1]: https://github.com/ossf/scorecard-action#workflow-restrictions