### PR TITLE
Bazel multi registries

### DIFF
--- a/clients/bazel-module-registry/src/main/kotlin/RemoteBazelModuleRegistryService.kt
+++ b/clients/bazel-module-registry/src/main/kotlin/RemoteBazelModuleRegistryService.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.clients.bazelmoduleregistry
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 
+import org.apache.logging.log4j.kotlin.logger
+
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.http.GET
@@ -46,9 +48,13 @@ interface RemoteBazelModuleRegistryService : BazelModuleRegistryService {
             val bmrClient = client ?: OkHttpClient()
 
             val contentType = "application/json".toMediaType()
+            val baseUrl = url ?: DEFAULT_URL
+
+            logger.info { "Creating remote Bazel module registry at '$baseUrl'." }
+
             val retrofit = Retrofit.Builder()
                 .client(bmrClient)
-                .baseUrl(url ?: DEFAULT_URL)
+                .baseUrl(baseUrl)
                 .addConverterFactory(JSON.asConverterFactory(contentType))
                 .build()
 

--- a/plugins/package-managers/bazel/build.gradle.kts
+++ b/plugins/package-managers/bazel/build.gradle.kts
@@ -45,5 +45,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.kotlinx.serialization.json)
 
+    testImplementation(libs.mockk)
+
     funTestImplementation(testFixtures(projects.analyzer))
 }

--- a/plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-expected-output-local-registry.yml
+++ b/plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-expected-output-local-registry.yml
@@ -33,25 +33,25 @@ packages:
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
-  homepage_url: ""
+  homepage_url: "https://gflags.github.io/gflags/"
   binary_artifact:
     url: ""
     hash:
       value: ""
       algorithm: ""
   source_artifact:
-    url: ""
+    url: "https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz"
     hash:
-      value: ""
-      algorithm: ""
+      value: "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf"
+      algorithm: "SHA-256"
   vcs:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://github.com/gflags/gflags"
     revision: ""
     path: ""
   vcs_processed:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://github.com/gflags/gflags.git"
     revision: ""
     path: ""
 - id: "Bazel::glog:0.5.0"
@@ -59,25 +59,25 @@ packages:
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
-  homepage_url: ""
+  homepage_url: "https://github.com/google/glog"
   binary_artifact:
     url: ""
     hash:
       value: ""
       algorithm: ""
   source_artifact:
-    url: ""
+    url: "https://github.com/google/glog/archive/refs/tags/v0.5.0.tar.gz"
     hash:
-      value: ""
-      algorithm: ""
+      value: "eede71f28371bf39aa69b45de23b329d37214016e2055269b3b5e7cfd40b59f5"
+      algorithm: "SHA-256"
   vcs:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://github.com/google/glog"
     revision: ""
     path: ""
   vcs_processed:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://github.com/google/glog.git"
     revision: ""
     path: ""
 - id: "Bazel::test_module:0.0.1"

--- a/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
@@ -143,10 +143,7 @@ class Bazel(
     private fun determineRegistry(lockfile: Lockfile, projectDir: File): BazelModuleRegistryService {
         // Bazel version < 7.2.0.
         if (lockfile.flags != null) {
-            val registryUrl = lockfile.registryUrl()
-
-            return LocalBazelModuleRegistryService.createForLocalUrl(registryUrl, projectDir)
-                ?: RemoteBazelModuleRegistryService.create(registryUrl)
+            return MultiBazelModuleRegistryService.create(lockfile.registryUrls(), projectDir)
         }
 
         // Bazel version >= 7.2.0.

--- a/plugins/package-managers/bazel/src/main/kotlin/BazelModel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/BazelModel.kt
@@ -43,8 +43,11 @@ internal data class Lockfile(
         }
     }
 
-    // TODO Support multiple registries.
-    fun registryUrl(): String? = flags?.cmdRegistries?.getOrElse(0) { null }
+    /**
+     * Return a collection with the URLs of the service registries defined for this project in case the model for
+     * Bazel < 7.2.0 is used.
+     */
+    fun registryUrls(): Collection<String> = flags?.cmdRegistries.orEmpty()
 }
 
 @Serializable

--- a/plugins/package-managers/bazel/src/main/kotlin/MultiBazelModuleRegistryService.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/MultiBazelModuleRegistryService.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.bazel
+
+import java.io.File
+
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.BazelModuleRegistryService
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.LocalBazelModuleRegistryService
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.ModuleMetadata
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.ModuleSourceInfo
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.RemoteBazelModuleRegistryService
+
+/**
+ * A special implementation of [BazelModuleRegistryService] that wraps an arbitrary number of other
+ * [BazelModuleRegistryService] instances. It can be used for projects that declare multiple registries.
+ *
+ * The functions of the interface are implemented by iterating over the wrapped services and returning the first
+ * successful result.
+ */
+internal class MultiBazelModuleRegistryService(
+    /** The wrapped [BazelModuleRegistryService] instances. */
+    private val registryServices: Collection<BazelModuleRegistryService>
+) : BazelModuleRegistryService {
+    companion object {
+        /**
+         * Create an instance of [MultiBazelModuleRegistryService] for the given [registryUrls]. Based on the URLs,
+         * concrete [BazelModuleRegistryService] implementations are created. Local registry services use the given
+         * [projectDir] as workspace. These services are then queried in the order defined by the passed in collection.
+         * Note that as the last service a remote module registry for the Bazel Central Registry is added that serves
+         * as a fallback.
+         */
+        fun create(registryUrls: Collection<String>, projectDir: File): MultiBazelModuleRegistryService {
+            val registryServices = registryUrls.mapTo(mutableListOf()) { url ->
+                LocalBazelModuleRegistryService.createForLocalUrl(url, projectDir)
+                    ?: RemoteBazelModuleRegistryService.create(url)
+            }
+
+            // Add the default Bazel registry as a fallback.
+            registryServices += RemoteBazelModuleRegistryService.create(null)
+
+            return MultiBazelModuleRegistryService(registryServices)
+        }
+
+        /**
+         * Return an exception with a message that combines the messages of all [Throwable]s in this list.
+         */
+        private fun List<Throwable>.combinedException(caption: String): Throwable =
+            IllegalArgumentException(
+                "$caption:\n${joinToString("\n") { it.message.orEmpty() }}"
+            )
+    }
+
+    override suspend fun getModuleMetadata(name: String): ModuleMetadata =
+        queryRegistryServices(
+            errorMessage = { "Failed to query metadata for package '$name'" },
+            query = { it.getModuleMetadata(name) }
+        )
+
+    override suspend fun getModuleSourceInfo(name: String, version: String): ModuleSourceInfo =
+        queryRegistryServices(
+            errorMessage = { "Failed to query source info for package '$name' and version '$version'" },
+            query = { it.getModuleSourceInfo(name, version) }
+        )
+
+    /**
+     * A generic function for sending a [query] to all managed [BazelModuleRegistryService] instances and returning the
+     * first successful result. In case no registry service can provide a result, throw an exception with the given
+     * [errorMessage] and a summary of all failures.
+     */
+    private suspend fun <T> queryRegistryServices(
+        errorMessage: () -> String,
+        query: suspend (BazelModuleRegistryService) -> T
+    ): T {
+        val failures = mutableListOf<Throwable>()
+
+        tailrec suspend fun queryServices(itServices: Iterator<BazelModuleRegistryService>): T? =
+            if (!itServices.hasNext()) {
+                null
+            } else {
+                val triedResult = runCatching { query(itServices.next()) }
+                val result = triedResult.getOrNull()
+
+                // The Elvis operator does not work here because of the tailrec modifier.
+                if (result != null) {
+                    result
+                } else {
+                    triedResult.exceptionOrNull()?.let(failures::add)
+                    queryServices(itServices)
+                }
+            }
+
+        val info = queryServices(registryServices.iterator())
+        return info ?: throw failures.combinedException(errorMessage())
+    }
+}

--- a/plugins/package-managers/bazel/src/test/kotlin/MultiBazelModuleRegistryServiceTest.kt
+++ b/plugins/package-managers/bazel/src/test/kotlin/MultiBazelModuleRegistryServiceTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.bazel
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+
+import java.io.File
+
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.BazelModuleRegistryService
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.LocalBazelModuleRegistryService
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.ModuleMetadata
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.ModuleSourceInfo
+import org.ossreviewtoolkit.clients.bazelmoduleregistry.RemoteBazelModuleRegistryService
+
+class MultiBazelModuleRegistryServiceTest : WordSpec({
+    beforeTest {
+        mockkObject(LocalBazelModuleRegistryService, RemoteBazelModuleRegistryService)
+    }
+
+    afterTest {
+        unmockkAll()
+    }
+
+    "getModuleMetadata" should {
+        "throw an exception if no metadata can be obtained from all registries" {
+            val projectDir = tempdir()
+            val mockRegistries = MockRegistryServices.create(projectDir)
+            mockRegistries.prepareFailedMetadata()
+
+            val multiRegistry = MultiBazelModuleRegistryService.create(registryUrls, projectDir)
+
+            shouldThrow<IllegalArgumentException> {
+                multiRegistry.getModuleMetadata(PACKAGE_NAME)
+            }
+        }
+
+        "return the metadata from the first registry that contains it" {
+            val projectDir = tempdir()
+            val mockRegistries = MockRegistryServices.create(projectDir)
+            val metadata = mockk<ModuleMetadata>()
+            mockRegistries.prepareSuccessMetadata(1, metadata)
+
+            val multiRegistry = MultiBazelModuleRegistryService.create(registryUrls, projectDir)
+
+            multiRegistry.getModuleMetadata(PACKAGE_NAME) shouldBe metadata
+        }
+
+        "fall back to the default registry if no metadata can be obtained from the other registries" {
+            val projectDir = tempdir()
+            val mockRegistries = MockRegistryServices.create(projectDir)
+            val metadata = mockk<ModuleMetadata>()
+            mockRegistries.prepareSuccessMetadata(3, metadata)
+
+            val multiRegistry = MultiBazelModuleRegistryService.create(registryUrls, projectDir)
+
+            multiRegistry.getModuleMetadata(PACKAGE_NAME) shouldBe metadata
+        }
+    }
+
+    "getModuleSourceInfo" should {
+        "throw an exception if no source info can be obtained from all registries" {
+            val projectDir = tempdir()
+            val mockRegistries = MockRegistryServices.create(projectDir)
+            mockRegistries.prepareFailedSourceInfo()
+
+            val multiRegistry = MultiBazelModuleRegistryService.create(registryUrls, projectDir)
+
+            shouldThrow<IllegalArgumentException> {
+                multiRegistry.getModuleSourceInfo(PACKAGE_NAME, PACKAGE_VERSION)
+            }
+        }
+
+        "return the source info from the first registry that contains it" {
+            val projectDir = tempdir()
+            val mockRegistries = MockRegistryServices.create(projectDir)
+            val sourceInfo = mockk<ModuleSourceInfo>()
+            mockRegistries.prepareSuccessModuleInfo(1, sourceInfo)
+
+            val multiRegistry = MultiBazelModuleRegistryService.create(registryUrls, projectDir)
+
+            multiRegistry.getModuleSourceInfo(PACKAGE_NAME, PACKAGE_VERSION) shouldBe sourceInfo
+        }
+
+        "fall back to the default registry if no source info can be obtained from the other registries" {
+            val projectDir = tempdir()
+            val mockRegistries = MockRegistryServices.create(projectDir)
+            val sourceInfo = mockk<ModuleSourceInfo>()
+            mockRegistries.prepareSuccessModuleInfo(3, sourceInfo)
+
+            val multiRegistry = MultiBazelModuleRegistryService.create(registryUrls, projectDir)
+
+            multiRegistry.getModuleSourceInfo(PACKAGE_NAME, PACKAGE_VERSION) shouldBe sourceInfo
+        }
+    }
+})
+
+/** Name of a test package. */
+private const val PACKAGE_NAME = "test-package"
+
+/** Version of a test package. */
+private const val PACKAGE_VERSION = "0.8.15"
+
+/** A list of URLs for local and remote test registries. */
+private val registryUrls = listOf(
+    "file://local/registry/url",
+    "https://bazel-remote.example.com",
+    "file://%workspace%/registry"
+)
+
+private class MockRegistryServices(
+    val registryServices: List<BazelModuleRegistryService>
+) {
+    companion object {
+        /** An exception thrown by mock registries to simulate a failure. */
+        private val testException = Exception("Test exception: Registry invocation failed.")
+
+        /**
+         * Create an instance of [MockRegistryServices] with mocks for the test registry URLs. The factory methods
+         * of the local and remote service implementations have been prepared to return the mock instances.
+         */
+        fun create(projectDir: File): MockRegistryServices {
+            val localRegistry1 = mockk<LocalBazelModuleRegistryService>()
+            val localRegistry2 = mockk<LocalBazelModuleRegistryService>()
+            val remoteRegistry = mockk<RemoteBazelModuleRegistryService>()
+            val centralRegistry = mockk<RemoteBazelModuleRegistryService>()
+
+            every {
+                LocalBazelModuleRegistryService.createForLocalUrl(any(), projectDir)
+            } returns null
+            every {
+                LocalBazelModuleRegistryService.createForLocalUrl(registryUrls[0], projectDir)
+            } returns localRegistry1
+            every {
+                LocalBazelModuleRegistryService.createForLocalUrl(registryUrls[2], projectDir)
+            } returns localRegistry2
+            every {
+                RemoteBazelModuleRegistryService.create(registryUrls[1])
+            } returns remoteRegistry
+            every {
+                RemoteBazelModuleRegistryService.create(url = null)
+            } returns centralRegistry
+
+            return MockRegistryServices(listOf(localRegistry1, localRegistry2, remoteRegistry, centralRegistry))
+        }
+
+        /**
+         * Prepare the given [services] mocks to expect a query for module metadata and to fail with a test exception.
+         */
+        private fun prepareFailedMetadata(services: Collection<BazelModuleRegistryService>) {
+            services.forEach { service ->
+                coEvery { service.getModuleMetadata(PACKAGE_NAME) } throws testException
+            }
+        }
+
+        /**
+         * Prepare the given [services] mocks to expect a query for module source info and to fail with a test
+         * exception.
+         */
+        fun prepareFailedSourceInfo(services: Collection<BazelModuleRegistryService>) {
+            services.forEach { service ->
+                coEvery { service.getModuleSourceInfo(PACKAGE_NAME, PACKAGE_VERSION) } throws testException
+            }
+        }
+    }
+
+    /**
+     * Prepare the mock registries to expect a query for module metadata and to fail with a test exception.
+     */
+    fun prepareFailedMetadata() {
+        prepareFailedMetadata(registryServices)
+    }
+
+    /**
+     * Prepare the mock registries to expect a query for module source info and to fail with a test exception.
+     */
+    fun prepareFailedSourceInfo() {
+        prepareFailedSourceInfo(registryServices)
+    }
+
+    /**
+     * Prepare the mock registries to expect a query for module metadata that will eventually succeed. The registry
+     * with the given [index] is configured to return the given [metadata].
+     */
+    fun prepareSuccessMetadata(index: Int, metadata: ModuleMetadata) {
+        prepareFailedMetadata(registryServices.take(index))
+        coEvery { registryServices[index].getModuleMetadata(PACKAGE_NAME) } returns metadata
+    }
+
+    /**
+     * Prepare the mock registries to expect a query for module source info that will eventually succeed. The registry
+     * with the given [index] is configured to return the given [info].
+     */
+    fun prepareSuccessModuleInfo(index: Int, info: ModuleSourceInfo) {
+        prepareFailedSourceInfo(registryServices.take(index))
+        coEvery { registryServices[index].getModuleSourceInfo(PACKAGE_NAME, PACKAGE_VERSION) } returns info
+    }
+}


### PR DESCRIPTION
This PR adds support for multiple registry services defined in the `.bazelrc` file.

Taking over from @nnobelis during his vacation.