### PR TITLE
fix(clearly-defined): Consistently use ORT's OkHttp client for requests

### DIFF
--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -37,6 +37,7 @@ import kotlinx.serialization.json.decodeFromStream
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
+import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class ClearlyDefinedServiceFunTest : WordSpec({
@@ -62,7 +63,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         )
 
         "return single curation data" {
-            val service = ClearlyDefinedService.create()
+            val service = ClearlyDefinedService.create(client = okHttpClient)
 
             val curation = service.getCuration(coordinates)
 
@@ -70,7 +71,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         }
 
         "return bulk curation data" {
-            val service = ClearlyDefinedService.create()
+            val service = ClearlyDefinedService.create(client = okHttpClient)
 
             val curations = service.getCurations(listOf(coordinates))
             val curation = curations[coordinates]?.curations?.get(coordinates)
@@ -114,7 +115,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         // Disable this test by default as it talks to the real development instance of ClearlyDefined and creates
         // pull-requests at https://github.com/clearlydefined/curated-data-dev.
         "return a summary of the created pull-request".config(enabled = false) {
-            val service = ClearlyDefinedService.create(Server.DEVELOPMENT)
+            val service = ClearlyDefinedService.create(Server.DEVELOPMENT, okHttpClient)
 
             val summary = service.putCuration(ContributionPatch(info, listOf(patch)))
 
@@ -127,7 +128,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
 
     "Definitions" should {
         "contain facets for file entries" {
-            val service = ClearlyDefinedService.create()
+            val service = ClearlyDefinedService.create(client = okHttpClient)
             val coordinates = Coordinates(
                 type = ComponentType.NPM,
                 provider = Provider.NPM_JS,

--- a/plugins/commands/upload-curations/src/main/kotlin/UploadCurationsCommand.kt
+++ b/plugins/commands/upload-curations/src/main/kotlin/UploadCurationsCommand.kt
@@ -53,7 +53,7 @@ import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.utils.common.expandTilde
-import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.ossreviewtoolkit.utils.ort.runBlocking
 
 class UploadCurationsCommand : OrtCommand(
@@ -74,7 +74,7 @@ class UploadCurationsCommand : OrtCommand(
         help = "The ClearlyDefined server to upload to. Must be one of ${Server.entries.map { it.name }}."
     ).enum<Server>().default(Server.DEVELOPMENT)
 
-    private val service by lazy { ClearlyDefinedService.create(server, OkHttpClientHelper.buildClient()) }
+    private val service by lazy { ClearlyDefinedService.create(server, okHttpClient) }
 
     override fun run() {
         val allCurations = inputFile.readValueOrDefault(emptyList<PackageCuration>())

--- a/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.ossreviewtoolkit.utils.ort.runBlocking
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression.Strictness
@@ -86,7 +86,7 @@ class ClearlyDefinedPackageCurationProvider(
     )
 
     private val service by lazy {
-        ClearlyDefinedService.create(config.serverUrl, client ?: OkHttpClientHelper.buildClient())
+        ClearlyDefinedService.create(config.serverUrl, client ?: okHttpClient)
     }
 
     override fun getCurationsFor(packages: Collection<Package>): Set<PackageCuration> {

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -56,7 +56,7 @@ import org.ossreviewtoolkit.scanner.storages.utils.getScanCodeDetails
 import org.ossreviewtoolkit.utils.common.AlphaNumericComparator
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.withoutPrefix
-import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.ossreviewtoolkit.utils.ort.runBlocking
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -79,7 +79,7 @@ class ClearlyDefinedStorage(
 
     /** The service for interacting with ClearlyDefined. */
     private val service by lazy {
-        ClearlyDefinedService.create(config.serverUrl, client ?: OkHttpClientHelper.buildClient())
+        ClearlyDefinedService.create(config.serverUrl, client ?: okHttpClient)
     }
 
     override fun readInternal(pkg: Package, scannerMatcher: ScannerMatcher?): Result<List<ScanResult>> =


### PR DESCRIPTION
That client has a higher read timeout value and properly sets the user agent.