### PR TITLE
fix(spdx-utils): Accept the "no patent" exception

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -410,7 +410,10 @@ class SpdxLicenseWithExceptionExpression(
     val exception: String
 ) : SpdxSingleLicenseExpression() {
     companion object {
-        private val EXCEPTION_STRING_PATTERN = Regex("\\b(exception|additional-terms)\\b", RegexOption.IGNORE_CASE)
+        private val EXCEPTION_STRING_PATTERN = Regex(
+            "\\b(exception|additional-terms|no-patent)\\b",
+            RegexOption.IGNORE_CASE
+        )
 
         /**
          * Parse a string into an [SpdxLicenseWithExceptionExpression]. Throws an [SpdxException] if the string cannot


### PR DESCRIPTION
See e.g. [1], which is marked as an exception.

[1]: https://scancode-licensedb.aboutcode.org/?search=LicenseRef-scancode-ecma-no-patent