### PR TITLE
node: Port all remaining Jackson-based code to KxS

### DIFF
--- a/plugins/package-managers/node/build.gradle.kts
+++ b/plugins/package-managers/node/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines)
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.yaml)
 
     funTestImplementation(testFixtures(projects.analyzer))
 

--- a/plugins/package-managers/node/build.gradle.kts
+++ b/plugins/package-managers/node/build.gradle.kts
@@ -42,10 +42,6 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.jackson.annotations)
-    implementation(libs.jackson.core)
-    implementation(libs.jackson.dataformat.yaml)
-    implementation(libs.jackson.module.kotlin)
     implementation(libs.kotlinx.coroutines)
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.kotlinx.serialization.json)

--- a/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
+++ b/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
@@ -106,6 +106,8 @@ data class PackageJson(
     @SerialName("_integrity")
     val integrity: String? = null,
     val packageManager: String? = null,
+    val dependencies: Map<String, String> = emptyMap(),
+    val devDependencies: Map<String, String> = emptyMap(),
     /** This property does not belong to package.json but to the JSON returned by 'npm info'. */
     val dist: Distribution? = null
 ) {

--- a/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
+++ b/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
@@ -51,7 +51,7 @@ internal fun parsePackageJsons(jsons: String): List<PackageJson> =
         JSON.decodeToSequence<JsonElement>(input).mapTo(mutableListOf()) { parsePackageJson(it) }
     }
 
-private fun parsePackageJson(element: JsonElement): PackageJson {
+internal fun parsePackageJson(element: JsonElement): PackageJson {
     val transformedElement = transformPackageJson(element)
     return JSON.decodeFromJsonElement<PackageJson>(transformedElement)
 }

--- a/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
+++ b/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
@@ -105,6 +105,7 @@ data class PackageJson(
     val from: String? = null,
     @SerialName("_integrity")
     val integrity: String? = null,
+    val packageManager: String? = null,
     /** This property does not belong to package.json but to the JSON returned by 'npm info'. */
     val dist: Distribution? = null
 ) {

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.node.yarn2
 
-import com.fasterxml.jackson.module.kotlin.contains
-
 import java.io.File
 
 import kotlinx.coroutines.Dispatchers
@@ -131,11 +129,6 @@ class Yarn2(
         private const val MANIFEST_FILE = "package.json"
 
         /**
-         * The name of the property that defines the package manager and its version if Corepack is enabled.
-         */
-        private const val PACKAGE_MANAGER_PROPERTY = "packageManager"
-
-        /**
          * The name of the default executable. This is used when the [OPTION_COREPACK_OVERRIDE] option is set.
          */
         private const val DEFAULT_EXECUTABLE_NAME = "yarn"
@@ -146,7 +139,8 @@ class Yarn2(
          */
         private fun isCorepackEnabledInManifest(workingDir: File): Boolean =
             runCatching {
-                PACKAGE_MANAGER_PROPERTY in jsonMapper.readTree(workingDir.resolve(MANIFEST_FILE))
+                val packageJson = parsePackageJson(workingDir.resolve(MANIFEST_FILE))
+                !packageJson.packageManager.isNullOrEmpty()
             }.getOrDefault(false)
     }
 

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -741,7 +741,7 @@ private fun getYarnExecutable(workingDir: File): File {
     val yarnrcFile = workingDir.resolve(YARN2_RESOURCE_FILE)
     val yarnConfig = yamlMapper.readTree(yarnrcFile)
     val yarnPath = requireNotNull(yarnConfig[YARN_PATH_PROPERTY_NAME].textValueOrEmpty().ifBlank { null }) {
-        "No Yarn 2+ executable could be found in 'yarnrc.yml'."
+        "No Yarn 2+ executable could be found in '$YARN2_RESOURCE_FILE'."
     }
 
     return workingDir.resolve(yarnPath)


### PR DESCRIPTION
See individual commits.
