### PR TITLE
fix(cyclonedx): Sanitize copyrights for the CycloneDX XML report

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ asciidoctorj = "3.0.0"
 asciidoctorjPdf = "2.3.18"
 clikt = "5.0.1"
 commonsCompress = "1.27.1"
+commonsText = "1.12.0"
 cvssCalculator = "1.4.3"
 cyclonedx = "9.1.0"
 diffUtils = "4.12"
@@ -90,6 +91,7 @@ asciidoctorj-pdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = 
 awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
+commonsText = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }
 cvssCalculator = { module = "us.springett:cvss-calculator", version.ref = "cvssCalculator" }
 cyclonedx = { module = "org.cyclonedx:cyclonedx-core-java", version.ref = "cyclonedx" }
 detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detektPlugin" }

--- a/plugins/reporters/cyclonedx/build.gradle.kts
+++ b/plugins/reporters/cyclonedx/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
+    implementation(libs.commonsText)
+
     funTestImplementation(testFixtures(projects.reporter))
 
     funTestImplementation(libs.kotest.assertions.json)

--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
@@ -42,6 +42,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.PluginConfiguration
 import org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporter.Companion.REPORT_BASE_FILENAME
 import org.ossreviewtoolkit.reporter.ORT_RESULT
+import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_ILLEGAL_COPYRIGHTS
 import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_VULNERABILITIES
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.Options
@@ -99,6 +100,18 @@ class CycloneDxReporterFunTest : WordSpec({
 
                     val actualBom = bomFile.readText().patchCycloneDxResult().normalizeLineBreaks()
                     actualBom shouldBe expectedBom
+                }
+            }
+        }
+
+        "the expected XML file even if some copyrights contain non printable characters" {
+            val jsonOptions = optionSingle + mapOf("output.file.formats" to "xml")
+            val bomFileResults = CycloneDxReporter().generateReport(ORT_RESULT_WITH_ILLEGAL_COPYRIGHTS, jsonOptions)
+
+            bomFileResults.shouldBeSingleton {
+                it shouldBeSuccess { bomFile ->
+                    bomFile shouldBe aFile()
+                    bomFile shouldNotBe emptyFile()
                 }
             }
         }

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -24,6 +24,7 @@ import java.util.Date
 import java.util.SortedSet
 import java.util.UUID
 
+import org.apache.commons.text.StringEscapeUtils
 import org.apache.logging.log4j.kotlin.logger
 
 import org.cyclonedx.Format
@@ -341,7 +342,9 @@ class CycloneDxReporter : Reporter {
 
             // TODO: Find a way to associate copyrights to the license they belong to, see
             //       https://github.com/CycloneDX/cyclonedx-core-java/issues/58
-            copyright = resolvedLicenseInfo.getCopyrights().joinToString().takeUnless { it.isEmpty() }
+            copyright = StringEscapeUtils.escapeXml11(
+                resolvedLicenseInfo.getCopyrights().joinToString().takeUnless { it.isEmpty() }
+            )
 
             purl = pkg.purl + purlQualifier
             isModified = pkg.isModified

--- a/reporter/src/testFixtures/kotlin/TestData.kt
+++ b/reporter/src/testFixtures/kotlin/TestData.kt
@@ -427,4 +427,31 @@ val ADVISOR_WITH_VULNERABILITIES = AdvisorRun(
     )
 )
 
+val SCANNER_WITH_ILLEGAL_COPYRIGHTS = scannerRunOf(
+    Identifier("NPM:@ort:no-license-file:1.0") to listOf(
+        ScanResult(
+            provenance = UnknownProvenance,
+            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+            summary = ScanSummary.EMPTY.copy(
+                licenseFindings = setOf(
+                    LicenseFinding(
+                        license = "MIT",
+                        location = TextLocation("file", 1)
+                    )
+                ),
+                copyrightFindings = setOf(
+                    CopyrightFinding(
+                        statement = "Portions created by the Initial Developer are Copyright (c) 2002 the Initial " +
+                            "Developer, holder is Tim Hudson (tjh@cryptsoft.com), Objc, (c) Objv, " +
+                            "\u0002 \u0002 \u0001A\u0002\u0002\u0001o\u0002\u0012 AB, Copyright (c)",
+                        location = TextLocation("file", 1)
+                    )
+                )
+            )
+        )
+    )
+)
+
 val ORT_RESULT_WITH_VULNERABILITIES = ORT_RESULT.copy(advisor = ADVISOR_WITH_VULNERABILITIES)
+
+val ORT_RESULT_WITH_ILLEGAL_COPYRIGHTS = ORT_RESULT.copy(scanner = SCANNER_WITH_ILLEGAL_COPYRIGHTS)


### PR DESCRIPTION
Some characters in copyrights cannot be outputted to XML. Therefore, sanitize the copyrights content for XML.

This fixes the following exception:

> org.cyclonedx.exception.GeneratorException: com.fasterxml.jackson.databind.JsonMappingException: Invalid white space character (0x1) in text to output (in xml 1.1, could output as a character entity) (through reference chain: org.cyclonedx.model.Bom["component"]->java.util.ArrayList[164]->org.cyclonedx.model.Component["copyright"])	at org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporter.writeBom(CycloneDxReporter.kt:369)	at org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporterKt.access$generateBom(CycloneDxReporter.kt:1)	at org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporterKt.generateBom(CycloneDxReporter.kt:394)	at org.cyclonedx.generators.xml.BomXmlGenerator.toXmlString(BomXmlGenerator.java:131)	at org.cyclonedx.generators.xml.BomXmlGenerator.toXML(BomXmlGenerator.java:116) 