### PR TITLE
refactor(vcs)!: Make the `aliases` property private

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -193,7 +193,7 @@ abstract class VersionControlSystem(
     /**
      * Return true if this VCS can handle the given [vcsType].
      */
-    fun isApplicableType(vcsType: VcsType) = type in vcsType.aliases
+    fun isApplicableType(vcsType: VcsType) = VcsType.forName(type) == vcsType
 
     /**
      * Return true if this [VersionControlSystem] can be used to download from the provided [vcsUrl]. First, try to find
@@ -359,7 +359,7 @@ abstract class VersionControlSystem(
 
         addMetadataRevision(pkg.vcsProcessed.revision)
 
-        if (type in VcsType.GIT.aliases && pkg.vcsProcessed.revision == "master") {
+        if (VcsType.forName(type) == VcsType.GIT && pkg.vcsProcessed.revision == "master") {
             // Also try with Git's upcoming default branch name in case the repository is already using it.
             addMetadataRevision("main")
         }

--- a/model/src/main/kotlin/VcsType.kt
+++ b/model/src/main/kotlin/VcsType.kt
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonValue
  * alias is the definite name. This class is not implemented as an enum as constructing from an unknown type should be
  * supported while maintaining that type as the primary alias for the string representation.
  */
-data class VcsType private constructor(val aliases: List<String>) {
+data class VcsType private constructor(private val aliases: List<String>) {
     /**
      * A constructor that takes a [name] in addition to a variable number of other [aliases] to enforce a non-empty list
      * of final aliases.


### PR DESCRIPTION
The alias names of a VCS should be an implementation detail.