### PR TITLE
build(gradle): Resolve eventual conflicts between dependency capabilities

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     implementation(libs.jgit)
     implementation(libs.plugin.dependencyAnalysis)
+    implementation(libs.plugin.dependencyConflictResolution)
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.dokkatoo)
     implementation(libs.plugin.graalVmNativeImage)

--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -17,9 +17,24 @@
  * License-Filename: LICENSE
  */
 
+import org.gradlex.jvm.dependency.conflict.detection.rules.CapabilityDefinition
+
 plugins {
     // Apply third-party plugins.
+    id("org.gradlex.jvm-dependency-conflict-resolution")
     id("org.gradlex.reproducible-builds")
+}
+
+jvmDependencyConflicts {
+    logging {
+        enforceLogback()
+    }
+
+    conflictResolution {
+        select(CapabilityDefinition.JAKARTA_ACTIVATION_API, "jakarta.activation:jakarta.activation-api")
+        select(CapabilityDefinition.JAVAX_ACTIVATION_API, "jakarta.activation:jakarta.activation-api")
+        select(CapabilityDefinition.JAVAX_INJECT_API, "jakarta.inject:jakarta.inject-api")
+    }
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 dependencyAnalysisPlugin = "2.4.2"
+dependencyConflictResolutionPlugin = "2.1.2"
 detektPlugin = "1.23.7"
 dokkatooPlugin = "2.4.0"
 downloadPlugin = "5.6.0"
@@ -76,6 +77,7 @@ versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin
 [libraries]
 # These are Maven coordinates for Gradle plugins, which are required for use in precompiled plugin scripts.
 plugin-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
+plugin-dependencyConflictResolution = { module = "org.gradlex:jvm-dependency-conflict-resolution", version.ref = "dependencyConflictResolutionPlugin" }
 plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
 plugin-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detektPlugin" }
 plugin-dokkatoo = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version.ref = "dokkatooPlugin" }


### PR DESCRIPTION
See [1]. Give this plugin a try as a safety measure when adding new dependencies.

[1]: https://github.com/gradlex-org/jvm-dependency-conflict-resolution