### PR TITLE
ci: Simplify the reuse check

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -119,12 +119,7 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-    - name: Setup Python
-      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
-      with:
-        python-version: "3.10"
-        cache: pip
     - name: Check REUSE Compliance
       run: |
-        pip install --user reuse
-        ~/.local/bin/reuse lint
+        pipx install reuse
+        reuse lint


### PR DESCRIPTION
After upgrading to Ubuntu 24.04 in 90c8fb0 we do not need to setup a specific Python version anymore, but with the pre-installed Python we need to use `pipx` instead of `pip` to install the package.