### PR TITLE
fix(advisors): Make configuration properties secrets

### DIFF
--- a/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
+++ b/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
@@ -89,8 +89,8 @@ class NexusIq(override val descriptor: PluginDescriptor, private val config: Nex
     private val service by lazy {
         NexusIqService.create(
             config.serverUrl,
-            config.username,
-            config.password,
+            config.username?.value,
+            config.password?.value,
             OkHttpClientHelper.buildClient {
                 readTimeout(READ_TIMEOUT)
             }

--- a/plugins/advisors/nexus-iq/src/main/kotlin/NexusIqConfiguration.kt
+++ b/plugins/advisors/nexus-iq/src/main/kotlin/NexusIqConfiguration.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.plugins.advisors.nexusiq
 
+import org.ossreviewtoolkit.plugins.api.Secret
+
 /**
  * The configuration for Nexus IQ as a security vulnerability provider.
  */
@@ -37,11 +39,11 @@ data class NexusIqConfiguration(
      * The username to use for authentication. If not both [username] and [password] are provided, authentication is
      * disabled.
      */
-    val username: String?,
+    val username: Secret?,
 
     /**
      * The password to use for authentication. If not both [username] and [password] are provided, authentication is
      * disabled.
      */
-    val password: String?
+    val password: Secret?
 )

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -87,7 +87,7 @@ class VulnerableCode(override val descriptor: PluginDescriptor, config: Vulnerab
             if (config.readTimeout != null) readTimeout(config.readTimeout, TimeUnit.SECONDS)
         }
 
-        VulnerableCodeService.create(config.serverUrl, config.apiKey, client)
+        VulnerableCodeService.create(config.serverUrl, config.apiKey?.value, client)
     }
 
     override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
 
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
+import org.ossreviewtoolkit.plugins.api.Secret
 
 /**
  * The configuration for VulnerableCode as security vulnerability provider.
@@ -35,7 +36,7 @@ data class VulnerableCodeConfiguration(
     /**
      * The optional API key to use.
      */
-    val apiKey: String?,
+    val apiKey: Secret?,
 
     /**
      * The read timeout for the server connection in seconds. Defaults to whatever is the HTTP client's default value.


### PR DESCRIPTION
Fix some advisor plugin options to be secrets. This is a fixup for 848e666.