### PR TITLE
Make `Pnpm` separate from `Npm`

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel-expected-output.yml
@@ -46,17 +46,17 @@ project:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::esutils:2.0.3"
             - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
@@ -74,13 +74,13 @@ project:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-template:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-traverse:6.26.0"
               dependencies:
               - id: "NPM::babel-code-frame:6.26.0"
@@ -103,17 +103,17 @@ project:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
                   - id: "NPM::core-js:2.6.12"
-                  - id: "NPM::regenerator-runtime:0.10.5"
+                  - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-types:6.26.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
                   - id: "NPM::core-js:2.6.12"
-                  - id: "NPM::regenerator-runtime:0.10.5"
+                  - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::esutils:2.0.3"
                 - id: "NPM::lodash:4.17.21"
                 - id: "NPM::to-fast-properties:1.0.3"
@@ -126,14 +126,14 @@ project:
                 dependencies:
                 - id: "NPM::loose-envify:1.4.0"
                   dependencies:
-                  - id: "NPM::js-tokens:3.0.2"
+                  - id: "NPM::js-tokens:4.0.0"
               - id: "NPM::lodash:4.17.21"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::esutils:2.0.3"
               - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
@@ -144,13 +144,14 @@ project:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
         - id: "NPM::babel-register:6.26.0"
           dependencies:
+          - id: "NPM::babel-core:6.26.3"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::core-js:2.6.12"
           - id: "NPM::home-or-tmp:2.0.0"
             dependencies:
@@ -166,13 +167,13 @@ project:
         - id: "NPM::babel-runtime:6.26.0"
           dependencies:
           - id: "NPM::core-js:2.6.12"
-          - id: "NPM::regenerator-runtime:0.10.5"
+          - id: "NPM::regenerator-runtime:0.11.1"
         - id: "NPM::babel-template:6.26.0"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-traverse:6.26.0"
             dependencies:
             - id: "NPM::babel-code-frame:6.26.0"
@@ -195,17 +196,17 @@ project:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::esutils:2.0.3"
               - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
@@ -218,14 +219,14 @@ project:
               dependencies:
               - id: "NPM::loose-envify:1.4.0"
                 dependencies:
-                - id: "NPM::js-tokens:3.0.2"
+                - id: "NPM::js-tokens:4.0.0"
             - id: "NPM::lodash:4.17.21"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::esutils:2.0.3"
             - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
@@ -253,17 +254,17 @@ project:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::esutils:2.0.3"
             - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
@@ -276,14 +277,14 @@ project:
             dependencies:
             - id: "NPM::loose-envify:1.4.0"
               dependencies:
-              - id: "NPM::js-tokens:3.0.2"
+              - id: "NPM::js-tokens:4.0.0"
           - id: "NPM::lodash:4.17.21"
         - id: "NPM::babel-types:6.26.0"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::esutils:2.0.3"
           - id: "NPM::lodash:4.17.21"
           - id: "NPM::to-fast-properties:1.0.3"
@@ -309,7 +310,7 @@ project:
         - id: "NPM::babel-runtime:6.26.0"
           dependencies:
           - id: "NPM::core-js:2.6.12"
-          - id: "NPM::regenerator-runtime:0.10.5"
+          - id: "NPM::regenerator-runtime:0.11.1"
         - id: "NPM::core-js:2.6.12"
         - id: "NPM::regenerator-runtime:0.10.5"
       - id: "NPM::babel-register:6.26.0"
@@ -338,17 +339,17 @@ project:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::esutils:2.0.3"
               - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
@@ -366,13 +367,13 @@ project:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-template:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-traverse:6.26.0"
                 dependencies:
                 - id: "NPM::babel-code-frame:6.26.0"
@@ -395,17 +396,17 @@ project:
                   - id: "NPM::babel-runtime:6.26.0"
                     dependencies:
                     - id: "NPM::core-js:2.6.12"
-                    - id: "NPM::regenerator-runtime:0.10.5"
+                    - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
                   - id: "NPM::core-js:2.6.12"
-                  - id: "NPM::regenerator-runtime:0.10.5"
+                  - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::babel-types:6.26.0"
                   dependencies:
                   - id: "NPM::babel-runtime:6.26.0"
                     dependencies:
                     - id: "NPM::core-js:2.6.12"
-                    - id: "NPM::regenerator-runtime:0.10.5"
+                    - id: "NPM::regenerator-runtime:0.11.1"
                   - id: "NPM::esutils:2.0.3"
                   - id: "NPM::lodash:4.17.21"
                   - id: "NPM::to-fast-properties:1.0.3"
@@ -418,14 +419,14 @@ project:
                   dependencies:
                   - id: "NPM::loose-envify:1.4.0"
                     dependencies:
-                    - id: "NPM::js-tokens:3.0.2"
+                    - id: "NPM::js-tokens:4.0.0"
                 - id: "NPM::lodash:4.17.21"
               - id: "NPM::babel-types:6.26.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
                   - id: "NPM::core-js:2.6.12"
-                  - id: "NPM::regenerator-runtime:0.10.5"
+                  - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::esutils:2.0.3"
                 - id: "NPM::lodash:4.17.21"
                 - id: "NPM::to-fast-properties:1.0.3"
@@ -436,17 +437,18 @@ project:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
+          - id: "NPM::babel-register:6.26.0"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
             - id: "NPM::core-js:2.6.12"
-            - id: "NPM::regenerator-runtime:0.10.5"
+            - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-template:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-traverse:6.26.0"
               dependencies:
               - id: "NPM::babel-code-frame:6.26.0"
@@ -469,17 +471,17 @@ project:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
                   - id: "NPM::core-js:2.6.12"
-                  - id: "NPM::regenerator-runtime:0.10.5"
+                  - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-types:6.26.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
                   - id: "NPM::core-js:2.6.12"
-                  - id: "NPM::regenerator-runtime:0.10.5"
+                  - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::esutils:2.0.3"
                 - id: "NPM::lodash:4.17.21"
                 - id: "NPM::to-fast-properties:1.0.3"
@@ -492,14 +494,14 @@ project:
                 dependencies:
                 - id: "NPM::loose-envify:1.4.0"
                   dependencies:
-                  - id: "NPM::js-tokens:3.0.2"
+                  - id: "NPM::js-tokens:4.0.0"
               - id: "NPM::lodash:4.17.21"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::esutils:2.0.3"
               - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
@@ -527,17 +529,17 @@ project:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
                 - id: "NPM::core-js:2.6.12"
-                - id: "NPM::regenerator-runtime:0.10.5"
+                - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::esutils:2.0.3"
               - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
@@ -550,14 +552,14 @@ project:
               dependencies:
               - id: "NPM::loose-envify:1.4.0"
                 dependencies:
-                - id: "NPM::js-tokens:3.0.2"
+                - id: "NPM::js-tokens:4.0.0"
             - id: "NPM::lodash:4.17.21"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
               - id: "NPM::core-js:2.6.12"
-              - id: "NPM::regenerator-runtime:0.10.5"
+              - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::esutils:2.0.3"
             - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
@@ -581,7 +583,7 @@ project:
         - id: "NPM::babel-runtime:6.26.0"
           dependencies:
           - id: "NPM::core-js:2.6.12"
-          - id: "NPM::regenerator-runtime:0.10.5"
+          - id: "NPM::regenerator-runtime:0.11.1"
         - id: "NPM::core-js:2.6.12"
         - id: "NPM::home-or-tmp:2.0.0"
           dependencies:
@@ -597,7 +599,7 @@ project:
       - id: "NPM::babel-runtime:6.26.0"
         dependencies:
         - id: "NPM::core-js:2.6.12"
-        - id: "NPM::regenerator-runtime:0.10.5"
+        - id: "NPM::regenerator-runtime:0.11.1"
       - id: "NPM::chokidar:1.7.0"
         dependencies:
         - id: "NPM::anymatch:1.3.2"
@@ -612,30 +614,23 @@ project:
               dependencies:
               - id: "NPM::expand-range:1.8.2"
                 dependencies:
-                - id: "NPM::fill-range:4.0.0"
+                - id: "NPM::fill-range:2.2.4"
                   dependencies:
-                  - id: "NPM::extend-shallow:3.0.2"
-                    dependencies:
-                    - id: "NPM::assign-symbols:1.0.0"
-                    - id: "NPM::is-extendable:1.0.1"
-                      dependencies:
-                      - id: "NPM::is-plain-object:2.0.4"
-                        dependencies:
-                        - id: "NPM::isobject:3.0.1"
-                  - id: "NPM::is-number:3.0.0"
+                  - id: "NPM::is-number:2.1.0"
                     dependencies:
                     - id: "NPM::kind-of:3.2.2"
                       dependencies:
                       - id: "NPM::is-buffer:1.1.6"
-                  - id: "NPM::repeat-string:1.6.1"
-                  - id: "NPM::to-regex-range:2.1.1"
+                  - id: "NPM::isobject:2.1.0"
                     dependencies:
-                    - id: "NPM::is-number:3.0.0"
-                      dependencies:
-                      - id: "NPM::kind-of:3.2.2"
-                        dependencies:
-                        - id: "NPM::is-buffer:1.1.6"
-                    - id: "NPM::repeat-string:1.6.1"
+                    - id: "NPM::isarray:1.0.0"
+                  - id: "NPM::randomatic:3.1.1"
+                    dependencies:
+                    - id: "NPM::is-number:4.0.0"
+                    - id: "NPM::kind-of:6.0.3"
+                    - id: "NPM::math-random:1.0.4"
+                  - id: "NPM::repeat-element:1.1.4"
+                  - id: "NPM::repeat-string:1.6.1"
               - id: "NPM::preserve:0.2.0"
               - id: "NPM::repeat-element:1.1.4"
             - id: "NPM::expand-brackets:0.1.5"
@@ -660,11 +655,7 @@ project:
               - id: "NPM::for-own:0.1.5"
                 dependencies:
                 - id: "NPM::for-in:1.0.2"
-              - id: "NPM::is-extendable:1.0.1"
-                dependencies:
-                - id: "NPM::is-plain-object:2.0.4"
-                  dependencies:
-                  - id: "NPM::isobject:3.0.1"
+              - id: "NPM::is-extendable:0.1.1"
             - id: "NPM::parse-glob:3.0.4"
               dependencies:
               - id: "NPM::glob-base:0.3.0"
@@ -707,17 +698,296 @@ project:
         - id: "NPM::readdirp:2.2.1"
           dependencies:
           - id: "NPM::graceful-fs:4.2.11"
-          - id: "NPM::micromatch:2.3.11"
+          - id: "NPM::micromatch:3.1.10"
             dependencies:
-            - id: "NPM::arr-diff:2.0.0"
+            - id: "NPM::arr-diff:4.0.0"
+            - id: "NPM::array-unique:0.3.2"
+            - id: "NPM::braces:2.3.2"
               dependencies:
               - id: "NPM::arr-flatten:1.1.0"
-            - id: "NPM::array-unique:0.2.1"
-            - id: "NPM::braces:1.8.5"
-              dependencies:
-              - id: "NPM::expand-range:1.8.2"
+              - id: "NPM::array-unique:0.3.2"
+              - id: "NPM::extend-shallow:2.0.1"
                 dependencies:
-                - id: "NPM::fill-range:4.0.0"
+                - id: "NPM::is-extendable:0.1.1"
+              - id: "NPM::fill-range:4.0.0"
+                dependencies:
+                - id: "NPM::extend-shallow:2.0.1"
+                  dependencies:
+                  - id: "NPM::is-extendable:0.1.1"
+                - id: "NPM::is-number:3.0.0"
+                  dependencies:
+                  - id: "NPM::kind-of:3.2.2"
+                    dependencies:
+                    - id: "NPM::is-buffer:1.1.6"
+                - id: "NPM::repeat-string:1.6.1"
+                - id: "NPM::to-regex-range:2.1.1"
+                  dependencies:
+                  - id: "NPM::is-number:3.0.0"
+                    dependencies:
+                    - id: "NPM::kind-of:3.2.2"
+                      dependencies:
+                      - id: "NPM::is-buffer:1.1.6"
+                  - id: "NPM::repeat-string:1.6.1"
+              - id: "NPM::isobject:3.0.1"
+              - id: "NPM::repeat-element:1.1.4"
+              - id: "NPM::snapdragon:0.8.2"
+                dependencies:
+                - id: "NPM::base:0.11.2"
+                  dependencies:
+                  - id: "NPM::cache-base:1.0.1"
+                    dependencies:
+                    - id: "NPM::collection-visit:1.0.0"
+                      dependencies:
+                      - id: "NPM::map-visit:1.0.0"
+                        dependencies:
+                        - id: "NPM::object-visit:1.0.1"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::object-visit:1.0.1"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::component-emitter:1.3.1"
+                    - id: "NPM::get-value:2.0.6"
+                    - id: "NPM::has-value:1.0.0"
+                      dependencies:
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::has-values:1.0.0"
+                        dependencies:
+                        - id: "NPM::is-number:3.0.0"
+                          dependencies:
+                          - id: "NPM::kind-of:3.2.2"
+                            dependencies:
+                            - id: "NPM::is-buffer:1.1.6"
+                        - id: "NPM::kind-of:4.0.0"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                      - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::set-value:2.0.1"
+                      dependencies:
+                      - id: "NPM::extend-shallow:2.0.1"
+                        dependencies:
+                        - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::split-string:3.1.0"
+                        dependencies:
+                        - id: "NPM::extend-shallow:3.0.2"
+                          dependencies:
+                          - id: "NPM::assign-symbols:1.0.0"
+                          - id: "NPM::is-extendable:1.0.1"
+                            dependencies:
+                            - id: "NPM::is-plain-object:2.0.4"
+                              dependencies:
+                              - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::to-object-path:0.3.0"
+                      dependencies:
+                      - id: "NPM::kind-of:3.2.2"
+                        dependencies:
+                        - id: "NPM::is-buffer:1.1.6"
+                    - id: "NPM::union-value:1.0.1"
+                      dependencies:
+                      - id: "NPM::arr-union:3.1.0"
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::set-value:2.0.1"
+                        dependencies:
+                        - id: "NPM::extend-shallow:2.0.1"
+                          dependencies:
+                          - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-plain-object:2.0.4"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                        - id: "NPM::split-string:3.1.0"
+                          dependencies:
+                          - id: "NPM::extend-shallow:3.0.2"
+                            dependencies:
+                            - id: "NPM::assign-symbols:1.0.0"
+                            - id: "NPM::is-extendable:1.0.1"
+                              dependencies:
+                              - id: "NPM::is-plain-object:2.0.4"
+                                dependencies:
+                                - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::unset-value:1.0.0"
+                      dependencies:
+                      - id: "NPM::has-value:0.3.1"
+                        dependencies:
+                        - id: "NPM::get-value:2.0.6"
+                        - id: "NPM::has-values:0.1.4"
+                        - id: "NPM::isobject:2.1.0"
+                          dependencies:
+                          - id: "NPM::isarray:1.0.0"
+                      - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::class-utils:0.3.6"
+                    dependencies:
+                    - id: "NPM::arr-union:3.1.0"
+                    - id: "NPM::define-property:0.2.5"
+                      dependencies:
+                      - id: "NPM::is-descriptor:0.1.7"
+                        dependencies:
+                        - id: "NPM::is-accessor-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::is-data-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::static-extend:0.1.2"
+                      dependencies:
+                      - id: "NPM::define-property:0.2.5"
+                        dependencies:
+                        - id: "NPM::is-descriptor:0.1.7"
+                          dependencies:
+                          - id: "NPM::is-accessor-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                          - id: "NPM::is-data-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::object-copy:0.1.0"
+                        dependencies:
+                        - id: "NPM::copy-descriptor:0.1.1"
+                        - id: "NPM::define-property:0.2.5"
+                          dependencies:
+                          - id: "NPM::is-descriptor:0.1.7"
+                            dependencies:
+                            - id: "NPM::is-accessor-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                            - id: "NPM::is-data-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::kind-of:3.2.2"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                  - id: "NPM::component-emitter:1.3.1"
+                  - id: "NPM::define-property:1.0.0"
+                    dependencies:
+                    - id: "NPM::is-descriptor:1.0.3"
+                      dependencies:
+                      - id: "NPM::is-accessor-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::is-data-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::mixin-deep:1.3.2"
+                    dependencies:
+                    - id: "NPM::for-in:1.0.2"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::pascalcase:0.1.1"
+                - id: "NPM::debug:2.6.9"
+                  dependencies:
+                  - id: "NPM::ms:2.0.0"
+                - id: "NPM::define-property:0.2.5"
+                  dependencies:
+                  - id: "NPM::is-descriptor:0.1.7"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::extend-shallow:2.0.1"
+                  dependencies:
+                  - id: "NPM::is-extendable:0.1.1"
+                - id: "NPM::map-cache:0.2.2"
+                - id: "NPM::source-map:0.5.7"
+                - id: "NPM::source-map-resolve:0.5.3"
+                  dependencies:
+                  - id: "NPM::atob:2.1.2"
+                  - id: "NPM::decode-uri-component:0.2.2"
+                  - id: "NPM::resolve-url:0.2.1"
+                  - id: "NPM::source-map-url:0.4.1"
+                  - id: "NPM::urix:0.1.0"
+                - id: "NPM::use:3.1.1"
+              - id: "NPM::snapdragon-node:2.1.1"
+                dependencies:
+                - id: "NPM::define-property:1.0.0"
+                  dependencies:
+                  - id: "NPM::is-descriptor:1.0.3"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::isobject:3.0.1"
+                - id: "NPM::snapdragon-util:3.0.1"
+                  dependencies:
+                  - id: "NPM::kind-of:3.2.2"
+                    dependencies:
+                    - id: "NPM::is-buffer:1.1.6"
+              - id: "NPM::split-string:3.1.0"
+                dependencies:
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+              - id: "NPM::to-regex:3.0.2"
+                dependencies:
+                - id: "NPM::define-property:2.0.2"
+                  dependencies:
+                  - id: "NPM::is-descriptor:1.0.3"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::regex-not:1.0.2"
                   dependencies:
                   - id: "NPM::extend-shallow:3.0.2"
                     dependencies:
@@ -727,71 +997,1139 @@ project:
                       - id: "NPM::is-plain-object:2.0.4"
                         dependencies:
                         - id: "NPM::isobject:3.0.1"
-                  - id: "NPM::is-number:3.0.0"
+                  - id: "NPM::safe-regex:1.1.0"
                     dependencies:
-                    - id: "NPM::kind-of:3.2.2"
-                      dependencies:
-                      - id: "NPM::is-buffer:1.1.6"
-                  - id: "NPM::repeat-string:1.6.1"
-                  - id: "NPM::to-regex-range:2.1.1"
-                    dependencies:
-                    - id: "NPM::is-number:3.0.0"
-                      dependencies:
-                      - id: "NPM::kind-of:3.2.2"
-                        dependencies:
-                        - id: "NPM::is-buffer:1.1.6"
-                    - id: "NPM::repeat-string:1.6.1"
-              - id: "NPM::preserve:0.2.0"
-              - id: "NPM::repeat-element:1.1.4"
-            - id: "NPM::expand-brackets:0.1.5"
+                    - id: "NPM::ret:0.1.15"
+                - id: "NPM::safe-regex:1.1.0"
+                  dependencies:
+                  - id: "NPM::ret:0.1.15"
+            - id: "NPM::define-property:2.0.2"
               dependencies:
-              - id: "NPM::is-posix-bracket:0.1.1"
-            - id: "NPM::extglob:0.3.2"
-              dependencies:
-              - id: "NPM::is-extglob:1.0.0"
-            - id: "NPM::filename-regex:2.0.1"
-            - id: "NPM::is-extglob:1.0.0"
-            - id: "NPM::is-glob:2.0.1"
-              dependencies:
-              - id: "NPM::is-extglob:1.0.0"
-            - id: "NPM::kind-of:3.2.2"
-              dependencies:
-              - id: "NPM::is-buffer:1.1.6"
-            - id: "NPM::normalize-path:2.1.1"
-              dependencies:
-              - id: "NPM::remove-trailing-separator:1.1.0"
-            - id: "NPM::object.omit:2.0.1"
-              dependencies:
-              - id: "NPM::for-own:0.1.5"
+              - id: "NPM::is-descriptor:1.0.3"
                 dependencies:
-                - id: "NPM::for-in:1.0.2"
+                - id: "NPM::is-accessor-descriptor:1.0.1"
+                  dependencies:
+                  - id: "NPM::hasown:2.0.2"
+                    dependencies:
+                    - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::is-data-descriptor:1.0.1"
+                  dependencies:
+                  - id: "NPM::hasown:2.0.2"
+                    dependencies:
+                    - id: "NPM::function-bind:1.1.2"
+              - id: "NPM::isobject:3.0.1"
+            - id: "NPM::extend-shallow:3.0.2"
+              dependencies:
+              - id: "NPM::assign-symbols:1.0.0"
               - id: "NPM::is-extendable:1.0.1"
                 dependencies:
                 - id: "NPM::is-plain-object:2.0.4"
                   dependencies:
                   - id: "NPM::isobject:3.0.1"
-            - id: "NPM::parse-glob:3.0.4"
+            - id: "NPM::extglob:2.0.4"
               dependencies:
-              - id: "NPM::glob-base:0.3.0"
+              - id: "NPM::array-unique:0.3.2"
+              - id: "NPM::define-property:1.0.0"
                 dependencies:
-                - id: "NPM::glob-parent:2.0.0"
+                - id: "NPM::is-descriptor:1.0.3"
                   dependencies:
-                  - id: "NPM::is-glob:2.0.1"
+                  - id: "NPM::is-accessor-descriptor:1.0.1"
                     dependencies:
-                    - id: "NPM::is-extglob:1.0.0"
-                - id: "NPM::is-glob:2.0.1"
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::is-data-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+              - id: "NPM::expand-brackets:2.1.4"
+                dependencies:
+                - id: "NPM::debug:2.6.9"
                   dependencies:
-                  - id: "NPM::is-extglob:1.0.0"
-              - id: "NPM::is-dotfile:1.0.3"
-              - id: "NPM::is-extglob:1.0.0"
-              - id: "NPM::is-glob:2.0.1"
+                  - id: "NPM::ms:2.0.0"
+                - id: "NPM::define-property:0.2.5"
+                  dependencies:
+                  - id: "NPM::is-descriptor:0.1.7"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::extend-shallow:2.0.1"
+                  dependencies:
+                  - id: "NPM::is-extendable:0.1.1"
+                - id: "NPM::posix-character-classes:0.1.1"
+                - id: "NPM::regex-not:1.0.2"
+                  dependencies:
+                  - id: "NPM::extend-shallow:3.0.2"
+                    dependencies:
+                    - id: "NPM::assign-symbols:1.0.0"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::safe-regex:1.1.0"
+                    dependencies:
+                    - id: "NPM::ret:0.1.15"
+                - id: "NPM::snapdragon:0.8.2"
+                  dependencies:
+                  - id: "NPM::base:0.11.2"
+                    dependencies:
+                    - id: "NPM::cache-base:1.0.1"
+                      dependencies:
+                      - id: "NPM::collection-visit:1.0.0"
+                        dependencies:
+                        - id: "NPM::map-visit:1.0.0"
+                          dependencies:
+                          - id: "NPM::object-visit:1.0.1"
+                            dependencies:
+                            - id: "NPM::isobject:3.0.1"
+                        - id: "NPM::object-visit:1.0.1"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::component-emitter:1.3.1"
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::has-value:1.0.0"
+                        dependencies:
+                        - id: "NPM::get-value:2.0.6"
+                        - id: "NPM::has-values:1.0.0"
+                          dependencies:
+                          - id: "NPM::is-number:3.0.0"
+                            dependencies:
+                            - id: "NPM::kind-of:3.2.2"
+                              dependencies:
+                              - id: "NPM::is-buffer:1.1.6"
+                          - id: "NPM::kind-of:4.0.0"
+                            dependencies:
+                            - id: "NPM::is-buffer:1.1.6"
+                        - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::set-value:2.0.1"
+                        dependencies:
+                        - id: "NPM::extend-shallow:2.0.1"
+                          dependencies:
+                          - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-plain-object:2.0.4"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                        - id: "NPM::split-string:3.1.0"
+                          dependencies:
+                          - id: "NPM::extend-shallow:3.0.2"
+                            dependencies:
+                            - id: "NPM::assign-symbols:1.0.0"
+                            - id: "NPM::is-extendable:1.0.1"
+                              dependencies:
+                              - id: "NPM::is-plain-object:2.0.4"
+                                dependencies:
+                                - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::to-object-path:0.3.0"
+                        dependencies:
+                        - id: "NPM::kind-of:3.2.2"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                      - id: "NPM::union-value:1.0.1"
+                        dependencies:
+                        - id: "NPM::arr-union:3.1.0"
+                        - id: "NPM::get-value:2.0.6"
+                        - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::set-value:2.0.1"
+                          dependencies:
+                          - id: "NPM::extend-shallow:2.0.1"
+                            dependencies:
+                            - id: "NPM::is-extendable:0.1.1"
+                          - id: "NPM::is-extendable:0.1.1"
+                          - id: "NPM::is-plain-object:2.0.4"
+                            dependencies:
+                            - id: "NPM::isobject:3.0.1"
+                          - id: "NPM::split-string:3.1.0"
+                            dependencies:
+                            - id: "NPM::extend-shallow:3.0.2"
+                              dependencies:
+                              - id: "NPM::assign-symbols:1.0.0"
+                              - id: "NPM::is-extendable:1.0.1"
+                                dependencies:
+                                - id: "NPM::is-plain-object:2.0.4"
+                                  dependencies:
+                                  - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::unset-value:1.0.0"
+                        dependencies:
+                        - id: "NPM::has-value:0.3.1"
+                          dependencies:
+                          - id: "NPM::get-value:2.0.6"
+                          - id: "NPM::has-values:0.1.4"
+                          - id: "NPM::isobject:2.1.0"
+                            dependencies:
+                            - id: "NPM::isarray:1.0.0"
+                        - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::class-utils:0.3.6"
+                      dependencies:
+                      - id: "NPM::arr-union:3.1.0"
+                      - id: "NPM::define-property:0.2.5"
+                        dependencies:
+                        - id: "NPM::is-descriptor:0.1.7"
+                          dependencies:
+                          - id: "NPM::is-accessor-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                          - id: "NPM::is-data-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::static-extend:0.1.2"
+                        dependencies:
+                        - id: "NPM::define-property:0.2.5"
+                          dependencies:
+                          - id: "NPM::is-descriptor:0.1.7"
+                            dependencies:
+                            - id: "NPM::is-accessor-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                            - id: "NPM::is-data-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::object-copy:0.1.0"
+                          dependencies:
+                          - id: "NPM::copy-descriptor:0.1.1"
+                          - id: "NPM::define-property:0.2.5"
+                            dependencies:
+                            - id: "NPM::is-descriptor:0.1.7"
+                              dependencies:
+                              - id: "NPM::is-accessor-descriptor:1.0.1"
+                                dependencies:
+                                - id: "NPM::hasown:2.0.2"
+                                  dependencies:
+                                  - id: "NPM::function-bind:1.1.2"
+                              - id: "NPM::is-data-descriptor:1.0.1"
+                                dependencies:
+                                - id: "NPM::hasown:2.0.2"
+                                  dependencies:
+                                  - id: "NPM::function-bind:1.1.2"
+                          - id: "NPM::kind-of:3.2.2"
+                            dependencies:
+                            - id: "NPM::is-buffer:1.1.6"
+                    - id: "NPM::component-emitter:1.3.1"
+                    - id: "NPM::define-property:1.0.0"
+                      dependencies:
+                      - id: "NPM::is-descriptor:1.0.3"
+                        dependencies:
+                        - id: "NPM::is-accessor-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::is-data-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::mixin-deep:1.3.2"
+                      dependencies:
+                      - id: "NPM::for-in:1.0.2"
+                      - id: "NPM::is-extendable:1.0.1"
+                        dependencies:
+                        - id: "NPM::is-plain-object:2.0.4"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::pascalcase:0.1.1"
+                  - id: "NPM::debug:2.6.9"
+                    dependencies:
+                    - id: "NPM::ms:2.0.0"
+                  - id: "NPM::define-property:0.2.5"
+                    dependencies:
+                    - id: "NPM::is-descriptor:0.1.7"
+                      dependencies:
+                      - id: "NPM::is-accessor-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::is-data-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::extend-shallow:2.0.1"
+                    dependencies:
+                    - id: "NPM::is-extendable:0.1.1"
+                  - id: "NPM::map-cache:0.2.2"
+                  - id: "NPM::source-map:0.5.7"
+                  - id: "NPM::source-map-resolve:0.5.3"
+                    dependencies:
+                    - id: "NPM::atob:2.1.2"
+                    - id: "NPM::decode-uri-component:0.2.2"
+                    - id: "NPM::resolve-url:0.2.1"
+                    - id: "NPM::source-map-url:0.4.1"
+                    - id: "NPM::urix:0.1.0"
+                  - id: "NPM::use:3.1.1"
+                - id: "NPM::to-regex:3.0.2"
+                  dependencies:
+                  - id: "NPM::define-property:2.0.2"
+                    dependencies:
+                    - id: "NPM::is-descriptor:1.0.3"
+                      dependencies:
+                      - id: "NPM::is-accessor-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::is-data-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::extend-shallow:3.0.2"
+                    dependencies:
+                    - id: "NPM::assign-symbols:1.0.0"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::regex-not:1.0.2"
+                    dependencies:
+                    - id: "NPM::extend-shallow:3.0.2"
+                      dependencies:
+                      - id: "NPM::assign-symbols:1.0.0"
+                      - id: "NPM::is-extendable:1.0.1"
+                        dependencies:
+                        - id: "NPM::is-plain-object:2.0.4"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::safe-regex:1.1.0"
+                      dependencies:
+                      - id: "NPM::ret:0.1.15"
+                  - id: "NPM::safe-regex:1.1.0"
+                    dependencies:
+                    - id: "NPM::ret:0.1.15"
+              - id: "NPM::extend-shallow:2.0.1"
                 dependencies:
-                - id: "NPM::is-extglob:1.0.0"
-            - id: "NPM::regex-cache:0.4.4"
+                - id: "NPM::is-extendable:0.1.1"
+              - id: "NPM::fragment-cache:0.2.1"
+                dependencies:
+                - id: "NPM::map-cache:0.2.2"
+              - id: "NPM::regex-not:1.0.2"
+                dependencies:
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::safe-regex:1.1.0"
+                  dependencies:
+                  - id: "NPM::ret:0.1.15"
+              - id: "NPM::snapdragon:0.8.2"
+                dependencies:
+                - id: "NPM::base:0.11.2"
+                  dependencies:
+                  - id: "NPM::cache-base:1.0.1"
+                    dependencies:
+                    - id: "NPM::collection-visit:1.0.0"
+                      dependencies:
+                      - id: "NPM::map-visit:1.0.0"
+                        dependencies:
+                        - id: "NPM::object-visit:1.0.1"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::object-visit:1.0.1"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::component-emitter:1.3.1"
+                    - id: "NPM::get-value:2.0.6"
+                    - id: "NPM::has-value:1.0.0"
+                      dependencies:
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::has-values:1.0.0"
+                        dependencies:
+                        - id: "NPM::is-number:3.0.0"
+                          dependencies:
+                          - id: "NPM::kind-of:3.2.2"
+                            dependencies:
+                            - id: "NPM::is-buffer:1.1.6"
+                        - id: "NPM::kind-of:4.0.0"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                      - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::set-value:2.0.1"
+                      dependencies:
+                      - id: "NPM::extend-shallow:2.0.1"
+                        dependencies:
+                        - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::split-string:3.1.0"
+                        dependencies:
+                        - id: "NPM::extend-shallow:3.0.2"
+                          dependencies:
+                          - id: "NPM::assign-symbols:1.0.0"
+                          - id: "NPM::is-extendable:1.0.1"
+                            dependencies:
+                            - id: "NPM::is-plain-object:2.0.4"
+                              dependencies:
+                              - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::to-object-path:0.3.0"
+                      dependencies:
+                      - id: "NPM::kind-of:3.2.2"
+                        dependencies:
+                        - id: "NPM::is-buffer:1.1.6"
+                    - id: "NPM::union-value:1.0.1"
+                      dependencies:
+                      - id: "NPM::arr-union:3.1.0"
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::set-value:2.0.1"
+                        dependencies:
+                        - id: "NPM::extend-shallow:2.0.1"
+                          dependencies:
+                          - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-plain-object:2.0.4"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                        - id: "NPM::split-string:3.1.0"
+                          dependencies:
+                          - id: "NPM::extend-shallow:3.0.2"
+                            dependencies:
+                            - id: "NPM::assign-symbols:1.0.0"
+                            - id: "NPM::is-extendable:1.0.1"
+                              dependencies:
+                              - id: "NPM::is-plain-object:2.0.4"
+                                dependencies:
+                                - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::unset-value:1.0.0"
+                      dependencies:
+                      - id: "NPM::has-value:0.3.1"
+                        dependencies:
+                        - id: "NPM::get-value:2.0.6"
+                        - id: "NPM::has-values:0.1.4"
+                        - id: "NPM::isobject:2.1.0"
+                          dependencies:
+                          - id: "NPM::isarray:1.0.0"
+                      - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::class-utils:0.3.6"
+                    dependencies:
+                    - id: "NPM::arr-union:3.1.0"
+                    - id: "NPM::define-property:0.2.5"
+                      dependencies:
+                      - id: "NPM::is-descriptor:0.1.7"
+                        dependencies:
+                        - id: "NPM::is-accessor-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::is-data-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::static-extend:0.1.2"
+                      dependencies:
+                      - id: "NPM::define-property:0.2.5"
+                        dependencies:
+                        - id: "NPM::is-descriptor:0.1.7"
+                          dependencies:
+                          - id: "NPM::is-accessor-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                          - id: "NPM::is-data-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::object-copy:0.1.0"
+                        dependencies:
+                        - id: "NPM::copy-descriptor:0.1.1"
+                        - id: "NPM::define-property:0.2.5"
+                          dependencies:
+                          - id: "NPM::is-descriptor:0.1.7"
+                            dependencies:
+                            - id: "NPM::is-accessor-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                            - id: "NPM::is-data-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::kind-of:3.2.2"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                  - id: "NPM::component-emitter:1.3.1"
+                  - id: "NPM::define-property:1.0.0"
+                    dependencies:
+                    - id: "NPM::is-descriptor:1.0.3"
+                      dependencies:
+                      - id: "NPM::is-accessor-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::is-data-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::mixin-deep:1.3.2"
+                    dependencies:
+                    - id: "NPM::for-in:1.0.2"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::pascalcase:0.1.1"
+                - id: "NPM::debug:2.6.9"
+                  dependencies:
+                  - id: "NPM::ms:2.0.0"
+                - id: "NPM::define-property:0.2.5"
+                  dependencies:
+                  - id: "NPM::is-descriptor:0.1.7"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::extend-shallow:2.0.1"
+                  dependencies:
+                  - id: "NPM::is-extendable:0.1.1"
+                - id: "NPM::map-cache:0.2.2"
+                - id: "NPM::source-map:0.5.7"
+                - id: "NPM::source-map-resolve:0.5.3"
+                  dependencies:
+                  - id: "NPM::atob:2.1.2"
+                  - id: "NPM::decode-uri-component:0.2.2"
+                  - id: "NPM::resolve-url:0.2.1"
+                  - id: "NPM::source-map-url:0.4.1"
+                  - id: "NPM::urix:0.1.0"
+                - id: "NPM::use:3.1.1"
+              - id: "NPM::to-regex:3.0.2"
+                dependencies:
+                - id: "NPM::define-property:2.0.2"
+                  dependencies:
+                  - id: "NPM::is-descriptor:1.0.3"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::regex-not:1.0.2"
+                  dependencies:
+                  - id: "NPM::extend-shallow:3.0.2"
+                    dependencies:
+                    - id: "NPM::assign-symbols:1.0.0"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::safe-regex:1.1.0"
+                    dependencies:
+                    - id: "NPM::ret:0.1.15"
+                - id: "NPM::safe-regex:1.1.0"
+                  dependencies:
+                  - id: "NPM::ret:0.1.15"
+            - id: "NPM::fragment-cache:0.2.1"
               dependencies:
-              - id: "NPM::is-equal-shallow:0.1.3"
+              - id: "NPM::map-cache:0.2.2"
+            - id: "NPM::kind-of:6.0.3"
+            - id: "NPM::nanomatch:1.2.13"
+              dependencies:
+              - id: "NPM::arr-diff:4.0.0"
+              - id: "NPM::array-unique:0.3.2"
+              - id: "NPM::define-property:2.0.2"
                 dependencies:
-                - id: "NPM::is-primitive:2.0.0"
+                - id: "NPM::is-descriptor:1.0.3"
+                  dependencies:
+                  - id: "NPM::is-accessor-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::is-data-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::isobject:3.0.1"
+              - id: "NPM::extend-shallow:3.0.2"
+                dependencies:
+                - id: "NPM::assign-symbols:1.0.0"
+                - id: "NPM::is-extendable:1.0.1"
+                  dependencies:
+                  - id: "NPM::is-plain-object:2.0.4"
+                    dependencies:
+                    - id: "NPM::isobject:3.0.1"
+              - id: "NPM::fragment-cache:0.2.1"
+                dependencies:
+                - id: "NPM::map-cache:0.2.2"
+              - id: "NPM::is-windows:1.0.2"
+              - id: "NPM::kind-of:6.0.3"
+              - id: "NPM::object.pick:1.3.0"
+                dependencies:
+                - id: "NPM::isobject:3.0.1"
+              - id: "NPM::regex-not:1.0.2"
+                dependencies:
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::safe-regex:1.1.0"
+                  dependencies:
+                  - id: "NPM::ret:0.1.15"
+              - id: "NPM::snapdragon:0.8.2"
+                dependencies:
+                - id: "NPM::base:0.11.2"
+                  dependencies:
+                  - id: "NPM::cache-base:1.0.1"
+                    dependencies:
+                    - id: "NPM::collection-visit:1.0.0"
+                      dependencies:
+                      - id: "NPM::map-visit:1.0.0"
+                        dependencies:
+                        - id: "NPM::object-visit:1.0.1"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::object-visit:1.0.1"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::component-emitter:1.3.1"
+                    - id: "NPM::get-value:2.0.6"
+                    - id: "NPM::has-value:1.0.0"
+                      dependencies:
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::has-values:1.0.0"
+                        dependencies:
+                        - id: "NPM::is-number:3.0.0"
+                          dependencies:
+                          - id: "NPM::kind-of:3.2.2"
+                            dependencies:
+                            - id: "NPM::is-buffer:1.1.6"
+                        - id: "NPM::kind-of:4.0.0"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                      - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::set-value:2.0.1"
+                      dependencies:
+                      - id: "NPM::extend-shallow:2.0.1"
+                        dependencies:
+                        - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::split-string:3.1.0"
+                        dependencies:
+                        - id: "NPM::extend-shallow:3.0.2"
+                          dependencies:
+                          - id: "NPM::assign-symbols:1.0.0"
+                          - id: "NPM::is-extendable:1.0.1"
+                            dependencies:
+                            - id: "NPM::is-plain-object:2.0.4"
+                              dependencies:
+                              - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::to-object-path:0.3.0"
+                      dependencies:
+                      - id: "NPM::kind-of:3.2.2"
+                        dependencies:
+                        - id: "NPM::is-buffer:1.1.6"
+                    - id: "NPM::union-value:1.0.1"
+                      dependencies:
+                      - id: "NPM::arr-union:3.1.0"
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::set-value:2.0.1"
+                        dependencies:
+                        - id: "NPM::extend-shallow:2.0.1"
+                          dependencies:
+                          - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-extendable:0.1.1"
+                        - id: "NPM::is-plain-object:2.0.4"
+                          dependencies:
+                          - id: "NPM::isobject:3.0.1"
+                        - id: "NPM::split-string:3.1.0"
+                          dependencies:
+                          - id: "NPM::extend-shallow:3.0.2"
+                            dependencies:
+                            - id: "NPM::assign-symbols:1.0.0"
+                            - id: "NPM::is-extendable:1.0.1"
+                              dependencies:
+                              - id: "NPM::is-plain-object:2.0.4"
+                                dependencies:
+                                - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::unset-value:1.0.0"
+                      dependencies:
+                      - id: "NPM::has-value:0.3.1"
+                        dependencies:
+                        - id: "NPM::get-value:2.0.6"
+                        - id: "NPM::has-values:0.1.4"
+                        - id: "NPM::isobject:2.1.0"
+                          dependencies:
+                          - id: "NPM::isarray:1.0.0"
+                      - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::class-utils:0.3.6"
+                    dependencies:
+                    - id: "NPM::arr-union:3.1.0"
+                    - id: "NPM::define-property:0.2.5"
+                      dependencies:
+                      - id: "NPM::is-descriptor:0.1.7"
+                        dependencies:
+                        - id: "NPM::is-accessor-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::is-data-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::static-extend:0.1.2"
+                      dependencies:
+                      - id: "NPM::define-property:0.2.5"
+                        dependencies:
+                        - id: "NPM::is-descriptor:0.1.7"
+                          dependencies:
+                          - id: "NPM::is-accessor-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                          - id: "NPM::is-data-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::object-copy:0.1.0"
+                        dependencies:
+                        - id: "NPM::copy-descriptor:0.1.1"
+                        - id: "NPM::define-property:0.2.5"
+                          dependencies:
+                          - id: "NPM::is-descriptor:0.1.7"
+                            dependencies:
+                            - id: "NPM::is-accessor-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                            - id: "NPM::is-data-descriptor:1.0.1"
+                              dependencies:
+                              - id: "NPM::hasown:2.0.2"
+                                dependencies:
+                                - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::kind-of:3.2.2"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                  - id: "NPM::component-emitter:1.3.1"
+                  - id: "NPM::define-property:1.0.0"
+                    dependencies:
+                    - id: "NPM::is-descriptor:1.0.3"
+                      dependencies:
+                      - id: "NPM::is-accessor-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::is-data-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::mixin-deep:1.3.2"
+                    dependencies:
+                    - id: "NPM::for-in:1.0.2"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::pascalcase:0.1.1"
+                - id: "NPM::debug:2.6.9"
+                  dependencies:
+                  - id: "NPM::ms:2.0.0"
+                - id: "NPM::define-property:0.2.5"
+                  dependencies:
+                  - id: "NPM::is-descriptor:0.1.7"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::extend-shallow:2.0.1"
+                  dependencies:
+                  - id: "NPM::is-extendable:0.1.1"
+                - id: "NPM::map-cache:0.2.2"
+                - id: "NPM::source-map:0.5.7"
+                - id: "NPM::source-map-resolve:0.5.3"
+                  dependencies:
+                  - id: "NPM::atob:2.1.2"
+                  - id: "NPM::decode-uri-component:0.2.2"
+                  - id: "NPM::resolve-url:0.2.1"
+                  - id: "NPM::source-map-url:0.4.1"
+                  - id: "NPM::urix:0.1.0"
+                - id: "NPM::use:3.1.1"
+              - id: "NPM::to-regex:3.0.2"
+                dependencies:
+                - id: "NPM::define-property:2.0.2"
+                  dependencies:
+                  - id: "NPM::is-descriptor:1.0.3"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::regex-not:1.0.2"
+                  dependencies:
+                  - id: "NPM::extend-shallow:3.0.2"
+                    dependencies:
+                    - id: "NPM::assign-symbols:1.0.0"
+                    - id: "NPM::is-extendable:1.0.1"
+                      dependencies:
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::safe-regex:1.1.0"
+                    dependencies:
+                    - id: "NPM::ret:0.1.15"
+                - id: "NPM::safe-regex:1.1.0"
+                  dependencies:
+                  - id: "NPM::ret:0.1.15"
+            - id: "NPM::object.pick:1.3.0"
+              dependencies:
+              - id: "NPM::isobject:3.0.1"
+            - id: "NPM::regex-not:1.0.2"
+              dependencies:
+              - id: "NPM::extend-shallow:3.0.2"
+                dependencies:
+                - id: "NPM::assign-symbols:1.0.0"
+                - id: "NPM::is-extendable:1.0.1"
+                  dependencies:
+                  - id: "NPM::is-plain-object:2.0.4"
+                    dependencies:
+                    - id: "NPM::isobject:3.0.1"
+              - id: "NPM::safe-regex:1.1.0"
+                dependencies:
+                - id: "NPM::ret:0.1.15"
+            - id: "NPM::snapdragon:0.8.2"
+              dependencies:
+              - id: "NPM::base:0.11.2"
+                dependencies:
+                - id: "NPM::cache-base:1.0.1"
+                  dependencies:
+                  - id: "NPM::collection-visit:1.0.0"
+                    dependencies:
+                    - id: "NPM::map-visit:1.0.0"
+                      dependencies:
+                      - id: "NPM::object-visit:1.0.1"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::object-visit:1.0.1"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::component-emitter:1.3.1"
+                  - id: "NPM::get-value:2.0.6"
+                  - id: "NPM::has-value:1.0.0"
+                    dependencies:
+                    - id: "NPM::get-value:2.0.6"
+                    - id: "NPM::has-values:1.0.0"
+                      dependencies:
+                      - id: "NPM::is-number:3.0.0"
+                        dependencies:
+                        - id: "NPM::kind-of:3.2.2"
+                          dependencies:
+                          - id: "NPM::is-buffer:1.1.6"
+                      - id: "NPM::kind-of:4.0.0"
+                        dependencies:
+                        - id: "NPM::is-buffer:1.1.6"
+                    - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::set-value:2.0.1"
+                    dependencies:
+                    - id: "NPM::extend-shallow:2.0.1"
+                      dependencies:
+                      - id: "NPM::is-extendable:0.1.1"
+                    - id: "NPM::is-extendable:0.1.1"
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                    - id: "NPM::split-string:3.1.0"
+                      dependencies:
+                      - id: "NPM::extend-shallow:3.0.2"
+                        dependencies:
+                        - id: "NPM::assign-symbols:1.0.0"
+                        - id: "NPM::is-extendable:1.0.1"
+                          dependencies:
+                          - id: "NPM::is-plain-object:2.0.4"
+                            dependencies:
+                            - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::to-object-path:0.3.0"
+                    dependencies:
+                    - id: "NPM::kind-of:3.2.2"
+                      dependencies:
+                      - id: "NPM::is-buffer:1.1.6"
+                  - id: "NPM::union-value:1.0.1"
+                    dependencies:
+                    - id: "NPM::arr-union:3.1.0"
+                    - id: "NPM::get-value:2.0.6"
+                    - id: "NPM::is-extendable:0.1.1"
+                    - id: "NPM::set-value:2.0.1"
+                      dependencies:
+                      - id: "NPM::extend-shallow:2.0.1"
+                        dependencies:
+                        - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-extendable:0.1.1"
+                      - id: "NPM::is-plain-object:2.0.4"
+                        dependencies:
+                        - id: "NPM::isobject:3.0.1"
+                      - id: "NPM::split-string:3.1.0"
+                        dependencies:
+                        - id: "NPM::extend-shallow:3.0.2"
+                          dependencies:
+                          - id: "NPM::assign-symbols:1.0.0"
+                          - id: "NPM::is-extendable:1.0.1"
+                            dependencies:
+                            - id: "NPM::is-plain-object:2.0.4"
+                              dependencies:
+                              - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::unset-value:1.0.0"
+                    dependencies:
+                    - id: "NPM::has-value:0.3.1"
+                      dependencies:
+                      - id: "NPM::get-value:2.0.6"
+                      - id: "NPM::has-values:0.1.4"
+                      - id: "NPM::isobject:2.1.0"
+                        dependencies:
+                        - id: "NPM::isarray:1.0.0"
+                    - id: "NPM::isobject:3.0.1"
+                - id: "NPM::class-utils:0.3.6"
+                  dependencies:
+                  - id: "NPM::arr-union:3.1.0"
+                  - id: "NPM::define-property:0.2.5"
+                    dependencies:
+                    - id: "NPM::is-descriptor:0.1.7"
+                      dependencies:
+                      - id: "NPM::is-accessor-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::is-data-descriptor:1.0.1"
+                        dependencies:
+                        - id: "NPM::hasown:2.0.2"
+                          dependencies:
+                          - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::isobject:3.0.1"
+                  - id: "NPM::static-extend:0.1.2"
+                    dependencies:
+                    - id: "NPM::define-property:0.2.5"
+                      dependencies:
+                      - id: "NPM::is-descriptor:0.1.7"
+                        dependencies:
+                        - id: "NPM::is-accessor-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                        - id: "NPM::is-data-descriptor:1.0.1"
+                          dependencies:
+                          - id: "NPM::hasown:2.0.2"
+                            dependencies:
+                            - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::object-copy:0.1.0"
+                      dependencies:
+                      - id: "NPM::copy-descriptor:0.1.1"
+                      - id: "NPM::define-property:0.2.5"
+                        dependencies:
+                        - id: "NPM::is-descriptor:0.1.7"
+                          dependencies:
+                          - id: "NPM::is-accessor-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                          - id: "NPM::is-data-descriptor:1.0.1"
+                            dependencies:
+                            - id: "NPM::hasown:2.0.2"
+                              dependencies:
+                              - id: "NPM::function-bind:1.1.2"
+                      - id: "NPM::kind-of:3.2.2"
+                        dependencies:
+                        - id: "NPM::is-buffer:1.1.6"
+                - id: "NPM::component-emitter:1.3.1"
+                - id: "NPM::define-property:1.0.0"
+                  dependencies:
+                  - id: "NPM::is-descriptor:1.0.3"
+                    dependencies:
+                    - id: "NPM::is-accessor-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                    - id: "NPM::is-data-descriptor:1.0.1"
+                      dependencies:
+                      - id: "NPM::hasown:2.0.2"
+                        dependencies:
+                        - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::isobject:3.0.1"
+                - id: "NPM::mixin-deep:1.3.2"
+                  dependencies:
+                  - id: "NPM::for-in:1.0.2"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::pascalcase:0.1.1"
+              - id: "NPM::debug:2.6.9"
+                dependencies:
+                - id: "NPM::ms:2.0.0"
+              - id: "NPM::define-property:0.2.5"
+                dependencies:
+                - id: "NPM::is-descriptor:0.1.7"
+                  dependencies:
+                  - id: "NPM::is-accessor-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::is-data-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+              - id: "NPM::extend-shallow:2.0.1"
+                dependencies:
+                - id: "NPM::is-extendable:0.1.1"
+              - id: "NPM::map-cache:0.2.2"
+              - id: "NPM::source-map:0.5.7"
+              - id: "NPM::source-map-resolve:0.5.3"
+                dependencies:
+                - id: "NPM::atob:2.1.2"
+                - id: "NPM::decode-uri-component:0.2.2"
+                - id: "NPM::resolve-url:0.2.1"
+                - id: "NPM::source-map-url:0.4.1"
+                - id: "NPM::urix:0.1.0"
+              - id: "NPM::use:3.1.1"
+            - id: "NPM::to-regex:3.0.2"
+              dependencies:
+              - id: "NPM::define-property:2.0.2"
+                dependencies:
+                - id: "NPM::is-descriptor:1.0.3"
+                  dependencies:
+                  - id: "NPM::is-accessor-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+                  - id: "NPM::is-data-descriptor:1.0.1"
+                    dependencies:
+                    - id: "NPM::hasown:2.0.2"
+                      dependencies:
+                      - id: "NPM::function-bind:1.1.2"
+                - id: "NPM::isobject:3.0.1"
+              - id: "NPM::extend-shallow:3.0.2"
+                dependencies:
+                - id: "NPM::assign-symbols:1.0.0"
+                - id: "NPM::is-extendable:1.0.1"
+                  dependencies:
+                  - id: "NPM::is-plain-object:2.0.4"
+                    dependencies:
+                    - id: "NPM::isobject:3.0.1"
+              - id: "NPM::regex-not:1.0.2"
+                dependencies:
+                - id: "NPM::extend-shallow:3.0.2"
+                  dependencies:
+                  - id: "NPM::assign-symbols:1.0.0"
+                  - id: "NPM::is-extendable:1.0.1"
+                    dependencies:
+                    - id: "NPM::is-plain-object:2.0.4"
+                      dependencies:
+                      - id: "NPM::isobject:3.0.1"
+                - id: "NPM::safe-regex:1.1.0"
+                  dependencies:
+                  - id: "NPM::ret:0.1.15"
+              - id: "NPM::safe-regex:1.1.0"
+                dependencies:
+                - id: "NPM::ret:0.1.15"
           - id: "NPM::readable-stream:2.3.8"
             dependencies:
             - id: "NPM::core-util-is:1.0.3"
@@ -963,6 +2301,37 @@ packages:
     url: "https://github.com/jonschlinkert/arr-diff.git"
     revision: "b89f54eb88ca51afd0e0ea6be9a4a63e5ccecf27"
     path: ""
+- id: "NPM::arr-diff:4.0.0"
+  purl: "pkg:npm/arr-diff@4.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns an array with only the unique values from the first array,\
+    \ by excluding all values from additional arrays using strict equality for comparisons."
+  homepage_url: "https://github.com/jonschlinkert/arr-diff"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz"
+    hash:
+      value: "d6461074febfec71e7e15235761a329a5dc7c520"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/arr-diff.git"
+    revision: "0a04556fb004b3db57f57de2777b1037090f6023"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/arr-diff.git"
+    revision: "0a04556fb004b3db57f57de2777b1037090f6023"
+    path: ""
 - id: "NPM::arr-flatten:1.1.0"
   purl: "pkg:npm/arr-flatten@1.1.0"
   authors:
@@ -993,6 +2362,37 @@ packages:
     url: "https://github.com/jonschlinkert/arr-flatten.git"
     revision: "76a1ae28b03fdb1cbe5d49fa521bc4807b9f94d3"
     path: ""
+- id: "NPM::arr-union:3.1.0"
+  purl: "pkg:npm/arr-union@3.1.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Combines a list of arrays, returning a single array with unique values,\
+    \ using strict equality for comparisons."
+  homepage_url: "https://github.com/jonschlinkert/arr-union"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
+    hash:
+      value: "e39b09aea9def866a8f206e288af63919bae39c4"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/arr-union.git"
+    revision: "ede857f5d5082467534e372fd3da45ce5e782e93"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/arr-union.git"
+    revision: "ede857f5d5082467534e372fd3da45ce5e782e93"
+    path: ""
 - id: "NPM::array-unique:0.2.1"
   purl: "pkg:npm/array-unique@0.2.1"
   authors:
@@ -1022,6 +2422,36 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/array-unique.git"
     revision: "36fde8e586fb7cf880b8b3aa6515df889e64ed85"
+    path: ""
+- id: "NPM::array-unique:0.3.2"
+  purl: "pkg:npm/array-unique@0.3.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Remove duplicate values from an array. Fastest ES5 implementation."
+  homepage_url: "https://github.com/jonschlinkert/array-unique"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz"
+    hash:
+      value: "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/array-unique.git"
+    revision: "d95d18b0d3188fb95d3c6c2bf349b2ed926b563b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/array-unique.git"
+    revision: "d95d18b0d3188fb95d3c6c2bf349b2ed926b563b"
     path: ""
 - id: "NPM::assign-symbols:1.0.0"
   purl: "pkg:npm/assign-symbols@1.0.0"
@@ -1086,6 +2516,36 @@ packages:
     type: "Git"
     url: "https://github.com/paulmillr/async-each.git"
     revision: "5a27da144b89c6b9cbf34e017c424801734ef6e2"
+    path: ""
+- id: "NPM::atob:2.1.2"
+  purl: "pkg:npm/atob@2.1.2"
+  authors:
+  - "AJ ONeal"
+  declared_licenses:
+  - "(MIT OR Apache-2.0)"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0 OR MIT"
+  description: "atob for Node.JS and Linux / Mac / Windows CLI (it's a one-liner)"
+  homepage_url: "https://git.coolaj86.com/coolaj86/atob.js.git"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
+    hash:
+      value: "6d9517eb9e030d2436666651e86bd9f6f13533c9"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://git.coolaj86.com/coolaj86/atob.js.git"
+    revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://git.coolaj86.com/coolaj86/atob.js.git"
+    revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
     path: ""
 - id: "NPM::babel-cli:6.26.0"
   purl: "pkg:npm/babel-cli@6.26.0"
@@ -1508,6 +2968,38 @@ packages:
     url: "https://github.com/juliangruber/balanced-match.git"
     revision: "c7412e09b95d6ad97fd1e2996f6adca7626a9ae8"
     path: ""
+- id: "NPM::base:0.11.2"
+  purl: "pkg:npm/base@0.11.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "base is the foundation for creating modular, unit testable and highly\
+    \ pluggable node.js applications, starting with a handful of common methods, like\
+    \ `set`, `get`, `del` and `use`."
+  homepage_url: "https://github.com/node-base/base"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/base/-/base-0.11.2.tgz"
+    hash:
+      value: "7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/node-base/base.git"
+    revision: "1885b1dc37dff5479d852dd0810d32207e190bab"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/node-base/base.git"
+    revision: "1885b1dc37dff5479d852dd0810d32207e190bab"
+    path: ""
 - id: "NPM::binary-extensions:1.13.1"
   purl: "pkg:npm/binary-extensions@1.13.1"
   authors:
@@ -1599,6 +3091,69 @@ packages:
     url: "https://github.com/jonschlinkert/braces.git"
     revision: "24874614ebeda1c5405180f1f6c9f374bcf384ce"
     path: ""
+- id: "NPM::braces:2.3.2"
+  purl: "pkg:npm/braces@2.3.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Bash-like brace expansion, implemented in JavaScript. Safer than other\
+    \ brace expansion libs, with complete support for the Bash 4.3 braces specification,\
+    \ without sacrificing speed."
+  homepage_url: "https://github.com/micromatch/braces"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz"
+    hash:
+      value: "5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/micromatch/braces.git"
+    revision: "8a3edbb31955881ae87ba540b9f86eb390e5c4bd"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/micromatch/braces.git"
+    revision: "8a3edbb31955881ae87ba540b9f86eb390e5c4bd"
+    path: ""
+- id: "NPM::cache-base:1.0.1"
+  purl: "pkg:npm/cache-base@1.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Basic object cache with `get`, `set`, `del`, and `has` methods for\
+    \ node.js/javascript projects."
+  homepage_url: "https://github.com/jonschlinkert/cache-base"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz"
+    hash:
+      value: "0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/cache-base.git"
+    revision: "0889aab765c66585ffbe7b41f9a733ef097665cf"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/cache-base.git"
+    revision: "0889aab765c66585ffbe7b41f9a733ef097665cf"
+    path: ""
 - id: "NPM::chalk:1.1.3"
   purl: "pkg:npm/chalk@1.1.3"
   declared_licenses:
@@ -1657,6 +3212,67 @@ packages:
     url: "https://github.com/paulmillr/chokidar.git"
     revision: "3b1071a6dd82397842f4f7dc63b72c703bd06275"
     path: ""
+- id: "NPM::class-utils:0.3.6"
+  purl: "pkg:npm/class-utils@0.3.6"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Utils for working with JavaScript classes and prototype methods."
+  homepage_url: "https://github.com/jonschlinkert/class-utils"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
+    hash:
+      value: "f93369ae8b9a7ce02fd41faad0ca83033190c463"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/class-utils.git"
+    revision: "0ad9e639d6a63d6dc04043ac5931df85fb898e06"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/class-utils.git"
+    revision: "0ad9e639d6a63d6dc04043ac5931df85fb898e06"
+    path: ""
+- id: "NPM::collection-visit:1.0.0"
+  purl: "pkg:npm/collection-visit@1.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Visit a method over the items in an object, or map visit over the\
+    \ objects in an array."
+  homepage_url: "https://github.com/jonschlinkert/collection-visit"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
+    hash:
+      value: "4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/collection-visit.git"
+    revision: "39c229dceb7e124cb821b59668df5da1d5c81a6c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/collection-visit.git"
+    revision: "39c229dceb7e124cb821b59668df5da1d5c81a6c"
+    path: ""
 - id: "NPM::commander:2.20.3"
   purl: "pkg:npm/commander@2.20.3"
   authors:
@@ -1686,6 +3302,34 @@ packages:
     type: "Git"
     url: "https://github.com/tj/commander.js.git"
     revision: "6b8499b24f4f6498ad630c50c8a00c9579a8536b"
+    path: ""
+- id: "NPM::component-emitter:1.3.1"
+  purl: "pkg:npm/component-emitter@1.3.1"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Event emitter"
+  homepage_url: "https://github.com/sindresorhus/component-emitter#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz"
+    hash:
+      value: "ef1d5796f7d93f135ee6fb684340b26403c97d17"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/sindresorhus/component-emitter.git"
+    revision: "6bd7817e8a444cb16e8abdf7dd2d7f04d5ca3dc8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/sindresorhus/component-emitter.git"
+    revision: "6bd7817e8a444cb16e8abdf7dd2d7f04d5ca3dc8"
     path: ""
 - id: "NPM::concat-map:0.0.1"
   purl: "pkg:npm/concat-map@0.0.1"
@@ -1747,6 +3391,36 @@ packages:
     type: "Git"
     url: "https://github.com/thlorenz/convert-source-map.git"
     revision: "46c2b78aa56d25a77d3ea237051aeb5d9e7f750c"
+    path: ""
+- id: "NPM::copy-descriptor:0.1.1"
+  purl: "pkg:npm/copy-descriptor@0.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Copy a descriptor from object A to object B"
+  homepage_url: "https://github.com/jonschlinkert/copy-descriptor"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
+    hash:
+      value: "676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/copy-descriptor.git"
+    revision: "572c31416d4538b7ba5f52e2bb0765ac237f79e2"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/copy-descriptor.git"
+    revision: "572c31416d4538b7ba5f52e2bb0765ac237f79e2"
     path: ""
 - id: "NPM::core-js:2.6.12"
   purl: "pkg:npm/core-js@2.6.12"
@@ -1835,6 +3509,127 @@ packages:
     type: "Git"
     url: "https://github.com/visionmedia/debug.git"
     revision: "13abeae468fea297d0dccc50bc55590809241083"
+    path: ""
+- id: "NPM::decode-uri-component:0.2.2"
+  purl: "pkg:npm/decode-uri-component@0.2.2"
+  authors:
+  - "Sam Verschueren"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "A better decodeURIComponent"
+  homepage_url: "https://github.com/SamVerschueren/decode-uri-component#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz"
+    hash:
+      value: "e69dbe25d37941171dd540e024c444cd5188e1e9"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/SamVerschueren/decode-uri-component.git"
+    revision: "a0eea469d26eb0df668b081672cdb9581feb78eb"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/SamVerschueren/decode-uri-component.git"
+    revision: "a0eea469d26eb0df668b081672cdb9581feb78eb"
+    path: ""
+- id: "NPM::define-property:0.2.5"
+  purl: "pkg:npm/define-property@0.2.5"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Define a non-enumerable property on an object."
+  homepage_url: "https://github.com/jonschlinkert/define-property"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
+    hash:
+      value: "c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/define-property.git"
+    revision: "5bf4e5e9d8d1fdf8fba07fff4bdf13a5d6df8ae4"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/define-property.git"
+    revision: "5bf4e5e9d8d1fdf8fba07fff4bdf13a5d6df8ae4"
+    path: ""
+- id: "NPM::define-property:1.0.0"
+  purl: "pkg:npm/define-property@1.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Define a non-enumerable property on an object."
+  homepage_url: "https://github.com/jonschlinkert/define-property"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz"
+    hash:
+      value: "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/define-property.git"
+    revision: "4811e7c7999e82ab086265eefeb5d9cbffe10912"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/define-property.git"
+    revision: "4811e7c7999e82ab086265eefeb5d9cbffe10912"
+    path: ""
+- id: "NPM::define-property:2.0.2"
+  purl: "pkg:npm/define-property@2.0.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Define a non-enumerable property on an object. Uses Reflect.defineProperty\
+    \ when available, otherwise Object.defineProperty."
+  homepage_url: "https://github.com/jonschlinkert/define-property"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz"
+    hash:
+      value: "d459689e8d654ba77e02a817f8710d702cb16e9d"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/define-property.git"
+    revision: "04717307be822f2ca2544778b92e5d2cbe300c55"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/define-property.git"
+    revision: "04717307be822f2ca2544778b92e5d2cbe300c55"
     path: ""
 - id: "NPM::detect-indent:4.0.0"
   purl: "pkg:npm/detect-indent@4.0.0"
@@ -1954,6 +3749,36 @@ packages:
     url: "https://github.com/jonschlinkert/expand-brackets.git"
     revision: "1b07fda8ee8b6426d95e6539785b74c57e9ee542"
     path: ""
+- id: "NPM::expand-brackets:2.1.4"
+  purl: "pkg:npm/expand-brackets@2.1.4"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Expand POSIX bracket expressions (character classes) in glob patterns."
+  homepage_url: "https://github.com/jonschlinkert/expand-brackets"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz"
+    hash:
+      value: "b77735e315ce30f6b6eff0f83b04151a22449622"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/expand-brackets.git"
+    revision: "9a0ec493825eb0aa9368c158927ca4ace945fefa"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/expand-brackets.git"
+    revision: "9a0ec493825eb0aa9368c158927ca4ace945fefa"
+    path: ""
 - id: "NPM::expand-range:1.8.2"
   purl: "pkg:npm/expand-range@1.8.2"
   authors:
@@ -1984,6 +3809,37 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/expand-range.git"
     revision: "4c873af0870df8382bafc66a93d5c89e3aad3d4d"
+    path: ""
+- id: "NPM::extend-shallow:2.0.1"
+  purl: "pkg:npm/extend-shallow@2.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Extend an object with the properties of additional objects. node.js/javascript\
+    \ util."
+  homepage_url: "https://github.com/jonschlinkert/extend-shallow"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+    hash:
+      value: "51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/extend-shallow.git"
+    revision: "e9b1f1d2ff9d2990ec4a127afa7c14732d1eec8a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/extend-shallow.git"
+    revision: "e9b1f1d2ff9d2990ec4a127afa7c14732d1eec8a"
     path: ""
 - id: "NPM::extend-shallow:3.0.2"
   purl: "pkg:npm/extend-shallow@3.0.2"
@@ -2047,6 +3903,37 @@ packages:
     url: "https://github.com/jonschlinkert/extglob.git"
     revision: "8c3f38bbd9e0afaf31a87e411c0d15532434ef41"
     path: ""
+- id: "NPM::extglob:2.0.4"
+  purl: "pkg:npm/extglob@2.0.4"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Extended glob support for JavaScript. Adds (almost) the expressive\
+    \ power of regular expressions to glob patterns."
+  homepage_url: "https://github.com/micromatch/extglob"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz"
+    hash:
+      value: "ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/micromatch/extglob.git"
+    revision: "b00d865652d844b80164ea544323a36c838b3e58"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/micromatch/extglob.git"
+    revision: "b00d865652d844b80164ea544323a36c838b3e58"
+    path: ""
 - id: "NPM::filename-regex:2.0.1"
   purl: "pkg:npm/filename-regex@2.0.1"
   authors:
@@ -2076,6 +3963,37 @@ packages:
     type: "Git"
     url: "https://github.com/regexhq/filename-regex.git"
     revision: "821fec482acdb1ce3f23a804ce8a86724d02b4e6"
+    path: ""
+- id: "NPM::fill-range:2.2.4"
+  purl: "pkg:npm/fill-range@2.2.4"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fill in a range of numbers or letters, optionally passing an increment\
+    \ or multiplier to use."
+  homepage_url: "https://github.com/jonschlinkert/fill-range"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz"
+    hash:
+      value: "eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/fill-range.git"
+    revision: "516e5ad9e40486c168b14062158d136aa3163f2b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/fill-range.git"
+    revision: "516e5ad9e40486c168b14062158d136aa3163f2b"
     path: ""
 - id: "NPM::fill-range:4.0.0"
   purl: "pkg:npm/fill-range@4.0.0"
@@ -2172,6 +4090,36 @@ packages:
     url: "https://github.com/jonschlinkert/for-own.git"
     revision: "e64ee3492f218c812011ec3feff4194e9272d2a1"
     path: ""
+- id: "NPM::fragment-cache:0.2.1"
+  purl: "pkg:npm/fragment-cache@0.2.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "A cache for managing namespaced sub-caches"
+  homepage_url: "https://github.com/jonschlinkert/fragment-cache"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz"
+    hash:
+      value: "4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/fragment-cache.git"
+    revision: "33583b03f505c67479ddbc66f825b0e653704207"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/fragment-cache.git"
+    revision: "33583b03f505c67479ddbc66f825b0e653704207"
+    path: ""
 - id: "NPM::fs-readdir-recursive:1.1.0"
   purl: "pkg:npm/fs-readdir-recursive@1.1.0"
   authors:
@@ -2232,6 +4180,66 @@ packages:
     type: "Git"
     url: "https://github.com/isaacs/fs.realpath.git"
     revision: "03e7c884431fe185dfebbc9b771aeca339c1807a"
+    path: ""
+- id: "NPM::function-bind:1.1.2"
+  purl: "pkg:npm/function-bind@1.1.2"
+  authors:
+  - "Raynos"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Implementation of Function.prototype.bind"
+  homepage_url: "https://github.com/Raynos/function-bind"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
+    hash:
+      value: "2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/Raynos/function-bind.git"
+    revision: "40197beb5f4cf89dd005f0b268256c1e4716ea81"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/Raynos/function-bind.git"
+    revision: "40197beb5f4cf89dd005f0b268256c1e4716ea81"
+    path: ""
+- id: "NPM::get-value:2.0.6"
+  purl: "pkg:npm/get-value@2.0.6"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Use property paths (`a.b.c`) to get a nested value from an object."
+  homepage_url: "https://github.com/jonschlinkert/get-value"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
+    hash:
+      value: "dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/get-value.git"
+    revision: "5dc7466a65eec37e3b9e3d94f274b7aba193ea60"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/get-value.git"
+    revision: "5dc7466a65eec37e3b9e3d94f274b7aba193ea60"
     path: ""
 - id: "NPM::glob:7.2.3"
   purl: "pkg:npm/glob@7.2.3"
@@ -2411,6 +4419,160 @@ packages:
     url: "https://github.com/sindresorhus/has-ansi.git"
     revision: "0722275e1bef139fcd09137da6e5550c3cd368b9"
     path: ""
+- id: "NPM::has-value:0.3.1"
+  purl: "pkg:npm/has-value@0.3.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value exists, false if empty. Works with deeply\
+    \ nested values using object paths."
+  homepage_url: "https://github.com/jonschlinkert/has-value"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz"
+    hash:
+      value: "7b1f58bada62ca827ec0a2078025654845995e1f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-value.git"
+    revision: "adecb27b13b7e99688694e228a946e6e635fcc64"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-value.git"
+    revision: "adecb27b13b7e99688694e228a946e6e635fcc64"
+    path: ""
+- id: "NPM::has-value:1.0.0"
+  purl: "pkg:npm/has-value@1.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value exists, false if empty. Works with deeply\
+    \ nested values using object paths."
+  homepage_url: "https://github.com/jonschlinkert/has-value"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz"
+    hash:
+      value: "18b281da585b1c5c51def24c930ed29a0be6b177"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-value.git"
+    revision: "61b5671a48ac40206eb33b4ea75dc2507168d687"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-value.git"
+    revision: "61b5671a48ac40206eb33b4ea75dc2507168d687"
+    path: ""
+- id: "NPM::has-values:0.1.4"
+  purl: "pkg:npm/has-values@0.1.4"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if any values exist, false if empty. Works for booleans,\
+    \ functions, numbers, strings, nulls, objects and arrays. "
+  homepage_url: "https://github.com/jonschlinkert/has-values"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
+    hash:
+      value: "6d61de95d91dfca9b9a02089ad384bff8f62b771"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-values.git"
+    revision: "199a3eacd663b4ae4b00aef5ef5541aa2c7c8089"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-values.git"
+    revision: "199a3eacd663b4ae4b00aef5ef5541aa2c7c8089"
+    path: ""
+- id: "NPM::has-values:1.0.0"
+  purl: "pkg:npm/has-values@1.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if any values exist, false if empty. Works for booleans,\
+    \ functions, numbers, strings, nulls, objects and arrays. "
+  homepage_url: "https://github.com/jonschlinkert/has-values"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz"
+    hash:
+      value: "95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-values.git"
+    revision: "fead695044aafcfb337c7125af5479c7eaf1c92c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/has-values.git"
+    revision: "fead695044aafcfb337c7125af5479c7eaf1c92c"
+    path: ""
+- id: "NPM::hasown:2.0.2"
+  purl: "pkg:npm/hasown@2.0.2"
+  authors:
+  - "Jordan Harband"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "A robust, ES3 compatible, \"has own property\" predicate."
+  homepage_url: "https://github.com/inspect-js/hasOwn#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
+    hash:
+      value: "003eaf91be7adc372e84ec59dc37252cedb80003"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/inspect-js/hasOwn.git"
+    revision: "d00d35005baf16a33d691a13f8ad627f35040742"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inspect-js/hasOwn.git"
+    revision: "d00d35005baf16a33d691a13f8ad627f35040742"
+    path: ""
 - id: "NPM::home-or-tmp:2.0.0"
   purl: "pkg:npm/home-or-tmp@2.0.0"
   authors:
@@ -2530,6 +4692,37 @@ packages:
     url: "https://github.com/zertosh/invariant.git"
     revision: "ce95a9badeee1c97daff1bca0d1f6cec5dda4fe8"
     path: ""
+- id: "NPM::is-accessor-descriptor:1.0.1"
+  purl: "pkg:npm/is-accessor-descriptor@1.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value has the characteristics of a valid JavaScript\
+    \ accessor descriptor."
+  homepage_url: "https://github.com/inspect-js/is-accessor-descriptor"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz"
+    hash:
+      value: "3223b10628354644b86260db29b3e693f5ceedd4"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/inspect-js/is-accessor-descriptor.git"
+    revision: "57637b356840c949c35949c533e3f2cdeb468534"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inspect-js/is-accessor-descriptor.git"
+    revision: "57637b356840c949c35949c533e3f2cdeb468534"
+    path: ""
 - id: "NPM::is-binary-path:1.0.1"
   purl: "pkg:npm/is-binary-path@1.0.1"
   authors:
@@ -2589,6 +4782,99 @@ packages:
     type: "Git"
     url: "https://github.com/feross/is-buffer.git"
     revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
+    path: ""
+- id: "NPM::is-data-descriptor:1.0.1"
+  purl: "pkg:npm/is-data-descriptor@1.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value has the characteristics of a valid JavaScript\
+    \ data descriptor."
+  homepage_url: "https://github.com/inspect-js/is-data-descriptor"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz"
+    hash:
+      value: "2109164426166d32ea38c405c1e0945d9e6a4eeb"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/inspect-js/is-data-descriptor.git"
+    revision: "0a9ea4a135a60200819a2ac4aad00debfd28d105"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inspect-js/is-data-descriptor.git"
+    revision: "0a9ea4a135a60200819a2ac4aad00debfd28d105"
+    path: ""
+- id: "NPM::is-descriptor:0.1.7"
+  purl: "pkg:npm/is-descriptor@0.1.7"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value has the characteristics of a valid JavaScript\
+    \ descriptor. Works for data descriptors and accessor descriptors."
+  homepage_url: "https://github.com/inspect-js/is-descriptor"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz"
+    hash:
+      value: "2727eb61fd789dcd5bdf0ed4569f551d2fe3be33"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/inspect-js/is-descriptor.git"
+    revision: "839ee8f13f3e6e53226132d8828073d8c2b4a543"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inspect-js/is-descriptor.git"
+    revision: "839ee8f13f3e6e53226132d8828073d8c2b4a543"
+    path: ""
+- id: "NPM::is-descriptor:1.0.3"
+  purl: "pkg:npm/is-descriptor@1.0.3"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value has the characteristics of a valid JavaScript\
+    \ descriptor. Works for data descriptors and accessor descriptors."
+  homepage_url: "https://github.com/inspect-js/is-descriptor"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.3.tgz"
+    hash:
+      value: "92d27cb3cd311c4977a4db47df457234a13cb306"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/inspect-js/is-descriptor.git"
+    revision: "ad08ba5a0d0359777a11e04952992e1a65963c64"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inspect-js/is-descriptor.git"
+    revision: "ad08ba5a0d0359777a11e04952992e1a65963c64"
     path: ""
 - id: "NPM::is-dotfile:1.0.3"
   purl: "pkg:npm/is-dotfile@1.0.3"
@@ -2651,6 +4937,38 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/is-equal-shallow.git"
     revision: "dceb47dd9c9c21066958116e3b54b3c8c251ee4a"
+    path: ""
+- id: "NPM::is-extendable:0.1.1"
+  purl: "pkg:npm/is-extendable@0.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if a value is any of the object types: array, regexp,\
+    \ plain object, function or date. This is useful for determining if a value can\
+    \ be extended, e.g. \"can the value have keys?\""
+  homepage_url: "https://github.com/jonschlinkert/is-extendable"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+    hash:
+      value: "62b110e289a471418e3ec36a617d472e301dfc89"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-extendable.git"
+    revision: "c36a0732e6a76931c6f66c5931d1f3e54fa44380"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-extendable.git"
+    revision: "c36a0732e6a76931c6f66c5931d1f3e54fa44380"
     path: ""
 - id: "NPM::is-extendable:1.0.1"
   purl: "pkg:npm/is-extendable@1.0.1"
@@ -2775,6 +5093,36 @@ packages:
     url: "https://github.com/jonschlinkert/is-glob.git"
     revision: "d7db1b2dd559b3d5a73f89dbe72d9e9f4d6587d7"
     path: ""
+- id: "NPM::is-number:2.1.0"
+  purl: "pkg:npm/is-number@2.1.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if the value is a number. comprehensive tests."
+  homepage_url: "https://github.com/jonschlinkert/is-number"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+    hash:
+      value: "01fcbbb393463a548f2f466cce16dece49db908f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-number.git"
+    revision: "d06c6e2cc048d3cad016cb8dfb055bb14d86fffa"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-number.git"
+    revision: "d06c6e2cc048d3cad016cb8dfb055bb14d86fffa"
+    path: ""
 - id: "NPM::is-number:3.0.0"
   purl: "pkg:npm/is-number@3.0.0"
   authors:
@@ -2804,6 +5152,36 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/is-number.git"
     revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
+    path: ""
+- id: "NPM::is-number:4.0.0"
+  purl: "pkg:npm/is-number@4.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if the value is a number. comprehensive tests."
+  homepage_url: "https://github.com/jonschlinkert/is-number"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz"
+    hash:
+      value: "0026e37f5454d73e356dfe6564699867c6a7f0ff"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-number.git"
+    revision: "0c6b15a88bc10cd47f67a09506399dfc9ddc075d"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-number.git"
+    revision: "0c6b15a88bc10cd47f67a09506399dfc9ddc075d"
     path: ""
 - id: "NPM::is-plain-object:2.0.4"
   purl: "pkg:npm/is-plain-object@2.0.4"
@@ -2896,6 +5274,37 @@ packages:
     url: "https://github.com/jonschlinkert/is-primitive.git"
     revision: "c512b7c95fb049aa9b1f039ddc0670611b66cce2"
     path: ""
+- id: "NPM::is-windows:1.0.2"
+  purl: "pkg:npm/is-windows@1.0.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if the platform is windows. UMD module, works with node.js,\
+    \ commonjs, browser, AMD, electron, etc."
+  homepage_url: "https://github.com/jonschlinkert/is-windows"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
+    hash:
+      value: "d1850eb9791ecd18e6182ce12a30f396634bb19d"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-windows.git"
+    revision: "4dcfff4ed9e36ad761a1a24d3899c832382d7254"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/is-windows.git"
+    revision: "4dcfff4ed9e36ad761a1a24d3899c832382d7254"
+    path: ""
 - id: "NPM::isarray:1.0.0"
   purl: "pkg:npm/isarray@1.0.0"
   authors:
@@ -2925,6 +5334,36 @@ packages:
     type: "Git"
     url: "https://github.com/juliangruber/isarray.git"
     revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
+    path: ""
+- id: "NPM::isobject:2.1.0"
+  purl: "pkg:npm/isobject@2.1.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns true if the value is an object and not an array or null."
+  homepage_url: "https://github.com/jonschlinkert/isobject"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+    hash:
+      value: "f065561096a3f1da2ef46272f815c840d87e0c89"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/isobject.git"
+    revision: "d693ec8d31b02b42a19b2d806407a4ecb2f9fb73"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/isobject.git"
+    revision: "d693ec8d31b02b42a19b2d806407a4ecb2f9fb73"
     path: ""
 - id: "NPM::isobject:3.0.1"
   purl: "pkg:npm/isobject@3.0.1"
@@ -2985,6 +5424,36 @@ packages:
     type: "Git"
     url: "https://github.com/lydell/js-tokens.git"
     revision: "8315904c840b14d28de1b0a4968194555f61bea3"
+    path: ""
+- id: "NPM::js-tokens:4.0.0"
+  purl: "pkg:npm/js-tokens@4.0.0"
+  authors:
+  - "Simon Lydell"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "A regex that tokenizes JavaScript."
+  homepage_url: "https://github.com/lydell/js-tokens#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
+    hash:
+      value: "19203fb59991df98e3a287050d4647cdeaf32499"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lydell/js-tokens.git"
+    revision: "0eb6e9daee32160ab0fca979b6dc91a1991b720c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lydell/js-tokens.git"
+    revision: "0eb6e9daee32160ab0fca979b6dc91a1991b720c"
     path: ""
 - id: "NPM::jsesc:1.3.0"
   purl: "pkg:npm/jsesc@1.3.0"
@@ -3077,6 +5546,66 @@ packages:
     url: "https://github.com/jonschlinkert/kind-of.git"
     revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
     path: ""
+- id: "NPM::kind-of:4.0.0"
+  purl: "pkg:npm/kind-of@4.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Get the native type of a value."
+  homepage_url: "https://github.com/jonschlinkert/kind-of"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+    hash:
+      value: "20813df3d712928b207378691a45066fae72dd57"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/kind-of.git"
+    revision: "30bee16e8dffa67417ba35d31bd9bc31517a2d83"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/kind-of.git"
+    revision: "30bee16e8dffa67417ba35d31bd9bc31517a2d83"
+    path: ""
+- id: "NPM::kind-of:6.0.3"
+  purl: "pkg:npm/kind-of@6.0.3"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Get the native type of a value."
+  homepage_url: "https://github.com/jonschlinkert/kind-of"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"
+    hash:
+      value: "07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/kind-of.git"
+    revision: "abab085d65f7ee978011da8f135291892fcd97db"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/kind-of.git"
+    revision: "abab085d65f7ee978011da8f135291892fcd97db"
+    path: ""
 - id: "NPM::lodash:4.17.21"
   purl: "pkg:npm/lodash@4.17.21"
   authors:
@@ -3138,6 +5667,98 @@ packages:
     url: "https://github.com/zertosh/loose-envify.git"
     revision: "a8fdd02e3a435195f526053882d64537d627b3e6"
     path: ""
+- id: "NPM::map-cache:0.2.2"
+  purl: "pkg:npm/map-cache@0.2.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Basic cache object for storing key-value pairs."
+  homepage_url: "https://github.com/jonschlinkert/map-cache"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+    hash:
+      value: "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/map-cache.git"
+    revision: "f36c7567cb85b50824db25a2a588c5f7b858823b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/map-cache.git"
+    revision: "f36c7567cb85b50824db25a2a588c5f7b858823b"
+    path: ""
+- id: "NPM::map-visit:1.0.0"
+  purl: "pkg:npm/map-visit@1.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Map `visit` over an array of objects."
+  homepage_url: "https://github.com/jonschlinkert/map-visit"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
+    hash:
+      value: "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/map-visit.git"
+    revision: "73bcd8385c9520c595a825486f19623a5e0550f0"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/map-visit.git"
+    revision: "73bcd8385c9520c595a825486f19623a5e0550f0"
+    path: ""
+- id: "NPM::math-random:1.0.4"
+  purl: "pkg:npm/math-random@1.0.4"
+  authors:
+  - "Michael Rhodes"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "math-random is an drop-in replacement for Math.random that uses cryptographically\
+    \ secure random number generation, where available. It works in both browser and\
+    \ node environments."
+  homepage_url: "https://github.com/michaelrhodes/math-random#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz"
+    hash:
+      value: "5dd6943c938548267016d4e34f057583080c514c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/michaelrhodes/math-random.git"
+    revision: "13ed513bd579eb868b5054b38836411ae6e29f6a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/michaelrhodes/math-random.git"
+    revision: "13ed513bd579eb868b5054b38836411ae6e29f6a"
+    path: ""
 - id: "NPM::micromatch:2.3.11"
   purl: "pkg:npm/micromatch@2.3.11"
   authors:
@@ -3168,6 +5789,37 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/micromatch.git"
     revision: "f194c187d04677b03047bb7d8d25643725f7a577"
+    path: ""
+- id: "NPM::micromatch:3.1.10"
+  purl: "pkg:npm/micromatch@3.1.10"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Glob matching for javascript/node.js. A drop-in replacement and faster\
+    \ alternative to minimatch and multimatch."
+  homepage_url: "https://github.com/micromatch/micromatch"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz"
+    hash:
+      value: "70859bc95c9840952f359a068a3fc49f9ecfac23"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/micromatch/micromatch.git"
+    revision: "0628af9a111c791ca69c809a6f8555337813cc05"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/micromatch/micromatch.git"
+    revision: "0628af9a111c791ca69c809a6f8555337813cc05"
     path: ""
 - id: "NPM::minimatch:3.1.2"
   purl: "pkg:npm/minimatch@3.1.2"
@@ -3229,6 +5881,37 @@ packages:
     url: "https://github.com/minimistjs/minimist.git"
     revision: "6901ee286bc4c16da6830b48b46ce1574703cea1"
     path: ""
+- id: "NPM::mixin-deep:1.3.2"
+  purl: "pkg:npm/mixin-deep@1.3.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Deeply mix the properties of objects into the first object. Like merge-deep,\
+    \ but doesn't clone."
+  homepage_url: "https://github.com/jonschlinkert/mixin-deep"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz"
+    hash:
+      value: "1120b43dc359a785dce65b55b82e257ccf479566"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/mixin-deep.git"
+    revision: "754f0c20e1bc13ea5a21a64fbc7d6ba5f7b359b9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/mixin-deep.git"
+    revision: "754f0c20e1bc13ea5a21a64fbc7d6ba5f7b359b9"
+    path: ""
 - id: "NPM::mkdirp:0.5.6"
   purl: "pkg:npm/mkdirp@0.5.6"
   authors:
@@ -3286,6 +5969,38 @@ packages:
     type: "Git"
     url: "https://github.com/zeit/ms.git"
     revision: "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4"
+    path: ""
+- id: "NPM::nanomatch:1.2.13"
+  purl: "pkg:npm/nanomatch@1.2.13"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fast, minimal glob matcher for node.js. Similar to micromatch, minimatch\
+    \ and multimatch, but complete Bash 4.3 wildcard support only (no support for\
+    \ exglobs, posix brackets or braces)"
+  homepage_url: "https://github.com/micromatch/nanomatch"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz"
+    hash:
+      value: "b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/micromatch/nanomatch.git"
+    revision: "d2af1083ae338c6c9a5834ee85ae40679be60a46"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/micromatch/nanomatch.git"
+    revision: "d2af1083ae338c6c9a5834ee85ae40679be60a46"
     path: ""
 - id: "NPM::normalize-path:2.1.1"
   purl: "pkg:npm/normalize-path@2.1.1"
@@ -3349,6 +6064,67 @@ packages:
     url: "https://github.com/sindresorhus/object-assign.git"
     revision: "a89774b252c91612203876984bbd6addbe3b5a0e"
     path: ""
+- id: "NPM::object-copy:0.1.0"
+  purl: "pkg:npm/object-copy@0.1.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Copy static properties, prototype properties, and descriptors from\
+    \ one object to another."
+  homepage_url: "https://github.com/jonschlinkert/object-copy"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
+    hash:
+      value: "7e7d858b781bd7c991a41ba975ed3812754e998c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/object-copy.git"
+    revision: "15b972a4a7137f6bf47886c68e73a2fffa8eacf2"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/object-copy.git"
+    revision: "15b972a4a7137f6bf47886c68e73a2fffa8eacf2"
+    path: ""
+- id: "NPM::object-visit:1.0.1"
+  purl: "pkg:npm/object-visit@1.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Call a specified method on each value in the given object."
+  homepage_url: "https://github.com/jonschlinkert/object-visit"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+    hash:
+      value: "f79c4493af0c5377b59fe39d395e41042dd045bb"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/object-visit.git"
+    revision: "2220cd6ea35008481c9e252488bcbde9ebca0983"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/object-visit.git"
+    revision: "2220cd6ea35008481c9e252488bcbde9ebca0983"
+    path: ""
 - id: "NPM::object.omit:2.0.1"
   purl: "pkg:npm/object.omit@2.0.1"
   authors:
@@ -3379,6 +6155,37 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/object.omit.git"
     revision: "6634673e6e88c65796f1df4bcb787dede6dc7ffc"
+    path: ""
+- id: "NPM::object.pick:1.3.0"
+  purl: "pkg:npm/object.pick@1.3.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Returns a filtered copy of an object with only the specified keys,\
+    \ similar to `_.pick` from lodash / underscore."
+  homepage_url: "https://github.com/jonschlinkert/object.pick"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz"
+    hash:
+      value: "87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/object.pick.git"
+    revision: "f9d89d96a8d5ec671dc39e2c2319d8aaa04dd2cc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/object.pick.git"
+    revision: "f9d89d96a8d5ec671dc39e2c2319d8aaa04dd2cc"
     path: ""
 - id: "NPM::once:1.4.0"
   purl: "pkg:npm/once@1.4.0"
@@ -3531,6 +6338,36 @@ packages:
     url: "https://github.com/jonschlinkert/parse-glob.git"
     revision: "9bfccb63acdeb3b1ed62035b3adef0e5081d8fc6"
     path: ""
+- id: "NPM::pascalcase:0.1.1"
+  purl: "pkg:npm/pascalcase@0.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Convert a string to pascal-case."
+  homepage_url: "https://github.com/jonschlinkert/pascalcase"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+    hash:
+      value: "b363e55e8006ca6fe21784d2db22bd15d7917f14"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/pascalcase.git"
+    revision: "c2600f8aa648fe093381a064ba364d99b374911c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/pascalcase.git"
+    revision: "c2600f8aa648fe093381a064ba364d99b374911c"
+    path: ""
 - id: "NPM::path-is-absolute:1.0.1"
   purl: "pkg:npm/path-is-absolute@1.0.1"
   authors:
@@ -3560,6 +6397,36 @@ packages:
     type: "Git"
     url: "https://github.com/sindresorhus/path-is-absolute.git"
     revision: "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6"
+    path: ""
+- id: "NPM::posix-character-classes:0.1.1"
+  purl: "pkg:npm/posix-character-classes@0.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "POSIX character classes for creating regular expressions."
+  homepage_url: "https://github.com/jonschlinkert/posix-character-classes"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
+    hash:
+      value: "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/posix-character-classes.git"
+    revision: "93acda996350d0b1571592765e45c31da9376aa7"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/posix-character-classes.git"
+    revision: "93acda996350d0b1571592765e45c31da9376aa7"
     path: ""
 - id: "NPM::preserve:0.2.0"
   purl: "pkg:npm/preserve@0.2.0"
@@ -3650,6 +6517,37 @@ packages:
     url: "https://github.com/calvinmetcalf/process-nextick-args.git"
     revision: "b96d59913025441b00c4fd40e6894ddfa8e1c398"
     path: ""
+- id: "NPM::randomatic:3.1.1"
+  purl: "pkg:npm/randomatic@3.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Generate randomized strings of a specified length using simple character\
+    \ sequences. The original generate-password."
+  homepage_url: "https://github.com/jonschlinkert/randomatic"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz"
+    hash:
+      value: "b776efc59375984e36c537b2f51a1f0aff0da1ed"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/randomatic.git"
+    revision: "b7451f4dac44a9920790f76a4d8a1dd081c37a5a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/randomatic.git"
+    revision: "b7451f4dac44a9920790f76a4d8a1dd081c37a5a"
+    path: ""
 - id: "NPM::readable-stream:2.3.8"
   purl: "pkg:npm/readable-stream@2.3.8"
   declared_licenses:
@@ -3738,6 +6636,36 @@ packages:
     url: "https://github.com/facebook/regenerator.git"
     revision: "master"
     path: "packages/regenerator-runtime"
+- id: "NPM::regenerator-runtime:0.11.1"
+  purl: "pkg:npm/regenerator-runtime@0.11.1"
+  authors:
+  - "Ben Newman"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Runtime for Regenerator-compiled generator and async functions."
+  homepage_url: "https://github.com/facebook/regenerator/tree/main#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
+    hash:
+      value: "be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/facebook/regenerator.git"
+    revision: "master"
+    path: "packages/regenerator-runtime"
 - id: "NPM::regex-cache:0.4.4"
   purl: "pkg:npm/regex-cache@0.4.4"
   authors:
@@ -3769,6 +6697,37 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/regex-cache.git"
     revision: "e5ced08e45d2cc2d286a9e7b5a574963f6577712"
+    path: ""
+- id: "NPM::regex-not:1.0.2"
+  purl: "pkg:npm/regex-not@1.0.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Create a javascript regular expression for matching everything except\
+    \ for the given string."
+  homepage_url: "https://github.com/jonschlinkert/regex-not"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz"
+    hash:
+      value: "1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/regex-not.git"
+    revision: "7e368998898e1fc7428596636ef5412ede414f3e"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/regex-not.git"
+    revision: "7e368998898e1fc7428596636ef5412ede414f3e"
     path: ""
 - id: "NPM::remove-trailing-separator:1.1.0"
   purl: "pkg:npm/remove-trailing-separator@1.1.0"
@@ -3891,6 +6850,66 @@ packages:
     url: "https://github.com/sindresorhus/repeating.git"
     revision: "be02bcaf9a674b3c155477b3bf282136bcf44770"
     path: ""
+- id: "NPM::resolve-url:0.2.1"
+  purl: "pkg:npm/resolve-url@0.2.1"
+  authors:
+  - "Simon Lydell"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Like Node.js’ `path.resolve`/`url.resolve` for the browser."
+  homepage_url: "https://github.com/lydell/resolve-url"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+    hash:
+      value: "2c637fe77c893afd2a663fe21aa9080068e2052a"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lydell/resolve-url.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lydell/resolve-url.git"
+    revision: ""
+    path: ""
+- id: "NPM::ret:0.1.15"
+  purl: "pkg:npm/ret@0.1.15"
+  authors:
+  - "Roly Fentanes"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Tokenizes a string that represents a regular expression."
+  homepage_url: "https://github.com/fent/ret.js#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
+    hash:
+      value: "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fent/ret.js.git"
+    revision: "7f7c436e2a85fbc068e6d94e2611ce78b3e9ad10"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fent/ret.js.git"
+    revision: "7f7c436e2a85fbc068e6d94e2611ce78b3e9ad10"
+    path: ""
 - id: "NPM::safe-buffer:5.1.2"
   purl: "pkg:npm/safe-buffer@5.1.2"
   authors:
@@ -3920,6 +6939,67 @@ packages:
     type: "Git"
     url: "https://github.com/feross/safe-buffer.git"
     revision: "649435cc8e2d1f3ecdc7caf323f1cb1187307a16"
+    path: ""
+- id: "NPM::safe-regex:1.1.0"
+  purl: "pkg:npm/safe-regex@1.1.0"
+  authors:
+  - "James Halliday"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "detect possibly catastrophic, exponential-time regular expressions"
+  homepage_url: "https://github.com/substack/safe-regex"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
+    hash:
+      value: "40a3669f3b077d1e943d44629e157dd48023bf2e"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/substack/safe-regex.git"
+    revision: "d2570f31bd9d779515015917bb8297c753e46572"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/substack/safe-regex.git"
+    revision: "d2570f31bd9d779515015917bb8297c753e46572"
+    path: ""
+- id: "NPM::set-value:2.0.1"
+  purl: "pkg:npm/set-value@2.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Create nested values and any intermediaries using dot notation (`'a.b.c'`)\
+    \ paths."
+  homepage_url: "https://github.com/jonschlinkert/set-value"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz"
+    hash:
+      value: "a18d40530e6f07de4228c7defe4227af8cad005b"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/set-value.git"
+    revision: "bb0f0382f7d7637f3de1bba52d1b4abdbbbde4d4"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/set-value.git"
+    revision: "bb0f0382f7d7637f3de1bba52d1b4abdbbbde4d4"
     path: ""
 - id: "NPM::slash:1.0.0"
   purl: "pkg:npm/slash@1.0.0"
@@ -3951,6 +7031,97 @@ packages:
     url: "https://github.com/sindresorhus/slash.git"
     revision: "c801dd4568ad9380b534067eabe88942394f82ff"
     path: ""
+- id: "NPM::snapdragon:0.8.2"
+  purl: "pkg:npm/snapdragon@0.8.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fast, pluggable and easy-to-use parser-renderer factory."
+  homepage_url: "https://github.com/jonschlinkert/snapdragon"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz"
+    hash:
+      value: "64922e7c565b0e14204ba1aa7d6964278d25182d"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon.git"
+    revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon.git"
+    revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
+    path: ""
+- id: "NPM::snapdragon-node:2.1.1"
+  purl: "pkg:npm/snapdragon-node@2.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Snapdragon utility for creating a new AST node in custom code, such\
+    \ as plugins."
+  homepage_url: "https://github.com/jonschlinkert/snapdragon-node"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
+    hash:
+      value: "6c175f86ff14bdb0724563e8f3c1b021a286853b"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon-node.git"
+    revision: "d2bc7304fc1b8103d6bb892d9ef099957468ff14"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon-node.git"
+    revision: "d2bc7304fc1b8103d6bb892d9ef099957468ff14"
+    path: ""
+- id: "NPM::snapdragon-util:3.0.1"
+  purl: "pkg:npm/snapdragon-util@3.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Utilities for the snapdragon parser/compiler."
+  homepage_url: "https://github.com/jonschlinkert/snapdragon-util"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
+    hash:
+      value: "f956479486f2acd79700693f6f7b805e45ab56e2"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon-util.git"
+    revision: "1655d7f02f5957ebddc9cc7757a25bf8f221e5a7"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon-util.git"
+    revision: "1655d7f02f5957ebddc9cc7757a25bf8f221e5a7"
+    path: ""
 - id: "NPM::source-map:0.5.7"
   purl: "pkg:npm/source-map@0.5.7"
   authors:
@@ -3981,6 +7152,36 @@ packages:
     url: "https://github.com/mozilla/source-map.git"
     revision: "326dd955a366569759d9537ef5f0f167c89d92d2"
     path: ""
+- id: "NPM::source-map-resolve:0.5.3"
+  purl: "pkg:npm/source-map-resolve@0.5.3"
+  authors:
+  - "Simon Lydell"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Resolve the source map and/or sources for a generated file."
+  homepage_url: "https://github.com/lydell/source-map-resolve#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz"
+    hash:
+      value: "190866bece7553e1f8f267a2ee82c606b5509a1a"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lydell/source-map-resolve.git"
+    revision: "b8244f108af0aaf34c32a61e97b66e38db682afc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lydell/source-map-resolve.git"
+    revision: "b8244f108af0aaf34c32a61e97b66e38db682afc"
+    path: ""
 - id: "NPM::source-map-support:0.4.18"
   purl: "pkg:npm/source-map-support@0.4.18"
   declared_licenses:
@@ -4008,6 +7209,98 @@ packages:
     type: "Git"
     url: "https://github.com/evanw/node-source-map-support.git"
     revision: "b9b5a5576272916237a253393220770c858685d6"
+    path: ""
+- id: "NPM::source-map-url:0.4.1"
+  purl: "pkg:npm/source-map-url@0.4.1"
+  authors:
+  - "Simon Lydell"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Tools for working with sourceMappingURL comments."
+  homepage_url: "https://github.com/lydell/source-map-url#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz"
+    hash:
+      value: "0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lydell/source-map-url.git"
+    revision: "b16c43ca630067c43a05cad7b6841d25e1248fb9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lydell/source-map-url.git"
+    revision: "b16c43ca630067c43a05cad7b6841d25e1248fb9"
+    path: ""
+- id: "NPM::split-string:3.1.0"
+  purl: "pkg:npm/split-string@3.1.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Split a string on a character except when the character is escaped."
+  homepage_url: "https://github.com/jonschlinkert/split-string"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
+    hash:
+      value: "7cb09dda3a86585705c64b39a6466038682e8fe2"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/split-string.git"
+    revision: "2f83feb70267a54ca01e795e6a0558a51b89d6c8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/split-string.git"
+    revision: "2f83feb70267a54ca01e795e6a0558a51b89d6c8"
+    path: ""
+- id: "NPM::static-extend:0.1.2"
+  purl: "pkg:npm/static-extend@0.1.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Adds a static `extend` method to a class, to simplify inheritance.\
+    \ Extends the static properties, prototype properties, and descriptors from a\
+    \ `Parent` constructor onto `Child` constructors."
+  homepage_url: "https://github.com/jonschlinkert/static-extend"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
+    hash:
+      value: "60809c39cbff55337226fd5e0b520f341f1fb5c6"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/static-extend.git"
+    revision: "ce41369391163eb9403848a1b4daf00be981c56b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/static-extend.git"
+    revision: "ce41369391163eb9403848a1b4daf00be981c56b"
     path: ""
 - id: "NPM::string_decoder:1.1.1"
   purl: "pkg:npm/string_decoder@1.1.1"
@@ -4127,6 +7420,66 @@ packages:
     url: "https://github.com/sindresorhus/to-fast-properties.git"
     revision: "76e30a0b6040781a705cb351fb2e4a1d879f1adb"
     path: ""
+- id: "NPM::to-object-path:0.3.0"
+  purl: "pkg:npm/to-object-path@0.3.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Create an object path from a list or array of strings."
+  homepage_url: "https://github.com/jonschlinkert/to-object-path"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+    hash:
+      value: "297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/to-object-path.git"
+    revision: "56f6627285b7f5b7563e6f3ffe3766d966368c17"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/to-object-path.git"
+    revision: "56f6627285b7f5b7563e6f3ffe3766d966368c17"
+    path: ""
+- id: "NPM::to-regex:3.0.2"
+  purl: "pkg:npm/to-regex@3.0.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Generate a regex from a string or array of strings."
+  homepage_url: "https://github.com/jonschlinkert/to-regex"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz"
+    hash:
+      value: "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/to-regex.git"
+    revision: "cc5735f98f62c8e9cfb98ae5b309abea1c8a2432"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/to-regex.git"
+    revision: "cc5735f98f62c8e9cfb98ae5b309abea1c8a2432"
+    path: ""
 - id: "NPM::to-regex-range:2.1.1"
   purl: "pkg:npm/to-regex-range@2.1.1"
   authors:
@@ -4187,6 +7540,127 @@ packages:
     type: "Git"
     url: "https://github.com/sindresorhus/trim-right.git"
     revision: "105fb46669afb0deb49d14bd688b276297e59dff"
+    path: ""
+- id: "NPM::union-value:1.0.1"
+  purl: "pkg:npm/union-value@1.0.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Set an array of unique values as the property of an object. Supports\
+    \ setting deeply nested properties using using object-paths/dot notation."
+  homepage_url: "https://github.com/jonschlinkert/union-value"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz"
+    hash:
+      value: "0b6fe7b835aecda61c6ea4d4f02c14221e109847"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/union-value.git"
+    revision: "ae70c7747afc57d6d868fd55f80041e623d2df6a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/union-value.git"
+    revision: "ae70c7747afc57d6d868fd55f80041e623d2df6a"
+    path: ""
+- id: "NPM::unset-value:1.0.0"
+  purl: "pkg:npm/unset-value@1.0.0"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Delete nested properties from an object using dot notation."
+  homepage_url: "https://github.com/jonschlinkert/unset-value"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
+    hash:
+      value: "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/unset-value.git"
+    revision: "36b62353cde18d6be17a1c0dc080fddcc262d2da"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/unset-value.git"
+    revision: "36b62353cde18d6be17a1c0dc080fddcc262d2da"
+    path: ""
+- id: "NPM::urix:0.1.0"
+  purl: "pkg:npm/urix@0.1.0"
+  authors:
+  - "Simon Lydell"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Makes Windows-style paths more unix and URI friendly."
+  homepage_url: "https://github.com/lydell/urix"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+    hash:
+      value: "da937f7a62e21fec1fd18d49b35c2935067a6c72"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lydell/urix.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lydell/urix.git"
+    revision: ""
+    path: ""
+- id: "NPM::use:3.1.1"
+  purl: "pkg:npm/use@3.1.1"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Easily add plugin support to your node.js application."
+  homepage_url: "https://github.com/jonschlinkert/use"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/use/-/use-3.1.1.tgz"
+    hash:
+      value: "d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/use.git"
+    revision: "163104d5c5cc8ed35602625eb90a687df1dbc487"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/use.git"
+    revision: "163104d5c5cc8ed35602625eb90a687df1dbc487"
     path: ""
 - id: "NPM::user-home:1.1.1"
   purl: "pkg:npm/user-home@1.1.1"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile-expected-output.yml
@@ -47,7 +47,7 @@ project:
         - id: "NPM::domhandler:2.4.2"
           dependencies:
           - id: "NPM::domelementtype:1.3.1"
-        - id: "NPM::domutils:1.5.1"
+        - id: "NPM::domutils:1.7.0"
           dependencies:
           - id: "NPM::dom-serializer:0.1.1"
             dependencies:
@@ -476,6 +476,36 @@ packages:
     type: "Git"
     url: "https://github.com/FB55/domutils.git"
     revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
+    path: ""
+- id: "NPM::domutils:1.7.0"
+  purl: "pkg:npm/domutils@1.7.0"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "utilities for working with htmlparser2's dom"
+  homepage_url: "https://github.com/FB55/domutils#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz"
+    hash:
+      value: "56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/FB55/domutils.git"
+    revision: "34f193ca17d11a98d9310b1965efe5f73d32d79f"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/FB55/domutils.git"
+    revision: "34f193ca17d11a98d9310b1965efe5f73d32d79f"
     path: ""
 - id: "NPM::eachr:3.3.0"
   purl: "pkg:npm/eachr@3.3.0"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces-expected-output.yml
@@ -89,6 +89,14 @@ analyzer:
         - id: "NPM::json-stable-stringify:1.0.1"
           dependencies:
           - id: "NPM::jsonify:0.0.0"
+        - id: "PNPM::pnpm-workspaces:1.0.1"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "NPM::json-stable-stringify:1.0.1"
+            dependencies:
+            - id: "NPM::jsonify:0.0.0"
+          - id: "PNPM::pnpm-workspaces:1.0.1"
+            linkage: "PROJECT_DYNAMIC"
     - id: "PNPM::testing-pnpm-package-a:1.0.2"
       definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/src/packages/package-a/package.json"
       authors:

--- a/plugins/package-managers/node/src/funTest/kotlin/pnpm/PnpmFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/pnpm/PnpmFunTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.node
+package org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should

--- a/plugins/package-managers/node/src/funTest/kotlin/yarn2/Yarn2FunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/yarn2/Yarn2FunTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.node
+package org.ossreviewtoolkit.plugins.packagemanagers.node.yarn2
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should

--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -123,11 +123,6 @@ open class Npm(
     protected open fun hasLockfile(projectDir: File) = NodePackageManager.NPM.hasLockfile(projectDir)
 
     /**
-     * Check if [this] represents a workspace within a `node_modules` directory.
-     */
-    protected open fun File.isWorkspaceDir() = isSymbolicLink()
-
-    /**
      * Load the submodule directories of the project defined in [moduleDir].
      */
     protected open fun loadWorkspaceSubmodules(moduleDir: File): Set<File> {
@@ -263,7 +258,7 @@ open class Npm(
     /**
      * Find the directories which are defined as submodules of the project within [moduleDir].
      */
-    protected fun findWorkspaceSubmodules(moduleDir: File): Set<File> =
+    private fun findWorkspaceSubmodules(moduleDir: File): Set<File> =
         submodulesCache.getOrPut(moduleDir.absolutePath) {
             loadWorkspaceSubmodules(moduleDir)
         }
@@ -603,7 +598,7 @@ internal fun parsePackage(
     return module
 }
 
-private fun parseProject(packageJsonFile: File, analysisRoot: File, managerName: String): Project {
+internal fun parseProject(packageJsonFile: File, analysisRoot: File, managerName: String): Project {
     Npm.logger.debug { "Parsing project info from '$packageJsonFile'." }
 
     val packageJson = parsePackageJson(packageJsonFile)

--- a/plugins/package-managers/node/src/main/kotlin/pnpm/ModuleInfo.kt
+++ b/plugins/package-managers/node/src/main/kotlin/pnpm/ModuleInfo.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private val JSON = Json { ignoreUnknownKeys = true }
+
+internal fun parsePnpmList(json: String): List<ModuleInfo> = JSON.decodeFromString(json)
+
+@Serializable
+internal data class ModuleInfo(
+    val name: String,
+    val version: String,
+    val path: String,
+    val private: Boolean,
+    val dependencies: Map<String, Dependency> = emptyMap(),
+    val devDependencies: Map<String, Dependency> = emptyMap(),
+    val optionalDependencies: Map<String, Dependency> = emptyMap()
+) {
+    @Serializable
+    data class Dependency(
+        val from: String,
+        val version: String,
+        val resolved: String? = null,
+        val path: String,
+        val dependencies: Map<String, Dependency> = emptyMap(),
+        val optionalDependencies: Map<String, Dependency> = emptyMap()
+    )
+}

--- a/plugins/package-managers/node/src/main/kotlin/pnpm/Pnpm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/pnpm/Pnpm.kt
@@ -17,13 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.node
+package org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm
 
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.plugins.packagemanagers.node.Npm
 import org.ossreviewtoolkit.plugins.packagemanagers.node.utils.NodePackageManager
 import org.ossreviewtoolkit.plugins.packagemanagers.node.utils.NpmDetection
 import org.ossreviewtoolkit.utils.common.Os

--- a/plugins/package-managers/node/src/main/kotlin/pnpm/PnpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/pnpm/PnpmDependencyHandler.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.utils.DependencyHandler
+import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageJson
+import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackage
+import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackageJson
+import org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm.ModuleInfo.Dependency
+import org.ossreviewtoolkit.utils.common.realFile
+
+internal class PnpmDependencyHandler(private val pnpm: Pnpm) : DependencyHandler<Dependency> {
+    private val workspaceModuleDirs = mutableSetOf<File>()
+    private val packageJsonCache = mutableMapOf<File, PackageJson>()
+
+    private fun Dependency.isProject(): Boolean = isInstalled && workingDir.realFile() in workspaceModuleDirs
+
+    fun setWorkspaceModuleDirs(dirs: Collection<File>) {
+        workspaceModuleDirs.apply {
+            clear()
+            addAll(dirs)
+        }
+    }
+
+    override fun identifierFor(dependency: Dependency): Identifier {
+        val type = pnpm.managerName.takeIf { dependency.isProject() } ?: "NPM"
+        val namespace = dependency.from.substringBeforeLast("/", "")
+        val name = dependency.from.substringAfterLast("/")
+        val version = if (dependency.isProject()) {
+            readPackageJson(dependency.packageJsonFile).version.orEmpty()
+        } else {
+            dependency.version.takeUnless { it.startsWith("link:") || it.startsWith("file:") }.orEmpty()
+        }
+
+        return Identifier(type, namespace, name, version)
+    }
+
+    override fun dependenciesFor(dependency: Dependency): List<Dependency> =
+        (dependency.dependencies + dependency.optionalDependencies).values.filter { it.isInstalled }
+
+    override fun linkageFor(dependency: Dependency): PackageLinkage =
+        PackageLinkage.DYNAMIC.takeUnless { dependency.isProject() } ?: PackageLinkage.PROJECT_DYNAMIC
+
+    override fun createPackage(dependency: Dependency, issues: MutableCollection<Issue>): Package? =
+        dependency.takeUnless { it.isProject() || !it.isInstalled }?.let {
+            parsePackage(
+                workingDir = it.workingDir,
+                packageJsonFile = it.packageJsonFile,
+                getRemotePackageDetails = pnpm::getRemotePackageDetails
+            )
+        }
+
+    private fun readPackageJson(packageJsonFile: File): PackageJson =
+        packageJsonCache.getOrPut(packageJsonFile.realFile()) { parsePackageJson(packageJsonFile) }
+}
+
+private val Dependency.workingDir: File get() = File(path)
+
+private val Dependency.packageJsonFile: File get() = File(path, "package.json")
+
+/**
+ * pnpm install skips optional dependencies which are not compatible with the environment. In this case the path
+ * property points to a non-existing directory. For example, the fsevents package gets skipped under Linux. One could
+ * install such dependencies too, with the --force option, but the documentation says that this also forces updating the
+ * lockfile. Maybe, this can be mitigated by also using --frozen-lockfile. However, the documentation does not explain
+ * how the combination of these two options works.
+ */
+private val Dependency.isInstalled: Boolean get() = workingDir.isDirectory

--- a/plugins/package-managers/node/src/main/resources/META-INF/services/org.ossreviewtoolkit.analyzer.PackageManagerFactory
+++ b/plugins/package-managers/node/src/main/resources/META-INF/services/org.ossreviewtoolkit.analyzer.PackageManagerFactory
@@ -1,4 +1,4 @@
 org.ossreviewtoolkit.plugins.packagemanagers.node.Npm$Factory
-org.ossreviewtoolkit.plugins.packagemanagers.node.Pnpm$Factory
+org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm.Pnpm$Factory
 org.ossreviewtoolkit.plugins.packagemanagers.node.Yarn$Factory
 org.ossreviewtoolkit.plugins.packagemanagers.node.yarn2.Yarn2$Factory


### PR DESCRIPTION
Rewrite large parts of Pnpm from scratch to figure out all information based on `pnpm` CLI output, and
remove the inheritance from `Npm`. 

Part of #9261.