### PR TITLE
ci(github): Associate the dependency graph to the `main` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           dependency-graph: generate-and-submit
       - name: Publish to OSSRH
         env:
+          GITHUB_DEPENDENCY_GRAPH_REF: refs/heads/main
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true


### PR DESCRIPTION
Apply the work-around from [1] to associate the dependency graph built from tags to the `main` branch.

[1]: https://github.com/gradle/actions/issues/242#issuecomment-2204385972