### PR TITLE
feat(scanner): Add flag to scanner to detect unlicensed files

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -45,6 +45,11 @@ data class ScannerConfiguration(
     val skipExcluded: Boolean = false,
 
     /**
+     * A flag to indicate whether the scanner should add files without license to the scanner results.
+     */
+    val includeFilesWithoutFindings: Boolean = false,
+
+    /**
      * Configuration of a [FileArchiver] that archives certain scanned files in an external [FileStorage].
      */
     val archive: FileArchiverConfiguration? = null,

--- a/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-all-pkgs-expected-ort-result.yml
@@ -197,6 +197,7 @@ scanner:
   config:
     skip_concluded: false
     skip_excluded: false
+    include_files_without_findings: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-free-unknown: "NOASSERTION"

--- a/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
+++ b/scanner/src/funTest/assets/scanner-integration-subset-pkgs-expected-ort-result.yml
@@ -116,6 +116,7 @@ scanner:
   config:
     skip_concluded: false
     skip_excluded: false
+    include_files_without_findings: false
     detected_license_mapping:
       LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
       LicenseRef-scancode-free-unknown: "NOASSERTION"


### PR DESCRIPTION
Based on #9435, it was stated that we could simply apply curations to files not listed in the license findings. The current PR is one such design but **breaks backwards compatibility**. I would like some feedback on how it would be preferred to deal with this. 

Below I state some of the approaches I have thought of. Any feedback is welcomed.

## PR Approach

- detects files without license and these are not added to the output of the scanner (as requested in #9435. As such, the evaluator reports errors for files without license. (**breaks backwards compatibility**)
- if we add curations, curations are applied to the unlicensed files (this is simply because of the curation mechanism)
- unlicensed files use the default value `NONE` when created as part of a `LicenseFinding`.
- **Not complete, missing tests, looking for feedback**

## Design Option

**Approach**
I have tried to look for ways to changes to the `FindingCurationMatcher.kt` (recommended by @sschuberth ). There are a bunch of methods in this file, but none of them have available the files needed from `ScanResult`s. I do not mind to "patch" all call sites that pass `findings`:
- `FindingCurationMatcher().matches(finding, curation)`
- `FindingCurationMatcher().apply(finding, curation)`
- `FindingCurationMatcher().applyAll(finding, curation)`

and add to the `findings` all files without licenses as `LicenseFinding(license="NONE"), location=...)`. In this way, a curation matcher with a glob pattern on a folder and `detected_license: NONE` can apply the curation. 

**Questions/Comments**
We apply curations to files not listed in the scanner results. 
To me, this may seem counter-intuitive, since I do not think ORT has ever dealt with files not listed in the scanner. The idea is to apply curations to unlicensed files, but I think it is more uniform if unlicensed files are listed in the scanner. Thoughts?

## Design Option 2

Add to the `.ort.yml` an option (or to the cli) to state that unlicensed files are part of the scanner and should be shown there.

**Use case**
- Opt-in to curate unlicensed files. AFAIK, unlicensed files are not considered in the `evaluator`.
From my point of view, we need to analyse [Erlang/OTP](https://github.com/erlang/otp) and would like warnings/errors for any files without license. Design option 2 makes explicit this option, and the scanner shows the truth result of scanned files. 