### PR TITLE
fix(compose): Ignore definition files from vendor directories

### DIFF
--- a/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
+++ b/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
@@ -21,10 +21,13 @@ package org.ossreviewtoolkit.plugins.packagemanagers.composer
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
+
+import java.io.File
 
 import org.ossreviewtoolkit.analyzer.create
 import org.ossreviewtoolkit.analyzer.resolveSingleProject
@@ -34,6 +37,22 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
 
 class ComposerFunTest : StringSpec({
+    "Project files from vendor directories are ignored" {
+        val projectFiles = create("Composer").mapDefinitionFiles(
+            listOf(
+                "projectA/composer.json",
+                "projectA/vendor/dependency1/composer.json",
+                "projectB/composer.json",
+                "projectB/vendor/dependency2/composer.json"
+            ).map { File(it) }
+        )
+
+        projectFiles.map { it.path } should containExactly(
+            "projectA/composer.json",
+            "projectB/composer.json"
+        )
+    }
+
     "Project dependencies are detected correctly" {
         val definitionFile = getAssetFile("projects/synthetic/lockfile/composer.json")
         val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output.yml")

--- a/plugins/package-managers/composer/src/main/kotlin/Composer.kt
+++ b/plugins/package-managers/composer/src/main/kotlin/Composer.kt
@@ -110,6 +110,19 @@ class Composer(
         checkVersion()
     }
 
+    override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> {
+        val projectFiles = definitionFiles.toMutableList()
+
+        var index = 0
+        while (index < projectFiles.size - 1) {
+            val projectFile = projectFiles[index++]
+            val vendorDir = projectFile.resolveSibling("vendor")
+            projectFiles.subList(index, projectFiles.size).removeAll { it.startsWith(vendorDir) }
+        }
+
+        return projectFiles
+    }
+
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 


### PR DESCRIPTION
In addition to 471a65d, also ignore any `composer.json` files from `vendor` directories before resolving dependencies. This avoids packages for dependencies being recognized as projects by the ORT analyzer.