### PR TITLE
ci(github): Use latest instead of linked CodeQL tooling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,6 @@ jobs:
       uses: github/codeql-action/init@eb055d739abdc2e8de2e5f4ba1a8b246daa779aa # v3
       with:
         languages: java
-        tools: linked
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4
       with:


### PR DESCRIPTION
The latest tooling catches up more quickly with new Kotlin versions.