### PR TITLE
fix(maven): Correctly convert repositories

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -25,6 +25,7 @@ import java.net.URI
 import kotlin.time.Duration.Companion.hours
 
 import org.apache.logging.log4j.kotlin.logger
+import org.apache.maven.artifact.repository.Authentication
 import org.apache.maven.artifact.repository.LegacyLocalRepositoryManager
 import org.apache.maven.bridge.MavenRepositorySystem
 import org.apache.maven.execution.DefaultMavenExecutionRequest
@@ -42,6 +43,7 @@ import org.apache.maven.project.ProjectBuildingException
 import org.apache.maven.project.ProjectBuildingRequest
 import org.apache.maven.project.ProjectBuildingResult
 import org.apache.maven.properties.internal.EnvironmentUtils
+import org.apache.maven.repository.Proxy
 import org.apache.maven.session.scope.internal.SessionScope
 
 import org.codehaus.plexus.DefaultContainerConfiguration
@@ -58,6 +60,7 @@ import org.eclipse.aether.artifact.Artifact
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.impl.RemoteRepositoryManager
 import org.eclipse.aether.impl.RepositoryConnectorProvider
+import org.eclipse.aether.repository.AuthenticationContext
 import org.eclipse.aether.repository.MirrorSelector
 import org.eclipse.aether.repository.RemoteRepository
 import org.eclipse.aether.repository.WorkspaceReader
@@ -309,6 +312,57 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             checksum.splitOnWhitespace().firstNotNullOfOrNull {
                 runCatching { Hash(it, algorithm) }.getOrNull()
             } ?: Hash.NONE
+
+        /**
+         * Convert this [RemoteRepository] to a repository in the format used by the Maven Repository System.
+         * Make sure that all relevant properties are set, especially the proxy and authentication.
+         */
+        internal fun RemoteRepository.toArtifactRepository(
+            repositorySystemSession: RepositorySystemSession,
+            repositorySystem: MavenRepositorySystem,
+            id: String
+        ) = repositorySystem.createRepository(url, id, true, null, true, null, null).apply {
+            this@toArtifactRepository.proxy?.also { repoProxy ->
+                proxy = Proxy().apply {
+                    host = repoProxy.host
+                    port = repoProxy.port
+                    protocol = repoProxy.type
+                    toMavenAuthentication(
+                        AuthenticationContext.forProxy(
+                            repositorySystemSession,
+                            this@toArtifactRepository
+                        )
+                    )?.also { authentication ->
+                        userName = authentication.username
+                        password = authentication.password
+                    }
+                }
+            }
+
+            this@toArtifactRepository.authentication?.also {
+                authentication = toMavenAuthentication(
+                    AuthenticationContext.forRepository(
+                        repositorySystemSession,
+                        this@toArtifactRepository
+                    )
+                )
+            }
+        }
+
+        /**
+         * Return authentication information for an artifact repository based on the given [authContext]. The
+         * libraries involved use different approaches to model authentication.
+         */
+        private fun toMavenAuthentication(authContext: AuthenticationContext?): Authentication? =
+            authContext?.let {
+                Authentication(
+                    it[AuthenticationContext.USERNAME],
+                    it[AuthenticationContext.PASSWORD]
+                ).apply {
+                    passphrase = it[AuthenticationContext.PRIVATE_KEY_PASSPHRASE]
+                    privateKey = it[AuthenticationContext.PRIVATE_KEY_PATH]
+                }
+            }
 
         /**
          * Return true if an artifact that has not been requested from Maven Central is also available on Maven Central
@@ -683,7 +737,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             // As the ID might be used as the key when generating a metadata file name, avoid the URL being used as the
             // ID as the URL is likely to contain characters like ":" which not all file systems support.
             val id = repo.id.takeUnless { it == repo.url } ?: repo.host
-            mavenRepositorySystem.createRepository(repo.url, id, true, null, true, null, null)
+            repo.toArtifactRepository(repositorySystemSession, mavenRepositorySystem, id)
         } + projectBuildingRequest.remoteRepositories
 
         val localProject = localProjects[artifact.identifier()]


### PR DESCRIPTION
When resolving artifacts using a `ProjectBuilder`, remote repositories from the Eclipse Aether library have to be converted to the model used by the Maven repository system. So far, only the most prominent properties have been converted. In certain constellations, this is not sufficient. In a concrete case, resolution failed for an artifact located in a repository that was defined in a pom of a transitive dependency. For this repository the information about the required proxy was lost, and so network requests caused exceptions.

Fix this by also dealing with the properties related to the proxy and authentication.

Note: It would probably be good to have a synthetic fun test for the problematic constellation, but I don't think it is feasible to create one, since the constellation is rather special and also requires a specific network/proxy setup.