### PR TITLE
fix(gradle): Ignore `dependencySources` configurations during resolution

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
@@ -50,7 +50,11 @@ internal fun Configuration.isRelevant(): Boolean {
     // https://gist.github.com/h0tk3y/41c73d1f822378f52f1e6cce8dcf56aa for some background information.
     val isDependenciesMetadata = name.endsWith("DependenciesMetadata")
 
-    return canBeResolved && !isDeprecatedConfiguration && !isDependenciesMetadata
+    // Ignore Kotlin Multiplatform Project configurations for resolving source files because by nature not every
+    // published library has sources variants that can be resolved.
+    val isDependencySources = name == "dependencySources" || name.endsWith("DependencySources")
+
+    return canBeResolved && !isDeprecatedConfiguration && !isDependenciesMetadata && !isDependencySources
 }
 
 /**


### PR DESCRIPTION
See [1] for how Kotlin itself ignores the resolution of `dependencySources` configurations. Also, Kotlin 2.0.20 will fix the issue by using detachable vari9ants instead [2].

Fixes #8755.

[1]: https://github.com/JetBrains/kotlin/commit/73b290a94831a1aee547c99ab319fafc311864d7#diff-13384ab95f3c49314bc7e8d26b20c8981d5c514272bbd8c20130b9761be57fb6R724-R729
[2]: https://github.com/JetBrains/kotlin/commit/659a6fbea22557c59f097acc94ec7f99f95e0bf6