### PR TITLE
fix(gradle): Also check for non-empty resolution alternatives

### DIFF
--- a/plugins/package-managers/gradle/src/main/resources/init.gradle
+++ b/plugins/package-managers/gradle/src/main/resources/init.gradle
@@ -409,7 +409,7 @@ class AbstractOrtDependencyTreePlugin<T> implements Plugin<T> {
             // available since Gradle 6.0.
             boolean isDeprecatedForResolving = false
             if (configuration.metaClass.respondsTo(configuration, 'getResolutionAlternatives')) {
-                isDeprecatedForResolving = configuration.getResolutionAlternatives() != null
+                isDeprecatedForResolving = configuration.getResolutionAlternatives()
             }
 
             return canBeResolved && !isDeprecatedForResolving


### PR DESCRIPTION
Starting with Gradle 8.2, a property that defines if a Gradle configuration is deprecated can be an empty list instead of just `null`. This is misinterpreted by the Gradle analyzer plugin, and all Gradle configurations are considered deprecated. As a result, no dependencies for no Gradle configurations are returned.

Fixes #9255

