### PR TITLE
fix(vulnerable-code): Fix search for Go package vulnerabilities

### DIFF
--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
@@ -27,6 +27,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
@@ -270,6 +271,16 @@ class VulnerableCodeTest : WordSpec({
                 ADVISOR_NAME,
                 enumSetOf(AdvisorCapability.VULNERABILITIES)
             )
+        }
+
+        "assume that Go package names are percent-encoded" {
+            // The code therefore replaces the percent-encoded slashes with actual slashes.
+            // If this assumption is not valid any longer, then this conversion can be removed from the code.
+            val idQuicGo = Identifier("Go::github.com/quic-go/quic-go:0.40.0")
+
+            withClue("Encoding strategy of slashes in Go-purls has changed: ") {
+                idQuicGo.toPurl() shouldBe "pkg:golang/github.com%2Fquic-go%2Fquic-go@0.40.0"
+            }
         }
     }
 


### PR DESCRIPTION
For Go packages, both the namespace and name may contain path segments separated by a "/" character. The purl specification requires these "/" characters to be percent-encoded in the namespace and name components of a purl.
The VulnerableCode bulk-search API is unable to handle these percent-encoded "/" characters, resulting in no vulnerability records being returned.
This bugfix decodes any percent-encoded "/" characters just before making the VulnerableCode query to ensure proper functionality.

Fixes #9298