### PR TITLE
Migrate curation providers to new plugin api

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -86,7 +86,7 @@ class Advisor(
 
                         logger.info {
                             "Found ${providerResults.values.flatMap { it.vulnerabilities }.distinct().size} distinct " +
-                                "vulnerabilities via ${provider.descriptor.name}. "
+                                "vulnerabilities via ${provider.descriptor.displayName}. "
                         }
 
                         providerResults.keys.takeIf { it.isNotEmpty() }?.let { pkgs ->

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -76,7 +76,7 @@ class Advisor(
                 logger.info { "There are no packages to give advice for." }
             } else {
                 val providers = providerFactories.map {
-                    val providerConfig = config.config?.get(it.descriptor.className)
+                    val providerConfig = config.config?.get(it.descriptor.id)
                     it.create(PluginConfig(providerConfig?.options.orEmpty(), providerConfig?.secrets.orEmpty()))
                 }
 

--- a/advisor/src/test/kotlin/AdvisorTest.kt
+++ b/advisor/src/test/kotlin/AdvisorTest.kt
@@ -148,7 +148,7 @@ private fun createPackage(index: Int): Package =
 
 private fun mockkAdviceProvider(): AdviceProvider =
     mockk<AdviceProvider>().apply {
-        every { descriptor } returns PluginDescriptor("provider", "Provider", "", emptyList())
+        every { descriptor } returns PluginDescriptor("Provider", "provider", "", emptyList())
     }
 
 private fun mockkAdvisorResult(): AdvisorResult =

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -47,9 +47,9 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
-import org.ossreviewtoolkit.model.utils.setPackageCurations
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
+import org.ossreviewtoolkit.utils.config.setPackageCurations
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.runBlocking
 

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.toYaml
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.config.setPackageCurations

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(projects.plugins.packageCurationProviders.filePackageCurationProvider)
 
     implementation(projects.scanner)
+    implementation(projects.utils.configUtils)
     implementation(projects.utils.ortUtils)
 
     implementation(libs.clikt)

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -51,9 +51,9 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.orEmpty
-import org.ossreviewtoolkit.model.utils.setPackageCurations
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.expandTilde
+import org.ossreviewtoolkit.utils.config.setPackageCurations
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory

--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -32,9 +32,9 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.utils.setPackageConfigurations
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.expandTilde
+import org.ossreviewtoolkit.utils.config.setPackageConfigurations
 
 internal class ListCopyrightsCommand : CliktCommand(
     help = "Lists the copyright findings."

--- a/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
@@ -28,10 +28,10 @@ import com.github.ajalt.clikt.parameters.types.file
 import org.ossreviewtoolkit.helper.utils.readOrtResult
 import org.ossreviewtoolkit.helper.utils.writeOrtResult
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
-import org.ossreviewtoolkit.model.utils.setPackageCurations
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.file.FilePackageCurationProvider
 import org.ossreviewtoolkit.utils.common.expandTilde
+import org.ossreviewtoolkit.utils.config.setPackageCurations
 
 internal class SetCommand : CliktCommand(
     help = "(Re-)set all package curations for a given ORT file to the curations specified via package curations " +

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -27,45 +27,6 @@ import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 
 /**
- * Replace the package configurations in [OrtResult.resolvedConfiguration] with the ones obtained from
- * [packageConfigurationProvider].
- */
-fun OrtResult.setPackageConfigurations(packageConfigurationProvider: PackageConfigurationProvider): OrtResult {
-    val packageConfigurations = ConfigurationResolver.resolvePackageConfigurations(
-        identifiers = getUncuratedPackages().mapTo(mutableSetOf()) { it.id },
-        scanResultProvider = { id -> getScanResultsForId(id) },
-        packageConfigurationProvider = packageConfigurationProvider
-    )
-
-    return copy(resolvedConfiguration = resolvedConfiguration.copy(packageConfigurations = packageConfigurations))
-}
-
-/**
- * Replace the package curations in [OrtResult.resolvedConfiguration] with the ones obtained from
- * [packageCurationProviders]. The [packageCurationProviders] must be ordered highest-priority-first.
- */
-fun OrtResult.setPackageCurations(packageCurationProviders: List<Pair<String, PackageCurationProvider>>): OrtResult {
-    val packageCurations =
-        ConfigurationResolver.resolvePackageCurations(getUncuratedPackages(), packageCurationProviders)
-
-    return copy(resolvedConfiguration = resolvedConfiguration.copy(packageCurations = packageCurations))
-}
-
-/**
- * Replace the resolutions in [OrtResult.resolvedConfiguration] with the ones obtained from [resolutionProvider].
- */
-fun OrtResult.setResolutions(resolutionProvider: ResolutionProvider): OrtResult {
-    val resolutions = ConfigurationResolver.resolveResolutions(
-        issues = getIssues().values.flatten(),
-        ruleViolations = getRuleViolations(),
-        vulnerabilities = getVulnerabilities().values.flatten(),
-        resolutionProvider = resolutionProvider
-    )
-
-    return copy(resolvedConfiguration = resolvedConfiguration.copy(resolutions = resolutions))
-}
-
-/**
  * Create a [LicenseInfoResolver] for [this] [OrtResult]. If the resolver is used multiple times it should be stored
  * instead of calling this function multiple times for better performance.
  */

--- a/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
+++ b/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
@@ -132,7 +132,7 @@ class NexusIq(override val descriptor: PluginDescriptor, private val config: Nex
                     component.packageUrl to ComponentDetails(component, SecurityData(emptyList()))
                 }
 
-                issues += Issue(source = descriptor.name, message = it.collectMessages())
+                issues += Issue(source = descriptor.displayName, message = it.collectMessages())
             }
         }
 

--- a/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
+++ b/plugins/advisors/nexus-iq/src/main/kotlin/NexusIq.kt
@@ -84,7 +84,7 @@ private val READ_TIMEOUT = Duration.ofSeconds(60)
     factory = AdviceProviderFactory::class
 )
 class NexusIq(override val descriptor: PluginDescriptor, private val config: NexusIqConfiguration) : AdviceProvider {
-    override val details = AdvisorDetails(descriptor.className, enumSetOf(AdvisorCapability.VULNERABILITIES))
+    override val details = AdvisorDetails(descriptor.id, enumSetOf(AdvisorCapability.VULNERABILITIES))
 
     private val service by lazy {
         NexusIqService.create(

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
@@ -72,7 +72,7 @@ private const val BULK_REQUEST_SIZE = 128
     factory = AdviceProviderFactory::class
 )
 class OssIndex(override val descriptor: PluginDescriptor, config: OssIndexConfiguration) : AdviceProvider {
-    override val details = AdvisorDetails(descriptor.className, enumSetOf(AdvisorCapability.VULNERABILITIES))
+    override val details = AdvisorDetails(descriptor.id, enumSetOf(AdvisorCapability.VULNERABILITIES))
 
     private val service by lazy {
         OssIndexService.create(

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
@@ -113,7 +113,7 @@ class OssIndex(override val descriptor: PluginDescriptor, config: OssIndexConfig
                     ComponentReport(purl, reference = "", vulnerabilities = emptyList())
                 }
 
-                issues += Issue(source = descriptor.name, message = it.collectMessages())
+                issues += Issue(source = descriptor.displayName, message = it.collectMessages())
             }
         }
 

--- a/plugins/advisors/osv/src/main/kotlin/Osv.kt
+++ b/plugins/advisors/osv/src/main/kotlin/Osv.kt
@@ -66,7 +66,7 @@ import us.springett.cvss.Cvss
     factory = AdviceProviderFactory::class
 )
 class Osv(override val descriptor: PluginDescriptor, config: OsvConfiguration) : AdviceProvider {
-    override val details = AdvisorDetails(descriptor.className, enumSetOf(AdvisorCapability.VULNERABILITIES))
+    override val details = AdvisorDetails(descriptor.id, enumSetOf(AdvisorCapability.VULNERABILITIES))
 
     private val service = OsvServiceWrapper(
         serverUrl = config.serverUrl,

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -80,7 +80,7 @@ class VulnerableCode(override val descriptor: PluginDescriptor, config: Vulnerab
      * The details returned with each [AdvisorResult] produced by this instance. As this is constant, it can be
      * created once beforehand.
      */
-    override val details = AdvisorDetails(descriptor.className, enumSetOf(AdvisorCapability.VULNERABILITIES))
+    override val details = AdvisorDetails(descriptor.id, enumSetOf(AdvisorCapability.VULNERABILITIES))
 
     private val service by lazy {
         val client = OkHttpClientHelper.buildClient {

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -111,7 +111,7 @@ class VulnerableCode(override val descriptor: PluginDescriptor, config: Vulnerab
                 // issues that are not associated to any package.
                 allVulnerabilities += chunk.associateWith { emptyList() }
 
-                issues += Issue(source = descriptor.name, message = it.collectMessages())
+                issues += Issue(source = descriptor.displayName, message = it.collectMessages())
 
                 logger.error {
                     "The request of chunk ${index + 1} of ${chunks.size} failed for the following ${chunk.size} " +
@@ -161,7 +161,11 @@ class VulnerableCode(override val descriptor: PluginDescriptor, config: Vulnerab
                 VulnerabilityReference(sourceUri, it.scoringSystem, severity)
             }
         }.onFailure {
-            issues += createAndLogIssue(descriptor.name, "Failed to map $this to ORT model due to $it.", Severity.HINT)
+            issues += createAndLogIssue(
+                descriptor.displayName,
+                "Failed to map $this to ORT model due to $it.",
+                Severity.HINT
+            )
         }.getOrElse { emptyList() }
 
     /**

--- a/plugins/api/src/main/kotlin/PluginDescriptor.kt
+++ b/plugins/api/src/main/kotlin/PluginDescriptor.kt
@@ -41,7 +41,7 @@ data class PluginDescriptor(
     /**
      * The configuration options supported by the plugin.
      */
-    val options: List<PluginOption>
+    val options: List<PluginOption> = emptyList()
 )
 
 /**

--- a/plugins/api/src/main/kotlin/PluginDescriptor.kt
+++ b/plugins/api/src/main/kotlin/PluginDescriptor.kt
@@ -24,9 +24,9 @@ package org.ossreviewtoolkit.plugins.api
  */
 data class PluginDescriptor(
     /**
-     * The name of the plugin. Must be unique among all plugins for the same factory class.
+     * The display name of the plugin. Must be unique among all plugins for the same factory class.
      */
-    val name: String,
+    val displayName: String,
 
     /**
      * The name of the plugin class.

--- a/plugins/api/src/main/kotlin/PluginDescriptor.kt
+++ b/plugins/api/src/main/kotlin/PluginDescriptor.kt
@@ -24,14 +24,14 @@ package org.ossreviewtoolkit.plugins.api
  */
 data class PluginDescriptor(
     /**
-     * The display name of the plugin.
-     */
-    val displayName: String,
-
-    /**
      * The name of the plugin class. Must be unique among all plugins for the same factory class.
      */
     val id: String,
+
+    /**
+     * The display name of the plugin.
+     */
+    val displayName: String,
 
     /**
      * The description of the plugin.

--- a/plugins/api/src/main/kotlin/PluginDescriptor.kt
+++ b/plugins/api/src/main/kotlin/PluginDescriptor.kt
@@ -24,12 +24,12 @@ package org.ossreviewtoolkit.plugins.api
  */
 data class PluginDescriptor(
     /**
-     * The display name of the plugin. Must be unique among all plugins for the same factory class.
+     * The display name of the plugin.
      */
     val displayName: String,
 
     /**
-     * The name of the plugin class.
+     * The name of the plugin class. Must be unique among all plugins for the same factory class.
      */
     val className: String,
 

--- a/plugins/api/src/main/kotlin/PluginDescriptor.kt
+++ b/plugins/api/src/main/kotlin/PluginDescriptor.kt
@@ -31,7 +31,7 @@ data class PluginDescriptor(
     /**
      * The name of the plugin class. Must be unique among all plugins for the same factory class.
      */
-    val className: String,
+    val id: String,
 
     /**
      * The description of the plugin.

--- a/plugins/api/src/main/kotlin/PluginFactory.kt
+++ b/plugins/api/src/main/kotlin/PluginFactory.kt
@@ -35,7 +35,7 @@ interface PluginFactory<out PLUGIN : Plugin> {
                 .iterator()
                 .asSequence()
                 .associateByTo(sortedMapOf(String.CASE_INSENSITIVE_ORDER)) {
-                    it.descriptor.className
+                    it.descriptor.id
                 }
     }
 

--- a/plugins/commands/evaluator/build.gradle.kts
+++ b/plugins/commands/evaluator/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.evaluator)
     implementation(projects.model)
     implementation(projects.utils.commonUtils)
+    implementation(projects.utils.configUtils)
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -58,9 +58,6 @@ import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
-import org.ossreviewtoolkit.model.utils.setPackageConfigurations
-import org.ossreviewtoolkit.model.utils.setPackageCurations
-import org.ossreviewtoolkit.model.utils.setResolutions
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStatsPrinter
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
@@ -75,6 +72,9 @@ import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCu
 import org.ossreviewtoolkit.plugins.packagecurationproviders.file.FilePackageCurationProvider
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.safeMkdirs
+import org.ossreviewtoolkit.utils.config.setPackageConfigurations
+import org.ossreviewtoolkit.utils.config.setPackageCurations
+import org.ossreviewtoolkit.utils.config.setResolutions
 import org.ossreviewtoolkit.utils.ort.ORT_COPYRIGHT_GARBAGE_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_EVALUATOR_RULES_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME

--- a/plugins/commands/reporter/build.gradle.kts
+++ b/plugins/commands/reporter/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(projects.model)
     implementation(projects.reporter)
     implementation(projects.utils.commonUtils)
+    implementation(projects.utils.configUtils)
     implementation(projects.utils.ortUtils)
 
     implementation(libs.clikt)

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -54,8 +54,6 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
-import org.ossreviewtoolkit.model.utils.setPackageConfigurations
-import org.ossreviewtoolkit.model.utils.setResolutions
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
@@ -70,6 +68,8 @@ import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.safeMkdirs
+import org.ossreviewtoolkit.utils.config.setPackageConfigurations
+import org.ossreviewtoolkit.utils.config.setResolutions
 import org.ossreviewtoolkit.utils.ort.ORT_COPYRIGHT_GARBAGE_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_CUSTOM_LICENSE_TEXTS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME

--- a/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
@@ -40,8 +40,8 @@ class JsonSpecGenerator(private val codeGenerator: CodeGenerator) {
     fun generate(pluginSpec: PluginSpec) {
         val jsonObject = buildJsonObject {
             putJsonObject("descriptor") {
-                put("displayName", pluginSpec.descriptor.displayName)
                 put("id", pluginSpec.descriptor.id)
+                put("displayName", pluginSpec.descriptor.displayName)
                 put("description", pluginSpec.descriptor.description)
 
                 putJsonArray("options") {

--- a/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
@@ -41,7 +41,7 @@ class JsonSpecGenerator(private val codeGenerator: CodeGenerator) {
         val jsonObject = buildJsonObject {
             putJsonObject("descriptor") {
                 put("displayName", pluginSpec.descriptor.displayName)
-                put("className", pluginSpec.descriptor.className)
+                put("id", pluginSpec.descriptor.id)
                 put("description", pluginSpec.descriptor.description)
 
                 putJsonArray("options") {
@@ -63,7 +63,7 @@ class JsonSpecGenerator(private val codeGenerator: CodeGenerator) {
 
         codeGenerator.createNewFileByPath(
             dependencies = Dependencies(aggregating = true, *listOfNotNull(pluginSpec.containingFile).toTypedArray()),
-            path = "META-INF/plugin/${pluginSpec.packageName}.${pluginSpec.descriptor.className}",
+            path = "META-INF/plugin/${pluginSpec.packageName}.${pluginSpec.descriptor.id}",
             extensionName = "json"
         ).use { output ->
             json.encodeToStream(jsonObject, output)

--- a/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
@@ -40,7 +40,7 @@ class JsonSpecGenerator(private val codeGenerator: CodeGenerator) {
     fun generate(pluginSpec: PluginSpec) {
         val jsonObject = buildJsonObject {
             putJsonObject("descriptor") {
-                put("name", pluginSpec.descriptor.name)
+                put("displayName", pluginSpec.descriptor.displayName)
                 put("className", pluginSpec.descriptor.className)
                 put("description", pluginSpec.descriptor.description)
 

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.plugins.compiler
 
 import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.Dependencies
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -39,9 +38,9 @@ import org.ossreviewtoolkit.plugins.api.PluginOptionType
 import org.ossreviewtoolkit.plugins.api.Secret
 
 class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
-    fun generate(pluginSpec: PluginSpec) {
+    fun generate(pluginSpec: PluginSpec): ServiceLoaderSpec {
         val generatedFactory = generateFactoryClass(pluginSpec)
-        generateServiceLoaderFile(pluginSpec, generatedFactory)
+        return ServiceLoaderSpec(pluginSpec, generatedFactory)
     }
 
     /**
@@ -188,19 +187,4 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
                 """.trimIndent()
             )
         }.build()
-
-    /**
-     * Generate a service loader file for the [generatedFactory].
-     */
-    private fun generateServiceLoaderFile(pluginSpec: PluginSpec, generatedFactory: TypeSpec) {
-        codeGenerator.createNewFileByPath(
-            dependencies = Dependencies(aggregating = true, *listOfNotNull(pluginSpec.containingFile).toTypedArray()),
-            path = "META-INF/services/${pluginSpec.factory.qualifiedName}",
-            extensionName = ""
-        ).use { output ->
-            output.writer().use { writer ->
-                writer.write("${pluginSpec.packageName}.${generatedFactory.name}\n")
-            }
-        }
-    }
 }

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -148,13 +148,13 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
             add(
                 """
                 PluginDescriptor(
-                    name = %S,
+                    displayName = %S,
                     className = %S,
                     description = %S,
                     options = listOf(
             
                 """.trimIndent(),
-                descriptor.name,
+                descriptor.displayName,
                 descriptor.className,
                 descriptor.description
             )

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -75,7 +75,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
         }.build()
 
         // Create the factory class.
-        val className = "${pluginSpec.descriptor.className}Factory"
+        val className = "${pluginSpec.descriptor.id}Factory"
         val classSpec = TypeSpec.classBuilder(className)
             .addSuperinterface(pluginSpec.factory.typeName)
             .addProperty(descriptorProperty)
@@ -83,7 +83,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
             .build()
 
         // Write the factory class to a file.
-        FileSpec.builder(ClassName(pluginSpec.packageName, "${pluginSpec.descriptor.className}Factory"))
+        FileSpec.builder(ClassName(pluginSpec.packageName, "${pluginSpec.descriptor.id}Factory"))
             .addType(classSpec)
             .build()
             .writeTo(codeGenerator, aggregating = true, originatingKSFiles = listOfNotNull(pluginSpec.containingFile))
@@ -149,13 +149,13 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
                 """
                 PluginDescriptor(
                     displayName = %S,
-                    className = %S,
+                    id = %S,
                     description = %S,
                     options = listOf(
             
                 """.trimIndent(),
                 descriptor.displayName,
-                descriptor.className,
+                descriptor.id,
                 descriptor.description
             )
 

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -74,7 +74,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
         }.build()
 
         // Create the factory class.
-        val className = "${pluginSpec.descriptor.id}Factory"
+        val className = "${pluginSpec.typeName.toString().substringAfterLast('.')}Factory"
         val classSpec = TypeSpec.classBuilder(className)
             .addSuperinterface(pluginSpec.factory.typeName)
             .addProperty(descriptorProperty)
@@ -82,7 +82,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
             .build()
 
         // Write the factory class to a file.
-        FileSpec.builder(ClassName(pluginSpec.packageName, "${pluginSpec.descriptor.id}Factory"))
+        FileSpec.builder(ClassName(pluginSpec.packageName, className))
             .addType(classSpec)
             .build()
             .writeTo(codeGenerator, aggregating = true, originatingKSFiles = listOfNotNull(pluginSpec.containingFile))

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -148,14 +148,14 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
             add(
                 """
                 PluginDescriptor(
-                    displayName = %S,
                     id = %S,
+                    displayName = %S,
                     description = %S,
                     options = listOf(
             
                 """.trimIndent(),
-                descriptor.displayName,
                 descriptor.id,
+                descriptor.displayName,
                 descriptor.description
             )
 

--- a/plugins/compiler/src/main/kotlin/PluginProcessor.kt
+++ b/plugins/compiler/src/main/kotlin/PluginProcessor.kt
@@ -70,7 +70,7 @@ class PluginProcessor(codeGenerator: CodeGenerator) : SymbolProcessor {
             val pluginParentClass = getPluginParentClass(pluginFactoryClass)
             checkExtendsPluginClass(pluginClass, pluginParentClass)
 
-            val pluginSpec = specFactory.create(pluginAnnotation, pluginClass, pluginFactoryClass)
+            val pluginSpec = specFactory.create(pluginAnnotation, pluginClass, pluginParentClass, pluginFactoryClass)
             serviceLoaderSpecs += factoryGenerator.generate(pluginSpec)
             jsonGenerator.generate(pluginSpec)
         }

--- a/plugins/compiler/src/main/kotlin/PluginSpec.kt
+++ b/plugins/compiler/src/main/kotlin/PluginSpec.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.compiler
 import com.google.devtools.ksp.symbol.KSFile
 
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
 
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 
@@ -51,4 +52,12 @@ data class PluginConfigClassSpec(
 data class PluginFactorySpec(
     val typeName: TypeName,
     val qualifiedName: String
+)
+
+/**
+ * A specification for a service loader, used to generate service loader files.
+ */
+data class ServiceLoaderSpec(
+    val pluginSpec: PluginSpec,
+    val factory: TypeSpec
 )

--- a/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
+++ b/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
@@ -63,7 +63,7 @@ class PluginSpecFactory {
         return PluginSpec(
             containingFile = pluginClass.containingFile,
             descriptor = PluginDescriptor(
-                name = ortPlugin.name,
+                displayName = ortPlugin.name,
                 className = pluginClass.simpleName.asString(),
                 description = ortPlugin.description,
                 options = pluginOptions

--- a/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
+++ b/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
@@ -63,8 +63,8 @@ class PluginSpecFactory {
         return PluginSpec(
             containingFile = pluginClass.containingFile,
             descriptor = PluginDescriptor(
-                displayName = ortPlugin.name,
                 id = pluginClass.simpleName.asString(),
+                displayName = ortPlugin.name,
                 description = ortPlugin.description,
                 options = pluginOptions
             ),

--- a/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
+++ b/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
@@ -45,6 +45,7 @@ class PluginSpecFactory {
     fun create(
         ortPlugin: OrtPlugin,
         pluginClass: KSClassDeclaration,
+        pluginParentClass: KSClassDeclaration,
         pluginFactoryClass: KSClassDeclaration
     ): PluginSpec {
         val pluginType = pluginClass.asType(emptyList()).toTypeName()
@@ -63,7 +64,7 @@ class PluginSpecFactory {
         return PluginSpec(
             containingFile = pluginClass.containingFile,
             descriptor = PluginDescriptor(
-                id = pluginClass.simpleName.asString(),
+                id = pluginClass.simpleName.asString().removeSuffix(pluginParentClass.simpleName.asString()),
                 displayName = ortPlugin.name,
                 description = ortPlugin.description,
                 options = pluginOptions

--- a/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
+++ b/plugins/compiler/src/main/kotlin/PluginSpecFactory.kt
@@ -64,7 +64,7 @@ class PluginSpecFactory {
             containingFile = pluginClass.containingFile,
             descriptor = PluginDescriptor(
                 displayName = ortPlugin.name,
-                className = pluginClass.simpleName.asString(),
+                id = pluginClass.simpleName.asString(),
                 description = ortPlugin.description,
                 options = pluginOptions
             ),

--- a/plugins/compiler/src/main/kotlin/ServiceLoaderGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/ServiceLoaderGenerator.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.compiler
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+
+/**
+ * A class to generate service loader files for plugin factories.
+ */
+class ServiceLoaderGenerator(private val codeGenerator: CodeGenerator) {
+    fun generate(serviceLoaderSpecs: List<ServiceLoaderSpec>) {
+        serviceLoaderSpecs.groupBy { it.pluginSpec.factory.qualifiedName }.forEach { (factoryName, specs) ->
+            val containingFiles = specs.mapNotNull { it.pluginSpec.containingFile }
+
+            codeGenerator.createNewFileByPath(
+                dependencies = Dependencies(
+                    aggregating = true,
+                    *containingFiles.toTypedArray()
+                ),
+                path = "META-INF/services/$factoryName",
+                extensionName = ""
+            ).use { output ->
+                output.writer().use { writer ->
+                    specs.forEach { spec ->
+                        writer.write("${spec.pluginSpec.packageName}.${spec.factory.name}\n")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/package-curation-providers/api/build.gradle.kts
+++ b/plugins/package-curation-providers/api/build.gradle.kts
@@ -24,4 +24,5 @@ plugins {
 
 dependencies {
     api(projects.model)
+    api(projects.plugins.api)
 }

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProvider.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProvider.kt
@@ -21,11 +21,12 @@ package org.ossreviewtoolkit.plugins.packagecurationproviders.api
 
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.plugins.api.Plugin
 
 /**
  * A provider for [PackageCuration]s.
  */
-fun interface PackageCurationProvider {
+interface PackageCurationProvider : Plugin {
     /**
      * Return all available [PackageCuration]s which are applicable to any of the given [packages].
      */

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProvider.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProvider.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model.utils
+package org.ossreviewtoolkit.plugins.packagecurationproviders.api
 
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -23,20 +23,20 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
-import org.ossreviewtoolkit.utils.common.Plugin
-import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
+import org.ossreviewtoolkit.plugins.api.PluginConfig
+import org.ossreviewtoolkit.plugins.api.PluginFactory
 import org.ossreviewtoolkit.utils.common.getDuplicates
 
 /**
  * The extension point for [PackageCurationProvider]s.
  */
-interface PackageCurationProviderFactory<CONFIG> : TypedConfigurablePluginFactory<CONFIG, PackageCurationProvider> {
+interface PackageCurationProviderFactory : PluginFactory<PackageCurationProvider> {
     companion object {
         /**
          * All [package curation provider factories][PackageCurationProviderFactory] available in the classpath,
          * associated by their names.
          */
-        val ALL by lazy { Plugin.getAll<PackageCurationProviderFactory<*>>() }
+        val ALL by lazy { PluginFactory.getAll<PackageCurationProviderFactory, PackageCurationProvider>() }
 
         /**
          * Return a new (identifier, provider instance) tuple for each
@@ -48,7 +48,7 @@ interface PackageCurationProviderFactory<CONFIG> : TypedConfigurablePluginFactor
                 it.enabled
             }.mapNotNull {
                 ALL[it.type]?.let { factory ->
-                    it.id to factory.create(it.options, it.secrets)
+                    it.id to factory.create(PluginConfig(it.options, it.secrets))
                 }.also { factory ->
                     factory ?: logger.error {
                         "Curation provider of type '${it.type}' is enabled in configuration but not available in the " +

--- a/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.getDuplicates

--- a/plugins/package-curation-providers/api/src/main/kotlin/SimplePackageCurationProvider.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/SimplePackageCurationProvider.kt
@@ -21,11 +21,27 @@ package org.ossreviewtoolkit.plugins.packagecurationproviders.api
 
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+
+/**
+ * The default [PluginDescriptor] for a [SimplePackageCurationProvider]. Classes inheriting from this class
+ * have to provide their own descriptor.
+ */
+private val pluginDescriptor = PluginDescriptor(
+    id = "Simple",
+    displayName = "Simple Package Curation Provider",
+    description = "A simple package curation provider, which provides a fixed set of package curations."
+)
 
 /**
  * A [PackageCurationProvider] that provides the specified [packageCurations].
  */
-open class SimplePackageCurationProvider(val packageCurations: List<PackageCuration>) : PackageCurationProvider {
+open class SimplePackageCurationProvider(
+    override val descriptor: PluginDescriptor,
+    val packageCurations: List<PackageCuration>
+) : PackageCurationProvider {
+    constructor(packageCurations: List<PackageCuration>) : this(pluginDescriptor, packageCurations)
+
     override fun getCurationsFor(packages: Collection<Package>): Set<PackageCuration> =
         packageCurations.filterTo(mutableSetOf()) { curation ->
             packages.any { pkg -> curation.isApplicable(pkg.id) }

--- a/plugins/package-curation-providers/api/src/main/kotlin/SimplePackageCurationProvider.kt
+++ b/plugins/package-curation-providers/api/src/main/kotlin/SimplePackageCurationProvider.kt
@@ -21,7 +21,6 @@ package org.ossreviewtoolkit.plugins.packagecurationproviders.api
 
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 
 /**
  * A [PackageCurationProvider] that provides the specified [packageCurations].

--- a/plugins/package-curation-providers/clearly-defined/build.gradle.kts
+++ b/plugins/package-curation-providers/clearly-defined/build.gradle.kts
@@ -19,12 +19,14 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.clients.clearlyDefinedClient)
     api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+
+    ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 
     testImplementation(libs.wiremock)
 }

--- a/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -31,11 +31,12 @@ import kotlin.time.Duration.Companion.seconds
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
     "The production server" should {
-        val provider = ClearlyDefinedPackageCurationProvider()
+        val provider = ClearlyDefinedPackageCurationProviderFactory().create(PluginConfig())
 
         "return an existing curation for the javax.servlet-api Maven package" {
             val packages = createPackagesFromIds("Maven:javax.servlet:javax.servlet-api:3.1.0")
@@ -76,7 +77,10 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
                 serverUrl = Server.PRODUCTION.apiUrl,
                 minTotalLicenseScore = 80
             )
-            val provider = ClearlyDefinedPackageCurationProvider(config)
+            val provider = ClearlyDefinedPackageCurationProvider(
+                ClearlyDefinedPackageCurationProviderFactory().descriptor,
+                config
+            )
 
             // Use an id which is known to have non-empty results from an earlier test.
             val packages = createPackagesFromIds("Maven:org.slf4j:slf4j-log4j12:1.7.30")
@@ -89,7 +93,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
         }
 
         "be retrieved for packages without a namespace" {
-            val provider = ClearlyDefinedPackageCurationProvider()
+            val provider = ClearlyDefinedPackageCurationProviderFactory().create(PluginConfig())
             val packages = createPackagesFromIds("NPM::acorn:0.6.0")
 
             withRetry {

--- a/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
@@ -40,8 +40,8 @@ import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfoCurationData
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.collectMessages

--- a/plugins/package-curation-providers/clearly-defined/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+++ b/plugins/package-curation-providers/clearly-defined/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
@@ -1,1 +1,0 @@
-org.ossreviewtoolkit.plugins.packagecurationproviders.clearlydefined.ClearlyDefinedPackageCurationProviderFactory

--- a/plugins/package-curation-providers/clearly-defined/src/test/kotlin/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/test/kotlin/ClearlyDefinedPackageCurationProviderTest.kt
@@ -68,7 +68,12 @@ class ClearlyDefinedPackageCurationProviderTest : WordSpec({
                 readTimeout(Duration.ofMillis(1))
             }
 
-            val provider = ClearlyDefinedPackageCurationProvider("http://localhost:${server.port()}", client)
+            val provider = ClearlyDefinedPackageCurationProvider(
+                ClearlyDefinedPackageCurationProviderFactory().descriptor,
+                ClearlyDefinedPackageCurationProviderConfig(serverUrl = "http://localhost:${server.port()}", 0),
+                client
+            )
+
             val id = Identifier("Maven:some-ns:some-component:1.2.3")
             val packages = listOf(Package.EMPTY.copy(id = id))
 

--- a/plugins/package-curation-providers/file/build.gradle.kts
+++ b/plugins/package-curation-providers/file/build.gradle.kts
@@ -19,9 +19,11 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+
+    ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 }

--- a/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
+++ b/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
@@ -25,7 +25,6 @@ import java.io.IOException
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCurationProvider
 import org.ossreviewtoolkit.utils.common.Options

--- a/plugins/package-curation-providers/file/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+++ b/plugins/package-curation-providers/file/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
@@ -1,3 +1,0 @@
-org.ossreviewtoolkit.plugins.packagecurationproviders.file.DefaultDirPackageCurationProviderFactory
-org.ossreviewtoolkit.plugins.packagecurationproviders.file.DefaultFilePackageCurationProviderFactory
-org.ossreviewtoolkit.plugins.packagecurationproviders.file.FilePackageCurationProviderFactory

--- a/plugins/package-curation-providers/ort-config/build.gradle.kts
+++ b/plugins/package-curation-providers/ort-config/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+
+    ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 
     implementation(projects.downloader)
 }

--- a/plugins/package-curation-providers/ort-config/src/funTest/kotlin/OrtConfigPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/ort-config/src/funTest/kotlin/OrtConfigPackageCurationProviderFunTest.kt
@@ -26,14 +26,17 @@ import io.kotest.matchers.shouldNot
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.plugins.api.PluginConfig
 
 class OrtConfigPackageCurationProviderFunTest : StringSpec({
+    fun createProvider() = OrtConfigPackageCurationProviderFactory().create(PluginConfig())
+
     "The provider succeeds to return known curations for packages" {
         val azureCore = Identifier("NuGet:Azure:Core:1.22.0")
         val azureCoreAmqp = Identifier("NuGet:Azure.Core:Amqp:1.2.0")
         val packages = createPackagesFromIds(azureCore, azureCoreAmqp)
 
-        val curations = OrtConfigPackageCurationProvider().getCurationsFor(packages)
+        val curations = createProvider().getCurationsFor(packages)
 
         curations.filter { it.isApplicable(azureCore) } shouldNot beEmpty()
         curations.filter { it.isApplicable(azureCoreAmqp) } shouldNot beEmpty()
@@ -43,7 +46,7 @@ class OrtConfigPackageCurationProviderFunTest : StringSpec({
         val xrd4j = Identifier("Maven:org.niis.xrd4j:foo:0.0.0")
         val packages = createPackagesFromIds(xrd4j)
 
-        val curations = OrtConfigPackageCurationProvider().getCurationsFor(packages)
+        val curations = createProvider().getCurationsFor(packages)
 
         curations.filter { it.isApplicable(xrd4j) } shouldNot beEmpty()
     }
@@ -51,7 +54,7 @@ class OrtConfigPackageCurationProviderFunTest : StringSpec({
     "The provider does not fail for packages which have no curations" {
         val packages = createPackagesFromIds(Identifier("Some:Bogus:Package:Id"))
 
-        val curations = OrtConfigPackageCurationProvider().getCurationsFor(packages)
+        val curations = createProvider().getCurationsFor(packages)
 
         curations should beEmpty()
     }

--- a/plugins/package-curation-providers/ort-config/src/main/kotlin/OrtConfigPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/ort-config/src/main/kotlin/OrtConfigPackageCurationProvider.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.encodeOr

--- a/plugins/package-curation-providers/ort-config/src/main/kotlin/OrtConfigPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/ort-config/src/main/kotlin/OrtConfigPackageCurationProvider.kt
@@ -31,9 +31,10 @@ import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
-import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.encodeOr
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
@@ -41,19 +42,16 @@ import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 private const val ORT_CONFIG_REPOSITORY_BRANCH = "main"
 private const val ORT_CONFIG_REPOSITORY_URL = "https://github.com/oss-review-toolkit/ort-config.git"
 
-class OrtConfigPackageCurationProviderFactory : PackageCurationProviderFactory<Unit> {
-    override val type = "OrtConfig"
-
-    override fun create(config: Unit) = OrtConfigPackageCurationProvider()
-
-    override fun parseConfig(options: Options, secrets: Options) = Unit
-}
-
 /**
  * A [PackageCurationProvider] that provides [PackageCuration]s loaded from the
  * [ort-config repository](https://github.com/oss-review-toolkit/ort-config).
  */
-open class OrtConfigPackageCurationProvider : PackageCurationProvider {
+@OrtPlugin(
+    name = "ort-config",
+    description = "A package curation provider that loads package curations from the ort-config repository.",
+    factory = PackageCurationProviderFactory::class
+)
+open class OrtConfigPackageCurationProvider(override val descriptor: PluginDescriptor) : PackageCurationProvider {
     private val curationsDir by lazy {
         ortDataDirectory.resolve("ort-config").also {
             updateOrtConfig(it)

--- a/plugins/package-curation-providers/ort-config/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+++ b/plugins/package-curation-providers/ort-config/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
@@ -1,1 +1,0 @@
-org.ossreviewtoolkit.plugins.packagecurationproviders.ortconfig.OrtConfigPackageCurationProviderFactory

--- a/plugins/package-curation-providers/sw360/build.gradle.kts
+++ b/plugins/package-curation-providers/sw360/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+
+    ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 
     implementation(libs.sw360Client)
 }

--- a/plugins/package-curation-providers/sw360/src/main/kotlin/Sw360PackageCurationProvider.kt
+++ b/plugins/package-curation-providers/sw360/src/main/kotlin/Sw360PackageCurationProvider.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.orEmpty
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor

--- a/plugins/package-curation-providers/sw360/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+++ b/plugins/package-curation-providers/sw360/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
@@ -1,1 +1,0 @@
-org.ossreviewtoolkit.plugins.packagecurationproviders.sw360.Sw360PackageCurationProviderFactory

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(":notifier")
 include(":reporter")
 include(":scanner")
 include(":utils:common")
+include(":utils:config")
 include(":utils:ort")
 include(":utils:scripting")
 include(":utils:spdx")
@@ -58,6 +59,7 @@ project(":clients:osv").name = "osv-client"
 project(":clients:vulnerable-code").name = "vulnerable-code-client"
 
 project(":utils:common").name = "common-utils"
+project(":utils:config").name = "config-utils"
 project(":utils:ort").name = "ort-utils"
 project(":utils:scripting").name = "scripting-utils"
 project(":utils:spdx").name = "spdx-utils"

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,29 +18,10 @@
  */
 
 plugins {
-    // Apply core plugins.
-    `java-test-fixtures`
-
     // Apply precompiled plugins.
     id("ort-library-conventions")
 }
 
 dependencies {
     api(projects.model)
-
-    implementation(projects.downloader)
-    implementation(projects.utils.configUtils)
-    implementation(projects.utils.ortUtils)
-
-    implementation(libs.kotlinx.coroutines)
-
-    funTestImplementation(platform(projects.plugins.packageManagers))
-
-    // Only the Java plugin's built-in "test" source set automatically depends on the test fixtures.
-    funTestImplementation(testFixtures(project))
-
-    testFixturesImplementation(projects.utils.testUtils)
-
-    testFixturesImplementation(libs.kotest.assertions.core)
-    testFixturesImplementation(libs.kotest.runner.junit5)
 }

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -24,4 +24,5 @@ plugins {
 
 dependencies {
     api(projects.model)
+    api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 }

--- a/utils/config/src/main/kotlin/ConfigurationResolver.kt
+++ b/utils/config/src/main/kotlin/ConfigurationResolver.kt
@@ -33,9 +33,9 @@ import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 
 object ConfigurationResolver {
     /**

--- a/utils/config/src/main/kotlin/ConfigurationResolver.kt
+++ b/utils/config/src/main/kotlin/ConfigurationResolver.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model.utils
+package org.ossreviewtoolkit.utils.config
 
 import kotlin.time.measureTimedValue
 
@@ -32,6 +32,9 @@ import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
+import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 
 object ConfigurationResolver {

--- a/utils/config/src/main/kotlin/OrtResultExtensions.kt
+++ b/utils/config/src/main/kotlin/OrtResultExtensions.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.config
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
+import org.ossreviewtoolkit.model.utils.ResolutionProvider
+
+/**
+ * Replace the package configurations in [OrtResult.resolvedConfiguration] with the ones obtained from
+ * [packageConfigurationProvider].
+ */
+fun OrtResult.setPackageConfigurations(packageConfigurationProvider: PackageConfigurationProvider): OrtResult {
+    val packageConfigurations = ConfigurationResolver.resolvePackageConfigurations(
+        identifiers = getUncuratedPackages().mapTo(mutableSetOf()) { it.id },
+        scanResultProvider = { id -> getScanResultsForId(id) },
+        packageConfigurationProvider = packageConfigurationProvider
+    )
+
+    return copy(resolvedConfiguration = resolvedConfiguration.copy(packageConfigurations = packageConfigurations))
+}
+
+/**
+ * Replace the package curations in [OrtResult.resolvedConfiguration] with the ones obtained from
+ * [packageCurationProviders]. The [packageCurationProviders] must be ordered highest-priority-first.
+ */
+fun OrtResult.setPackageCurations(packageCurationProviders: List<Pair<String, PackageCurationProvider>>): OrtResult {
+    val packageCurations =
+        ConfigurationResolver.resolvePackageCurations(getUncuratedPackages(), packageCurationProviders)
+
+    return copy(resolvedConfiguration = resolvedConfiguration.copy(packageCurations = packageCurations))
+}
+
+/**
+ * Replace the resolutions in [OrtResult.resolvedConfiguration] with the ones obtained from [resolutionProvider].
+ */
+fun OrtResult.setResolutions(resolutionProvider: ResolutionProvider): OrtResult {
+    val resolutions = ConfigurationResolver.resolveResolutions(
+        issues = getIssues().values.flatten(),
+        ruleViolations = getRuleViolations(),
+        vulnerabilities = getVulnerabilities().values.flatten(),
+        resolutionProvider = resolutionProvider
+    )
+
+    return copy(resolvedConfiguration = resolvedConfiguration.copy(resolutions = resolutions))
+}

--- a/utils/config/src/main/kotlin/OrtResultExtensions.kt
+++ b/utils/config/src/main/kotlin/OrtResultExtensions.kt
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.utils.config
 
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 
 /**
  * Replace the package configurations in [OrtResult.resolvedConfiguration] with the ones obtained from


### PR DESCRIPTION
Migrate the package curation provider API to the new plugin API. Also implement some required improvements for the plugin API. See the commit messages for details.