### PR TITLE
Migrate package configuration providers to new plugin API

### DIFF
--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -60,11 +60,11 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.model.utils.filterByVcsPath
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -36,7 +36,6 @@ import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.RuleViolationResolution
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.config.orEmpty
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.utils.common.zipWithCollections
@@ -89,7 +88,7 @@ data class OrtResult(
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val labels: Map<String, String> = emptyMap()
-) : ResolutionProvider, PackageConfigurationProvider {
+) : ResolutionProvider {
     companion object {
         /**
          * A constant for an [OrtResult] with an empty repository and all other properties `null`.
@@ -363,7 +362,7 @@ data class OrtResult(
     /**
      * Return a list of [PackageConfiguration]s for the given [packageId] and [provenance].
      */
-    override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
+    fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
         packageConfigurationsById[packageId].orEmpty().filter { it.matches(packageId, provenance) }
 
     /**

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -286,7 +286,7 @@ class EvaluatorCommand : OrtCommand(
             val repositoryPackageConfigurations = ortResultInput.repository.config.packageConfigurations
 
             if (ortConfig.enableRepositoryPackageConfigurations) {
-                add(SimplePackageConfigurationProvider(repositoryPackageConfigurations))
+                add(SimplePackageConfigurationProvider(configurations = repositoryPackageConfigurations))
             } else {
                 if (repositoryPackageConfigurations.isNotEmpty()) {
                     logger.info { "Local package configurations were not applied because the feature is not enabled." }

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -55,7 +55,6 @@ import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.licenses.orEmpty
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
-import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
@@ -65,6 +64,7 @@ import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.plugins.commands.api.utils.writeOrtResult
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -216,12 +216,14 @@ class ReporterCommand : OrtCommand(
         val resolvedPackageConfigurations = ortResult.resolvedConfiguration.packageConfigurations
         val packageConfigurationProvider = when {
             resolvedPackageConfigurations != null && packageConfigurationsDir == null -> {
-                SimplePackageConfigurationProvider(resolvedPackageConfigurations)
+                SimplePackageConfigurationProvider(configurations = resolvedPackageConfigurations)
             }
 
             ortConfig.enableRepositoryPackageConfigurations -> {
                 CompositePackageConfigurationProvider(
-                    SimplePackageConfigurationProvider(ortResult.repository.config.packageConfigurations),
+                    SimplePackageConfigurationProvider(
+                        configurations = ortResult.repository.config.packageConfigurations
+                    ),
                     DirPackageConfigurationProvider(packageConfigurationsDir)
                 )
             }

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -52,13 +52,13 @@ import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.licenses.orEmpty
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
-import org.ossreviewtoolkit.model.utils.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
 import org.ossreviewtoolkit.reporter.DefaultLicenseTextProvider

--- a/plugins/package-configuration-providers/api/build.gradle.kts
+++ b/plugins/package-configuration-providers/api/build.gradle.kts
@@ -24,4 +24,5 @@ plugins {
 
 dependencies {
     api(projects.model)
+    api(projects.plugins.api)
 }

--- a/plugins/package-configuration-providers/api/src/main/kotlin/CompositePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/CompositePackageConfigurationProvider.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 
 /**
  * A [PackageConfigurationProvider] that combines the provided [providers] into a single provider. The order of the
@@ -31,6 +32,12 @@ class CompositePackageConfigurationProvider(
     private val providers: List<PackageConfigurationProvider>
 ) : PackageConfigurationProvider {
     constructor(vararg providers: PackageConfigurationProvider) : this(providers.asList())
+
+    override val descriptor = PluginDescriptor(
+        id = "Composite",
+        displayName = "Composite Package Configuration Provider",
+        description = "A package configuration provider that combines multiple package configuration providers."
+    )
 
     override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
         providers.flatMap { it.getPackageConfigurations(packageId, provenance) }

--- a/plugins/package-configuration-providers/api/src/main/kotlin/CompositePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/CompositePackageConfigurationProvider.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model.utils
+package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProvider.kt
@@ -27,14 +27,6 @@ import org.ossreviewtoolkit.model.config.PackageConfiguration
  * A provider for [PackageConfiguration]s.
  */
 fun interface PackageConfigurationProvider {
-    companion object {
-        /**
-         * A provider that does not provide any curations.
-         */
-        @JvmField
-        val EMPTY = PackageConfigurationProvider { _, _ -> emptyList() }
-    }
-
     /**
      * Return a list of [PackageConfiguration]s for the given [packageId] and [provenance].
      */

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProvider.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model.utils
+package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProvider.kt
@@ -22,11 +22,12 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.plugins.api.Plugin
 
 /**
  * A provider for [PackageConfiguration]s.
  */
-fun interface PackageConfigurationProvider {
+interface PackageConfigurationProvider : Plugin {
     /**
      * Return a list of [PackageConfiguration]s for the given [packageId] and [provenance].
      */

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
@@ -22,21 +22,20 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
-import org.ossreviewtoolkit.utils.common.Plugin
-import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
+import org.ossreviewtoolkit.plugins.api.PluginConfig
+import org.ossreviewtoolkit.plugins.api.PluginFactory
 import org.ossreviewtoolkit.utils.common.getDuplicates
 
 /**
  * The extension point for [PackageConfigurationProvider]s.
  */
-interface PackageConfigurationProviderFactory<CONFIG> :
-    TypedConfigurablePluginFactory<CONFIG, PackageConfigurationProvider> {
+interface PackageConfigurationProviderFactory : PluginFactory<PackageConfigurationProvider> {
     companion object {
         /**
          * All [package configuration provider factories][PackageConfigurationProviderFactory] available in the
          * classpath, associated by their names.
          */
-        val ALL by lazy { Plugin.getAll<PackageConfigurationProviderFactory<*>>() }
+        val ALL by lazy { PluginFactory.getAll<PackageConfigurationProviderFactory, PackageConfigurationProvider>() }
 
         /**
          * Create a new (identifier, provider instance) tuple for each
@@ -50,7 +49,7 @@ interface PackageConfigurationProviderFactory<CONFIG> :
                 it.enabled
             }.mapNotNull {
                 ALL[it.type]?.let { factory ->
-                    it.id to factory.create(it.options, it.secrets)
+                    it.id to factory.create(PluginConfig(it.options, it.secrets))
                 }.also { factory ->
                     factory ?: logger.error {
                         "Configuration provider of type '${it.type}' is enabled in configuration but not available " +

--- a/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/PackageConfigurationProviderFactory.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.getDuplicates

--- a/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
@@ -23,7 +23,6 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 
 /**
  * A [PackageConfigurationProvider] that provides the [PackageConfiguration]s specified in the collection. Throws an

--- a/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
@@ -23,12 +23,24 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+
+/**
+ * The default [PluginDescriptor] for a [SimplePackageConfigurationProvider]. Classes inheriting from this class
+ * have to provide their own descriptor.
+ */
+private val pluginDescriptor = PluginDescriptor(
+    id = "Simple",
+    displayName = "Simple Package Configuration Provider",
+    description = "A simple package configuration provider, which provides a fixed set of package configurations."
+)
 
 /**
  * A [PackageConfigurationProvider] that provides the [PackageConfiguration]s specified in the collection. Throws an
  * exception if there is more than one configuration per [Identifier] and [Provenance].
  */
 open class SimplePackageConfigurationProvider(
+    override val descriptor: PluginDescriptor = pluginDescriptor,
     configurations: Collection<PackageConfiguration>
 ) : PackageConfigurationProvider {
     private val configurationsById: Map<Identifier, List<PackageConfiguration>>

--- a/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
+++ b/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
@@ -37,7 +37,7 @@ class SimplePackageConfigurationProviderTest : WordSpec({
             val configurations = listOf(packageConfig, packageConfig.copy())
 
             shouldThrow<IllegalArgumentException> {
-                SimplePackageConfigurationProvider(configurations)
+                SimplePackageConfigurationProvider(configurations = configurations)
             }
         }
 
@@ -53,7 +53,7 @@ class SimplePackageConfigurationProviderTest : WordSpec({
             val configurations = listOf(packageConfig, packageConfig.copy())
 
             shouldThrow<IllegalArgumentException> {
-                SimplePackageConfigurationProvider(configurations)
+                SimplePackageConfigurationProvider(configurations = configurations)
             }
         }
     }

--- a/plugins/package-configuration-providers/dir/build.gradle.kts
+++ b/plugins/package-configuration-providers/dir/build.gradle.kts
@@ -19,9 +19,11 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
+
+    ksp(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
 }

--- a/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
@@ -25,9 +25,12 @@ import java.io.IOException
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.OrtPluginOption
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
-import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
@@ -36,46 +39,46 @@ data class DirPackageConfigurationProviderConfig(
     /**
      * The path of the package configuration directory.
      */
-    val path: File,
+    val path: String,
 
     /**
      * A flag to denote whether the path is required to exist.
      */
+    @OrtPluginOption(defaultValue = "false")
     val mustExist: Boolean
 )
 
-open class DirPackageConfigurationProviderFactory :
-    PackageConfigurationProviderFactory<DirPackageConfigurationProviderConfig> {
-    override val type = "Dir"
-
-    override fun create(config: DirPackageConfigurationProviderConfig) = DirPackageConfigurationProvider(config)
-
-    override fun parseConfig(options: Options, secrets: Options) =
-        DirPackageConfigurationProviderConfig(
-            path = File(options.getValue("path")),
-            mustExist = options["mustExist"]?.toBooleanStrict() != false
-        )
-}
-
-class DefaultDirPackageConfigurationProviderFactory : DirPackageConfigurationProviderFactory() {
-    override val type = "DefaultDir"
-
-    override fun parseConfig(options: Options, secrets: Options) =
-        DirPackageConfigurationProviderConfig(
-            path = ortConfigDirectory.resolve(ORT_PACKAGE_CONFIGURATIONS_DIRNAME),
-            mustExist = false
-        )
-}
+@OrtPlugin(
+    name = "Default Dir Package Configuration Provider",
+    description = "A package configuration provider that loads package curations from the default directory.",
+    factory = PackageConfigurationProviderFactory::class
+)
+class DefaultDirPackageConfigurationProvider(descriptor: PluginDescriptor) : DirPackageConfigurationProvider(
+    descriptor,
+    DirPackageConfigurationProviderConfig(
+        path = ortConfigDirectory.resolve(ORT_PACKAGE_CONFIGURATIONS_DIRNAME).absolutePath,
+        mustExist = false
+    )
+)
 
 /**
  * A [PackageConfigurationProvider] that loads [PackageConfiguration]s from all given package configuration files.
  * Supports all file formats specified in [FileFormat].
  */
-class DirPackageConfigurationProvider(
+@OrtPlugin(
+    name = "Dir Package Configuration Provider",
+    description = "Provides package configurations from a directory.",
+    factory = PackageConfigurationProviderFactory::class
+)
+open class DirPackageConfigurationProvider(
+    descriptor: PluginDescriptor = DirPackageConfigurationProviderFactory.descriptor,
     vararg paths: File?
-) : SimplePackageConfigurationProvider(readConfigurationFiles(paths.filterNotNull())) {
-    constructor(config: DirPackageConfigurationProviderConfig) : this(
-        config.path.takeUnless { !it.exists() && !config.mustExist }
+) : SimplePackageConfigurationProvider(descriptor, readConfigurationFiles(paths.filterNotNull())) {
+    constructor(vararg paths: File?) : this(DirPackageConfigurationProviderFactory.descriptor, *paths)
+
+    constructor(descriptor: PluginDescriptor, config: DirPackageConfigurationProviderConfig) : this(
+        descriptor,
+        File(config.path).takeUnless { !it.exists() && !config.mustExist }
     )
 
     companion object {

--- a/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dir/src/main/kotlin/DirPackageConfigurationProvider.kt
@@ -25,7 +25,6 @@ import java.io.IOException
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.Options

--- a/plugins/package-configuration-providers/dir/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
+++ b/plugins/package-configuration-providers/dir/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
@@ -1,2 +1,0 @@
-org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DefaultDirPackageConfigurationProviderFactory
-org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProviderFactory

--- a/plugins/package-configuration-providers/dos/build.gradle.kts
+++ b/plugins/package-configuration-providers/dos/build.gradle.kts
@@ -19,7 +19,7 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
@@ -27,4 +27,6 @@ dependencies {
 
     implementation(projects.clients.dosClient)
     implementation(libs.kotlinx.coroutines)
+
+    ksp(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
 }

--- a/plugins/package-configuration-providers/dos/src/main/kotlin/DosPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dos/src/main/kotlin/DosPackageConfigurationProvider.kt
@@ -35,10 +35,10 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.VcsMatcher
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.associateLicensesWithExceptions
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.utils.toPurlExtras
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.ort.runBlocking

--- a/plugins/package-configuration-providers/dos/src/main/kotlin/DosPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dos/src/main/kotlin/DosPackageConfigurationProvider.kt
@@ -38,9 +38,10 @@ import org.ossreviewtoolkit.model.config.VcsMatcher
 import org.ossreviewtoolkit.model.utils.associateLicensesWithExceptions
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.utils.toPurlExtras
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
-import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.ort.runBlocking
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
@@ -55,24 +56,19 @@ data class DosPackageConfigurationProviderConfig(
     val timeout: Long?
 )
 
-class DosPackageConfigurationProviderFactory :
-    PackageConfigurationProviderFactory<DosPackageConfigurationProviderConfig> {
-    override val type = "DOS"
-
-    override fun create(config: DosPackageConfigurationProviderConfig) = DosPackageConfigurationProvider(config)
-
-    override fun parseConfig(options: Options, secrets: Options) =
-        DosPackageConfigurationProviderConfig(
-            url = options.getValue("url"),
-            token = secrets.getValue("token"),
-            timeout = options["timeout"]?.toLongOrNull()
-        )
-}
-
 /**
  * A [PackageConfigurationProvider] that loads [PackageConfiguration]s from a Double Open Server instance.
  */
-class DosPackageConfigurationProvider(config: DosPackageConfigurationProviderConfig) : PackageConfigurationProvider {
+@OrtPlugin(
+    name = "Double Open Server Package Configuration Provider",
+    description = "A package configuration provider that loads package configurations from a Double Open Server " +
+        "instance.",
+    factory = PackageConfigurationProviderFactory::class
+)
+class DosPackageConfigurationProvider(
+    override val descriptor: PluginDescriptor,
+    config: DosPackageConfigurationProviderConfig
+) : PackageConfigurationProvider {
     private val service = DosService.create(config.url, config.token, config.timeout?.let { Duration.ofSeconds(it) })
     private val client = DosClient(service)
 

--- a/plugins/package-configuration-providers/dos/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
+++ b/plugins/package-configuration-providers/dos/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
@@ -1,2 +1,0 @@
-org.ossreviewtoolkit.plugins.packageconfigurationproviders.dos.DosPackageConfigurationProviderFactory
-

--- a/plugins/package-configuration-providers/ort-config/build.gradle.kts
+++ b/plugins/package-configuration-providers/ort-config/build.gradle.kts
@@ -19,7 +19,7 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
@@ -27,4 +27,6 @@ dependencies {
 
     implementation(projects.downloader)
     implementation(projects.plugins.packageConfigurationProviders.dirPackageConfigurationProvider)
+
+    ksp(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
 }

--- a/plugins/package-configuration-providers/ort-config/src/main/kotlin/OrtConfigPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/ort-config/src/main/kotlin/OrtConfigPackageConfigurationProvider.kt
@@ -29,10 +29,11 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
-import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 
@@ -40,19 +41,18 @@ private const val ORT_CONFIG_REPOSITORY_BRANCH = "main"
 private const val ORT_CONFIG_REPOSITORY_URL = "https://github.com/oss-review-toolkit/ort-config.git"
 private const val PACKAGE_CONFIGURATIONS_DIR = "package-configurations"
 
-class OrtConfigPackageConfigurationProviderFactory : PackageConfigurationProviderFactory<Unit> {
-    override val type = "OrtConfig"
-
-    override fun create(config: Unit): PackageConfigurationProvider = OrtConfigPackageConfigurationProvider()
-
-    override fun parseConfig(options: Options, secrets: Options) = Unit
-}
-
 /**
  * A [PackageConfigurationProvider] that provides [PackageConfiguration]s from the
  * [ort-config repository](https://github.com/oss-review-toolkit/ort-config).
  */
-class OrtConfigPackageConfigurationProvider : PackageConfigurationProvider {
+@OrtPlugin(
+    name = "ort-config",
+    description = "A package configuration provider that loads package configurations from the ort-config repository.",
+    factory = PackageConfigurationProviderFactory::class
+)
+class OrtConfigPackageConfigurationProvider(
+    override val descriptor: PluginDescriptor = OrtConfigPackageConfigurationProviderFactory.descriptor
+) : PackageConfigurationProvider {
     private val configurationsDir by lazy {
         ortDataDirectory.resolve("ort-config").also {
             updateOrtConfig(it)

--- a/plugins/package-configuration-providers/ort-config/src/main/kotlin/OrtConfigPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/ort-config/src/main/kotlin/OrtConfigPackageConfigurationProvider.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.PackageConfiguration
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
 import org.ossreviewtoolkit.utils.common.Options

--- a/plugins/package-configuration-providers/ort-config/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
+++ b/plugins/package-configuration-providers/ort-config/src/main/resources/META-INF/services/org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
@@ -1,1 +1,0 @@
-org.ossreviewtoolkit.plugins.packageconfigurationproviders.ortconfig.OrtConfigPackageConfigurationProviderFactory

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -24,5 +24,6 @@ plugins {
 
 dependencies {
     api(projects.model)
+    api(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
     api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 }

--- a/utils/config/src/main/kotlin/ConfigurationResolver.kt
+++ b/utils/config/src/main/kotlin/ConfigurationResolver.kt
@@ -32,9 +32,9 @@ import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 
 object ConfigurationResolver {

--- a/utils/config/src/main/kotlin/OrtResultExtensions.kt
+++ b/utils/config/src/main/kotlin/OrtResultExtensions.kt
@@ -20,8 +20,8 @@
 package org.ossreviewtoolkit.utils.config
 
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 
 /**


### PR DESCRIPTION
Migrate the package configuration provider API to the new plugin API. See the commit messages for details.
