### PR TITLE
docs(integrations): Fix README.md to include required plugin for Jenkins >= 2.462.3

### DIFF
--- a/integrations/jenkins/README.md
+++ b/integrations/jenkins/README.md
@@ -6,6 +6,7 @@ This example allows you to run ORT in a [Jenkins](https://www.jenkins.io/) [pipe
 
 Please follow the regular [installation instructions](https://www.jenkins.io/doc/book/installing/) and additionally ensure to have the following Jenkins plugins installed:
 
+* [Copy Artifact](https://plugins.jenkins.io/copyartifact/)
 * [Docker Pipeline](https://plugins.jenkins.io/docker-workflow)
 * [File Parameter](https://plugins.jenkins.io/file-parameters/)
 * [Pipeline Utility Steps](https://plugins.jenkins.io/pipeline-utility-steps)


### PR DESCRIPTION
Add [Copy Artifact](https://plugins.jenkins.io/copyartifact/) as a required plugin since it's not installed/enabled by default in Jenkins >= 2.462.3

Signed-off-by: Grigori Prokhorov <hello@feinberg.it>