### PR TITLE
ci(renovate): Automatically pin GitHub action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     "docker:disable",
+    "helpers:pinGitHubActionDigests",
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)"
   ],


### PR DESCRIPTION
This should silence OpenSSF Scorecard's warnings about a "GitHubAction not pinned by hash".