### PR TITLE
fix(gradle-plugin): Guard `dependencyResolutionManagement` usage

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -58,11 +58,14 @@ internal class OrtModelBuilder : ToolingModelBuilder {
     override fun canBuild(modelName: String): Boolean = modelName == OrtDependencyTreeModel::class.java.name
 
     override fun buildAll(modelName: String, project: Project): OrtDependencyTreeModel {
-        // There currently is no way to access Gradle settings without using internal API, see
-        // https://github.com/gradle/gradle/issues/18616.
-        val settings = (project.gradle as GradleInternal).settings
+        if (GradleVersion.current() >= GradleVersion.version("6.8")) {
+            // There currently is no way to access Gradle settings without using internal API, see
+            // https://github.com/gradle/gradle/issues/18616.
+            val settings = (project.gradle as GradleInternal).settings
 
-        settings.dependencyResolutionManagement.repositories.associateNamesWithUrlsTo(repositories)
+            settings.dependencyResolutionManagement.repositories.associateNamesWithUrlsTo(repositories)
+        }
+
         project.repositories.associateNamesWithUrlsTo(repositories)
 
         val relevantConfigurations = project.configurations.filter { it.isRelevant() }


### PR DESCRIPTION
Do not use that feature before it was added in Gradle 6.8, see [1]. This is a fixup for 8deb4b3.

Fixes #9282.

[1]: https://docs.gradle.org/6.8/release-notes.html#central-declaration-of-repositories