### PR TITLE
Rename `RootLicenseMatcher` to `PathLicenseMatcher`

### DIFF
--- a/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
-import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
 import org.ossreviewtoolkit.scanner.ScanStorages
@@ -94,7 +94,7 @@ internal class GetPackageLicensesCommand : OrtHelperCommand(
 
             val detectedLicense = curatedFindings.toSpdxExpression()
 
-            val rootLicense = RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+            val rootLicense = PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                 licenseFindings = curatedFindings,
                 directories = listOf("") // TODO: use the proper VCS path.
             ).values.flatten().toSpdxExpression()

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
-import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 
 /**
  * The result of a single scan of a single package.
@@ -51,7 +51,7 @@ data class ScanResult(
 ) {
     /**
      * Filter all detected licenses and copyrights from the [summary] which are underneath [path], and set the [path]
-     * for [provenance]. Findings which [RootLicenseMatcher] assigns as root license files for [path] are also kept.
+     * for [provenance]. Findings which [PathLicenseMatcher] assigns as root license files for [path] are also kept.
      */
     fun filterByPath(path: String): ScanResult =
         when {

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -32,7 +32,7 @@ import java.time.Instant
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.utils.CopyrightFindingSortedSetConverter
 import org.ossreviewtoolkit.model.utils.LicenseFindingSortedSetConverter
-import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 import org.ossreviewtoolkit.model.utils.SnippetFindingSortedSetConverter
 import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
@@ -100,19 +100,19 @@ data class ScanSummary(
 
     /**
      * Filter all detected licenses and copyrights from this [ScanSummary] which are underneath [path]. Findings which
-     * [RootLicenseMatcher] assigns as root license files for [path] are also kept.
+     * [PathLicenseMatcher] assigns as root license files for [path] are also kept.
      */
     fun filterByPath(path: String): ScanSummary = filterByPaths(listOf(path))
 
     /**
      * Filter all detected licenses and copyrights from this [ScanSummary] which are underneath the given [paths].
-     * Findings which [RootLicenseMatcher] assigns as root license files for path in [paths] are also kept.
+     * Findings which [PathLicenseMatcher] assigns as root license files for path in [paths] are also kept.
      */
     fun filterByPaths(paths: Collection<String>): ScanSummary {
         if (paths.any { it.isBlank() }) return this
 
-        val rootLicenseMatcher = RootLicenseMatcher(LicenseFilePatterns.getInstance())
-        val applicableLicenseFiles = rootLicenseMatcher.getApplicableRootLicenseFindingsForDirectories(
+        val pathLicenseMatcher = PathLicenseMatcher(LicenseFilePatterns.getInstance())
+        val applicableLicenseFiles = pathLicenseMatcher.getApplicableLicenseFindingsForDirectories(
             licenseFindings = licenseFindings,
             directories = paths
         ).values.flatten().mapTo(mutableSetOf()) { it.location.path }

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
-import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 import org.ossreviewtoolkit.model.utils.prependedPath
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
@@ -49,10 +49,10 @@ class LicenseInfoResolver(
 ) {
     private val resolvedLicenseInfo = ConcurrentHashMap<Identifier, ResolvedLicenseInfo>()
     private val resolvedLicenseFiles = ConcurrentHashMap<Identifier, ResolvedLicenseFileInfo>()
-    private val rootLicenseMatcher = RootLicenseMatcher(
+    private val pathLicenseMatcher = PathLicenseMatcher(
         licenseFilePatterns = licenseFilePatterns.copy(rootLicenseFilenames = emptyList())
     )
-    private val findingsMatcher = FindingsMatcher(RootLicenseMatcher(licenseFilePatterns))
+    private val findingsMatcher = FindingsMatcher(PathLicenseMatcher(licenseFilePatterns))
 
     /**
      * Get the [ResolvedLicenseInfo] for the project or package identified by [id].
@@ -268,7 +268,7 @@ class LicenseInfoResolver(
             }
 
             val directory = (provenance as? RepositoryProvenance)?.vcsInfo?.path.orEmpty()
-            val rootLicenseFiles = rootLicenseMatcher.getApplicableLicenseFilesForDirectories(
+            val rootLicenseFiles = pathLicenseMatcher.getApplicableLicenseFilesForDirectories(
                 relativeFilePaths = archiveDir.walk().filter { it.isFile }.mapTo(mutableSetOf()) {
                     it.toRelativeString(archiveDir)
                 },

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -40,10 +40,10 @@ import org.ossreviewtoolkit.utils.spdx.toSpdx
 /**
  * A class for matching copyright findings to license findings. Copyright statements may be matched either to license
  * findings located nearby in the same file or to a license found in a license file whereas the given
- * [rootLicenseMatcher] determines whether a file is a license file.
+ * [pathLicenseMatcher] determines whether a file is a license file.
  */
 class FindingsMatcher(
-    private val rootLicenseMatcher: RootLicenseMatcher = RootLicenseMatcher(),
+    private val pathLicenseMatcher: PathLicenseMatcher = PathLicenseMatcher(),
     private val toleranceLines: Int = DEFAULT_TOLERANCE_LINES,
     private val expandToleranceLines: Int = DEFAULT_EXPAND_TOLERANCE_LINES
 ) {
@@ -137,7 +137,7 @@ class FindingsMatcher(
      * Associate the [copyrightFindings] to the [licenseFindings]. Copyright findings are matched to license findings
      * located nearby in the same file. Copyright findings that are not located close to a license finding are
      * associated to the root licenses instead. The root licenses are the licenses found in any of the license files
-     * defined by [rootLicenseMatcher].
+     * defined by [pathLicenseMatcher].
      */
     fun match(licenseFindings: Set<LicenseFinding>, copyrightFindings: Set<CopyrightFinding>): FindingsMatcherResult {
         val licenseFindingsByPath = licenseFindings.groupBy { it.location.path }
@@ -172,7 +172,7 @@ class FindingsMatcher(
         licenseFindings: Set<LicenseFinding>,
         copyrightFindings: Set<CopyrightFinding>
     ): Map<LicenseFinding, Set<CopyrightFinding>> {
-        val rootLicensesForDirectories = rootLicenseMatcher.getApplicableRootLicenseFindingsForDirectories(
+        val rootLicensesForDirectories = pathLicenseMatcher.getApplicableLicenseFindingsForDirectories(
             licenseFindings = licenseFindings,
             directories = copyrightFindings.map { it.location.directory() }
         )

--- a/model/src/main/kotlin/utils/PathLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/PathLicenseMatcher.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.utils.common.getAllAncestorDirectories
  *
  * Patent files are assigned in an analog way, but without any fallback pattern.
  */
-class RootLicenseMatcher(licenseFilePatterns: LicenseFilePatterns = LicenseFilePatterns.DEFAULT) {
+class PathLicenseMatcher(licenseFilePatterns: LicenseFilePatterns = LicenseFilePatterns.DEFAULT) {
     private val licenseFileMatcher = createFileMatcher(licenseFilePatterns.licenseFilenames)
     private val patentFileMatcher = createFileMatcher(licenseFilePatterns.patentFilenames)
     private val rootLicenseFileMatcher = createFileMatcher(licenseFilePatterns.rootLicenseFilenames)
@@ -52,7 +52,7 @@ class RootLicenseMatcher(licenseFilePatterns: LicenseFilePatterns = LicenseFileP
      * applicable to the respective directory. The values of the map entries are subsets of the given
      * [licenseFindings].
      */
-    fun getApplicableRootLicenseFindingsForDirectories(
+    fun getApplicableLicenseFindingsForDirectories(
         licenseFindings: Collection<LicenseFinding>,
         directories: Collection<String>
     ): Map<String, Set<LicenseFinding>> {
@@ -60,8 +60,8 @@ class RootLicenseMatcher(licenseFilePatterns: LicenseFilePatterns = LicenseFileP
 
         return getApplicableLicenseFilesForDirectories(
             licenseFindingsByPath.keys, directories
-        ).mapValues { (_, rootLicenseFilePath) ->
-            rootLicenseFilePath.flatMapTo(mutableSetOf()) { licenseFindingsByPath.getValue(it) }
+        ).mapValues { (_, licenseFilePath) ->
+            licenseFilePath.flatMapTo(mutableSetOf()) { licenseFindingsByPath.getValue(it) }
         }
     }
 

--- a/model/src/test/kotlin/utils/PathLicenseMatcherTest.kt
+++ b/model/src/test/kotlin/utils/PathLicenseMatcherTest.kt
@@ -45,10 +45,10 @@ private val COMMONLY_USED_LICENSE_FILE_NAMES = listOf(
     "unlicense"
 )
 
-class RootLicenseMatcherTest : WordSpec({
+class PathLicenseMatcherTest : WordSpec({
     "getApplicableLicenseFilesForDirectories" should {
         "override license files of ancestors as expected" {
-            RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+            PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                 licenseFindings = licenseFindings(
                     "README",
                     "PATENTS",
@@ -68,7 +68,7 @@ class RootLicenseMatcherTest : WordSpec({
         }
 
         "not use the readme if there is a license file" {
-            RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+            PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                 licenseFindings = licenseFindings(
                     "README",
                     "LICENSE"
@@ -78,7 +78,7 @@ class RootLicenseMatcherTest : WordSpec({
         }
 
         "use the readme if there is no license but a patents file" {
-            RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+            PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                 licenseFindings = licenseFindings(
                     "README",
                     "PATENTS"
@@ -89,7 +89,7 @@ class RootLicenseMatcherTest : WordSpec({
 
         "match commonly used license file paths in lower-case" {
             COMMONLY_USED_LICENSE_FILE_NAMES.map { it.lowercase() }.forAll {
-                RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+                PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                     licenseFindings = licenseFindings(it),
                     directories = listOf("")
                 ).paths() shouldBe mapOf("" to setOf(it))
@@ -98,7 +98,7 @@ class RootLicenseMatcherTest : WordSpec({
 
         "match commonly used license file paths in upper-case" {
             COMMONLY_USED_LICENSE_FILE_NAMES.map { it.uppercase() }.forAll {
-                RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+                PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                     licenseFindings = licenseFindings(it),
                     directories = listOf("")
                 ).paths() shouldBe mapOf("" to setOf(it))
@@ -107,7 +107,7 @@ class RootLicenseMatcherTest : WordSpec({
 
         "match commonly used license file paths in capital-case" {
             COMMONLY_USED_LICENSE_FILE_NAMES.map { it.uppercaseFirstChar() }.forAll {
-                RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+                PathLicenseMatcher().getApplicableLicenseFindingsForDirectories(
                     licenseFindings = licenseFindings(it),
                     directories = listOf("")
                 ).paths() shouldBe mapOf("" to setOf(it))

--- a/model/src/test/kotlin/utils/RootLicenseMatcherTest.kt
+++ b/model/src/test/kotlin/utils/RootLicenseMatcherTest.kt
@@ -17,13 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model
+package org.ossreviewtoolkit.model.utils
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.utils.common.uppercaseFirstChar
 
 private val COMMONLY_USED_LICENSE_FILE_NAMES = listOf(

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -48,7 +48,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
-import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 import org.ossreviewtoolkit.model.utils.filterByVcsPath
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -78,7 +78,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private val vulnerabilitiesResolutions = mutableListOf<VulnerabilityResolution>()
 
     private val curationsMatcher = FindingCurationMatcher()
-    private val findingsMatcher = FindingsMatcher(RootLicenseMatcher(input.ortConfig.licenseFilePatterns))
+    private val findingsMatcher = FindingsMatcher(PathLicenseMatcher(input.ortConfig.licenseFilePatterns))
 
     private data class PackageExcludeInfo(
         var id: Identifier,


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 