### PR TITLE
ci(github): Do not configure a custom linter version anymore

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -20,4 +20,4 @@ profile:
   name: qodana.recommended
 include:
   - name: CheckDependencyLicenses
-linter: jetbrains/qodana-jvm-community:2024.1
+linter: jetbrains/qodana-jvm-community


### PR DESCRIPTION
This is to check whether the issue at [1] is resolved.

[1]: https://youtrack.jetbrains.com/issue/QD-9917