### PR TITLE
fix(bazel): Force the generation of a `MODULE.bazel.lock` file

### DIFF
--- a/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
@@ -388,7 +388,15 @@ class Bazel(
         depDirectives: Map<String, BazelDepDirective>,
         archiveOverrides: Map<String, ArchiveOverride>
     ): Set<Scope> {
-        val process = run("mod", "graph", "--output", "json", "--disk_cache=", workingDir = projectDir)
+        val process = run(
+            "mod",
+            "graph",
+            "--output",
+            "json",
+            "--disk_cache=",
+            "--lockfile_mode=update",
+            workingDir = projectDir
+        )
         val mainModule = process.stdout.parseBazelModule()
         val (mainDeps, devDeps) = mainModule.dependencies.map { module ->
             val name = module.name ?: module.key.substringBefore("@", "")


### PR DESCRIPTION
Some projects can explicitly disable the lock file generation by putting 'common --lockfile_mode=off' in their '.bazelrc'. In such projects, running 'bazel mod graph' does not generate a lock file anymore if it is missing. Since ORT requires a lock file to be present, this commit adds a flag to force the (re)generation of the lock file. See [1].

[1]: https://bazel.build/versions/7.1.0/external/lockfile

This fixes the following error:
```
level=INFO  o.o.utils.common.ProcessCapture - Running 'bazel mod graph --output json --disk_cache=' in '/tmp/ort-AnalyzerDownloader-analyzer-worker9834012411938558324'... 
level=ERROR o.o.analyzer.PackageManager - Bazel failed to resolve dependencies for path 'MODULE.bazel': FileNotFoundException: /tmp/ort-AnalyzerDownloader-analyzer-worker9834012411938558324/MODULE.bazel.lock (No such file or directory)
```