### PR TITLE
chore(cocoapods): Generalize mapping IDs to packages

### DIFF
--- a/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
@@ -116,7 +116,7 @@ class CocoaPods(
             val lockfileData = parseLockfile(lockfile)
 
             scopes += Scope(SCOPE_NAME, lockfileData.dependencies)
-            packages += scopes.flatMap { it.collectDependencies() }.map {
+            packages += scopes.flatMapTo(mutableSetOf()) { it.collectDependencies() }.map {
                 lockfileData.packagesFromCheckoutOptionsForId[it] ?: getPackage(it, workingDir)
             }
         } else {


### PR DESCRIPTION
The code suggests that it works for any amount of scopes, while it may produce duplicates in case `scopes` contains more than one element. Avoid any duplicates by mapping the IDs into a set.
