### PR TITLE
ci(renovate): Disable NuGet package manager updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,5 +42,8 @@
       "matchManagers": ["npm"],
       "schedule": "after 9pm on sunday"
     }
-  ]
+  ],
+  "nuget": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Avoid bogus updates of NuGet test projects which should be prevented by ignoring "**/src/funTest/assets/**" already, but that stopped to work.