### PR TITLE
deps(docker): Upgrade the `INCLUDE`-syntax extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=devthefuture/dockerfile-x:v1.4.1
+# syntax=devthefuture/dockerfile-x:v1.4.2
 # The above opts-in for an extended syntax that supports e.g. "INCLUDE" statements, see
 # https://codeberg.org/devthefuture/dockerfile-x
 


### PR DESCRIPTION
See [1].

[1]: https://codeberg.org/devthefuture/dockerfile-x/src/branch/master/CHANGELOG.md#1-4-2-https-codeberg-org-devthefuture-dockerfile-x-compare-v1-4-1-v1-4-2-2024-08-05