### PR TITLE
build(gradle): Update transitive commons-io versions

### DIFF
--- a/plugins/commands/upload-result-to-sw360/build.gradle.kts
+++ b/plugins/commands/upload-result-to-sw360/build.gradle.kts
@@ -33,5 +33,10 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     implementation(libs.clikt)
-    implementation(libs.sw360Client)
+    implementation(libs.sw360Client) {
+        constraints {
+            implementation("commons-io:commons-io:2.17.0")
+                .because("commons-io 2.11.0 is vulnerable by CVE-2024-47554")
+        }
+    }
 }

--- a/plugins/package-curation-providers/sw360/build.gradle.kts
+++ b/plugins/package-curation-providers/sw360/build.gradle.kts
@@ -27,5 +27,10 @@ dependencies {
 
     ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 
-    implementation(libs.sw360Client)
+    implementation(libs.sw360Client) {
+        constraints {
+            implementation("commons-io:commons-io:2.17.0")
+                .because("commons-io 2.11.0 is vulnerable by CVE-2024-47554")
+        }
+    }
 }

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -38,7 +38,12 @@ dependencies {
     implementation(libs.kotlinx.coroutines)
     implementation(libs.postgres)
     implementation(libs.retrofit.converter.jackson)
-    implementation(libs.sw360Client)
+    implementation(libs.sw360Client) {
+        constraints {
+            implementation("commons-io:commons-io:2.17.0")
+                .because("commons-io 2.11.0 is vulnerable by CVE-2024-47554")
+        }
+    }
 
     funTestApi(testFixtures(projects.scanner))
 


### PR DESCRIPTION
Avoid CVE-2024-47554 by manually updating transitive commons-io versions until a new SW360 client version is available.