### PR TITLE
chore(model): Avoid superfluous `toSet()` calls

### DIFF
--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -62,8 +62,7 @@ data class AnalyzerConfiguration(
         packageManagers?.toSortedMap(String.CASE_INSENSITIVE_ORDER)
 
     init {
-        val duplicatePackageManagers =
-            packageManagers?.keys.orEmpty() - packageManagersCaseInsensitive?.keys?.toSet().orEmpty()
+        val duplicatePackageManagers = packageManagers?.keys.orEmpty() - packageManagersCaseInsensitive?.keys.orEmpty()
 
         require(duplicatePackageManagers.isEmpty()) {
             "The following package managers have duplicate configuration: ${duplicatePackageManagers.joinToString()}."

--- a/model/src/main/kotlin/config/RepositoryAnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryAnalyzerConfiguration.kt
@@ -74,8 +74,7 @@ data class RepositoryAnalyzerConfiguration(
         packageManagers?.toSortedMap(String.CASE_INSENSITIVE_ORDER)
 
     init {
-        val duplicatePackageManagers =
-            packageManagers?.keys.orEmpty() - packageManagersCaseInsensitive?.keys?.toSet().orEmpty()
+        val duplicatePackageManagers = packageManagers?.keys.orEmpty() - packageManagersCaseInsensitive?.keys.orEmpty()
 
         require(duplicatePackageManagers.isEmpty()) {
             "The following package managers have duplicate configuration: ${duplicatePackageManagers.joinToString()}."


### PR DESCRIPTION
Keys of a map are already stored in a set.