### PR TITLE
build(gradle): Make the Java version used for KSP configurable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,10 @@ org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true
 
 kotlin.code.style = official
+ksp.useKSP2 = true
 
 # The version of the JDK to use for building ORT.
+# Keep this aligned with `toolchainVersion` in `gradle/gradle-daemon-jvm.properties`.
 javaLanguageVersion = 11
 
 # The version of the SPDX license list which is used to import license texts and generate SPDX enums. Must be a valid

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,3 @@
+# The version of the JDK to use for building ORT.
+# Keep this aligned with `javaLanguageVersion` in `gradle.properties`.
+toolchainVersion = 11


### PR DESCRIPTION
Use K2 for KSP to make KSP use the Gradle daemon instead of its own [1]. Then also configure the JVM to be used by the Gradle daemon [2], as the daemon is not affected by the regular toolchains mechanism [3].

Also see [4] for some background information.

[1]: https://github.com/google/ksp/blob/main/docs/ksp2.md#using-ksp-2-in-gradle
[2]: https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:daemon_jvm_criteria
[3]: https://docs.gradle.org/current/userguide/toolchains.html
[4]: https://github.com/google/ksp/issues/740