### PR TITLE
fix(sbt): Filter out garbage from sbt projects command

### DIFF
--- a/plugins/package-managers/sbt/src/main/kotlin/Sbt.kt
+++ b/plugins/package-managers/sbt/src/main/kotlin/Sbt.kt
@@ -210,7 +210,7 @@ class Sbt(
 private const val SBT_VERSION_PATTERN = "\\d(\\.\\d+){2}(-\\w+)?"
 
 private val VERSION_REGEX = Regex("\\[info]\\s+($SBT_VERSION_PATTERN)")
-private val PROJECT_REGEX = Regex("\\[info] \t [ *] (.+)")
+private val PROJECT_REGEX = Regex("\\[info] \t [ *] (\\S+)")
 private val POM_REGEX = Regex("\\[info] Wrote (.+\\.pom)")
 
 // Batch mode (which suppresses interactive prompts) is not supported on Windows, compare


### PR DESCRIPTION
`sbt projects` was outputting extra lines, which ORT confused as projects

```
[info] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[info] 	* net.java.dev.jna:jna:5.6.0 is selected over {4.5.0, 4.5.0}
[info] 	    +- io.methvin:directory-watcher:0.10.1                (depends on 5.6.0)
[info] 	    +- org.scala-sbt:io_2.12:1.2.2                        (depends on 4.5.0)
[info] 	    +- net.java.dev.jna:jna-platform:4.5.0                (depends on 4.5.0)
```

Project names cannot contain spaces, so using `\S+` (One or more Non-whitespace characters) fixed the issue.