### PR TITLE
feat(model): Add Git-only VCS host names as Git aliases

### DIFF
--- a/model/src/main/kotlin/VcsType.kt
+++ b/model/src/main/kotlin/VcsType.kt
@@ -38,7 +38,7 @@ data class VcsType private constructor(private val aliases: List<String>) {
         /**
          * [Git](https://git-scm.com/) - the stupid content tracker.
          */
-        val GIT = VcsType("Git")
+        val GIT = VcsType("Git", "GitHub", "GitLab")
 
         /**
          * [Repo](https://source.android.com/setup/develop/repo) complements Git by simplifying work across multiple


### PR DESCRIPTION
See [1] for context and [2] for the package violating the spec [3].

[1]: https://github.com/eclipse-apoapsis/ort-server/issues/1137
[2]: https://github.com/js-sdsl/js-sdsl/blob/07d24014a3cb69adffa717ee1170824ac5b841c3/package.json#L124
[3]: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository