### PR TITLE
chore(model): Avoid a Hoplite deprecation warning

### DIFF
--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model.config
 
 import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.ExperimentalHoplite
 import com.sksamuel.hoplite.PropertySource
 import com.sksamuel.hoplite.addEnvironmentSource
 import com.sksamuel.hoplite.fp.getOrElse
@@ -153,6 +154,7 @@ data class OrtConfiguration(
          * The configuration file is optional and does not have to exist. However, if it exists, but does not
          * contain a valid configuration, an [IllegalArgumentException] is thrown.
          */
+        @OptIn(ExperimentalHoplite::class)
         fun load(args: Map<String, String>? = null, file: File? = null): OrtConfiguration {
             val sources = listOfNotNull(
                 args?.filterKeys { it.startsWith("ort.") }?.takeUnless { it.isEmpty() }?.let {
@@ -174,6 +176,7 @@ data class OrtConfiguration(
                 .addEnvironmentSource()
                 .addPropertySources(sources)
                 .withContextResolverMode(ContextResolverMode.SkipUnresolved)
+                .withExplicitSealedTypes()
                 .build()
 
             val config = loader.loadConfig<OrtConfigurationWrapper>()


### PR DESCRIPTION
This avoids the console output of:

"Hoplite is configured to infer which sealed type to choose by inspecting the config values at runtime. This behaviour is now deprecated in favour of explicitly specifying the type through a discriminator field. In 3.0 this new behavior will become the default. To enable this behavior now (and disable this warning), invoke withExplicitSealedTypes() on the ConfigLoaderBuilder."