### PR TITLE
test: Ensure to use a compatible Java version for Gradle projects

### DIFF
--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleAndroidFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleAndroidFunTest.kt
@@ -33,7 +33,8 @@ class GradleAndroidFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-android/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-android-expected-output-root.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -42,7 +43,8 @@ class GradleAndroidFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-android/app/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-android-expected-output-app.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -51,7 +53,8 @@ class GradleAndroidFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-android/lib/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-android-expected-output-lib.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -60,7 +63,8 @@ class GradleAndroidFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-android-cyclic/app/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-android-cyclic-expected-output-app.yml")
 
-        val result = create("Gradle").resolveDependencies(listOf(definitionFile), emptyMap())
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveDependencies(listOf(definitionFile), emptyMap())
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleBomFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleBomFunTest.kt
@@ -33,7 +33,8 @@ class GradleBomFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-bom/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-bom-expected-output.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleCompositeFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleCompositeFunTest.kt
@@ -33,7 +33,8 @@ class GradleCompositeFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-composite/project1/build.gradle.kts")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-composite-expected-output.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleFunTest.kt
@@ -69,7 +69,8 @@ class GradleFunTest : StringSpec() {
             val definitionFile = getAssetFile("projects/synthetic/gradle/build.gradle")
             val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-root.yml")
 
-            val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+            val result = create("Gradle", "javaVersion" to "17")
+                .resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }
@@ -78,7 +79,8 @@ class GradleFunTest : StringSpec() {
             val definitionFile = getAssetFile("projects/synthetic/gradle/app/build.gradle")
             val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-app.yml")
 
-            val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+            val result = create("Gradle", "javaVersion" to "17")
+                .resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }
@@ -87,7 +89,8 @@ class GradleFunTest : StringSpec() {
             val definitionFile = getAssetFile("projects/synthetic/gradle/lib/build.gradle")
             val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-lib.yml")
 
-            val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+            val result = create("Gradle", "javaVersion" to "17")
+                .resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }
@@ -96,7 +99,8 @@ class GradleFunTest : StringSpec() {
             val definitionFile = getAssetFile("projects/synthetic/gradle/lib-without-repo/build.gradle")
             val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-lib-without-repo.yml")
 
-            val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+            val result = create("Gradle", "javaVersion" to "17")
+                .resolveSingleProject(definitionFile, resolveScopes = true)
 
             patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
         }
@@ -105,7 +109,7 @@ class GradleFunTest : StringSpec() {
             val definitionFile = getAssetFile("projects/synthetic/gradle/app/build.gradle")
             val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-scopes-excludes.yml")
 
-            val result = create("Gradle", excludedScopes = setOf("test.*"))
+            val result = create("Gradle", "javaVersion" to "17", excludedScopes = setOf("test.*"))
                 .resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
@@ -119,7 +123,8 @@ class GradleFunTest : StringSpec() {
             val definitionFile = getAssetFile("projects/synthetic/gradle-unsupported-version/build.gradle")
             val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-unsupported-version.yml")
 
-            val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+            val result = create("Gradle", "javaVersion" to "17")
+                .resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
         }
@@ -171,7 +176,8 @@ class GradleFunTest : StringSpec() {
                 val definitionFile = getAssetFile("projects/synthetic/app/build.gradle")
                 val expectedResultFile = getAssetFile("projects/synthetic/gradle-expected-output-app$suffix.yml")
 
-                val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+                val result = create("Gradle", "javaVersion" to "17")
+                    .resolveSingleProject(definitionFile, resolveScopes = true)
 
                 result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
             }

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleKotlinScriptFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleKotlinScriptFunTest.kt
@@ -33,7 +33,8 @@ class GradleKotlinScriptFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/multi-kotlin-project/build.gradle.kts")
         val expectedResultFile = getAssetFile("projects/synthetic/multi-kotlin-project-expected-output-root.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -42,7 +43,8 @@ class GradleKotlinScriptFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/multi-kotlin-project/core/build.gradle.kts")
         val expectedResultFile = getAssetFile("projects/synthetic/multi-kotlin-project-expected-output-core.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -51,7 +53,8 @@ class GradleKotlinScriptFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/multi-kotlin-project/cli/build.gradle.kts")
         val expectedResultFile = getAssetFile("projects/synthetic/multi-kotlin-project-expected-output-cli.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleLibraryFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleLibraryFunTest.kt
@@ -33,7 +33,8 @@ class GradleLibraryFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-library/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-library-expected-output-root.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -42,7 +43,8 @@ class GradleLibraryFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-library/app/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-library-expected-output-app.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
@@ -51,7 +53,8 @@ class GradleLibraryFunTest : StringSpec({
         val definitionFile = getAssetFile("projects/synthetic/gradle-library/lib/build.gradle")
         val expectedResultFile = getAssetFile("projects/synthetic/gradle-library-expected-output-lib.yml")
 
-        val result = create("Gradle").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Gradle", "javaVersion" to "17")
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }


### PR DESCRIPTION
This is a fixup for e34734a to also handle "legacy" Gradle tests. It is unclear why this was not required earlier by CI: Probably due to some caching, which got invalidated with CI's upgrade to Ubuntu 24.04.