### PR TITLE
ci: Ensure that the generate shell completion scripts are up-to-date

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,6 +34,34 @@ jobs:
         gradle-home-cache-cleanup: true
     - name: Check copyrights, license headers, and .gitattributes
       run: ./gradlew checkCopyrightsInNoticeFile checkLicenseHeaders checkGitAttributes
+  completions:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4
+      with:
+        gradle-home-cache-cleanup: true
+    - name: Generate completions
+      run: |
+        ./gradlew -q :cli:installDist
+        cli/build/install/ort/bin/ort --generate-completion=bash > integrations/completions/ort-completion.bash
+        cli/build/install/ort/bin/ort --generate-completion=fish > integrations/completions/ort-completion.fish
+        cli/build/install/ort/bin/ort --generate-completion=zsh > integrations/completions/ort-completion.zsh
+    - name: Check if completions are up-to-date
+      run: |
+        if git diff --exit-code; then
+          echo "Completions are up-to-date."
+        else
+          echo "Completions are not up-to-date."
+          echo "Please always run the commands below when changing CLI commands:"
+          echo "./gradlew -q :cli:installDist"
+          echo "cli/build/install/ort/bin/ort --generate-completion=bash > integrations/completions/ort-completion.bash"
+          echo "cli/build/install/ort/bin/ort --generate-completion=fish > integrations/completions/ort-completion.fish"
+          echo "cli/build/install/ort/bin/ort --generate-completion=zsh > integrations/completions/ort-completion.zsh"
+          exit 1
+        fi
   detekt-issues:
     runs-on: ubuntu-22.04
     permissions:

--- a/integrations/completions/ort-completion.bash
+++ b/integrations/completions/ort-completion.bash
@@ -260,7 +260,7 @@ _ort_advise() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --label)
       ;;
@@ -366,7 +366,7 @@ _ort_analyze() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --repository-configuration-file)
        COMPREPLY=($(compgen -o default -- "${word}"))
@@ -646,6 +646,12 @@ _ort_download() {
           in_param=''
           continue
           ;;
+        --max-parallel-downloads|-p)
+          __skip_opt_eq
+          (( i = i + 1 ))
+          [[ ${i} -gt COMP_CWORD ]] && in_param='--max-parallel-downloads' || in_param=''
+          continue
+          ;;
         -h|--help)
           __skip_opt_eq
           in_param=''
@@ -663,7 +669,7 @@ _ort_download() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '--ort-file -i --project-url --project-name --vcs-type --vcs-revision --vcs-path --license-classifications-file --output-dir -o --archive --archive-all --package-types --package-ids --skip-excluded --dry-run -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '--ort-file -i --project-url --project-name --vcs-type --vcs-revision --vcs-path --license-classifications-file --output-dir -o --archive --archive-all --package-types --package-ids --skip-excluded --dry-run --max-parallel-downloads -p -h --help' -- "${word}"))
     return
   fi
 
@@ -704,6 +710,8 @@ _ort_download() {
     --skip-excluded)
       ;;
     --dry-run)
+      ;;
+    --max-parallel-downloads)
       ;;
     --help)
       ;;
@@ -842,7 +850,7 @@ _ort_evaluate() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --rules-file)
        COMPREPLY=($(compgen -o default -- "${word}"))
@@ -1344,7 +1352,7 @@ _ort_scan() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --label)
       ;;

--- a/integrations/completions/ort-completion.fish
+++ b/integrations/completions/ort-completion.fish
@@ -22,10 +22,10 @@ complete -c ort -f -n __fish_use_subcommand -a advise -d 'Check dependencies for
 ## Options for advise
 complete -c ort -n "__fish_seen_subcommand_from advise" -l ort-file -s i -r -F -d 'An ORT result file with an analyzer result to use.'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l output-dir -s o -r -F -d 'The directory to write the ORT result file with advisor results to.'
-complete -c ort -n "__fish_seen_subcommand_from advise" -l output-formats -s f -r -fa "JSON XML YAML" -d 'The list of output formats to be used for the ORT result file(s).'
+complete -c ort -n "__fish_seen_subcommand_from advise" -l output-formats -s f -r -fa "JSON YAML" -d 'The list of output formats to be used for the ORT result file(s).'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l label -s l -r -d 'Set a label in the ORT result, overwriting any existing label of the same name. Can be used multiple times. For example: --label distribution=external'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l resolutions-file -r -F -d 'A file containing issue and rule violation resolutions.'
-complete -c ort -n "__fish_seen_subcommand_from advise" -l advisors -s a -r -d 'The comma-separated advisors to use, any of [GitHubDefects, NexusIQ, OssIndex, OSV, VulnerableCode].'
+complete -c ort -n "__fish_seen_subcommand_from advise" -l advisors -s a -r -d 'The comma-separated advisors to use, any of [NexusIQ, OssIndex, OSV, VulnerableCode].'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l skip-excluded -d 'Do not check excluded projects or packages.'
 complete -c ort -n "__fish_seen_subcommand_from advise" -s h -l help -d 'Show this message and exit'
 
@@ -36,7 +36,7 @@ complete -c ort -f -n __fish_use_subcommand -a analyze -d 'Determine dependencie
 ## Options for analyze
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l input-dir -s i -r -F -d 'The project directory to analyze. May point to a definition file if only a single package manager is enabled.'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l output-dir -s o -r -F -d 'The directory to write the ORT result file with analyzer results to.'
-complete -c ort -n "__fish_seen_subcommand_from analyze" -l output-formats -s f -r -fa "JSON XML YAML" -d 'The list of output formats to be used for the ORT result file(s).'
+complete -c ort -n "__fish_seen_subcommand_from analyze" -l output-formats -s f -r -fa "JSON YAML" -d 'The list of output formats to be used for the ORT result file(s).'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l repository-configuration-file -r -F -d 'A file containing the repository configuration. If set, overrides any repository configuration contained in a \'.ort.yml\' file in the repository.'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l resolutions-file -r -F -d 'A file containing issue and rule violation resolutions.'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l label -s l -r -d 'Set a label in the ORT result, overwriting any existing label of the same name. Can be used multiple times. For example: --label distribution=external'
@@ -89,6 +89,7 @@ complete -c ort -n "__fish_seen_subcommand_from download" -l package-types -r -f
 complete -c ort -n "__fish_seen_subcommand_from download" -l package-ids -r -d 'A comma-separated list of regular expressions for matching package ids from the ORT file\'s analyzer result to limit downloads to. If not specified, all packages are downloaded.'
 complete -c ort -n "__fish_seen_subcommand_from download" -l skip-excluded -d 'Do not download excluded projects or packages. Works only with the \'--ort-file\' parameter.'
 complete -c ort -n "__fish_seen_subcommand_from download" -l dry-run -d 'Do not actually download anything but just verify that all source code locations are valid.'
+complete -c ort -n "__fish_seen_subcommand_from download" -l max-parallel-downloads -s p -r -d 'The maximum number of parallel downloads to happen.'
 complete -c ort -n "__fish_seen_subcommand_from download" -s h -l help -d 'Show this message and exit'
 
 
@@ -98,7 +99,7 @@ complete -c ort -f -n __fish_use_subcommand -a evaluate -d 'Evaluate ORT result 
 ## Options for evaluate
 complete -c ort -n "__fish_seen_subcommand_from evaluate" -l ort-file -s i -r -F -d 'The ORT result file to read as input.'
 complete -c ort -n "__fish_seen_subcommand_from evaluate" -l output-dir -s o -r -F -d 'The directory to write the ORT result file with evaluation results to.  If no output directory is specified, no ORT result file is written and only the exit code signals a success or failure.'
-complete -c ort -n "__fish_seen_subcommand_from evaluate" -l output-formats -s f -r -fa "JSON XML YAML" -d 'The list of output formats to be used for the ORT result file(s).'
+complete -c ort -n "__fish_seen_subcommand_from evaluate" -l output-formats -s f -r -fa "JSON YAML" -d 'The list of output formats to be used for the ORT result file(s).'
 complete -c ort -n "__fish_seen_subcommand_from evaluate" -l rules-file -s r -r -F -d 'The name of a script file containing rules.'
 complete -c ort -n "__fish_seen_subcommand_from evaluate" -l rules-resource -r -d 'The name of a script resource on the classpath that contains rules.'
 complete -c ort -n "__fish_seen_subcommand_from evaluate" -l copyright-garbage-file -r -F -d 'A file containing copyright statements which are marked as garbage.'
@@ -140,7 +141,7 @@ complete -c ort -f -n __fish_use_subcommand -a report -d 'Present Analyzer, Scan
 ## Options for report
 complete -c ort -n "__fish_seen_subcommand_from report" -l ort-file -s i -r -F -d 'The ORT result file to use.'
 complete -c ort -n "__fish_seen_subcommand_from report" -l output-dir -s o -r -F -d 'The output directory to store the generated reports in.'
-complete -c ort -n "__fish_seen_subcommand_from report" -l report-formats -s f -r -d 'The comma-separated reports to generate, any of [CtrlXAutomation, CycloneDx, DocBookTemplate, EvaluatedModel, FossId, FossIdSnippet, GitLabLicenseModel, HtmlTemplate, ManPageTemplate, Opossum, PdfTemplate, PlainTextTemplate, SpdxDocument, StaticHtml, TrustSource, WebApp].'
+complete -c ort -n "__fish_seen_subcommand_from report" -l report-formats -s f -r -d 'A comma-separated list of report formats to generate, any of [AOSD, CtrlXAutomation, CycloneDx, DocBookTemplate, EvaluatedModel, FossId, FossIdSnippet, GitLabLicenseModel, HtmlTemplate, ManPageTemplate, Opossum, PdfTemplate, PlainTextTemplate, SpdxDocument, StaticHtml, TrustSource, WebApp].'
 complete -c ort -n "__fish_seen_subcommand_from report" -l copyright-garbage-file -r -F -d 'A file containing copyright statements which are marked as garbage. This can make the output inconsistent with the evaluator output but is useful when testing copyright garbage.'
 complete -c ort -n "__fish_seen_subcommand_from report" -l custom-license-texts-dir -r -F -d 'A directory which maps custom license IDs to license texts. It should contain one text file per license with the license ID as the filename. A custom license text is used only if its ID has a \'LicenseRef-\' prefix and if the respective license text is not known by ORT.'
 complete -c ort -n "__fish_seen_subcommand_from report" -l how-to-fix-text-provider-script -r -F -d 'The path to a Kotlin script which returns an instance of a \'HowToFixTextProvider\'. That provider injects how-to-fix texts in Markdown format for ORT issues.'
@@ -167,7 +168,7 @@ complete -c ort -f -n __fish_use_subcommand -a scan -d 'Run external license / c
 ## Options for scan
 complete -c ort -n "__fish_seen_subcommand_from scan" -l ort-file -s i -r -F -d 'An ORT result file with an analyzer result to use. Source code is downloaded automatically if needed.'
 complete -c ort -n "__fish_seen_subcommand_from scan" -l output-dir -s o -r -F -d 'The directory to write the ORT result file with scan results to.'
-complete -c ort -n "__fish_seen_subcommand_from scan" -l output-formats -s f -r -fa "JSON XML YAML" -d 'The list of output formats to be used for the ORT result file(s).'
+complete -c ort -n "__fish_seen_subcommand_from scan" -l output-formats -s f -r -fa "JSON YAML" -d 'The list of output formats to be used for the ORT result file(s).'
 complete -c ort -n "__fish_seen_subcommand_from scan" -l label -s l -r -d 'Set a label in the ORT result, overwriting any existing label of the same name. Can be used multiple times. For example: --label distribution=external'
 complete -c ort -n "__fish_seen_subcommand_from scan" -l scanners -s s -r -d 'A comma-separated list of scanners to use.'
 complete -c ort -n "__fish_seen_subcommand_from scan" -l project-scanners -r -d 'A comma-separated list of scanners to use for scanning the source code of projects. By default, projects and packages are scanned with the same scanners as specified by \'--scanners\'.'

--- a/integrations/completions/ort-completion.zsh
+++ b/integrations/completions/ort-completion.zsh
@@ -265,7 +265,7 @@ _ort_advise() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --label)
       ;;
@@ -371,7 +371,7 @@ _ort_analyze() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --repository-configuration-file)
        COMPREPLY=($(compgen -o default -- "${word}"))
@@ -651,6 +651,12 @@ _ort_download() {
           in_param=''
           continue
           ;;
+        --max-parallel-downloads|-p)
+          __skip_opt_eq
+          (( i = i + 1 ))
+          [[ ${i} -gt COMP_CWORD ]] && in_param='--max-parallel-downloads' || in_param=''
+          continue
+          ;;
         -h|--help)
           __skip_opt_eq
           in_param=''
@@ -668,7 +674,7 @@ _ort_download() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '--ort-file -i --project-url --project-name --vcs-type --vcs-revision --vcs-path --license-classifications-file --output-dir -o --archive --archive-all --package-types --package-ids --skip-excluded --dry-run -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '--ort-file -i --project-url --project-name --vcs-type --vcs-revision --vcs-path --license-classifications-file --output-dir -o --archive --archive-all --package-types --package-ids --skip-excluded --dry-run --max-parallel-downloads -p -h --help' -- "${word}"))
     return
   fi
 
@@ -709,6 +715,8 @@ _ort_download() {
     --skip-excluded)
       ;;
     --dry-run)
+      ;;
+    --max-parallel-downloads)
       ;;
     --help)
       ;;
@@ -847,7 +855,7 @@ _ort_evaluate() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --rules-file)
        COMPREPLY=($(compgen -o default -- "${word}"))
@@ -1349,7 +1357,7 @@ _ort_scan() {
        COMPREPLY=($(compgen -o default -- "${word}"))
       ;;
     --output-formats)
-      COMPREPLY=($(compgen -W 'JSON XML YAML' -- "${word}"))
+      COMPREPLY=($(compgen -W 'JSON YAML' -- "${word}"))
       ;;
     --label)
       ;;


### PR DESCRIPTION
Add a job that verifies that the generated shell completion scripts are up-to-date and fails otherwise. This ensures that the scripts are always updated when the signature of the CLI commands is changed.