### PR TITLE
refactor(vcs): VCS configuration to support common and custom attributes

### DIFF
--- a/cli/src/funTest/kotlin/AnalyzerFunTest.kt
+++ b/cli/src/funTest/kotlin/AnalyzerFunTest.kt
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.analyzer.analyze
+import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -52,7 +53,10 @@ class AnalyzerFunTest : WordSpec({
                     revision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
                 )
             )
-            val outputDir = tempdir().also { GitRepo().download(pkg, it) }
+            val outputDir = tempdir().also {
+                GitRepo.Factory().create(VersionControlSystemConfiguration())
+                    .download(pkg, it)
+            }
 
             val result = analyze(outputDir, packageManagers = emptySet()).toYaml()
 

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -232,7 +232,9 @@ class Downloader(private val config: DownloaderConfiguration) {
         var applicableVcs: VersionControlSystem? = null
 
         if (pkg.vcsProcessed.type != VcsType.UNKNOWN) {
-            applicableVcs = VersionControlSystem.forType(pkg.vcsProcessed.type)
+            applicableVcs = VersionControlSystem.forType(
+                pkg.vcsProcessed.type, config.getCaseInsensitiveVersionControlSystems()
+            )
             logger.info {
                 applicableVcs?.let {
                     "Detected VCS type '${it.type}' from type name '${pkg.vcsProcessed.type}'."
@@ -241,7 +243,9 @@ class Downloader(private val config: DownloaderConfiguration) {
         }
 
         if (applicableVcs == null) {
-            applicableVcs = VersionControlSystem.forUrl(pkg.vcsProcessed.url)
+            applicableVcs = VersionControlSystem.forUrl(
+                pkg.vcsProcessed.url, config.getCaseInsensitiveVersionControlSystems()
+            )
             logger.info {
                 applicableVcs?.let {
                     "Detected VCS type '${it.type}' from URL ${pkg.vcsProcessed.url}."

--- a/downloader/src/main/kotlin/VersionControlSystemFactory.kt
+++ b/downloader/src/main/kotlin/VersionControlSystemFactory.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.downloader
+
+import org.ossreviewtoolkit.utils.common.Plugin
+import org.ossreviewtoolkit.utils.common.TypedConfigurablePluginFactory
+
+/**
+ * An abstract class to be implemented by factories for [version contral systems][VersionControlSystem].
+ * The constructor parameter [type] denotes which VCS type is supported by this plugin.
+ * The constructor parameter [priority] is used to determine the order in which the VCS plugins are used.
+ */
+abstract class VersionControlSystemFactory<CONFIG>(override val type: String, val priority: Int) :
+    TypedConfigurablePluginFactory<CONFIG, VersionControlSystem> {
+    companion object {
+        /**
+         * All [version control system factories][VersionControlSystemFactory] available in the classpath,
+         * associated by their names, sorted by priority.
+         */
+        val ALL by lazy {
+            Plugin.getAll<VersionControlSystemFactory<*>>()
+                .toList()
+                .sortedByDescending { (_, vcsFactory) -> vcsFactory.priority }
+                .toMap()
+        }
+    }
+}
+
+/**
+ * A base class for specific version control system configurations.
+ */
+open class VersionControlSystemConfiguration

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.plugins.versioncontrolsystems.git.Git
+import org.ossreviewtoolkit.plugins.versioncontrolsystems.git.GitConfiguration
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 
 class VersionControlSystemTest : WordSpec({
@@ -87,7 +88,7 @@ class VersionControlSystemTest : WordSpec({
 
             every { workingTree.guessRevisionName(any(), any()) } returns "v1.6.0"
 
-            Git.Factory().create(VersionControlSystemConfiguration())
+            Git.Factory().create(GitConfiguration())
                 .getRevisionCandidates(workingTree, pkg, allowMovingRevisions = true) shouldBeSuccess listOf(
                 "v1.6.0"
             )
@@ -111,7 +112,7 @@ class VersionControlSystemTest : WordSpec({
             every { workingTree.listRemoteBranches() } returns listOf("main")
             every { workingTree.listRemoteTags() } returns emptyList()
 
-            Git.Factory().create(VersionControlSystemConfiguration())
+            Git.Factory().create(GitConfiguration())
                 .getRevisionCandidates(workingTree, pkg, allowMovingRevisions = true) shouldBeSuccess listOf(
                 "master",
                 "main"

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -87,7 +87,8 @@ class VersionControlSystemTest : WordSpec({
 
             every { workingTree.guessRevisionName(any(), any()) } returns "v1.6.0"
 
-            Git().getRevisionCandidates(workingTree, pkg, allowMovingRevisions = true) shouldBeSuccess listOf(
+            Git.Factory().create(VersionControlSystemConfiguration())
+                .getRevisionCandidates(workingTree, pkg, allowMovingRevisions = true) shouldBeSuccess listOf(
                 "v1.6.0"
             )
         }
@@ -110,7 +111,8 @@ class VersionControlSystemTest : WordSpec({
             every { workingTree.listRemoteBranches() } returns listOf("main")
             every { workingTree.listRemoteTags() } returns emptyList()
 
-            Git().getRevisionCandidates(workingTree, pkg, allowMovingRevisions = true) shouldBeSuccess listOf(
+            Git.Factory().create(VersionControlSystemConfiguration())
+                .getRevisionCandidates(workingTree, pkg, allowMovingRevisions = true) shouldBeSuccess listOf(
                 "master",
                 "main"
             )

--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -89,6 +89,28 @@
                     "items": {
                         "$ref": "#/definitions/SourceCodeOrigins"
                     }
+                },
+                "versionControlSystems": {
+                    "type": "object",
+                    "properties": {
+                        "Git": {
+                            "type": "object",
+                            "properties": {
+                                "options": {
+                                    "type": "object",
+                                    "properties": {
+                                        "submoduleHistoryDepth": {
+                                            "type": "integer",
+                                            "minimum": 1
+                                        },
+                                        "updateNestedSubmodules": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -44,9 +44,35 @@ data class DownloaderConfiguration(
      * Configuration of the considered source code origins and their priority order. This must not be empty and not
      * contain any duplicates.
      */
-    val sourceCodeOrigins: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
+    val sourceCodeOrigins: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT),
+
+    /**
+     * Version control system specific configurations. The key needs to match VCS type,
+     * e.g. "Git" for the Git version control system.
+     */
+    val versionControlSystems: Map<String, VersionControlSystemConfiguration> = emptyMap()
 ) {
+    /**
+     * A copy of [versionControlSystems] with case-insensitive keys.
+     */
+    private val versionControlSystemsCaseInsensitive: Map<String, VersionControlSystemConfiguration> =
+        versionControlSystems.toSortedMap(String.CASE_INSENSITIVE_ORDER)
+
     init {
         sourceCodeOrigins.requireNotEmptyNoDuplicates()
+
+        val duplicateVersionControlSystems =
+            versionControlSystems.keys - versionControlSystemsCaseInsensitive.keys.toSet()
+
+        require(duplicateVersionControlSystems.isEmpty()) {
+            "The following version control systems have duplicate configuration: " +
+                "${duplicateVersionControlSystems.joinToString()}."
+        }
     }
+
+    /**
+     * Get a [VersionControlSystemConfiguration] from [versionControlSystems].
+     * The difference to accessing the map directly is that VCS type can be case-insensitive.
+     */
+    fun getCaseInsensitiveVersionControlSystems() = versionControlSystemsCaseInsensitive
 }

--- a/model/src/main/kotlin/config/VersionControlSystemConfiguration.kt
+++ b/model/src/main/kotlin/config/VersionControlSystemConfiguration.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+import org.ossreviewtoolkit.utils.common.Options
+
+/**
+ * The configuration for a Version Control System (VCS).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class VersionControlSystemConfiguration(
+    /**
+     * Custom configuration options. See the documentation of the respective class for available options.
+     */
+    val options: Options = emptyMap()
+)

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -167,6 +167,20 @@ ort:
 
     sourceCodeOrigins: [VCS, ARTIFACT]
 
+    # Optional VCS-specific configuration options that allow to add VCS-specific configurations to leverage certain
+    # features directly in a VCS plugin. The effects are limited to usage through the command-line interface of the
+    # Downloader tool, designed primarily for scripted operations. In other stages of the ORT pipeline these
+    # configuration options have no effect.
+    versionControlSystems:
+      Git:
+        options:
+          # Depth of the commit history to fetch when updating submodules
+          submoduleHistoryDepth: 10
+
+          # A flag to control whether nested submodules should be updated (true), or if only the submodules
+          # on the first layer should be considered (false).
+          updateNestedSubmodules: true
+
   scanner:
     skipConcluded: true
     skipExcluded: true

--- a/model/src/test/kotlin/config/DownloaderConfigurationTest.kt
+++ b/model/src/test/kotlin/config/DownloaderConfigurationTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class DownloaderConfigurationTest : WordSpec({
+    "DownloaderConfiguration()" should {
+        "throw an exception on duplicate VCS configurations" {
+            shouldThrow<IllegalArgumentException> {
+                DownloaderConfiguration(
+                    versionControlSystems = mapOf(
+                        "Git" to VersionControlSystemConfiguration(),
+                        "git" to VersionControlSystemConfiguration()
+                    )
+                )
+            }
+        }
+    }
+
+    "getVersionControlSystemConfiguration" should {
+        "return configuration case-insensitively" {
+            val vcsConfiguration = VersionControlSystemConfiguration()
+            val downloaderConfiguration = DownloaderConfiguration(
+                versionControlSystems = mapOf(
+                    "MyVCS" to vcsConfiguration
+                )
+            )
+
+            downloaderConfiguration.getCaseInsensitiveVersionControlSystems()["MyVCS"] shouldBe vcsConfiguration
+            downloaderConfiguration.getCaseInsensitiveVersionControlSystems()["myvcs"] shouldBe vcsConfiguration
+            downloaderConfiguration.getCaseInsensitiveVersionControlSystems()["MYVCS"] shouldBe vcsConfiguration
+        }
+    }
+})

--- a/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
+++ b/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
@@ -447,7 +447,9 @@ class DownloaderCommand : OrtCommand(
                 echo("Downloading $archiveType artifact from $projectUrl...")
                 Package.EMPTY.copy(id = dummyId, sourceArtifact = RemoteArtifact.EMPTY.copy(url = projectUrl))
             } else {
-                val vcs = VersionControlSystem.forUrl(projectUrl)
+                val vcs = VersionControlSystem.forUrl(
+                    projectUrl, ortConfig.downloader.getCaseInsensitiveVersionControlSystems()
+                )
                 val vcsType = listOfNotNull(vcsTypeOption, vcs?.type).map { VcsType.forName(it) }.firstOrNull()
                     ?: VcsType.UNKNOWN
                 val vcsRevision = vcsRevisionOption ?: vcs?.getDefaultBranchName(projectUrl).orEmpty()

--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -45,10 +45,13 @@ import org.eclipse.jgit.transport.sshd.ServerKeyDatabase
 import org.eclipse.jgit.transport.sshd.SshdSessionFactory
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
+import org.ossreviewtoolkit.downloader.VersionControlSystemFactory
 import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.CommandLineTool
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.safeMkdirs
@@ -117,8 +120,17 @@ class Git : VersionControlSystem(GitCommand) {
     }
 
     override val type = VcsType.GIT.toString()
-    override val priority = 100
     override val latestRevisionNames = listOf("HEAD", "@")
+
+    class Factory : VersionControlSystemFactory<VersionControlSystemConfiguration>(VcsType.GIT.toString(), 100) {
+        override fun create(config: VersionControlSystemConfiguration): VersionControlSystem {
+            return Git()
+        }
+
+        override fun parseConfig(options: Options, secrets: Options): VersionControlSystemConfiguration {
+            return VersionControlSystemConfiguration() // No specific Subversion configuration yet.
+        }
+    }
 
     override fun getVersion() = GitCommand.getVersion(null)
 

--- a/plugins/version-control-systems/git/src/main/kotlin/GitConfiguration.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/GitConfiguration.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package org.ossreviewtoolkit.plugins.versioncontrolsystems.git
+
+import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
+
+data class GitConfiguration(
+    /**
+     * Depth of the commit history to fetch when updating submodules
+     */
+    val submoduleHistoryDepth: Int = 50,
+
+    /**
+     * Whether nested submodules should be updated, or if only the submodules
+     * on the first layer should be considered.
+     */
+    val updateNestedSubmodules: Boolean = true
+) : VersionControlSystemConfiguration()

--- a/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
@@ -150,7 +150,7 @@ class GitRepo internal constructor() : VersionControlSystem(GitRepoCommand) {
 
                     paths.forEach { path ->
                         // Add the nested Repo project.
-                        val workingTree = Git.Factory().create(VersionControlSystemConfiguration())
+                        val workingTree = Git.Factory().create(GitConfiguration())
                             .getWorkingTree(getRootPath().resolve(path))
                         nested[path] = workingTree.getInfo()
 

--- a/plugins/version-control-systems/git/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystem
+++ b/plugins/version-control-systems/git/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -1,2 +1,0 @@
-org.ossreviewtoolkit.plugins.versioncontrolsystems.git.Git
-org.ossreviewtoolkit.plugins.versioncontrolsystems.git.GitRepo

--- a/plugins/version-control-systems/git/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystemFactory
+++ b/plugins/version-control-systems/git/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystemFactory
@@ -1,0 +1,2 @@
+org.ossreviewtoolkit.plugins.versioncontrolsystems.git.Git$Factory
+org.ossreviewtoolkit.plugins.versioncontrolsystems.git.GitRepo$Factory

--- a/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
+++ b/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
@@ -24,10 +24,13 @@ import java.io.File
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
+import org.ossreviewtoolkit.downloader.VersionControlSystemFactory
 import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.CommandLineTool
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 
 const val MERCURIAL_LARGE_FILES_EXTENSION = "largefiles = "
@@ -47,10 +50,21 @@ object MercurialCommand : CommandLineTool {
     override fun displayName(): String = "Mercurial"
 }
 
-class Mercurial : VersionControlSystem(MercurialCommand) {
+@Suppress("UnusedPrivateProperty")
+class Mercurial internal constructor() : VersionControlSystem(MercurialCommand) {
+
     override val type = VcsType.MERCURIAL.toString()
-    override val priority = 20
     override val latestRevisionNames = listOf("tip")
+
+    class Factory : VersionControlSystemFactory<VersionControlSystemConfiguration>(VcsType.MERCURIAL.toString(), 20) {
+        override fun create(config: VersionControlSystemConfiguration): VersionControlSystem {
+            return Mercurial()
+        }
+
+        override fun parseConfig(options: Options, secrets: Options): VersionControlSystemConfiguration {
+            return VersionControlSystemConfiguration() // No specific Mercurial configuration yet.
+        }
+    }
 
     override fun getVersion() = MercurialCommand.getVersion(null)
 

--- a/plugins/version-control-systems/mercurial/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystem
+++ b/plugins/version-control-systems/mercurial/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -1,1 +1,0 @@
-org.ossreviewtoolkit.plugins.versioncontrolsystems.mercurial.Mercurial

--- a/plugins/version-control-systems/mercurial/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystemFactory
+++ b/plugins/version-control-systems/mercurial/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystemFactory
@@ -1,0 +1,1 @@
+org.ossreviewtoolkit.plugins.versioncontrolsystems.mercurial.Mercurial$Factory

--- a/plugins/version-control-systems/subversion/src/main/kotlin/Subversion.kt
+++ b/plugins/version-control-systems/subversion/src/main/kotlin/Subversion.kt
@@ -28,9 +28,12 @@ import java.nio.file.Paths
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
+import org.ossreviewtoolkit.downloader.VersionControlSystemFactory
 import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.utils.common.Options
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.OrtAuthenticator
 import org.ossreviewtoolkit.utils.ort.OrtProxySelector
@@ -52,15 +55,26 @@ import org.tmatesoft.svn.core.wc.SVNClientManager
 import org.tmatesoft.svn.core.wc.SVNRevision
 import org.tmatesoft.svn.util.Version
 
-class Subversion : VersionControlSystem() {
+@Suppress("UnusedPrivateProperty")
+class Subversion internal constructor() : VersionControlSystem() {
+
     private val ortAuthManager = OrtSVNAuthenticationManager()
     private val clientManager = SVNClientManager.newInstance().apply {
         setAuthenticationManager(ortAuthManager)
     }
 
     override val type = VcsType.SUBVERSION.toString()
-    override val priority = 10
     override val latestRevisionNames = listOf("HEAD")
+
+    class Factory : VersionControlSystemFactory<VersionControlSystemConfiguration>(VcsType.SUBVERSION.toString(), 10) {
+        override fun create(config: VersionControlSystemConfiguration): VersionControlSystem {
+            return Subversion()
+        }
+
+        override fun parseConfig(options: Options, secrets: Options): VersionControlSystemConfiguration {
+            return VersionControlSystemConfiguration() // No specific Subversion configuration yet.
+        }
+    }
 
     override fun getVersion(): String = Version.getVersionString()
 

--- a/plugins/version-control-systems/subversion/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystem
+++ b/plugins/version-control-systems/subversion/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -1,1 +1,0 @@
-org.ossreviewtoolkit.plugins.versioncontrolsystems.subversion.Subversion

--- a/plugins/version-control-systems/subversion/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystemFactory
+++ b/plugins/version-control-systems/subversion/src/main/resources/META-INF/services/org.ossreviewtoolkit.downloader.VersionControlSystemFactory
@@ -1,0 +1,1 @@
+org.ossreviewtoolkit.plugins.versioncontrolsystems.subversion.Subversion$Factory

--- a/utils/common/src/funTest/kotlin/SafeDeleteRecursivelyFunTest.kt
+++ b/utils/common/src/funTest/kotlin/SafeDeleteRecursivelyFunTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.shouldBe
 
 import java.io.IOException
 
+import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -58,7 +59,8 @@ class SafeDeleteRecursivelyFunTest : WordSpec({
             )
 
             val nodeDir = tempdir().resolve("node-dir")
-            Git().download(pkg, nodeDir)
+            Git.Factory().create(VersionControlSystemConfiguration())
+                .download(pkg, nodeDir)
 
             shouldNotThrow<IOException> {
                 nodeDir.safeDeleteRecursively()

--- a/utils/common/src/funTest/kotlin/SafeDeleteRecursivelyFunTest.kt
+++ b/utils/common/src/funTest/kotlin/SafeDeleteRecursivelyFunTest.kt
@@ -26,11 +26,11 @@ import io.kotest.matchers.shouldBe
 
 import java.io.IOException
 
-import org.ossreviewtoolkit.downloader.VersionControlSystemConfiguration
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.plugins.versioncontrolsystems.git.Git
+import org.ossreviewtoolkit.plugins.versioncontrolsystems.git.GitConfiguration
 
 class SafeDeleteRecursivelyFunTest : WordSpec({
     "File.safeDeleteRecursively()" should {
@@ -59,7 +59,7 @@ class SafeDeleteRecursivelyFunTest : WordSpec({
             )
 
             val nodeDir = tempdir().resolve("node-dir")
-            Git.Factory().create(VersionControlSystemConfiguration())
+            Git.Factory().create(GitConfiguration())
                 .download(pkg, nodeDir)
 
             shouldNotThrow<IOException> {


### PR DESCRIPTION
While VCS implementations are already plugins, they are not yet configurable. VCS implementations require common configurations (e.g., `revision`, `recursive`) and should support also VCS-specific configurations **if they are consumed via their API**. 

This allows to add functionality to individual VCS implementations without the need to implement them for all of them.

This refactoring keeps the **common** configuration attributes as they are,  while VCS-specific configurations are stored generically in an `options` attribute. The effects are limited to usage through the command-line interface of the
_Downloader_ tool, designed primarily for scripted operations. In other stages of the ORT pipeline these  configuration options have no effect.

The change also adds VCS-specific configuration options for Git: The strategy for checking out repositories with submodules now allows to only check out **the first layer** of submodules.

Example configuration in `config.yml`:
```
ort:
  analyzer:
    versionControlSystems:
      Git:
        options:
          submoduleHistoryDepth: 2
          updateNestedSubmodules: false

```

The change is split up into 2 commits:
* First one deals with refactoring to use a new plugin interface for version control systems, that also allows to supply specific configurations.
* Second one is for 2 configuration options for Github VCS, dealing with submodules.

For more details, please have a look at the respective commits.

Fixes #8556.

