### PR TITLE
fix(downloader): Correctly get the repository root path

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -254,15 +254,15 @@ abstract class VersionControlSystem(
 
         val workingTreeRevision = results.last().getOrElse {
             throw DownloadException(
-                "$type failed to download from ${pkg.vcsProcessed.url} to '${workingTree.workingDir}'.", it
+                "$type failed to download from ${pkg.vcsProcessed.url} to '${workingTree.getRootPath()}'.", it
             )
         }
 
         pkg.vcsProcessed.path.let {
-            if (it.isNotBlank() && !workingTree.workingDir.resolve(it).exists()) {
+            if (it.isNotBlank() && !workingTree.getRootPath().resolve(it).exists()) {
                 throw DownloadException(
-                    "The $type working directory at '${workingTree.workingDir}' does not contain the requested path " +
-                        "'$it'."
+                    "The $type working directory at '${workingTree.getRootPath()}' does not contain the requested " +
+                        "path '$it'."
                 )
             }
         }

--- a/plugins/version-control-systems/git/src/funTest/kotlin/GitDownloadFunTest.kt
+++ b/plugins/version-control-systems/git/src/funTest/kotlin/GitDownloadFunTest.kt
@@ -76,8 +76,8 @@ class GitDownloadFunTest : StringSpec() {
             )
 
             val workingTree = git.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
-                it.toRelativeString(workingTree.workingDir).ifEmpty { null }
+            val actualFiles = workingTree.getRootPath().walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
+                it.toRelativeString(workingTree.getRootPath()).ifEmpty { null }
             }.sorted()
 
             workingTree.isValid() shouldBe true
@@ -95,7 +95,7 @@ class GitDownloadFunTest : StringSpec() {
             )
 
             val workingTree = git.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walkBottomUp()
+            val actualFiles = workingTree.getRootPath().walkBottomUp()
                 .onEnter { it.name != ".git" }
                 .filter { it.isFile }
                 .map { it.relativeTo(outputDir) }
@@ -135,7 +135,7 @@ class GitDownloadFunTest : StringSpec() {
             )
 
             val workingTree = git.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walkBottomUp()
+            val actualFiles = workingTree.getRootPath().walkBottomUp()
                 .onEnter { it.name != ".git" }
                 .filter { it.isFile }
                 .map { it.relativeTo(outputDir) }

--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -242,7 +242,7 @@ class Git : VersionControlSystem(GitCommand) {
         }.mapCatching { fetchResult ->
             // TODO: Migrate this to JGit once sparse checkout (https://bugs.eclipse.org/bugs/show_bug.cgi?id=383772) is
             //       implemented. Also see the "reset" call below.
-            GitCommand.run("checkout", revision, workingDir = workingTree.workingDir)
+            GitCommand.run("checkout", revision, workingDir = workingTree.getRootPath())
 
             // In case of a non-fixed revision (branch or tag) reset the working tree to ensure that the previously
             // fetched changes are applied.
@@ -266,7 +266,7 @@ class Git : VersionControlSystem(GitCommand) {
                     "Requested revision '$revision' not found in refs advertised by the server."
                 }
 
-                GitCommand.run("reset", "--hard", resolvedRevision, workingDir = workingTree.workingDir)
+                GitCommand.run("reset", "--hard", resolvedRevision, workingDir = workingTree.getRootPath())
             }
 
             revision

--- a/plugins/version-control-systems/mercurial/src/funTest/kotlin/MercurialDownloadFunTest.kt
+++ b/plugins/version-control-systems/mercurial/src/funTest/kotlin/MercurialDownloadFunTest.kt
@@ -66,8 +66,8 @@ class MercurialDownloadFunTest : StringSpec() {
             )
 
             val workingTree = hg.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
-                it.toRelativeString(workingTree.workingDir).ifEmpty { null }
+            val actualFiles = workingTree.getRootPath().walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
+                it.toRelativeString(workingTree.getRootPath()).ifEmpty { null }
             }.sorted()
 
             workingTree.isValid() shouldBe true
@@ -90,7 +90,7 @@ class MercurialDownloadFunTest : StringSpec() {
                 )
 
                 val workingTree = hg.download(pkg, outputDir)
-                val actualFiles = workingTree.workingDir.walkBottomUp()
+                val actualFiles = workingTree.getRootPath().walkBottomUp()
                     .onEnter { it.name != ".hg" }
                     .filter { it.isFile }
                     .map { it.relativeTo(outputDir) }
@@ -136,7 +136,7 @@ class MercurialDownloadFunTest : StringSpec() {
                 )
 
                 val workingTree = hg.download(pkg, outputDir)
-                val actualFiles = workingTree.workingDir.walkBottomUp()
+                val actualFiles = workingTree.getRootPath().walkBottomUp()
                     .onEnter { it.name != ".hg" }
                     .filter { it.isFile }
                     .map { it.relativeTo(outputDir) }

--- a/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
+++ b/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
@@ -98,12 +98,12 @@ class Mercurial : VersionControlSystem(MercurialCommand) {
             // To safe network bandwidth, only pull exactly the revision we want. Do not use "-u" to update the
             // working tree just yet, as Mercurial would only update if new changesets were pulled. But that might
             // not be the case if the requested revision is already available locally.
-            MercurialCommand.run(workingTree.workingDir, "pull", "-r", revision)
+            MercurialCommand.run(workingTree.getRootPath(), "pull", "-r", revision)
 
             // TODO: Implement updating of subrepositories.
 
             // Explicitly update the working tree to the desired revision.
-            MercurialCommand.run(workingTree.workingDir, "update", revision).isSuccess
+            MercurialCommand.run(workingTree.getRootPath(), "update", revision).isSuccess
         }.map {
             revision
         }

--- a/plugins/version-control-systems/subversion/src/funTest/kotlin/SubversionDownloadFunTest.kt
+++ b/plugins/version-control-systems/subversion/src/funTest/kotlin/SubversionDownloadFunTest.kt
@@ -61,8 +61,8 @@ class SubversionDownloadFunTest : StringSpec() {
             )
 
             val workingTree = svn.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
-                it.toRelativeString(workingTree.workingDir).ifEmpty { null }
+            val actualFiles = workingTree.getRootPath().walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
+                it.toRelativeString(workingTree.getRootPath()).ifEmpty { null }
             }.sorted()
 
             workingTree.isValid() shouldBe true
@@ -80,10 +80,10 @@ class SubversionDownloadFunTest : StringSpec() {
             )
 
             val workingTree = svn.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walk()
+            val actualFiles = workingTree.getRootPath().walk()
                 .onEnter { it.name !in VCS_DIRECTORIES }
                 .filter { it.isFile }
-                .mapTo(mutableListOf()) { it.toRelativeString(workingTree.workingDir) }
+                .mapTo(mutableListOf()) { it.toRelativeString(workingTree.getRootPath()) }
                 .sorted()
 
             workingTree.isValid() shouldBe true
@@ -103,8 +103,8 @@ class SubversionDownloadFunTest : StringSpec() {
             )
 
             val workingTree = svn.download(pkg, outputDir)
-            val actualFiles = workingTree.workingDir.walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
-                it.toRelativeString(workingTree.workingDir).ifEmpty { null }
+            val actualFiles = workingTree.getRootPath().walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
+                it.toRelativeString(workingTree.getRootPath()).ifEmpty { null }
             }.sorted()
 
             workingTree.isValid() shouldBe true
@@ -137,7 +137,7 @@ class SubversionDownloadFunTest : StringSpec() {
             )
 
             val workingTree = svn.download(pkg, outputDir)
-            val pathForVersion = workingTree.workingDir.resolve(REPO_PATH_FOR_VERSION)
+            val pathForVersion = workingTree.getRootPath().resolve(REPO_PATH_FOR_VERSION)
             val actualFiles = pathForVersion.walk().maxDepth(1).mapNotNullTo(mutableListOf()) {
                 it.toRelativeString(pathForVersion).ifEmpty { null }
             }.sorted()

--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -230,7 +230,7 @@ class DefaultPackageProvenanceResolver(
                 val result = vcs.updateWorkingTree(workingTree, revision)
 
                 if (pkg.vcsProcessed.path.isNotBlank() &&
-                    !workingTree.workingDir.resolve(pkg.vcsProcessed.path).exists()
+                    !workingTree.getRootPath().resolve(pkg.vcsProcessed.path).exists()
                 ) {
                     addAndLogMessage(
                         "Discarding revision '$revision' because the requested VCS path '${pkg.vcsProcessed.path}' " +


### PR DESCRIPTION
The `WorkingTree`'s `workingDir` does not necessarily match the repository root in all cases. Explicitly use `getRootPath()` instead where it matters.