### PR TITLE
fix(pnpm): Tolerate absent name / version in projects' `package.json`

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/pnpm/ModuleInfo.kt
+++ b/plugins/package-managers/node/src/main/kotlin/pnpm/ModuleInfo.kt
@@ -28,8 +28,8 @@ internal fun parsePnpmList(json: String): List<ModuleInfo> = JSON.decodeFromStri
 
 @Serializable
 internal data class ModuleInfo(
-    val name: String,
-    val version: String,
+    val name: String? = null,
+    val version: String? = null,
     val path: String,
     val private: Boolean,
     val dependencies: Map<String, Dependency> = emptyMap(),


### PR DESCRIPTION
The name and version fields may be absent for projects, while they are not absent for (published) dependencies. Specify a default value to avoid running into an exception during deserialization.

Fixes #9461.
