### PR TITLE
fix(pub): Support deserializing hosted deps without version constraint

### DIFF
--- a/plugins/package-managers/pub/src/main/kotlin/model/Pubspec.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/model/Pubspec.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.packagemanagers.pub.model
 import com.charleskorn.kaml.YamlInput
 import com.charleskorn.kaml.YamlMap
 import com.charleskorn.kaml.YamlNode
+import com.charleskorn.kaml.YamlNull
 import com.charleskorn.kaml.YamlScalar
 import com.charleskorn.kaml.yamlMap
 import com.charleskorn.kaml.yamlScalar
@@ -71,7 +72,7 @@ internal data class Pubspec(
     /** See https://dart.dev/tools/pub/dependencies#hosted-packages. */
     @Serializable
     data class HostedDependency(
-        val version: String,
+        val version: String?,
         val url: String? = null
     ) : Dependency
 
@@ -113,6 +114,9 @@ private object DependencyMapSerializer : KSerializer<Map<String, Dependency>> by
 
     private fun YamlNode.decodeDependency(): Dependency {
         if (this is YamlScalar) return HostedDependency(yamlScalar.content)
+        // https://dart.dev/tools/pub/dependencies says that "The version constraint is optional but recommended. If no
+        // version constraint is given, any is assumed.".
+        if (this is YamlNull) return HostedDependency(version = null)
 
         yamlMap.get<YamlNode>("hosted")?.let { hosted ->
             val version = checkNotNull(yamlMap.get<YamlScalar>("version")).content

--- a/plugins/package-managers/pub/src/test/kotlin/model/PubspecTest.kt
+++ b/plugins/package-managers/pub/src/test/kotlin/model/PubspecTest.kt
@@ -52,7 +52,8 @@ class PubspecTest : WordSpec({
                     hosted:
                       name: pkg-3
                       url: https://some-other-package-server.com
-                    version: ^1.4.0  
+                    version: ^1.4.0
+                  pkg-4:
             """.trimIndent()
 
             parsePubspec(yaml).dependencies shouldBe mapOf(
@@ -66,6 +67,10 @@ class PubspecTest : WordSpec({
                 "pkg-3" to HostedDependency(
                     url = "https://some-other-package-server.com",
                     version = "^1.4.0"
+                ),
+                "pkg-4" to HostedDependency(
+                    url = null,
+                    version = null
                 )
             )
         }


### PR DESCRIPTION
Fixes #9310.

