### PR TITLE
fix(scanner): Create intermediate nested provenance directories

### DIFF
--- a/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.ort.runBlocking
 
@@ -64,7 +65,7 @@ fun interface ProvenanceDownloader {
 
         nestedProvenance.subRepositories.forEach { (path, provenance) ->
             val tempDir = download(provenance)
-            val targetDir = root.resolve(path)
+            val targetDir = root.resolve(path).apply { parentFile.safeMkdirs() }
             tempDir.toPath().moveTo(targetDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
         }
 


### PR DESCRIPTION
If the `targetDir` is not directly below the `root`, any intermediate directory needs to be created before directories can be moved to it.