### PR TITLE
Add the descriptor to the plugin factory companion object

### DIFF
--- a/plugins/advisors/oss-index/src/test/kotlin/OssIndexTest.kt
+++ b/plugins/advisors/oss-index/src/test/kotlin/OssIndexTest.kt
@@ -71,7 +71,7 @@ class OssIndexTest : WordSpec({
         "return vulnerability information" {
             server.stubComponentsRequest("response_components.json")
             val ossIndex = OssIndex(
-                OssIndexFactory().descriptor,
+                OssIndexFactory.descriptor,
                 OssIndexConfiguration("http://localhost:${server.port()}", null, null)
             )
             val packages = COMPONENTS_REQUEST_IDS.mapTo(mutableSetOf()) {
@@ -118,7 +118,7 @@ class OssIndexTest : WordSpec({
                     )
             )
             val ossIndex = OssIndex(
-                OssIndexFactory().descriptor,
+                OssIndexFactory.descriptor,
                 OssIndexConfiguration("http://localhost:${server.port()}", null, null)
             )
             val packages = COMPONENTS_REQUEST_IDS.mapTo(mutableSetOf()) {
@@ -137,7 +137,7 @@ class OssIndexTest : WordSpec({
 
         "provide correct details" {
             val ossIndex = OssIndex(
-                OssIndexFactory().descriptor,
+                OssIndexFactory.descriptor,
                 OssIndexConfiguration("http://localhost:${server.port()}", null, null)
             )
 

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
@@ -336,7 +336,7 @@ private fun createConfig(server: WireMockServer): VulnerableCodeConfiguration {
  * Create a test instance of [VulnerableCode] that communicates with the local [server].
  */
 private fun createVulnerableCode(server: WireMockServer): VulnerableCode =
-    VulnerableCode(VulnerableCodeFactory().descriptor, createConfig(server))
+    VulnerableCode(VulnerableCodeFactory.descriptor, createConfig(server))
 
 /**
  * Return the test file with an analyzer result.

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -54,8 +54,16 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
 
         // Create the plugin descriptor property.
         val descriptorInitializer = getDescriptorInitializer(pluginSpec.descriptor)
-        val descriptorProperty = PropertySpec.builder("descriptor", PluginDescriptor::class, KModifier.OVERRIDE)
+        val descriptorProperty = PropertySpec.builder("descriptor", PluginDescriptor::class)
             .initializer(descriptorInitializer)
+            .build()
+
+        val companionObject = TypeSpec.companionObjectBuilder()
+            .addProperty(descriptorProperty)
+            .build()
+
+        val descriptorDelegateProperty = PropertySpec.builder("descriptor", PluginDescriptor::class, KModifier.OVERRIDE)
+            .delegate("Companion::descriptor")
             .build()
 
         // Create the create function that initializes the plugin with the descriptor and the config object.
@@ -77,7 +85,8 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
         val className = "${pluginSpec.typeName.toString().substringAfterLast('.')}Factory"
         val classSpec = TypeSpec.classBuilder(className)
             .addSuperinterface(pluginSpec.factory.typeName)
-            .addProperty(descriptorProperty)
+            .addType(companionObject)
+            .addProperty(descriptorDelegateProperty)
             .addFunction(createFunction)
             .build()
 

--- a/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -78,7 +78,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
                 minTotalLicenseScore = 80
             )
             val provider = ClearlyDefinedPackageCurationProvider(
-                ClearlyDefinedPackageCurationProviderFactory().descriptor,
+                ClearlyDefinedPackageCurationProviderFactory.descriptor,
                 config
             )
 

--- a/plugins/package-curation-providers/clearly-defined/src/test/kotlin/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/test/kotlin/ClearlyDefinedPackageCurationProviderTest.kt
@@ -69,7 +69,7 @@ class ClearlyDefinedPackageCurationProviderTest : WordSpec({
             }
 
             val provider = ClearlyDefinedPackageCurationProvider(
-                ClearlyDefinedPackageCurationProviderFactory().descriptor,
+                ClearlyDefinedPackageCurationProviderFactory.descriptor,
                 ClearlyDefinedPackageCurationProviderConfig(serverUrl = "http://localhost:${server.port()}", 0),
                 client
             )

--- a/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
+++ b/plugins/package-curation-providers/file/src/main/kotlin/FilePackageCurationProvider.kt
@@ -91,7 +91,7 @@ open class FilePackageCurationProvider(descriptor: PluginDescriptor, vararg path
         File(config.path).takeUnless { !it.exists() && !config.mustExist }
     )
 
-    constructor(vararg paths: File?) : this(FilePackageCurationProviderFactory().descriptor, *paths)
+    constructor(vararg paths: File?) : this(FilePackageCurationProviderFactory.descriptor, *paths)
 
     companion object {
         /**


### PR DESCRIPTION
Add the plugin descriptors to the companion objects of the generated plugin factories. See the commit messages for details.