### PR TITLE
refactor: Prefer KxS's string API over the stream API

### DIFF
--- a/clients/bazel-module-registry/src/main/kotlin/LocalBazelModuleRegistryService.kt
+++ b/clients/bazel-module-registry/src/main/kotlin/LocalBazelModuleRegistryService.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.clients.bazelmoduleregistry
 import java.io.File
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.decodeFromStream
 
 private const val BAZEL_MODULES_DIR = "modules"
 
@@ -40,27 +39,20 @@ class LocalBazelModuleRegistryService(directory: File) : BazelModuleRegistryServ
             "The Bazel registry file bazel_registry.json does not exist in '${directory.canonicalPath}'."
         }
 
-        bazelRegistry = registryFile.inputStream().use {
-            JSON.decodeFromStream<BazelRegistry>(it)
-        }
-
+        bazelRegistry = JSON.decodeFromString<BazelRegistry>(registryFile.readText())
         moduleDirectory = registryFile.resolveSibling(BAZEL_MODULES_DIR)
     }
 
     override suspend fun getModuleMetadata(name: String): ModuleMetadata {
         val metadataJson = moduleDirectory.resolve(name).resolve("metadata.json")
         require(metadataJson.isFile)
-        return metadataJson.inputStream().use {
-            JSON.decodeFromStream<ModuleMetadata>(it)
-        }
+        return JSON.decodeFromString<ModuleMetadata>(metadataJson.readText())
     }
 
     override suspend fun getModuleSourceInfo(name: String, version: String): ModuleSourceInfo {
         val sourceJson = moduleDirectory.resolve(name).resolve(version).resolve("source.json")
         require(sourceJson.isFile)
-        return sourceJson.inputStream().use {
-            JSON.decodeFromStream<ModuleSourceInfo>(it)
-        }
+        return JSON.decodeFromString<ModuleSourceInfo>(sourceJson.readText())
     }
 }
 

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -32,20 +32,17 @@ import io.kotest.matchers.string.include
 import io.kotest.matchers.string.shouldStartWith
 
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.decodeFromStream
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
-import org.ossreviewtoolkit.utils.test.getAssetFile
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class ClearlyDefinedServiceFunTest : WordSpec({
     "A contribution patch" should {
         "be correctly deserialized when using empty facet arrays" {
             // See https://github.com/clearlydefined/curated-data/blob/0b2db78/curations/maven/mavencentral/com.google.code.gson/gson.yaml#L10-L11.
-            val curation = getAssetFile("gson.json").inputStream().use {
-                ClearlyDefinedService.JSON.decodeFromStream<Curation>(it)
-            }
+            val curation = ClearlyDefinedService.JSON.decodeFromString<Curation>(getAssetAsString("gson.json"))
 
             curation.described?.facets?.dev.shouldNotBeNull() should beEmpty()
             curation.described?.facets?.tests.shouldNotBeNull() should beEmpty()

--- a/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
+++ b/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
@@ -85,7 +85,7 @@ private const val BUNDLER_GEM_NAME = "bundler"
 internal const val BUNDLER_LOCKFILE_NAME = "Gemfile.lock"
 
 // TODO: Remove this again once available upstream.
-private inline fun <reified T> Yaml.decodeFromString(string: String): T = decodeFromString(serializer<T>(), string)
+internal inline fun <reified T> Yaml.decodeFromString(string: String): T = decodeFromString(serializer<T>(), string)
 
 private fun runScriptCode(code: String, workingDir: File? = null): String {
     val bytes = ByteArrayOutputStream()

--- a/plugins/package-managers/bundler/src/test/kotlin/BundlerTest.kt
+++ b/plugins/package-managers/bundler/src/test/kotlin/BundlerTest.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.bundler
 
-import com.charleskorn.kaml.decodeFromStream
-
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.shouldBe
@@ -60,9 +58,7 @@ class BundlerTest : WordSpec({
     "createFromGem()" should {
         "parse YAML metadata for a Gem correctly" {
             val rubyGemsFile = File("src/test/assets/rspec-3.7.0.yaml")
-            val details = rubyGemsFile.inputStream().use {
-                YAML.decodeFromStream<VersionDetails>(it)
-            }
+            val details = YAML.decodeFromString<VersionDetails>(rubyGemsFile.readText())
 
             val gemInfo = GemInfo.createFromGem(details)
 

--- a/plugins/package-managers/go/src/main/kotlin/GoMod.kt
+++ b/plugins/package-managers/go/src/main/kotlin/GoMod.kt
@@ -24,7 +24,6 @@ import java.io.File
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.decodeToSequence
 
 import org.apache.logging.log4j.kotlin.logger
@@ -443,7 +442,7 @@ private fun ModuleInfo.toSourceArtifact(): RemoteArtifact {
 private fun ModuleInfo.toVcsInfo(): VcsInfo? {
     val escapedVersion = escapeModuleVersion(version)
     val infoFile = goMod?.let { File(it).resolveSibling("$escapedVersion.info") } ?: return null
-    val info = infoFile.inputStream().use { JSON.decodeFromStream<ModuleInfoFile>(it) }
+    val info = JSON.decodeFromString<ModuleInfoFile>(infoFile.readText())
     val type = info.origin.vcs?.let { VcsType.forName(it) }.takeIf { it == VcsType.GIT } ?: return null
 
     return VcsInfo(

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspector.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspector.kt
@@ -24,7 +24,6 @@ import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
-import kotlinx.serialization.json.decodeFromStream
 
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
@@ -66,7 +65,7 @@ internal object NuGetInspector : CommandLineTool {
 
         return try {
             run(workingDir, *commandLineOptions.toTypedArray())
-            outputFile.inputStream().use { json.decodeFromStream(it) }
+            json.decodeFromString(outputFile.readText())
         } finally {
             workingDir.resolve(".cache").safeDeleteRecursively(force = true)
             outputFile.parentFile.safeDeleteRecursively(force = true)

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
@@ -25,7 +25,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
-import kotlinx.serialization.json.decodeFromStream
 
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
@@ -91,7 +90,7 @@ internal object PythonInspector : CommandLineTool {
 
         return try {
             run(workingDir, *commandLineOptions.toTypedArray())
-            outputFile.inputStream().use { json.decodeFromStream(it) }
+            json.decodeFromString(outputFile.readText())
         } finally {
             outputFile.parentFile.safeDeleteRecursively(force = true)
         }

--- a/plugins/reporters/ctrlx/src/funTest/kotlin/CtrlXAutomationReporterFunTest.kt
+++ b/plugins/reporters/ctrlx/src/funTest/kotlin/CtrlXAutomationReporterFunTest.kt
@@ -26,17 +26,14 @@ import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 
-import kotlinx.serialization.json.decodeFromStream
-
 import org.ossreviewtoolkit.plugins.reporters.ctrlx.CtrlXAutomationReporter.Companion.REPORT_FILENAME
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
-import org.ossreviewtoolkit.utils.test.getAssetFile
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class CtrlXAutomationReporterFunTest : StringSpec({
     "The official sample file can be deserialized" {
-        val fossInfoFile = getAssetFile("sample.fossinfo.json")
-        val fossInfo = fossInfoFile.inputStream().use { CtrlXAutomationReporter.JSON.decodeFromStream<FossInfo>(it) }
+        val fossInfo = CtrlXAutomationReporter.JSON.decodeFromString<FossInfo>(getAssetAsString("sample.fossinfo.json"))
 
         fossInfo.components shouldNotBeNull {
             this should haveSize(8)

--- a/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationReporter.kt
+++ b/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationReporter.kt
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.plugins.reporters.ctrlx
 
 import java.io.File
 
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToStream
 
 import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseView
@@ -89,7 +89,7 @@ class CtrlXAutomationReporter : Reporter {
         }
 
         val info = FossInfo(components = components)
-        reportFile.outputStream().use { JSON.encodeToStream(info, it) }
+        reportFile.writeText(JSON.encodeToString(info))
 
         return listOf(reportFile)
     }

--- a/plugins/reporters/trustsource/src/main/kotlin/TrustSourceReporter.kt
+++ b/plugins/reporters/trustsource/src/main/kotlin/TrustSourceReporter.kt
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.plugins.reporters.trustsource
 
 import java.io.File
 
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToStream
 
 import org.ossreviewtoolkit.model.DependencyNode
 import org.ossreviewtoolkit.model.config.PluginConfiguration
@@ -48,7 +48,7 @@ class TrustSourceReporter : Reporter {
             NewScan(module = project.id.name, dependencies = deps)
         }
 
-        outputFile.outputStream().use { JSON.encodeToStream(scans, it) }
+        outputFile.writeText(JSON.encodeToString(scans))
 
         return listOf(outputFile)
     }

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -30,8 +30,6 @@ import io.kotest.matchers.should
 import java.io.File
 import java.time.Instant
 
-import kotlinx.serialization.json.decodeFromStream
-
 import org.ossreviewtoolkit.clients.scanoss.FullScanResponse
 import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.CopyrightFinding
@@ -47,9 +45,9 @@ import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 class ScanOssResultParserTest : WordSpec({
     "generateSummary()" should {
         "properly summarize JUnit 4.12 findings" {
-            val result = File("src/test/assets/scanoss-junit-4.12.json").inputStream().use {
-                ScanOssService.JSON.decodeFromStream<FullScanResponse>(it)
-            }
+            val result = ScanOssService.JSON.decodeFromString<FullScanResponse>(
+                File("src/test/assets/scanoss-junit-4.12.json").readText()
+            )
 
             val time = Instant.now()
             val summary = generateSummary(time, time, result)
@@ -85,9 +83,9 @@ class ScanOssResultParserTest : WordSpec({
         }
 
         "properly summarize Semver4j 3.1.0 with snippet findings" {
-            val result = File("src/test/assets/scanoss-semver4j-3.1.0-with-snippet.json").inputStream().use {
-                ScanOssService.JSON.decodeFromStream<FullScanResponse>(it)
-            }
+            val result = ScanOssService.JSON.decodeFromString<FullScanResponse>(
+                File("src/test/assets/scanoss-semver4j-3.1.0-with-snippet.json").readText()
+            )
 
             val time = Instant.now()
             val summary = generateSummary(time, time, result)


### PR DESCRIPTION
The string API is generally considered to be faster, see e.g. [1] and [2].

[1]: https://github.com/Kotlin/kotlinx.serialization/issues/2186
[2]: https://github.com/Kotlin/kotlinx.serialization/issues/2657#issuecomment-2090482006