### PR TITLE
node: Represent workspace submodules as Projects

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces-expected-output.yml
@@ -28,6 +28,42 @@ analyzer:
     skip_excluded: false
   result:
     projects:
+    - id: "PNPM::pnpm-app-example:1.1.4"
+      definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/app/package.json"
+      authors:
+      - "DavidWells"
+      declared_licenses:
+      - "ISC"
+      declared_licenses_processed:
+        spdx_expression: "ISC"
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "<REPLACE_URL_PROCESSED>"
+        revision: "<REPLACE_REVISION>"
+        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/app"
+      homepage_url: ""
+      scopes:
+      - name: "dependencies"
+        dependencies:
+        - id: "PNPM::testing-pnpm-package-a:1.0.2"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "NPM::chalk:5.0.1"
+          - id: "NPM::is-even:1.0.0"
+            dependencies:
+            - id: "NPM::is-odd:0.1.2"
+              dependencies:
+              - id: "NPM::is-number:3.0.0"
+                dependencies:
+                - id: "NPM::kind-of:3.2.2"
+                  dependencies:
+                  - id: "NPM::is-buffer:1.1.6"
+          - id: "NPM::sax:1.2.4"
     - id: "PNPM::pnpm-workspaces:1.0.1"
       definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/package.json"
       authors:
@@ -50,16 +86,31 @@ analyzer:
       scopes:
       - name: "dependencies"
         dependencies:
-        - id: "NPM::chalk:4.0.0"
+        - id: "NPM::json-stable-stringify:1.0.1"
           dependencies:
-          - id: "NPM::ansi-styles:4.3.0"
-            dependencies:
-            - id: "NPM::color-convert:2.0.1"
-              dependencies:
-              - id: "NPM::color-name:1.1.4"
-          - id: "NPM::supports-color:7.2.0"
-            dependencies:
-            - id: "NPM::has-flag:4.0.0"
+          - id: "NPM::jsonify:0.0.0"
+    - id: "PNPM::testing-pnpm-package-a:1.0.2"
+      definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-a/package.json"
+      authors:
+      - "Marcel Bochtler"
+      declared_licenses:
+      - "ISC"
+      declared_licenses_processed:
+        spdx_expression: "ISC"
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "<REPLACE_URL_PROCESSED>"
+        revision: "<REPLACE_REVISION>"
+        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-a"
+      homepage_url: ""
+      scopes:
+      - name: "dependencies"
+        dependencies:
         - id: "NPM::chalk:5.0.1"
         - id: "NPM::is-even:1.0.0"
           dependencies:
@@ -70,28 +121,7 @@ analyzer:
               - id: "NPM::kind-of:3.2.2"
                 dependencies:
                 - id: "NPM::is-buffer:1.1.6"
-        - id: "NPM::json-stable-stringify:1.0.1"
-          dependencies:
-          - id: "NPM::jsonify:0.0.0"
-        - id: "NPM::pnpm-workspaces:1.0.1"
-          dependencies:
-          - id: "NPM::json-stable-stringify:1.0.1"
-            dependencies:
-            - id: "NPM::jsonify:0.0.0"
         - id: "NPM::sax:1.2.4"
-        - id: "NPM::testing-pnpm-package-a:1.0.2"
-          dependencies:
-          - id: "NPM::chalk:5.0.1"
-          - id: "NPM::is-even:1.0.0"
-            dependencies:
-            - id: "NPM::is-odd:0.1.2"
-              dependencies:
-              - id: "NPM::is-number:3.0.0"
-                dependencies:
-                - id: "NPM::kind-of:3.2.2"
-                  dependencies:
-                  - id: "NPM::is-buffer:1.1.6"
-          - id: "NPM::sax:1.2.4"
       - name: "devDependencies"
         dependencies:
         - id: "NPM::require-uncached:2.0.0"
@@ -100,6 +130,38 @@ analyzer:
             dependencies:
             - id: "NPM::callsites:0.2.0"
           - id: "NPM::resolve-from:1.0.1"
+    - id: "PNPM::testing-pnpm-package-b:1.0.2"
+      definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-b/package.json"
+      authors:
+      - "Marcel Bochtler"
+      declared_licenses:
+      - "ISC"
+      declared_licenses_processed:
+        spdx_expression: "ISC"
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "<REPLACE_URL_PROCESSED>"
+        revision: "<REPLACE_REVISION>"
+        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-b"
+      homepage_url: ""
+      scopes:
+      - name: "dependencies"
+        dependencies:
+        - id: "NPM::chalk:4.0.0"
+          dependencies:
+          - id: "NPM::ansi-styles:4.3.0"
+            dependencies:
+            - id: "NPM::color-convert:2.0.1"
+              dependencies:
+              - id: "NPM::color-name:1.1.4"
+          - id: "NPM::supports-color:7.2.0"
+            dependencies:
+            - id: "NPM::has-flag:4.0.0"
     - id: "PNPM::testing-pnpm-package-c:1.0.0"
       definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/non-workspace/package-c/package.json"
       authors:
@@ -604,66 +666,6 @@ analyzer:
         url: "https://github.com/dcodeIO/long.js.git"
         revision: "088e44e5e3343ef967698565678384fa474b003b"
         path: ""
-    - id: "NPM::pnpm-app-example:1.1.4"
-      purl: "pkg:npm/pnpm-app-example@1.1.4"
-      authors:
-      - "DavidWells"
-      declared_licenses:
-      - "ISC"
-      declared_licenses_processed:
-        spdx_expression: "ISC"
-      description: ""
-      homepage_url: ""
-      binary_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      source_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      vcs:
-        type: "Git"
-        url: "<REPLACE_URL>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/app"
-      vcs_processed:
-        type: "Git"
-        url: "<REPLACE_URL_PROCESSED>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/app"
-    - id: "NPM::pnpm-workspaces:1.0.1"
-      purl: "pkg:npm/pnpm-workspaces@1.0.1"
-      authors:
-      - "Marcel Bochtler"
-      declared_licenses:
-      - "MIT"
-      declared_licenses_processed:
-        spdx_expression: "MIT"
-      description: "PNPM workspaces test"
-      homepage_url: ""
-      binary_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      source_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      vcs:
-        type: "Git"
-        url: "<REPLACE_URL>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces"
-      vcs_processed:
-        type: "Git"
-        url: "<REPLACE_URL_PROCESSED>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces"
     - id: "NPM::require-uncached:2.0.0"
       purl: "pkg:npm/require-uncached@2.0.0"
       authors:
@@ -785,66 +787,6 @@ analyzer:
         url: "https://github.com/chalk/supports-color.git"
         revision: "c5edf46896d1fc1826cb1183a60d61eecb65d749"
         path: ""
-    - id: "NPM::testing-pnpm-package-a:1.0.2"
-      purl: "pkg:npm/testing-pnpm-package-a@1.0.2"
-      authors:
-      - "Marcel Bochtler"
-      declared_licenses:
-      - "ISC"
-      declared_licenses_processed:
-        spdx_expression: "ISC"
-      description: ""
-      homepage_url: ""
-      binary_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      source_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      vcs:
-        type: "Git"
-        url: "<REPLACE_URL>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-a"
-      vcs_processed:
-        type: "Git"
-        url: "<REPLACE_URL_PROCESSED>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-a"
-    - id: "NPM::testing-pnpm-package-b:1.0.2"
-      purl: "pkg:npm/testing-pnpm-package-b@1.0.2"
-      authors:
-      - "Marcel Bochtler"
-      declared_licenses:
-      - "ISC"
-      declared_licenses_processed:
-        spdx_expression: "ISC"
-      description: ""
-      homepage_url: ""
-      binary_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      source_artifact:
-        url: ""
-        hash:
-          value: ""
-          algorithm: ""
-      vcs:
-        type: "Git"
-        url: "<REPLACE_URL>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-b"
-      vcs_processed:
-        type: "Git"
-        url: "<REPLACE_URL_PROCESSED>"
-        revision: "<REPLACE_REVISION>"
-        path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-b"
 scanner: null
 advisor: null
 evaluator: null

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces-expected-output.yml
@@ -1,6 +1,29 @@
 ---
-project:
-  id: "Yarn::workspace:1.0.0"
+projects:
+- id: "Yarn::pkg2:1.0.0"
+  definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg2/package.json"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg2"
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "NPM:@here:harp-fetch:0.3.6"
+      dependencies:
+      - id: "NPM::node-fetch:2.6.0"
+- id: "Yarn::workspace:1.0.0"
   definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/package.json"
   declared_licenses:
   - "Apache-2.0"
@@ -17,12 +40,27 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces"
   homepage_url: ""
+  scopes: []
+- id: "Yarn:@scope1:pkg1:1.0.0"
+  definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg1/package.json"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg1"
+  homepage_url: ""
   scopes:
   - name: "dependencies"
     dependencies:
-    - id: "NPM:@here:harp-fetch:0.3.6"
-      dependencies:
-      - id: "NPM::node-fetch:2.6.0"
     - id: "NPM:@here:harp-fetch:0.11.0"
       dependencies:
       - id: "NPM::node-fetch:2.6.0"
@@ -57,34 +95,6 @@ packages:
     url: "https://github.com/bitinn/node-fetch.git"
     revision: "95286f52bb866283bc69521a04efe1de37b26a33"
     path: ""
-- id: "NPM::pkg2:1.0.0"
-  purl: "pkg:npm/pkg2@1.0.0"
-  declared_licenses:
-  - "Apache-2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "<REPLACE_URL>"
-    revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg2"
-  vcs_processed:
-    type: "Git"
-    url: "<REPLACE_URL_PROCESSED>"
-    revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg2"
 - id: "NPM:@here:harp-fetch:0.3.6"
   purl: "pkg:npm/%40here/harp-fetch@0.3.6"
   authors:
@@ -145,31 +155,3 @@ packages:
     url: "https://github.com/heremaps/harp.gl.git"
     revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
     path: "@here/harp-fetch"
-- id: "NPM:@scope1:pkg1:1.0.0"
-  purl: "pkg:npm/%40scope1/pkg1@1.0.0"
-  declared_licenses:
-  - "Apache-2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "<REPLACE_URL>"
-    revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg1"
-  vcs_processed:
-    type: "Git"
-    url: "<REPLACE_URL_PROCESSED>"
-    revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces/packages/pkg1"

--- a/plugins/package-managers/node/src/funTest/kotlin/YarnFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/YarnFunTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.packagemanagers.node
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should
 
+import org.ossreviewtoolkit.analyzer.collateMultipleProjects
 import org.ossreviewtoolkit.analyzer.create
 import org.ossreviewtoolkit.analyzer.resolveSingleProject
 import org.ossreviewtoolkit.model.toYaml
@@ -45,7 +46,7 @@ class YarnFunTest : WordSpec({
             val definitionFile = getAssetFile("projects/synthetic/yarn/workspaces/package.json")
             val expectedResultFile = getAssetFile("projects/synthetic/yarn/workspaces-expected-output.yml")
 
-            val result = create("Yarn").resolveSingleProject(definitionFile, resolveScopes = true)
+            val result = create("Yarn").collateMultipleProjects(definitionFile).withResolvedScopes()
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -418,12 +418,11 @@ open class Npm(
     private fun getModuleDependencies(moduleDir: File, scopes: Set<String>): Set<NpmModuleInfo> {
         val workspaceModuleDirs = findWorkspaceSubmodules(moduleDir)
 
-        @Suppress("UnsafeCallOnNullableType")
         return buildSet {
-            addAll(getModuleInfo(moduleDir, scopes)!!.dependencies)
+            addAll(checkNotNull(getModuleInfo(moduleDir, scopes)).dependencies)
 
             workspaceModuleDirs.forEach { workspaceModuleDir ->
-                addAll(getModuleInfo(workspaceModuleDir, scopes, listOf(moduleDir))!!.dependencies)
+                addAll(checkNotNull(getModuleInfo(workspaceModuleDir, scopes, listOf(moduleDir))).dependencies)
             }
         }
     }

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -177,6 +177,7 @@ open class Npm(
         }
     }
 
+    // TODO: Add support for bundledDependencies.
     private fun resolveDependenciesInternal(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
@@ -222,8 +223,6 @@ open class Npm(
                 DEV_DEPENDENCIES_SCOPE
             )
         )
-
-        // TODO: Add support for bundledDependencies.
 
         return listOf(
             ProjectAnalyzerResult(

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -134,15 +134,15 @@ open class Npm(
     /**
      * Load the submodule directories of the project defined in [moduleDir].
      */
-    protected open fun loadWorkspaceSubmodules(moduleDir: File): List<File> {
+    protected open fun loadWorkspaceSubmodules(moduleDir: File): Set<File> {
         val nodeModulesDir = moduleDir.resolve("node_modules")
-        if (!nodeModulesDir.isDirectory) return emptyList()
+        if (!nodeModulesDir.isDirectory) return emptySet()
 
         val searchDirs = nodeModulesDir.walk().maxDepth(1).filter {
             (it.isDirectory && it.name.startsWith("@")) || it == nodeModulesDir
         }
 
-        return searchDirs.flatMapTo(mutableListOf()) { dir ->
+        return searchDirs.flatMapTo(mutableSetOf()) { dir ->
             dir.walk().maxDepth(1).filter {
                 it.isDirectory && it.isSymbolicLink() && it != dir
             }
@@ -386,12 +386,12 @@ open class Npm(
     }
 
     /** Cache for submodules identified by its moduleDir absolutePath */
-    private val submodulesCache = ConcurrentHashMap<String, List<File>>()
+    private val submodulesCache = ConcurrentHashMap<String, Set<File>>()
 
     /**
      * Find the directories which are defined as submodules of the project within [moduleDir].
      */
-    protected fun findWorkspaceSubmodules(moduleDir: File): List<File> =
+    protected fun findWorkspaceSubmodules(moduleDir: File): Set<File> =
         submodulesCache.getOrPut(moduleDir.absolutePath) {
             loadWorkspaceSubmodules(moduleDir)
         }

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -475,7 +475,12 @@ open class Npm(
             }
         }
 
-        return NpmModuleInfo(moduleId, moduleDir, moduleInfo.packageJson, dependencies)
+        return NpmModuleInfo(
+            id = moduleId,
+            workingDir = moduleDir,
+            packageFile = moduleInfo.packageJson,
+            dependencies = dependencies
+        )
     }
 
     /**

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -138,12 +138,12 @@ open class Npm(
         val nodeModulesDir = moduleDir.resolve("node_modules")
         if (!nodeModulesDir.isDirectory) return emptyList()
 
-        val searchDirs = nodeModulesDir.walk().maxDepth(1).filterTo(mutableListOf()) {
+        val searchDirs = nodeModulesDir.walk().maxDepth(1).filter {
             (it.isDirectory && it.name.startsWith("@")) || it == nodeModulesDir
         }
 
-        return searchDirs.flatMap { dir ->
-            dir.walk().maxDepth(1).filterTo(mutableListOf()) {
+        return searchDirs.flatMapTo(mutableListOf()) { dir ->
+            dir.walk().maxDepth(1).filter {
                 it.isDirectory && it.isSymbolicLink() && it != dir
             }
         }

--- a/plugins/package-managers/node/src/main/kotlin/Pnpm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Pnpm.kt
@@ -55,10 +55,10 @@ class Pnpm(
 
     override fun File.isWorkspaceDir() = realFile() in findWorkspaceSubmodules(analysisRoot)
 
-    override fun loadWorkspaceSubmodules(moduleDir: File): List<File> {
+    override fun loadWorkspaceSubmodules(moduleDir: File): Set<File> {
         val process = run(moduleDir, "list", "--recursive", "--depth=-1", "--parseable")
 
-        return process.stdout.lines().filter { it.isNotEmpty() }.map { File(it) }
+        return process.stdout.lines().filter { it.isNotEmpty() }.mapTo(mutableSetOf()) { File(it) }
     }
 
     override fun command(workingDir: File?) = if (Os.isWindows) "pnpm.cmd" else "pnpm"

--- a/plugins/package-managers/node/src/test/kotlin/utils/NpmDependencyHandlerTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/utils/NpmDependencyHandlerTest.kt
@@ -95,8 +95,9 @@ private fun createIdentifier(name: String): Identifier =
 private fun createModuleInfo(
     id: Identifier,
     packageFile: File = File("project/package.json"),
-    dependencies: Set<NpmModuleInfo> = emptySet()
-): NpmModuleInfo = NpmModuleInfo(id, packageFile.parentFile, packageFile, dependencies)
+    dependencies: Set<NpmModuleInfo> = emptySet(),
+    isProject: Boolean = false
+): NpmModuleInfo = NpmModuleInfo(id, packageFile.parentFile, packageFile, dependencies, isProject)
 
 /**
  * Creates an [NpmDependencyHandler] instance to be used by test cases.


### PR DESCRIPTION
See individual commits for the details.

Fixes https://github.com/oss-review-toolkit/ort/issues/9196, fixes https://github.com/oss-review-toolkit/ort/issues/8940.

**Important**: Previously, submodules were represented as packages which were not referenced by any project scope. 
                             As consequence, this could lead to incorrect handling of all their transitive dependencies by the policy rules.