### PR TITLE
build(gradle): Add a "detektAll" convenience task

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,9 +47,7 @@ jobs:
       with:
         gradle-home-cache-cleanup: true
     - name: Check for Detekt Issues
-      run: ./gradlew detekt
-    - name: Check for Detekt Issues with type resolution
-      run: ./gradlew detektMain detektTestFixtures detektTest detektFunTest
+      run: ./gradlew detektAll
     - name: Upload SARIF File
       uses: github/codeql-action/upload-sarif@4fa2a7953630fd2f3fb380f21be14ede0169dd4f # v3
       if: always() # Upload even if the previous step failed.

--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -131,10 +131,13 @@ val mergeDetektReports = if (rootProject.tasks.findByName(mergeDetektReportsTask
     }
 }
 
+val detekt = tasks.named<Detekt>("detekt")
+
 tasks.withType<Detekt>().configureEach detekt@{
     jvmTarget = maxKotlinJvmTarget.target
 
     dependsOn(":detekt-rules:assemble")
+    if (this != detekt.get()) mustRunAfter(detekt)
 
     exclude {
         "/build/generated/" in it.file.absolutePath
@@ -158,6 +161,10 @@ tasks.withType<Detekt>().configureEach detekt@{
     }
 
     finalizedBy(mergeDetektReports)
+}
+
+tasks.register("detektAll") {
+    dependsOn(tasks.withType<Detekt>())
 }
 
 tasks.withType<KotlinCompile>().configureEach {


### PR DESCRIPTION
Ensure that Detekt tasks with type resolution do not run in parallel with the default "detekt" task to avoid problems as mentioned in 3c20400.