### PR TITLE
refactor(npm): Remove unused parallelization constructs

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/Npm.kt
@@ -245,10 +245,6 @@ open class Npm(
      * content via the `npm view` command. The result is a [Pair] with the raw identifier and the new package.
      */
     internal fun parsePackage(workingDir: File, packageJsonFile: File): Package {
-        val packageDir = packageJsonFile.parentFile
-
-        logger.debug { "Found a 'package.json' file in '$packageDir'." }
-
         val packageJson = parsePackageJson(packageJsonFile)
 
         // The "name" and "version" fields are only required if the package is going to be published, otherwise they are

--- a/plugins/package-managers/node/src/main/kotlin/utils/NpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/utils/NpmDependencyHandler.kt
@@ -28,7 +28,6 @@ import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.plugins.packagemanagers.node.Npm
-import org.ossreviewtoolkit.utils.ort.runBlocking
 
 /**
  * A data class storing information about a specific NPM module and its dependencies.
@@ -76,7 +75,5 @@ internal class NpmDependencyHandler(private val npm: Npm) : DependencyHandler<Np
         PackageLinkage.DYNAMIC.takeUnless { dependency.isProject } ?: PackageLinkage.PROJECT_DYNAMIC
 
     override fun createPackage(dependency: NpmModuleInfo, issues: MutableCollection<Issue>): Package? =
-        runBlocking {
-            npm.takeUnless { dependency.isProject }?.parsePackage(dependency.workingDir, dependency.packageFile)
-        }
+        npm.takeUnless { dependency.isProject }?.parsePackage(dependency.workingDir, dependency.packageFile)
 }


### PR DESCRIPTION
The code looks like it would run things in parallel, but it executes `getRemotePackageDetails()` strictly sequentially. The pull request which had introduced these constructs [1] also introduced the caching. So, the speed-up observed back then was probably solely due to the added cache. Remove the parallelization constructs to not mislead the reader and to simplify.

[1]: https://github.com/oss-review-toolkit/ort/pull/6009

Part of #9261.
