### PR TITLE
Fix AOSD2 export

### DIFF
--- a/plugins/reporters/aosd/src/main/kotlin/Aosd2Reporter.kt
+++ b/plugins/reporters/aosd/src/main/kotlin/Aosd2Reporter.kt
@@ -142,8 +142,7 @@ private fun RemoteArtifact.toDeployPackage(): AOSD2.DeployPackage =
 
 private fun Hash.toChecksums(): AOSD2.Checksums =
     when (algorithm) {
-        HashAlgorithm.MD5 -> AOSD2.Checksums(md5 = value)
-        HashAlgorithm.SHA1 -> AOSD2.Checksums(sha1 = value)
+        // Other algorithms than SHA256 create an error message when importing.
         HashAlgorithm.SHA256 -> AOSD2.Checksums(sha256 = value)
         else -> AOSD2.Checksums(integrity = value)
     }

--- a/plugins/reporters/aosd/src/main/kotlin/Model.kt
+++ b/plugins/reporters/aosd/src/main/kotlin/Model.kt
@@ -23,6 +23,7 @@ package org.ossreviewtoolkit.plugins.reporters.aosd
 
 import java.io.File
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -136,8 +137,11 @@ internal data class AOSD2(
      */
     @Serializable
     data class Provider(
-        val additionalLicenses: List<License>,
+        @EncodeDefault
+        val additionalLicenses: List<License> = emptyList(),
+        @EncodeDefault
         val modified: Boolean = false,
+        @EncodeDefault
         val usage: Usage = Usage.DYNAMIC_LINKING
     )
 

--- a/plugins/reporters/aosd/src/main/kotlin/Model.kt
+++ b/plugins/reporters/aosd/src/main/kotlin/Model.kt
@@ -130,6 +130,10 @@ internal data class AOSD2(
         val external: Boolean? = null
     )
 
+    /**
+     * If the version has been divided into individual parts, then these can be made available for third-party use by
+     * providing the usage features and license information if necessary (e.g. dual licensing).
+     */
     @Serializable
     data class Provider(
         val additionalLicenses: List<License>,


### PR DESCRIPTION
When trying to upload the AOSD 2.0 file generated with ORT to the AOSD platform we encountered some problems.

After always creating a default "part", including empty fields (that where marked as optional but seem to be necessary) and removing hash algorithms other than SHA256 the file can now be uploaded to the Audi AOSD platform.