### PR TITLE
fix(spdx-utils): Support dashed reference category names

### DIFF
--- a/utils/spdx/src/main/kotlin/model/SpdxExternalReference.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxExternalReference.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.utils.spdx.model
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.core.JsonParser
@@ -56,10 +57,20 @@ data class SpdxExternalReference(
      */
     val referenceLocator: String
 ) {
+    /**
+     * See https://spdx.github.io/spdx-spec/v2.2.2/package-information/#721-external-reference-field for valid category
+     * values. Note that early versions of the version 2.2 JSON schema erroneously used underscores instead of dashes.
+     * Follow the proposed practice to support both for compatibility.
+     */
     enum class Category {
         SECURITY,
+
+        @JsonAlias("PACKAGE-MANAGER")
         PACKAGE_MANAGER,
+
+        @JsonAlias("PERSISTENT-ID")
         PERSISTENT_ID,
+
         OTHER
     }
 

--- a/utils/spdx/src/test/kotlin/model/SpdxExternalReferenceTest.kt
+++ b/utils/spdx/src/test/kotlin/model/SpdxExternalReferenceTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.spdx.model
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactly
+
+import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper
+
+class SpdxExternalReferenceTest : WordSpec({
+    "Serializing categories" should {
+        "use underscores in names" {
+            SpdxModelMapper.toJson(SpdxExternalReference.Category.entries) shouldEqualJson """
+                [
+                  "SECURITY",
+                  "PACKAGE_MANAGER",
+                  "PERSISTENT_ID",
+                  "OTHER"
+                ]
+            """.trimIndent()
+        }
+    }
+
+    "Deserializing categories" should {
+        "accept dashes in names" {
+            SpdxModelMapper.fromJson<List<SpdxExternalReference.Category>>(
+                """
+                    [
+                      "SECURITY",
+                      "PACKAGE-MANAGER",
+                      "PERSISTENT-ID",
+                      "OTHER"
+                    ]
+                """.trimIndent()
+            ) shouldContainExactly SpdxExternalReference.Category.entries
+        }
+
+        "accept underscores in names" {
+            SpdxModelMapper.fromJson<List<SpdxExternalReference.Category>>(
+                """
+                    [
+                      "SECURITY",
+                      "PACKAGE_MANAGER",
+                      "PERSISTENT_ID",
+                      "OTHER"
+                    ]
+                """.trimIndent()
+            ) shouldContainExactly SpdxExternalReference.Category.entries
+        }
+    }
+})


### PR DESCRIPTION
This revives the change from [1] for compatibility when reading SPDX files.

[1]: https://github.com/oss-review-toolkit/ort/pull/7839/files#diff-d290822c4f4714ad4b5d29e52d75edfa3c70e3e80e258d69adf0f6a82d8ae9a4