### PR TITLE
fix(scanoss): Ignore the logging provider from `scanoss'

### DIFF
--- a/plugins/scanners/scanoss/build.gradle.kts
+++ b/plugins/scanners/scanoss/build.gradle.kts
@@ -32,7 +32,10 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     implementation(libs.kotlinx.coroutines)
-    implementation(libs.scanoss)
+    implementation(libs.scanoss) {
+        exclude(group = "org.slf4j", module = "slf4j-simple")
+            .because("the logging provider conflicts with ORT's")
+    }
 
     funTestApi(testFixtures(projects.scanner))
 


### PR DESCRIPTION
This works around [1].

[1]: https://github.com/scanoss/scanoss.java/issues/12