### PR TITLE
Revert "refactor(script): Migrate from deprecated `constructorArgs` to properties"

### DIFF
--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -21,9 +21,8 @@ package org.ossreviewtoolkit.evaluator
 
 import java.time.Instant
 
-import kotlin.script.experimental.api.KotlinType
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
-import kotlin.script.experimental.api.providedProperties
+import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
 
@@ -43,20 +42,10 @@ class Evaluator(
     licenseClassifications: LicenseClassifications = LicenseClassifications(),
     time: Instant = Instant.now()
 ) : ScriptRunner() {
-    private val customProperties = mapOf(
-        "ortResult" to ortResult,
-        "licenseInfoResolver" to licenseInfoResolver,
-        "resolutionProvider" to resolutionProvider,
-        "licenseClassifications" to licenseClassifications,
-        "time" to time
-    )
-
-    override val compConfig = createJvmCompilationConfigurationFromTemplate<RulesScriptTemplate> {
-        providedProperties(customProperties.mapValues { (_, v) -> KotlinType(v::class) })
-    }
+    override val compConfig = createJvmCompilationConfigurationFromTemplate<RulesScriptTemplate>()
 
     override val evalConfig = ScriptEvaluationConfiguration {
-        providedProperties(customProperties)
+        constructorArgs(ortResult, licenseInfoResolver, resolutionProvider, licenseClassifications, time)
         scriptsInstancesSharing(true)
     }
 

--- a/evaluator/src/main/kotlin/RulesScriptTemplate.kt
+++ b/evaluator/src/main/kotlin/RulesScriptTemplate.kt
@@ -19,11 +19,17 @@
 
 package org.ossreviewtoolkit.evaluator
 
+import java.time.Instant
+
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.defaultImports
 
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
+import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
 
 @KotlinScript(
@@ -31,7 +37,13 @@ import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
     fileExtension = "rules.kts",
     compilationConfiguration = RulesScriptCompilationConfiguration::class
 )
-open class RulesScriptTemplate {
+open class RulesScriptTemplate(
+    val ortResult: OrtResult,
+    val licenseInfoResolver: LicenseInfoResolver,
+    val resolutionProvider: ResolutionProvider,
+    val licenseClassifications: LicenseClassifications,
+    val time: Instant
+) {
     val ruleViolations = mutableListOf<RuleViolation>()
 }
 

--- a/notifier/src/main/kotlin/NotificationsScriptTemplate.kt
+++ b/notifier/src/main/kotlin/NotificationsScriptTemplate.kt
@@ -23,6 +23,7 @@ import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.defaultImports
 
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
 
 @KotlinScript(
@@ -30,7 +31,9 @@ import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
     fileExtension = "notifications.kts",
     compilationConfiguration = NotificationsScriptCompilationConfiguration::class
 )
-open class NotificationsScriptTemplate
+open class NotificationsScriptTemplate(
+    val ortResult: OrtResult
+)
 
 class NotificationsScriptCompilationConfiguration : ScriptCompilationConfiguration(
     OrtScriptCompilationConfiguration(),

--- a/notifier/src/main/kotlin/Notifier.kt
+++ b/notifier/src/main/kotlin/Notifier.kt
@@ -23,6 +23,7 @@ import java.time.Instant
 
 import kotlin.script.experimental.api.KotlinType
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
+import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.providedProperties
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
@@ -42,8 +43,6 @@ class Notifier(
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider()
 ) : ScriptRunner() {
     private val customProperties = buildMap {
-        put("ortResult", ortResult)
-
         config.mail?.let { put("mailClient", MailNotifier(it)) }
         config.jira?.let { put("jiraClient", JiraNotifier(it)) }
 
@@ -55,8 +54,10 @@ class Notifier(
     }
 
     override val evalConfig = ScriptEvaluationConfiguration {
-        providedProperties(customProperties)
+        constructorArgs(ortResult)
         scriptsInstancesSharing(true)
+
+        providedProperties(customProperties)
     }
 
     fun run(script: String): NotifierRun {

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -19,10 +19,9 @@
 
 package org.ossreviewtoolkit.reporter
 
-import kotlin.script.experimental.api.KotlinType
 import kotlin.script.experimental.api.ResultValue
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
-import kotlin.script.experimental.api.providedProperties
+import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
 
@@ -55,14 +54,10 @@ fun interface HowToFixTextProvider {
 }
 
 private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner() {
-    private val customProperties = mapOf("ortResult" to ortResult)
-
-    override val compConfig = createJvmCompilationConfigurationFromTemplate<HowToFixTextProviderScriptTemplate> {
-        providedProperties(customProperties.mapValues { (_, v) -> KotlinType(v::class) })
-    }
+    override val compConfig = createJvmCompilationConfigurationFromTemplate<HowToFixTextProviderScriptTemplate>()
 
     override val evalConfig = ScriptEvaluationConfiguration {
-        providedProperties(customProperties)
+        constructorArgs(ortResult)
         scriptsInstancesSharing(true)
     }
 

--- a/reporter/src/main/kotlin/HowToFixTextProviderScriptTemplate.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProviderScriptTemplate.kt
@@ -23,6 +23,7 @@ import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.defaultImports
 
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
 
 @KotlinScript(
@@ -30,7 +31,9 @@ import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
     fileExtension = "how-to-fix-text-provider.kts",
     compilationConfiguration = HowToFixTextProviderScriptCompilationConfiguration::class
 )
-open class HowToFixTextProviderScriptTemplate
+open class HowToFixTextProviderScriptTemplate(
+    val ortResult: OrtResult
+)
 
 class HowToFixTextProviderScriptCompilationConfiguration : ScriptCompilationConfiguration(
     OrtScriptCompilationConfiguration(),


### PR DESCRIPTION
This reverts commit 8451714 as IntelliJ still does not properly highlight the syntax / auto-complete with the change, see [1].

The original reason to do 8451714 was meanwhile fixed with Kotlin 2.0.20, see [2], so it should be safe to revert.

[1]: https://youtrack.jetbrains.com/issue/KTIJ-30059
[2]: https://youtrack.jetbrains.com/issue/KT-68336