### PR TITLE
docs(issues): Limit `ort requirements` output to commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -33,7 +33,7 @@ No screenshots of plain text please, to keep text searchable.
 
 ### Environment
 
-Output of the `ort requirements` command:
+Output of the `ort requirements -l commands` command:
 
 ```
 <copy & paste console output to here; no screenshots please>


### PR DESCRIPTION
Otherwise all bug reports contain the full list of plugins which makes searching e.g. for a specific package manager hard.