### PR TITLE
 fix(downloader): Support Git URLs with ".git" in domain

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -318,7 +318,7 @@ enum class VcsHost(
         private val SVN_BRANCH_OR_TAG_PATTERN = Regex("(.*svn.*)/(branches|tags)/([^/]+)/?(.*)")
         private val SVN_TRUNK_PATTERN = Regex("(.*svn.*)/(trunk)/?(.*)")
         private val GIT_REVISION_FRAGMENT = Regex("git.+#[a-fA-F0-9]{7,}")
-        private val GIT_PROJECT_NAME = Regex("/([^/]+)\\.git")
+        private val GIT_PROJECT_NAME = Regex("/([^/]+)\\.git$")
 
         /**
          * Return the applicable [VcsHost] for the given [url], or null if no applicable host is found.

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -511,6 +511,10 @@ class VcsHostTest : WordSpec({
             VcsHost.getProject("ssh://git@gitlab.custom.com:group/project.git") shouldBe "project"
         }
 
+        "work for a generic URL with .git twice to a Git repository" {
+            VcsHost.getProject("ssh://git@internal.gitlab.custom.com:group/project.git") shouldBe "project"
+        }
+
         "handle an unknown URL" {
             VcsHost.fromUrl("https://host.tld/path/to/repo") should beNull()
         }


### PR DESCRIPTION
I noticed that generic handling of VCS hosts fails sometimes. For example `VcsHost.getProject("ssh://git@internal.gitlab.custom.com/group/project.git")` returns `git@internal` because domain contains `.gitlab`.

I changed regex search to consider only the `.git` at the end.
