### PR TITLE
fix(jenkins): Allow to select DOS as a project and package scanner

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
         choice(
             name: 'PROJECT_SCANNER',
             description: 'The built-in scanner to use for project source code.',
-            choices: ['ScanCode', 'Askalono', 'BoyterLc', 'Licensee', 'ScanOSS', '<NONE>']
+            choices: ['ScanCode', 'DOS', 'Askalono', 'BoyterLc', 'Licensee', 'ScanOSS', '<NONE>']
         )
 
         string(
@@ -228,7 +228,7 @@ pipeline {
         choice(
             name: 'PACKAGE_SCANNER',
             description: 'The scanner to use for package source code.',
-            choices: ['ScanCode', 'Askalono', 'BoyterLc', 'Licensee', 'ScanOSS', '<NONE>']
+            choices: ['ScanCode', 'DOS', 'Askalono', 'BoyterLc', 'Licensee', 'ScanOSS', '<NONE>']
         )
 
         string(


### PR DESCRIPTION
This is a fixup for ae0ca85.