### PR TITLE
build(gradle): Prepare for eventually using `atlassian.io` artifacts

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -26,7 +26,7 @@ repositories {
         }
 
         filter {
-            includeGroupByRegex("com\\.atlassian\\..*")
+            includeGroupByRegex("(com|io)\\.atlassian\\..*")
             includeVersionByRegex("log4j", "log4j", ".*-atlassian-.*")
         }
     }


### PR DESCRIPTION
This eliminates a source of failure when eventually migration to the Jira REST API client version 6.