### PR TITLE
docs(README): Reword the contribution section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,5 +1,5 @@
 ---
-name: Bug Report
+name: Bug Report 🐞
 about: I want to report a bug that I am facing.
 title: ''
 labels: ['bug', 'to triage']

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-- name: Discuss an Idea
+- name: Discuss an Idea 💡
   about: Start a discussion or ask a longer question.
   url: https://github.com/oss-review-toolkit/ort/discussions
-- name: Ask a Question
+- name: Ask a Question 🤔
   about: Ask a quick question or just chat with the ORT community.
   url: http://slack.oss-review-toolkit.org/

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,5 +1,5 @@
 ---
-name: Enhancement Proposal
+name: Enhancement Proposal ⚡
 about: I want to propose to enhance existing functionality.
 title: ''
 labels: ['enhancement', 'to triage']

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,5 +1,5 @@
 ---
-name: Feature Request
+name: Feature Request 🎉
 about: I want to request a new feature that I find useful.
 title: ''
 labels: ['new feature', 'to triage']

--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Depending on how ORT was installed, it can be run in the following ways:
 
   Note that in this case the working directory used by ORT is that of the `cli` project, not the directory `gradlew` is located in (see https://github.com/gradle/gradle/issues/6074).
 
-# Want to Help or have Questions?
+# Contributing
 
 All contributions are welcome.
-If you are interested in contributing, please read our [contributing guide](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md).
-To get quick answers to any of your questions, we recommend you [join our Slack community][2].
+If you are interested in contributing code, please read our [contributing guide](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md).
+For everything from reporting bugs to asking questions, please go through the [issue workflow](https://github.com/oss-review-toolkit/ort/issues/new/choose).
 
 # License
 


### PR DESCRIPTION
Distinguish more clearly between code and non-code contributions and not only point out the community's Slack workspace, but all channels linked from the issue workflow.