### PR TITLE
model(refactor)!: Simplify the `DependencyNavigator` API

### DIFF
--- a/model/src/main/kotlin/CompatibilityDependencyNavigator.kt
+++ b/model/src/main/kotlin/CompatibilityDependencyNavigator.kt
@@ -68,12 +68,12 @@ class CompatibilityDependencyNavigator internal constructor(
     override fun directDependencies(project: Project, scopeName: String): Sequence<DependencyNode> =
         project.invokeNavigator { directDependencies(it, scopeName) }
 
-    override fun dependenciesForScope(
+    override fun scopeDependencies(
         project: Project,
         scopeName: String,
         maxDepth: Int,
         matcher: DependencyMatcher
-    ): Set<Identifier> = project.invokeNavigator { dependenciesForScope(it, scopeName, maxDepth, matcher) }
+    ): Set<Identifier> = project.invokeNavigator { scopeDependencies(it, scopeName, maxDepth, matcher) }
 
     override fun packageDependencies(
         project: Project,

--- a/model/src/main/kotlin/DependencyGraphNavigator.kt
+++ b/model/src/main/kotlin/DependencyGraphNavigator.kt
@@ -74,7 +74,7 @@ class DependencyGraphNavigator(
         return dependenciesSequence(graph, rootDependencies)
     }
 
-    override fun dependenciesForScope(
+    override fun scopeDependencies(
         project: Project,
         scopeName: String,
         maxDepth: Int,

--- a/model/src/main/kotlin/DependencyTreeNavigator.kt
+++ b/model/src/main/kotlin/DependencyTreeNavigator.kt
@@ -29,22 +29,16 @@ object DependencyTreeNavigator : DependencyNavigator {
     override fun directDependencies(project: Project, scopeName: String): Sequence<DependencyNode> =
         project.findScope(scopeName)?.dependencies?.asSequence().orEmpty()
 
-    override fun dependenciesForScope(
+    override fun scopeDependencies(
         project: Project,
         scopeName: String,
         maxDepth: Int,
         matcher: DependencyMatcher
     ): Set<Identifier> = project.findScope(scopeName)?.collectDependencies(maxDepth) { matcher(it) }.orEmpty()
 
-    override fun scopeDependencies(
-        project: Project,
-        maxDepth: Int,
-        matcher: DependencyMatcher
-    ): Map<String, Set<Identifier>> =
+    override fun projectDependencies(project: Project, maxDepth: Int, matcher: DependencyMatcher): Set<Identifier> =
         // Override the base implementation because a more efficient access to single scopes is possible.
-        project.scopes.associate { scope ->
-            scope.name to scope.collectDependencies(maxDepth, matcher.forReference())
-        }
+        project.scopes.flatMapTo(mutableSetOf()) { it.collectDependencies(maxDepth, matcher.forReference()) }
 
     override fun packageDependencies(
         project: Project,

--- a/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
@@ -150,7 +150,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
                 val treeNavigator = mockk<DependencyNavigator>()
                 val graphNavigator = mockk<DependencyNavigator>()
                 every {
-                    treeNavigator.dependenciesForScope(
+                    treeNavigator.scopeDependencies(
                         treeProject,
                         scopeName,
                         maxDepth,
@@ -160,7 +160,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
 
                 val navigator = CompatibilityDependencyNavigator(graphNavigator, treeNavigator)
 
-                navigator.dependenciesForScope(treeProject, scopeName, maxDepth, matcher) shouldBe dependencies
+                navigator.scopeDependencies(treeProject, scopeName, maxDepth, matcher) shouldBe dependencies
             }
 
             "return the dependencies of a dependency graph project" {
@@ -171,7 +171,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
                 val treeNavigator = mockk<DependencyNavigator>()
                 val graphNavigator = mockk<DependencyNavigator>()
                 every {
-                    graphNavigator.dependenciesForScope(
+                    graphNavigator.scopeDependencies(
                         graphProject,
                         scopeName,
                         maxDepth,
@@ -181,7 +181,7 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
 
                 val navigator = CompatibilityDependencyNavigator(graphNavigator, treeNavigator)
 
-                navigator.dependenciesForScope(graphProject, scopeName, maxDepth, matcher) shouldBe dependencies
+                navigator.scopeDependencies(graphProject, scopeName, maxDepth, matcher) shouldBe dependencies
             }
         }
 

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -187,17 +187,19 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                 }
             }
 
-            input.ortResult.dependencyNavigator.scopeDependencies(project).forEach { (scopeName, dependencies) ->
+            input.ortResult.dependencyNavigator.scopeNames(project).forEach { scopeName ->
+                val scopeDependencies = input.ortResult.dependencyNavigator.scopeDependencies(project, scopeName)
                 val scopeExcludes = input.ortResult.getExcludes().findScopeExcludes(scopeName)
+
                 if (scopeExcludes.isNotEmpty()) {
-                    dependencies.forEach { id ->
+                    scopeDependencies.forEach { id ->
                         val info = packageExcludeInfo.getOrPut(id) { PackageExcludeInfo(id, true) }
                         if (info.isExcluded) {
                             info.scopeExcludes += scopeExcludes
                         }
                     }
                 } else if (pathExcludes.isEmpty()) {
-                    dependencies.forEach { id ->
+                    scopeDependencies.forEach { id ->
                         val info = packageExcludeInfo.getOrPut(id) { PackageExcludeInfo(id, true) }
                         info.isExcluded = false
                         info.pathExcludes.clear()

--- a/plugins/reporters/static-html/src/main/kotlin/TablesReportModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/TablesReportModelMapper.kt
@@ -72,8 +72,8 @@ private fun OrtResult.getScopesForDependencies(project: Project): Map<Identifier
     val result = mutableMapOf<Identifier, MutableMap<String, List<ScopeExclude>>>()
     val excludes = getExcludes()
 
-    dependencyNavigator.scopeDependencies(project).forEach { (scopeName, dependencies) ->
-        dependencies.forEach { dependency ->
+    dependencyNavigator.scopeNames(project).forEach { scopeName ->
+        dependencyNavigator.scopeDependencies(project, scopeName).forEach { dependency ->
             result.getOrPut(dependency) { mutableMapOf() }
                 .getOrPut(scopeName) { excludes.findScopeExcludes(scopeName) }
         }


### PR DESCRIPTION
Reduce the number of very similar overloads and simplify return types in favor of calling fewer "orthogonal" functions in combination, if required. This also aligns the naming of functions to be more consistent.