### PR TITLE
fix(vulnerable-code): Still get vulnerabilities for which a fix exists

### DIFF
--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
@@ -147,6 +147,18 @@ class VulnerableCodeTest : WordSpec({
                             vector = null
                         )
                     )
+                ),
+                Vulnerability(
+                    id = "CVE-2009-2459",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2014-8242"),
+                            scoringSystem = "cvssv3.1",
+                            severity = "MEDIUM",
+                            score = 6.0f,
+                            vector = null
+                        )
+                    )
                 )
             )
             strutsResult.vulnerabilities should containExactlyInAnyOrder(expStrutsVulnerabilities)


### PR DESCRIPTION
Even if for a vulnerability a fix is available (in a later version of the package) the checked version of the package stays vulnerable, so still list fixed vulnerabilities.