### PR TITLE
feat(cli): Add a command to list installed plugins

### DIFF
--- a/integrations/completions/ort-completion.bash
+++ b/integrations/completions/ort-completion.bash
@@ -115,6 +115,10 @@ _ort() {
         _ort_notify $(( i + 1 ))
         return
         ;;
+      plugins)
+        _ort_plugins $(( i + 1 ))
+        return
+        ;;
       report)
         _ort_report $(( i + 1 ))
         return
@@ -176,7 +180,7 @@ _ort() {
     "--help")
       ;;
     *)
-      COMPREPLY=($(compgen -W 'advise analyze compare config download evaluate migrate notify report requirements scan upload-curations upload-result-to-postgres upload-result-to-sw360' -- "${word}"))
+      COMPREPLY=($(compgen -W 'advise analyze compare config download evaluate migrate notify plugins report requirements scan upload-curations upload-result-to-postgres upload-result-to-sw360' -- "${word}"))
       ;;
   esac
 }
@@ -1048,6 +1052,61 @@ _ort_notify() {
        __complete_files "${word}"
       ;;
     "--label")
+      ;;
+    "--help")
+      ;;
+  esac
+}
+
+_ort_plugins() {
+  local i=$1
+  local in_param=''
+  local fixed_arg_names=()
+  local vararg_name=''
+  local can_parse_options=1
+
+  while [[ ${i} -lt $COMP_CWORD ]]; do
+    if [[ ${can_parse_options} -eq 1 ]]; then
+      case "${COMP_WORDS[$i]}" in
+        --)
+          can_parse_options=0
+          (( i = i + 1 ));
+          continue
+          ;;
+        --types)
+          __skip_opt_eq
+          (( i = i + 1 ))
+          [[ ${i} -gt COMP_CWORD ]] && in_param='--types' || in_param=''
+          continue
+          ;;
+        -h|--help)
+          __skip_opt_eq
+          in_param=''
+          continue
+          ;;
+      esac
+    fi
+    case "${COMP_WORDS[$i]}" in
+      *)
+        (( i = i + 1 ))
+        # drop the head of the array
+        fixed_arg_names=("${fixed_arg_names[@]:1}")
+        ;;
+    esac
+  done
+  local word="${COMP_WORDS[$COMP_CWORD]}"
+  if [[ "${word}" =~ ^[-] ]]; then
+    COMPREPLY=($(compgen -W '--types -h --help' -- "${word}"))
+    return
+  fi
+
+  # We're either at an option's value, or the first remaining fixed size
+  # arg, or the vararg if there are no fixed args left
+  [[ -z "${in_param}" ]] && in_param=${fixed_arg_names[0]}
+  [[ -z "${in_param}" ]] && in_param=${vararg_name}
+
+  case "${in_param}" in
+    "--types")
       ;;
     "--help")
       ;;

--- a/integrations/completions/ort-completion.fish
+++ b/integrations/completions/ort-completion.fish
@@ -3,7 +3,7 @@
 
 
 ### Setup for ort
-set -l ort_subcommands 'advise analyze compare config download evaluate migrate notify report requirements scan upload-curations upload-result-to-postgres upload-result-to-sw360'
+set -l ort_subcommands 'advise analyze compare config download evaluate migrate notify plugins report requirements scan upload-curations upload-result-to-postgres upload-result-to-sw360'
 
 ## Options for ort
 complete -c ort -n "not __fish_seen_subcommand_from $ort_subcommands" -l config -s c -r -F -d 'The path to a configuration file.'
@@ -133,6 +133,14 @@ complete -c ort -n "__fish_seen_subcommand_from notify" -l notifications-file -s
 complete -c ort -n "__fish_seen_subcommand_from notify" -l resolutions-file -r -F -d 'A file containing issue and rule violation resolutions.'
 complete -c ort -n "__fish_seen_subcommand_from notify" -l label -s l -r -d 'Set a label in the ORT result passed to the notifier script, overwriting any existing label of the same name. Can be used multiple times. For example: --label distribution=external'
 complete -c ort -n "__fish_seen_subcommand_from notify" -s h -l help -d 'Show this message and exit'
+
+
+### Setup for plugins
+complete -c ort -f -n __fish_use_subcommand -a plugins -d 'Print information about the installed ORT plugins.'
+
+## Options for plugins
+complete -c ort -n "__fish_seen_subcommand_from plugins" -l types -r -d 'A comma-separated list of plugin types to show.'
+complete -c ort -n "__fish_seen_subcommand_from plugins" -s h -l help -d 'Show this message and exit'
 
 
 ### Setup for report

--- a/integrations/completions/ort-completion.zsh
+++ b/integrations/completions/ort-completion.zsh
@@ -120,6 +120,10 @@ _ort() {
         _ort_notify $(( i + 1 ))
         return
         ;;
+      plugins)
+        _ort_plugins $(( i + 1 ))
+        return
+        ;;
       report)
         _ort_report $(( i + 1 ))
         return
@@ -181,7 +185,7 @@ _ort() {
     "--help")
       ;;
     *)
-      COMPREPLY=($(compgen -W 'advise analyze compare config download evaluate migrate notify report requirements scan upload-curations upload-result-to-postgres upload-result-to-sw360' -- "${word}"))
+      COMPREPLY=($(compgen -W 'advise analyze compare config download evaluate migrate notify plugins report requirements scan upload-curations upload-result-to-postgres upload-result-to-sw360' -- "${word}"))
       ;;
   esac
 }
@@ -1053,6 +1057,61 @@ _ort_notify() {
        __complete_files "${word}"
       ;;
     "--label")
+      ;;
+    "--help")
+      ;;
+  esac
+}
+
+_ort_plugins() {
+  local i=$1
+  local in_param=''
+  local fixed_arg_names=()
+  local vararg_name=''
+  local can_parse_options=1
+
+  while [[ ${i} -lt $COMP_CWORD ]]; do
+    if [[ ${can_parse_options} -eq 1 ]]; then
+      case "${COMP_WORDS[$i]}" in
+        --)
+          can_parse_options=0
+          (( i = i + 1 ));
+          continue
+          ;;
+        --types)
+          __skip_opt_eq
+          (( i = i + 1 ))
+          [[ ${i} -gt COMP_CWORD ]] && in_param='--types' || in_param=''
+          continue
+          ;;
+        -h|--help)
+          __skip_opt_eq
+          in_param=''
+          continue
+          ;;
+      esac
+    fi
+    case "${COMP_WORDS[$i]}" in
+      *)
+        (( i = i + 1 ))
+        # drop the head of the array
+        fixed_arg_names=("${fixed_arg_names[@]:1}")
+        ;;
+    esac
+  done
+  local word="${COMP_WORDS[$COMP_CWORD]}"
+  if [[ "${word}" =~ ^[-] ]]; then
+    COMPREPLY=($(compgen -W '--types -h --help' -- "${word}"))
+    return
+  fi
+
+  # We're either at an option's value, or the first remaining fixed size
+  # arg, or the vararg if there are no fixed args left
+  [[ -z "${in_param}" ]] && in_param=${fixed_arg_names[0]}
+  [[ -z "${in_param}" ]] && in_param=${vararg_name}
+
+  case "${in_param}" in
+    "--types")
       ;;
     "--help")
       ;;

--- a/plugins/commands/plugins/build.gradle.kts
+++ b/plugins/commands/plugins/build.gradle.kts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-plugin-conventions")
+}
+
+dependencies {
+    api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
+
+    implementation(projects.advisor)
+    implementation(projects.downloader)
+    implementation(projects.plugins.api)
+    implementation(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
+    implementation(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+    implementation(projects.reporter)
+    implementation(projects.scanner)
+
+    implementation(libs.clikt)
+    implementation(libs.mordant)
+}

--- a/plugins/commands/plugins/src/main/kotlin/PluginsCommand.kt
+++ b/plugins/commands/plugins/src/main/kotlin/PluginsCommand.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.commands.plugins
+
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.mordant.widgets.HorizontalRule
+import com.github.ajalt.mordant.widgets.UnorderedList
+
+import org.ossreviewtoolkit.advisor.AdviceProviderFactory
+import org.ossreviewtoolkit.downloader.VersionControlSystemFactory
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
+import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.PackageConfigurationProviderFactory
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+import org.ossreviewtoolkit.reporter.ReporterFactory
+import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+
+@OrtPlugin(
+    id = "plugins",
+    displayName = "plugins command",
+    description = "Print information about the installed ORT plugins.",
+    factory = OrtCommandFactory::class
+)
+class PluginsCommand(descriptor: PluginDescriptor = PluginsCommandFactory.descriptor) : OrtCommand(descriptor) {
+    private val types by option(
+        "--types",
+        help = "A comma-separated list of plugin types to show."
+    ).split(",").default(PluginType.entries.map { it.optionName })
+
+    override fun run() {
+        types.forEach { type ->
+            PluginType.entries.find { it.optionName == type }?.let { pluginType ->
+                renderPlugins(pluginType.title, pluginType.descriptors.value)
+            }
+        }
+    }
+
+    private fun renderPlugins(title: String, plugins: List<PluginDescriptor>) {
+        echo(HorizontalRule(title, "="))
+        echo()
+
+        plugins.forEach { plugin ->
+            echo(
+                HorizontalRule(
+                    buildString {
+                        append(plugin.displayName)
+                        if (plugin.id != plugin.displayName) append(" (id: ${plugin.id})")
+                    },
+                    "-"
+                )
+            )
+            echo()
+            echo(plugin.description)
+            echo()
+
+            if (plugin.options.isNotEmpty()) {
+                echo("Configuration options:")
+
+                echo(
+                    UnorderedList(
+                        listEntries = plugin.options.map { option ->
+                            buildString {
+                                append("${option.name}: ${option.type.name}")
+                                option.defaultValue?.also { append(" (Default: $it)") }
+                                if (option.isRequired) append(" (Required)")
+                                appendLine()
+                                append(option.description)
+                            }
+                        }.toTypedArray(),
+                        bulletText = "*"
+                    )
+                )
+
+                echo()
+            }
+        }
+    }
+}
+
+private enum class PluginType(
+    val optionName: String,
+    val title: String,
+    val descriptors: Lazy<List<PluginDescriptor>>
+) {
+    ADVICE_PROVIDERS(
+        "advice-providers",
+        "Advice Providers",
+        lazy { AdviceProviderFactory.ALL.map { it.value.descriptor } }
+    ),
+    COMMANDS(
+        "commands",
+        "CLI Commands",
+        lazy { OrtCommandFactory.ALL.map { it.value.descriptor } }
+    ),
+    PACKAGE_CONFIGURATION_PROVIDERS(
+        "package-configuration-providers",
+        "Package Configuration Providers",
+        lazy { PackageConfigurationProviderFactory.ALL.map { it.value.descriptor } }
+    ),
+    PACKAGE_CURATION_PROVIDERS(
+        "package-curation-providers",
+        "Package Curation Providers",
+        lazy { PackageCurationProviderFactory.ALL.map { it.value.descriptor } }
+    ),
+    PACKAGE_MANAGERS(
+        "package-managers",
+        "Package Managers (TO BE IMPLEMENTED)",
+        lazy { emptyList() }
+    ),
+    REPORTERS(
+        "reporters",
+        "Reporters",
+        lazy { ReporterFactory.ALL.map { it.value.descriptor } }
+    ),
+    SCANNERS(
+        "scanners",
+        "Scanners",
+        lazy { ScannerWrapperFactory.ALL.map { it.value.descriptor } }
+    ),
+    VERSION_CONTROL_SYSTEMS(
+        "version-control-systems",
+        "Version Control Systems",
+        lazy { VersionControlSystemFactory.ALL.map { it.value.descriptor } }
+    )
+}


### PR DESCRIPTION
Add a command to list all installed plugins and their configuration options.

The command is limited to plugins using the new plugin API, missing plugins will be added once they are migrated.