### PR TITLE
fix: Tolerate `LicenseRef-*` exceptions in declared license mappings

### DIFF
--- a/utils/ort/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/ort/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -91,7 +91,9 @@ object DeclaredLicenseProcessor {
             ?: SpdxDeclaredLicenseMapping.map(strippedLicense.removePrefix(SpdxConstants.TAG).trim())
 
         val processedLicense = mappedLicense ?: strippedLicense.toSpdxOrNull()
-        return processedLicense?.normalize()?.takeIf { it.isValid() || it.toString() == SpdxConstants.NONE }
+        return processedLicense?.normalize()?.takeIf {
+            it.isValid(SpdxExpression.Strictness.ALLOW_LICENSEREF_EXCEPTIONS) || it.toString() == SpdxConstants.NONE
+        }
     }
 
     /**


### PR DESCRIPTION
Only allowing SPDX exceptions is too much of a limitation.

Fixes #9111.
