### PR TITLE
fix(bazel): `MODULE.bazel` files from a local registry should be ignored

### DIFF
--- a/clients/bazel-module-registry/src/main/kotlin/LocalBazelModuleRegistryService.kt
+++ b/clients/bazel-module-registry/src/main/kotlin/LocalBazelModuleRegistryService.kt
@@ -27,6 +27,8 @@ import kotlinx.serialization.json.decodeFromStream
 import org.apache.logging.log4j.kotlin.logger
 
 private const val BAZEL_MODULES_DIR = "modules"
+const val METADATA_JSON = "metadata.json"
+const val SOURCE_JSON = "source.json"
 
 /**
  * A Bazel registry which is located on the local file system.
@@ -71,7 +73,7 @@ class LocalBazelModuleRegistryService(directory: File) : BazelModuleRegistryServ
     }
 
     override suspend fun getModuleMetadata(name: String): ModuleMetadata {
-        val metadataJson = moduleDirectory.resolve(name).resolve("metadata.json")
+        val metadataJson = moduleDirectory.resolve(name).resolve(METADATA_JSON)
         require(metadataJson.isFile)
         return metadataJson.inputStream().use {
             JSON.decodeFromStream<ModuleMetadata>(it)
@@ -79,7 +81,7 @@ class LocalBazelModuleRegistryService(directory: File) : BazelModuleRegistryServ
     }
 
     override suspend fun getModuleSourceInfo(name: String, version: String): ModuleSourceInfo {
-        val sourceJson = moduleDirectory.resolve(name).resolve(version).resolve("source.json")
+        val sourceJson = moduleDirectory.resolve(name).resolve(version).resolve(SOURCE_JSON)
         require(sourceJson.isFile)
         return sourceJson.inputStream().use {
             JSON.decodeFromStream<ModuleSourceInfo>(it)

--- a/plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-expected-output-local-registry2.yml
+++ b/plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-expected-output-local-registry2.yml
@@ -1,0 +1,110 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-local-registry2"
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-local-registry2"
+  config: {}
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "HEAD"
+    build_jdk: "<REPLACE_JDK>"
+    java_version: "<REPLACE_JAVA>"
+    os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
+    variables: {}
+    tool_versions: {}
+  config:
+    allow_dynamic_versions: false
+    skip_excluded: false
+  result:
+    projects:
+    - id: "Bazel::plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-local-registry2/MODULE.bazel:"
+      definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: "Git"
+        url: "<REPLACE_URL_PROCESSED>"
+        revision: "<REPLACE_REVISION>"
+        path: "<REPLACE_PATH>"
+      vcs_processed:
+        type: "Git"
+        url: "<REPLACE_URL_PROCESSED>"
+        revision: "<REPLACE_REVISION>"
+        path: "<REPLACE_PATH>"
+      homepage_url: ""
+      scopes:
+      - name: "main"
+        dependencies:
+        - id: "Bazel::module_a:0.0.1"
+          linkage: "STATIC"
+          dependencies:
+          - id: "Bazel::module_b:0.0.1"
+            linkage: "STATIC"
+    packages:
+    - id: "Bazel::module_a:0.0.1"
+      purl: "pkg:generic/module_a@0.0.1"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      description: ""
+      homepage_url: ""
+      binary_artifact:
+        url: ""
+        hash:
+          value: ""
+          algorithm: ""
+      source_artifact:
+        url: "https://example.com/module_a-0.0.1.zip"
+        hash:
+          value: "562c4be7507dc6fb4997ecd648bf935d84efe17b54715fa5cfbddac05279f668"
+          algorithm: "SHA-256"
+      vcs:
+        type: "Git"
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: ""
+        revision: ""
+        path: ""
+    - id: "Bazel::module_b:0.0.1"
+      purl: "pkg:generic/module_b@0.0.1"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      description: ""
+      homepage_url: ""
+      binary_artifact:
+        url: ""
+        hash:
+          value: ""
+          algorithm: ""
+      source_artifact:
+        url: "https://example.com/module_b-0.0.1.zip"
+        hash:
+          value: "562c4be7507dc6fb4997ecd648bf935d84efe17b54715fa5cfbddac05279f668"
+          algorithm: "SHA-256"
+      vcs:
+        type: "Git"
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: ""
+        revision: ""
+        path: ""
+scanner: null
+advisor: null
+evaluator: null
+resolved_configuration: {}


### PR DESCRIPTION
`MODULE.bazel` files present in the local registry should not be considered as definition files.

Fixes #9076.