### PR TITLE
fix(conan): Ensure that Conan is running in non-interactive mode

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -148,6 +148,9 @@ class Conan(
             pkgInspectResults.clear()
         }
 
+    override fun run(vararg args: CharSequence, workingDir: File?, environment: Map<String, String>) =
+        super.run(args = args, workingDir = workingDir, environment = environment + ("CONAN_NON_INTERACTIVE" to "1"))
+
     private fun resolvedDependenciesInternal(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 


### PR DESCRIPTION
In some cases Conan falls back to an interactive terminal, e.g. when requiring credentials for a remote.
Avoid blocking the ORT process by disabling interactive mode for the Conan CLI and fail instead [1].

[1]: https://docs.conan.io/1/reference/env_vars.html#conan-non-interactive

