### PR TITLE
feat(model): Check if an archive exists before trying to download it

### DIFF
--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -102,6 +102,11 @@ class FileArchiver(
      * Unarchive the archive corresponding to [provenance].
      */
     fun unarchive(directory: File, provenance: KnownProvenance): Boolean {
+        if (!storage.hasData(provenance)) {
+            logger.info { "Could not find archive of directory '$directory'." }
+            return false
+        }
+
         val (zipInputStream, readDuration) = measureTimedValue { storage.getData(provenance) }
 
         logger.info { "Read archive of directory '$directory' from storage in $readDuration." }

--- a/scanner/src/main/kotlin/utils/FileListResolver.kt
+++ b/scanner/src/main/kotlin/utils/FileListResolver.kt
@@ -64,6 +64,7 @@ private fun ProvenanceFileStorage.putFileList(provenance: KnownProvenance, fileL
 }
 
 private fun ProvenanceFileStorage.getFileList(provenance: KnownProvenance): FileList? {
+    if (!hasData(provenance)) return null
     val data = getData(provenance) ?: return null
     return data.use { yamlMapper.readValue<FileList>(it) }
 }

--- a/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
@@ -37,115 +37,113 @@ import java.io.InputStream
 
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 
-class LocalFileStorageFunTest : WordSpec() {
-    private fun storage(block: (LocalFileStorage, File) -> Unit) {
+class LocalFileStorageFunTest : WordSpec({
+    fun storage(block: (LocalFileStorage, File) -> Unit) {
         val directory = tempdir()
         val storage = LocalFileStorage(directory)
         block(storage, directory)
     }
 
-    init {
-        "Creating the storage" should {
-            "succeed if the directory exists" {
-                shouldNotThrowAny {
-                    LocalFileStorage(tempdir())
-                }
+    "Creating the storage" should {
+        "succeed if the directory exists" {
+            shouldNotThrowAny {
+                LocalFileStorage(tempdir())
             }
+        }
 
-            "succeed if the directory does not exist and must be created" {
-                val directory = tempdir()
-                val storageDirectory = directory.resolve("create/storage")
+        "succeed if the directory does not exist and must be created" {
+            val directory = tempdir()
+            val storageDirectory = directory.resolve("create/storage")
 
+            LocalFileStorage(storageDirectory).write("file", InputStream.nullInputStream())
+
+            storageDirectory.isDirectory shouldBe true
+        }
+
+        "fail if the directory is a file" {
+            val storageDirectory = tempfile()
+
+            shouldThrow<IOException> {
                 LocalFileStorage(storageDirectory).write("file", InputStream.nullInputStream())
-
-                storageDirectory.isDirectory shouldBe true
             }
+        }
+    }
 
-            "fail if the directory is a file" {
-                val storageDirectory = tempfile()
+    "Reading a file" should {
+        "succeed if the file exists" {
+            storage { storage, directory ->
+                val file = directory.resolve("existing-file")
+                file.writeText("content")
 
-                shouldThrow<IOException> {
-                    LocalFileStorage(storageDirectory).write("file", InputStream.nullInputStream())
+                val content = storage.read("existing-file").bufferedReader().use(BufferedReader::readText)
+
+                content shouldBe "content"
+            }
+        }
+
+        "fail if the file does not exist" {
+            storage { storage, _ ->
+                shouldThrow<FileNotFoundException> {
+                    storage.read("file-does-not-exist")
                 }
             }
         }
 
-        "Reading a file" should {
-            "succeed if the file exists" {
-                storage { storage, directory ->
-                    val file = directory.resolve("existing-file")
-                    file.writeText("content")
-
-                    val content = storage.read("existing-file").bufferedReader().use(BufferedReader::readText)
-
-                    content shouldBe "content"
-                }
-            }
-
-            "fail if the file does not exist" {
-                storage { storage, _ ->
-                    shouldThrow<FileNotFoundException> {
-                        storage.read("file-does-not-exist")
-                    }
-                }
-            }
-
-            "fail if the requested path is not inside the storage directory" {
-                storage { storage, _ ->
-                    shouldThrow<IllegalArgumentException> {
-                        storage.read("../file")
-                    }
-                }
-            }
-        }
-
-        "Writing a file" should {
-            "succeed if the file does not exist" {
-                storage { storage, directory ->
-                    storage.write("target/file", "content".byteInputStream())
-
-                    val file = directory.resolve("target/file")
-
-                    file shouldBe aFile()
-                    file.readText() shouldBe "content"
-                }
-            }
-
-            "succeed if the file does exist" {
-                storage { storage, directory ->
-                    val file = directory.resolve("file")
-                    file.writeText("old content")
-
-                    storage.write("file", "content".byteInputStream())
-
-                    file shouldBe aFile()
-                    file.readText() shouldBe "content"
-                }
-            }
-
-            "fail if the target path is not inside the storage directory" {
-                storage { storage, directory ->
-                    shouldThrow<IllegalArgumentException> {
-                        storage.write("../file", "content".byteInputStream())
-                    }
-
-                    val file = directory.resolve("../file")
-
-                    file shouldNot exist()
-                }
-            }
-
-            "fail if the target path is a directory" {
-                storage { storage, directory ->
-                    val dir = directory.resolve("dir").safeMkdirs()
-
-                    shouldThrow<FileNotFoundException> {
-                        storage.write("dir", "content".byteInputStream())
-                    }
-
-                    dir.isDirectory shouldBe true
+        "fail if the requested path is not inside the storage directory" {
+            storage { storage, _ ->
+                shouldThrow<IllegalArgumentException> {
+                    storage.read("../file")
                 }
             }
         }
     }
-}
+
+    "Writing a file" should {
+        "succeed if the file does not exist" {
+            storage { storage, directory ->
+                storage.write("target/file", "content".byteInputStream())
+
+                val file = directory.resolve("target/file")
+
+                file shouldBe aFile()
+                file.readText() shouldBe "content"
+            }
+        }
+
+        "succeed if the file does exist" {
+            storage { storage, directory ->
+                val file = directory.resolve("file")
+                file.writeText("old content")
+
+                storage.write("file", "content".byteInputStream())
+
+                file shouldBe aFile()
+                file.readText() shouldBe "content"
+            }
+        }
+
+        "fail if the target path is not inside the storage directory" {
+            storage { storage, directory ->
+                shouldThrow<IllegalArgumentException> {
+                    storage.write("../file", "content".byteInputStream())
+                }
+
+                val file = directory.resolve("../file")
+
+                file shouldNot exist()
+            }
+        }
+
+        "fail if the target path is a directory" {
+            storage { storage, directory ->
+                val dir = directory.resolve("dir").safeMkdirs()
+
+                shouldThrow<FileNotFoundException> {
+                    storage.write("dir", "content".byteInputStream())
+                }
+
+                dir.isDirectory shouldBe true
+            }
+        }
+    }
+})

--- a/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
@@ -69,7 +69,7 @@ class LocalFileStorageFunTest : WordSpec({
         }
     }
 
-    "Reading a file" should {
+    "read()" should {
         "succeed if the file exists" {
             storage { storage, directory ->
                 val file = directory.resolve("existing-file")
@@ -98,7 +98,7 @@ class LocalFileStorageFunTest : WordSpec({
         }
     }
 
-    "Writing a file" should {
+    "write()" should {
         "succeed if the file does not exist" {
             storage { storage, directory ->
                 storage.write("target/file", "content".byteInputStream())

--- a/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
@@ -69,6 +69,22 @@ class LocalFileStorageFunTest : WordSpec({
         }
     }
 
+    "exists()" should {
+        "return true if the file exists" {
+            storage { storage, directory ->
+                directory.resolve("existing-file").writeText("content")
+
+                storage.exists("existing-file") shouldBe true
+            }
+        }
+
+        "return false if the file does not exist" {
+            storage { storage, _ ->
+                storage.exists("file-does-not-exist") shouldBe false
+            }
+        }
+    }
+
     "read()" should {
         "succeed if the file exists" {
             storage { storage, directory ->
@@ -143,6 +159,25 @@ class LocalFileStorageFunTest : WordSpec({
                 }
 
                 dir.isDirectory shouldBe true
+            }
+        }
+    }
+
+    "delete()" should {
+        "return true if the file exists" {
+            storage { storage, directory ->
+                val file = directory.resolve("file")
+                file.writeText("content")
+
+                storage.delete("file") shouldBe true
+
+                file shouldNot exist()
+            }
+        }
+
+        "return false if the file does not exist" {
+            storage { storage, _ ->
+                storage.delete("file-does-not-exist") shouldBe false
             }
         }
     }

--- a/utils/ort/src/funTest/kotlin/storage/XZCompressedLocalFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/XZCompressedLocalFileStorageFunTest.kt
@@ -26,33 +26,31 @@ import io.kotest.matchers.shouldBe
 import java.io.BufferedReader
 import java.io.File
 
-class XZCompressedLocalFileStorageFunTest : StringSpec() {
-    private fun storage(block: (XZCompressedLocalFileStorage, File) -> Unit) {
+class XZCompressedLocalFileStorageFunTest : StringSpec({
+    fun storage(block: (XZCompressedLocalFileStorage, File) -> Unit) {
         val directory = tempdir()
         val storage = XZCompressedLocalFileStorage(directory)
         block(storage, directory)
     }
 
-    init {
-        "Can read written compressed data" {
-            storage { storage, _ ->
-                storage.write("new-file", "content".byteInputStream())
+    "Can read written compressed data" {
+        storage { storage, _ ->
+            storage.write("new-file", "content".byteInputStream())
 
-                val content = storage.read("new-file").bufferedReader().use(BufferedReader::readText)
+            val content = storage.read("new-file").bufferedReader().use(BufferedReader::readText)
 
-                content shouldBe "content"
-            }
-        }
-
-        "Can read existing uncompressed data" {
-            storage { storage, directory ->
-                val file = directory.resolve("existing-file")
-                file.writeText("content")
-
-                val content = storage.read("existing-file").bufferedReader().use(BufferedReader::readText)
-
-                content shouldBe "content"
-            }
+            content shouldBe "content"
         }
     }
-}
+
+    "Can read existing uncompressed data" {
+        storage { storage, directory ->
+            val file = directory.resolve("existing-file")
+            file.writeText("content")
+
+            val content = storage.read("existing-file").bufferedReader().use(BufferedReader::readText)
+
+            content shouldBe "content"
+        }
+    }
+})

--- a/utils/ort/src/funTest/kotlin/storage/XZCompressedLocalFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/XZCompressedLocalFileStorageFunTest.kt
@@ -42,15 +42,4 @@ class XZCompressedLocalFileStorageFunTest : StringSpec({
             content shouldBe "content"
         }
     }
-
-    "Can read existing uncompressed data" {
-        storage { storage, directory ->
-            val file = directory.resolve("existing-file")
-            file.writeText("content")
-
-            val content = storage.read("existing-file").bufferedReader().use(BufferedReader::readText)
-
-            content shouldBe "content"
-        }
-    }
 })

--- a/utils/ort/src/main/kotlin/storage/LocalFileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/LocalFileStorage.kt
@@ -41,11 +41,11 @@ open class LocalFileStorage(
      */
     open fun transformPath(path: String): String = path
 
-    override fun exists(path: String) = directory.resolve(path).exists()
+    override fun exists(path: String) = directory.resolve(transformPath(path)).exists()
 
     @Synchronized
     override fun read(path: String): InputStream {
-        val file = directory.resolve(path)
+        val file = directory.resolve(transformPath(path))
 
         require(file.canonicalFile.startsWith(directory.canonicalFile)) {
             "Path '$path' is not in directory '${directory.invariantSeparatorsPath}'."
@@ -59,7 +59,7 @@ open class LocalFileStorage(
      * output stream for writing to the file.
      */
     protected open fun safeOutputStream(path: String): OutputStream {
-        val file = directory.resolve(path)
+        val file = directory.resolve(transformPath(path))
 
         require(file.canonicalFile.startsWith(directory.canonicalFile)) {
             "Path '$path' is not in directory '${directory.invariantSeparatorsPath}'."
@@ -78,5 +78,5 @@ open class LocalFileStorage(
     }
 
     @Synchronized
-    override fun delete(path: String): Boolean = directory.resolve(path).delete()
+    override fun delete(path: String): Boolean = directory.resolve(transformPath(path)).delete()
 }

--- a/utils/ort/src/main/kotlin/storage/XZCompressedLocalFileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/XZCompressedLocalFileStorage.kt
@@ -35,7 +35,7 @@ class XZCompressedLocalFileStorage(
 ) : LocalFileStorage(directory) {
     override fun transformPath(path: String) = "$path.xz"
 
-    override fun read(path: String) = XZCompressorInputStream(super.read(transformPath(path)))
+    override fun read(path: String) = XZCompressorInputStream(super.read(path))
 
-    override fun safeOutputStream(path: String) = XZCompressorOutputStream(super.safeOutputStream(transformPath(path)))
+    override fun safeOutputStream(path: String) = XZCompressorOutputStream(super.safeOutputStream(path))
 }

--- a/utils/ort/src/main/kotlin/storage/XZCompressedLocalFileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/XZCompressedLocalFileStorage.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.utils.ort.storage
 
 import java.io.File
-import java.io.FileNotFoundException
 
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
@@ -36,18 +35,7 @@ class XZCompressedLocalFileStorage(
 ) : LocalFileStorage(directory) {
     override fun transformPath(path: String) = "$path.xz"
 
-    override fun read(path: String) =
-        try {
-            XZCompressorInputStream(super.read(transformPath(path)))
-        } catch (compressedFileNotFoundException: FileNotFoundException) {
-            // Fall back to try reading the uncompressed file.
-            @Suppress("SwallowedException")
-            try {
-                super.read(path)
-            } catch (uncompressedFileNotFoundException: FileNotFoundException) {
-                throw uncompressedFileNotFoundException.initCause(compressedFileNotFoundException)
-            }
-        }
+    override fun read(path: String) = XZCompressorInputStream(super.read(transformPath(path)))
 
     override fun safeOutputStream(path: String) = XZCompressorOutputStream(super.safeOutputStream(transformPath(path)))
 }


### PR DESCRIPTION
Check if an archive exists in the storage before trying to read it in `FileArchiver.unarchive` and `FileListResolver.resolve`.

This prevents an error message when calling `storage.getData()` and the data does not exist.

Resolves #7041.

Also fix a bug in `XZCompressedFileStorage` which was discovered by the change.