### PR TITLE
refactor: More explicit Provenance Handling

### DIFF
--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -169,7 +169,9 @@ internal fun OrtResult.getLicenseFindingsById(
             packageConfigurationProvider.getPackageConfigurations(id, provenance).flatMap { it.licenseFindingCurations }
         }
 
-    getScanResultsForId(id).filter { it.provenance is KnownProvenance }.map {
+    getScanResultsForId(id).filter {
+        it.provenance is RepositoryProvenance || it.provenance is ArtifactProvenance
+    }.map {
         // If a VCS path curation has been applied after the scanning stage, it is possible to apply that
         // curation without re-scanning in case the new VCS path is a subdirectory of the scanned VCS path.
         // So, filter by VCS path to enable the user to see the effect on the detected license with a shorter

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -108,7 +108,7 @@ data class ScannerRun(
 
     init {
         scanResults.forEach { scanResult ->
-            require(scanResult.provenance is KnownProvenance) {
+            require(scanResult.provenance is RepositoryProvenance || scanResult.provenance is ArtifactProvenance) {
                 "Found a scan result with an unknown provenance, which is not allowed."
             }
 

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -19,11 +19,11 @@
 
 package org.ossreviewtoolkit.model.licenses
 
+import org.ossreviewtoolkit.model.ArtifactProvenance
 import java.util.concurrent.ConcurrentHashMap
 
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -264,7 +264,8 @@ class LicenseInfoResolver(
 
             when (provenance) {
                 is UnknownProvenance -> return@forEach
-                is KnownProvenance -> if (!archiver.unarchive(archiveDir, provenance)) return@forEach
+                is RepositoryProvenance -> if (!archiver.unarchive(archiveDir, provenance)) return@forEach
+                is ArtifactProvenance -> if (!archiver.unarchive(archiveDir, provenance)) return@forEach
             }
 
             val directory = (provenance as? RepositoryProvenance)?.vcsInfo?.path.orEmpty()

--- a/model/src/main/kotlin/utils/FileProvenanceFileStorage.kt
+++ b/model/src/main/kotlin/utils/FileProvenanceFileStorage.kt
@@ -81,6 +81,7 @@ private fun KnownProvenance.hash(): String {
     val key = when (this) {
         is ArtifactProvenance -> "${sourceArtifact.url}${sourceArtifact.hash.value}"
         is RepositoryProvenance -> "${vcsInfo.type}${vcsInfo.url}$resolvedRevision"
+        else -> ""
     }
 
     return HashAlgorithm.SHA1.calculate(key.toByteArray())

--- a/model/src/main/kotlin/utils/PostgresProvenanceFileStorage.kt
+++ b/model/src/main/kotlin/utils/PostgresProvenanceFileStorage.kt
@@ -120,4 +120,5 @@ private fun KnownProvenance.storageKey(): String =
         is ArtifactProvenance -> "source-artifact|${sourceArtifact.url}|${sourceArtifact.hash}"
         // The trailing "|" is kept for backward compatibility because there used to be an additional parameter.
         is RepositoryProvenance -> "vcs|${vcsInfo.type}|${vcsInfo.url}|$resolvedRevision|"
+        else -> ""
     }

--- a/scanner/src/funTest/kotlin/provenance/AbstractNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/AbstractNestedProvenanceStorageFunTest.kt
@@ -23,7 +23,6 @@ import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -78,6 +77,6 @@ private fun createRepositoryProvenance(
 ) = RepositoryProvenance(vcsInfo, resolvedRevision)
 
 private fun createNestedProvenance(
-    root: KnownProvenance,
+    root: RepositoryProvenance,
     subRepositories: Map<String, RepositoryProvenance> = emptyMap()
 ) = NestedProvenance(root, subRepositories)

--- a/scanner/src/main/kotlin/storages/ProvenanceBasedFileStorage.kt
+++ b/scanner/src/main/kotlin/storages/ProvenanceBasedFileStorage.kt
@@ -80,7 +80,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
 
         requireEmptyVcsPath(provenance)
 
-        if (provenance !is KnownProvenance) {
+        if (provenance !is RepositoryProvenance && provenance !is ArtifactProvenance) {
             throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
         }
 

--- a/scanner/src/main/kotlin/storages/ProvenanceBasedPostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/ProvenanceBasedPostgresStorage.kt
@@ -136,7 +136,7 @@ class ProvenanceBasedPostgresStorage(
 
         requireEmptyVcsPath(provenance)
 
-        if (provenance !is KnownProvenance) {
+        if (provenance !is RepositoryProvenance && provenance !is ArtifactProvenance) {
             throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
         }
 

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -152,7 +152,9 @@ fun readOrtResult(file: File) = file.mapper().readValue<OrtResult>(patchExpected
 fun scannerRunOf(vararg pkgScanResults: Pair<Identifier, List<ScanResult>>): ScannerRun {
     val pkgScanResultsWithKnownProvenance = pkgScanResults.associate { (id, scanResultsForId) ->
         id to scanResultsForId.map { scanResult ->
-            scanResult.takeIf { scanResult.provenance is KnownProvenance } ?: scanResult.copy(
+            scanResult.takeIf {
+                scanResult.provenance is RepositoryProvenance || scanResult.provenance is ArtifactProvenance
+            } ?: scanResult.copy(
                 provenance = ArtifactProvenance(
                     sourceArtifact = RemoteArtifact(
                         url = id.toPurl(),


### PR DESCRIPTION
Since `RepositoryProvenance` and `ArtifactProvenance` are both `KnownProvenance`, ORT's code base widely assumes the interface is synonymous with the classes.

This however might change in light of the proposed [provenance interface/class hierarchy](https://github.com/oss-review-toolkit/ort/issues/8803#issuecomment-2236958430).

To ensure Code, which expects `KnownProvenance` to be either `RepositoryProvenance` or `ArtifactProvenance`, will still function as expected during refactoring, this PR aims to remove some of the ambiguity regarding `KnownProvenance`, especially in conditional statements.

Marked as **Draft**, until I checked conditional statements calling `RepositoryProvenance` and `ArtifactProvenance` explicitly, when receiving a `KnownProvenance` as input, and make sure they have a case if neither is present. (Comparable to 94a3c3ff15b9f85e3a967fe27d2fa24b6e461bb5)

Signed-off-by: Jens Keim <jens.keim@forvia.com>