### PR TITLE
docs(model): Clarify an `Identifier`'s project vs. package use

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -68,11 +68,11 @@ data class Identifier(
             .thenComparing({ it.version }, AlphaNumericComparator)
     }
 
-    private constructor(components: List<String>) : this(
-        type = components.getOrElse(0) { "" },
-        namespace = components.getOrElse(1) { "" },
-        name = components.getOrElse(2) { "" },
-        version = components.getOrElse(3) { "" }
+    private constructor(properties: List<String>) : this(
+        type = properties.getOrElse(0) { "" },
+        namespace = properties.getOrElse(1) { "" },
+        name = properties.getOrElse(2) { "" },
+        version = properties.getOrElse(3) { "" }
     )
 
     /**
@@ -82,12 +82,12 @@ data class Identifier(
     @JsonCreator
     constructor(identifier: String) : this(identifier.split(':', limit = 4))
 
-    private val sanitizedComponents = listOf(type, namespace, name, version).map { component ->
+    private val sanitizedProperties = listOf(type, namespace, name, version).map { component ->
         component.trim().filterNot { it < ' ' }
     }
 
     init {
-        require(sanitizedComponents.none { ":" in it }) {
+        require(sanitizedProperties.none { ":" in it }) {
             "An identifier's properties must not contain ':' because that character is used as a separator in the " +
                 "string representation: type='$type', namespace='$namespace', name='$name', version='$version'."
         }
@@ -116,12 +116,12 @@ data class Identifier(
      * Create Maven-like coordinates based on the properties of the [Identifier].
      */
     @JsonValue
-    fun toCoordinates() = sanitizedComponents.joinToString(":")
+    fun toCoordinates() = sanitizedProperties.joinToString(":")
 
     /**
      * Create a file system path based on the properties of the [Identifier]. All properties are encoded using
      * [encodeOr] with [emptyValue] as parameter.
      */
     fun toPath(separator: String = "/", emptyValue: String = "unknown"): String =
-        sanitizedComponents.joinToString(separator) { it.encodeOr(emptyValue) }
+        sanitizedProperties.joinToString(separator) { it.encodeOr(emptyValue) }
 }

--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -26,28 +26,28 @@ import org.ossreviewtoolkit.utils.common.AlphaNumericComparator
 import org.ossreviewtoolkit.utils.common.encodeOr
 
 /**
- * A unique identifier for a software package.
+ * A unique identifier for a software component.
  */
 data class Identifier(
     /**
-     * The type of package. When used in the context of a [Project], the type is the name of the package manager that
-     * manages the project (e.g. "Gradle" for a Gradle project). When used in the context of a [Package], the type is
-     * the name of the package type or protocol (e.g. "Maven" for a file from a Maven repository).
+     * The type of component this identifier describes. When used in the context of a [Project], the type equals the one
+     * of the package manager that manages the project (e.g. "Gradle" for a Gradle project). When used in the context of
+     * a [Package], the type is the name of the artifact ecosystem (e.g. "Maven" for a file from a Maven repository).
      */
     val type: String,
 
     /**
-     * The namespace of the package, for example the group for "Maven" or the scope for "NPM".
+     * The namespace of the component, for example the group for "Maven" or the scope for "NPM".
      */
     val namespace: String,
 
     /**
-     * The name of the package.
+     * The name of the component.
      */
     val name: String,
 
     /**
-     * The version of the package.
+     * The version of the component.
      */
     val version: String
 ) : Comparable<Identifier> {


### PR DESCRIPTION
It does not make sense to limit the `type` to a package if the next sentence explains that it can be used for a project as well.