### PR TITLE
fix(node): Deserialize `repository: {}` in `package.json` to `null`

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
+++ b/plugins/package-managers/node/src/main/kotlin/PackageJson.kt
@@ -74,6 +74,13 @@ private fun transformPackageJson(element: JsonElement): JsonElement {
     val entries = obj.entries.associateTo(mutableMapOf()) { it.toPair() }.apply {
         remove("license")
         put("licenses", JsonArray(licenses.map { JsonPrimitive(it) }))
+
+        (obj["repository"] as? JsonObject)?.let { repository ->
+            // A repository object node without a `url` does not make sense. However, some packages use 'repository: {}'
+            // to describe the absence of a repository, see https://github.com/oss-review-toolkit/ort/issues/9378.
+            // Remove the repository node, so that Repository.url can remain non-nullable.
+            if ("url" !in repository.keys) remove("repository")
+        }
     }
 
     return JsonObject(entries)

--- a/plugins/package-managers/node/src/test/kotlin/PackageJsonTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/PackageJsonTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.packagemanagers.node
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 class PackageJsonTest : WordSpec({
     "parsePackageJson()" should {
@@ -67,6 +68,18 @@ class PackageJsonTest : WordSpec({
                 "Jane Doe <jane.doe@example.com>",
                 "John Doe"
             )
+        }
+
+        "deserialize the repository from an empty node" {
+            val json = """
+            {
+                "repository": {}
+            }
+            """.trimIndent()
+
+            val packageJson = parsePackageJson(json)
+
+            packageJson.repository shouldBe null
         }
     }
 })


### PR DESCRIPTION
A repository node wihtout a `url` does not make any sense. So, simply discard such nodes to not throw a `MissingFieldException` while keeping `Repository.url` non-nullable.

Fixes #9378.

