### PR TITLE
docs: Update link references of ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -394,7 +394,7 @@ RUN mkdir -p $DOTNET_HOME \
     fi
 
 RUN mkdir -p $DOTNET_HOME/bin \
-    && curl -L https://github.com/nexB/nuget-inspector/releases/download/v$NUGET_INSPECTOR_VERSION/nuget-inspector-v$NUGET_INSPECTOR_VERSION-linux-x64.tar.gz \
+    && curl -L https://github.com/aboutcode-org/nuget-inspector/releases/download/v$NUGET_INSPECTOR_VERSION/nuget-inspector-v$NUGET_INSPECTOR_VERSION-linux-x64.tar.gz \
     | tar --strip-components=1 -C $DOTNET_HOME/bin -xz
 
 FROM scratch AS dotnet

--- a/examples/license-classifications.yml
+++ b/examples/license-classifications.yml
@@ -1,6 +1,6 @@
 ---
 # Example license-classifications.yml based on categorization from
-# https://github.com/nexB/scancode-toolkit/commit/ed644e4
+# https://github.com/aboutcode-org/scancode-toolkit/commit/ed644e4
 #
 # To demonstrate how one can insert a custom written offer
 # include-source-code-offer-in-notice-file has been set to

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -55,7 +55,7 @@ private const val BULK_REQUEST_SIZE = 100
 
 /**
  * An [AdviceProvider] implementation that obtains security vulnerability information from a
- * [VulnerableCode][https://github.com/nexB/vulnerablecode] instance.
+ * [VulnerableCode][https://github.com/aboutcode-org/vulnerablecode] instance.
  *
  * This [AdviceProvider] offers the following configuration options:
  *
@@ -155,7 +155,7 @@ class VulnerableCode(override val descriptor: PluginDescriptor, config: Vulnerab
             if (scores.isEmpty()) return listOf(VulnerabilityReference(sourceUri, null, null))
             return scores.map {
                 // VulnerableCode returns MODERATE instead of MEDIUM in case of cvssv3.1_qr, see:
-                // https://github.com/nexB/vulnerablecode/issues/1186
+                // https://github.com/aboutcode-org/vulnerablecode/issues/1186
                 val severity = if (it.scoringSystem == "cvssv3.1_qr" && it.value == "MODERATE") "MEDIUM" else it.value
 
                 VulnerabilityReference(sourceUri, it.scoringSystem, severity)

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
@@ -147,7 +147,7 @@ internal fun List<PythonInspector.Package>.toOrtPackages(): Set<Package> =
             declaredLicenses = declaredLicenses,
             declaredLicensesProcessed = declaredLicensesProcessed,
             // Only use the first line of the description because the descriptions provided by python-inspector are
-            // currently far too long, see: https://github.com/nexB/python-inspector/issues/74
+            // currently far too long, see: https://github.com/aboutcode-org/python-inspector/issues/74
             description = pkg.description.lineSequence().firstOrNull { it.isNotBlank() }.orEmpty(),
             homepageUrl = pkg.homepageUrl.orEmpty(),
             binaryArtifact = getArtifact(".whl"),

--- a/plugins/scanners/dos/README.md
+++ b/plugins/scanners/dos/README.md
@@ -24,5 +24,5 @@ ort:
 The `DOS_FRONTEND_URL` is meant to point to the Clearance UI which can be used to inspect scan results and to create license finding curations for use with the [DOS Package Configuration Provider].
 
 [DOS]: https://github.com/doubleopen-project/dos
-[ScanCode]: https://github.com/nexB/scancode-toolkit
+[ScanCode]: https://github.com/aboutcode-org/scancode-toolkit
 [DOS Package Configuration Provider]: ../../package-configuration-providers/dos

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -46,7 +46,7 @@ import org.semver4j.RangesListFactory
 import org.semver4j.Semver
 
 /**
- * A wrapper for [ScanCode](https://github.com/nexB/scancode-toolkit).
+ * A wrapper for [ScanCode](https://github.com/aboutcode-org/scancode-toolkit).
  *
  * This scanner can be configured in [ScannerConfiguration.config] using the key "ScanCode". It offers the following
  * configuration [options][PluginConfiguration.options]:

--- a/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModelMapper.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCodeResultModelMapper.kt
@@ -87,7 +87,7 @@ fun ScanCodeResult.toScanSummary(preferFileLicense: Boolean = false): ScanSummar
         val licensesWithoutReferences = file.licenses.filter {
             it !is LicenseEntry.Version3 || it.fromFile == null
                 // Note that "fromFile" contains the name of the input directory, see
-                // https://github.com/nexB/scancode-toolkit/issues/3712.
+                // https://github.com/aboutcode-org/scancode-toolkit/issues/3712.
                 || inputPath.resolveSibling(it.fromFile) == inputPath.resolve(file.path)
                 // Check if input is a single file.
                 || it.fromFile == inputPath.name

--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -148,7 +148,7 @@ private fun getLicenseTextFile(id: String, dir: File): File? =
             idWithoutLicenseRefNamespace,
             "$idWithoutLicenseRefNamespace.LICENSE",
             "x11-xconsortium_veillard.LICENSE".takeIf {
-                // Work around for https://github.com/nexB/scancode-toolkit/issues/2813.
+                // Work around for https://github.com/aboutcode-org/scancode-toolkit/issues/2813.
                 id == "LicenseRef-scancode-x11-xconsortium-veillard"
             }
         ).firstNotNullOfOrNull { filename ->

--- a/website/docs/configuration/license-texts.md
+++ b/website/docs/configuration/license-texts.md
@@ -1,6 +1,6 @@
 # License Texts
 
-ORT does provide the license texts for all [SPDX licenses](https://spdx.org/licenses/) and for all license references from [ScanCode](https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses).
+ORT does provide the license texts for all [SPDX licenses](https://spdx.org/licenses/) and for all license references from [ScanCode](https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses).
 These license texts will be used when generating open source notices using the [PlainTextTemplateReporter](reporter-templates.md#plain-text-templates).
 
 If you need a license text not provided by ORT, you can put it in the custom license texts directory.

--- a/website/docs/getting-started/tutorial.md
+++ b/website/docs/getting-started/tutorial.md
@@ -256,8 +256,8 @@ ORT is designed to integrate lots of different scanners and is not limited to li
 The actual scanner does not have to run on the same computer.
 For example, the [FossID](https://github.com/oss-review-toolkit/ort/blob/main/plugins/scanners/fossid/src/main/kotlin/FossId.kt) uses a remote service to execute the scan.
 
-For this tutorial [ScanCode](https://github.com/nexB/scancode-toolkit) is used as a scanner.
-Please install it according to [these instructions](https://github.com/nexB/scancode-toolkit/#installation) first.
+For this tutorial [ScanCode](https://github.com/aboutcode-org/scancode-toolkit) is used as a scanner.
+Please install it according to [these instructions](https://github.com/aboutcode-org/scancode-toolkit/#installation) first.
 
 As for the *analyzer* you can get the command line options for the `scanner` using the `--help` option:
 

--- a/website/docs/tools/advisor.md
+++ b/website/docs/tools/advisor.md
@@ -39,7 +39,7 @@ To enable this provider, pass `-a OssIndex` on the command line.
 
 ## VulnerableCode
 
-This provider obtains information about security vulnerabilities from a [VulnerableCode](https://github.com/nexB/vulnerablecode) instance.
+This provider obtains information about security vulnerabilities from a [VulnerableCode](https://github.com/aboutcode-org/vulnerablecode) instance.
 The configuration is limited to the server URL, as authentication is not required:
 
 ```yaml

--- a/website/docs/tools/scanner.md
+++ b/website/docs/tools/scanner.md
@@ -10,7 +10,7 @@ If passed an ORT result file with an analyzer result (`-i`), the *scanner* will 
 We recommend using ORT with any of the following scanners as their integrations have been thoroughly tested (in alphabetical order):
 
 * [FossID](https://fossid.com/) (snippet scanner, commercial)
-* [ScanCode](https://github.com/nexB/scancode-toolkit)
+* [ScanCode](https://github.com/aboutcode-org/scancode-toolkit)
 
 Additionally, the following reference implementations exist (in alphabetical order):
 


### PR DESCRIPTION
Update link references of ownership from `nexB` to `aboutcode-org`
