### PR TITLE
test(pnpm): Drop the unsupported `workspaces` property

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/package.json
@@ -6,10 +6,6 @@
   "author": "Marcel Bochtler",
   "license": "MIT",
   "main": "index.js",
-  "workspaces": [
-    "src/app",
-    "src/packages/**"
-  ],
   "engines": {
     "node": ">16.0.0",
     "pnpm": ">=5"


### PR DESCRIPTION
When running `pnpm` in the project directory of the `workspaces` project, it outputs the warning [1]. Remove the `workspaces` tag, as to fix that warning.

[1] `The "workspaces" field in package.json is not supported by pnpm.
     Create a "pnpm-workspace.yaml" file instead.`
