### PR TITLE
ci(release): Increase the timeout for creating the staging repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
         run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
       - name: Build ORT Distributions
         env:


### PR DESCRIPTION
Creating the Sonatype staging repository occasionally fails with a timeout, therefore increase it from the default 1 minute [1] to 5 minutes.

[1]: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#timeouts