### PR TITLE
chore(pub): Align the Gradle check with `DependencyGraphNavigator`

### DIFF
--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -132,7 +132,15 @@ class Pub(
 
     private val flutterAbsolutePath = flutterHome.resolve("bin")
 
-    private val gradleFactory = analyzerConfig.determineEnabledPackageManagers().find { it.type.startsWith("Gradle") }
+    private val gradleFactory = analyzerConfig.determineEnabledPackageManagers()
+        .filter { it.type.startsWith("Gradle") }
+        .let { managers ->
+            require(managers.size < 2) {
+                "All of the $managers managers are able to manage 'Gradle' projects. Please enable only one of them."
+            }
+
+            managers.firstOrNull()
+        }
 
     private data class ParsePackagesResult(
         val packages: Map<Identifier, Package>,


### PR DESCRIPTION
Do not just pick the first Gradle package manager but throw if there are
multiple ones, similar to [1].

[1]: https://github.com/oss-review-toolkit/ort/blob/6d576c3d365e63535b15177bd9a41d5e4b7a51e9/model/src/main/kotlin/DependencyGraphNavigator.kt#L52-L55