### PR TITLE
Yarn2 simplifications

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -265,7 +265,7 @@ class Yarn2(
         logger.info { "Fetching packages details..." }
 
         val chunks = packagesHeaders
-            .filterValues { it.type != "workspace" }
+            .filterValues { !it.isProject }
             .values.map { it.moduleId }
             .chunked(YARN_NPM_INFO_CHUNK_SIZE)
 
@@ -402,7 +402,7 @@ class Yarn2(
         val declaredLicenses = manifest.license.orEmpty().let { setOf(it).mapNpmLicenses() }
         var homepageUrl = manifest.homepage.orEmpty()
 
-        val id = if (header.type == "workspace") {
+        val id = if (header.isProject) {
             val version = packageInfo.children.version
             val projectFile = definitionFile.resolveSibling(header.version).resolve(definitionFile.name)
             val packageJson = parsePackageJson(projectFile)
@@ -639,6 +639,8 @@ private data class PackageHeader(
     val type: String,
     val version: String
 )
+
+private val PackageHeader.isProject: Boolean get() = type == "workspace"
 
 private val PackageHeader.moduleId: String get() = "$rawName@${version.cleanVersionString()}"
 

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -193,8 +193,7 @@ class Yarn2(
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
-
-        run("install", workingDir = workingDir)
+        installDependencies(workingDir)
 
         val packageInfos = getPackageInfos(workingDir)
         val packageHeaders = parsePackageHeaders(packageInfos)
@@ -206,6 +205,10 @@ class Yarn2(
         return allProjects.values.map { project ->
             ProjectAnalyzerResult(project.copy(scopeNames = scopeNames), emptySet(), issues)
         }.toList()
+    }
+
+    private fun installDependencies(workingDir: File) {
+        run("install", workingDir = workingDir)
     }
 
     private fun getPackageInfos(workingDir: File): List<PackageInfo> {

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -194,9 +194,6 @@ class Yarn2(
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
-        // Running `yarn install` before `yarn info` allows to get the real local package version. Otherwise, it will be
-        // a generic one such as '0.0.0-use.local'.
-
         run("install", workingDir = workingDir)
 
         val packageInfos = getPackageInfos(workingDir)
@@ -212,7 +209,6 @@ class Yarn2(
     }
 
     private fun getPackageInfos(workingDir: File): List<PackageInfo> {
-        // Query the list of all packages with their dependencies. The output is in NDJSON format.
         val process = run(
             "info",
             "-A",

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -264,9 +264,10 @@ class Yarn2(
     ): Map<String, AdditionalData> {
         logger.info { "Fetching packages details..." }
 
-        val chunks = packagesHeaders.filterValues { it.type != "workspace" }.values.map {
-            "${it.rawName}@${it.version.cleanVersionString()}"
-        }.chunked(YARN_NPM_INFO_CHUNK_SIZE)
+        val chunks = packagesHeaders
+            .filterValues { it.type != "workspace" }
+            .values.map { it.moduleId }
+            .chunked(YARN_NPM_INFO_CHUNK_SIZE)
 
         return runBlocking(Dispatchers.IO) {
             chunks.mapIndexed { index, chunk ->
@@ -638,6 +639,8 @@ private data class PackageHeader(
     val type: String,
     val version: String
 )
+
+private val PackageHeader.moduleId: String get() = "$rawName@${version.cleanVersionString()}"
 
 /**
  * Class containing additional data returned by `yarn npm info`.

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -223,8 +223,6 @@ class Yarn2(
             environment = mapOf("YARN_NODE_LINKER" to "pnp")
         )
 
-        logger.info { "Parsing packages..." }
-
         return parsePackageInfos(process.stdout)
     }
 


### PR DESCRIPTION
This PR is only a starter for a series of PRs to make the code simpler and easier to read.

This are preparations which occurred when trying to re-use the `parsePackage()` and `parseProject()` functions used for the other three node managers, but further preparations will be needed.. 