### PR TITLE
fix(jenkins): Do not use deprecated config key names

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -476,11 +476,11 @@ pipeline {
                     cat >"$ORT_CONFIG_DIR/config.yml" <<EOF
                 ort:
                   packageCurationProviders:
-                    - name: DefaultFile
-                    - name: DefaultDir
-                    - name: OrtConfig
+                    - type: DefaultFile
+                    - type: DefaultDir
+                    - type: OrtConfig
                       enabled: ${USE_ORT_CONFIG_CURATIONS}
-                    - name: ClearlyDefined
+                    - type: ClearlyDefined
                       enabled: ${USE_CLEARLY_DEFINED_CURATIONS}
                 EOF
                 fi


### PR DESCRIPTION
This is a fixup for e4e8396.