### PR TITLE
test(vulnerable-code): Update expected results

### DIFF
--- a/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
+++ b/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
@@ -129,7 +129,7 @@ class VulnerableCodeFunTest : WordSpec({
                 } shouldNotBeNull {
                     scoringSystem shouldBe "cvssv3.1"
                     severity shouldBe "MEDIUM"
-                    score shouldBe 5.3f
+                    score shouldBe 4.8f
                     vector shouldBe "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
                 }
             }


### PR DESCRIPTION
The base score of 4.8 indeed seems to be correct according to [1].

[1]: https://nvd.nist.gov/vuln/detail/CVE-2024-48948