### PR TITLE
refactor(commands)!: Migrate command plugins to new plugin API

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -48,7 +48,8 @@ import kotlin.system.exitProcess
 
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
-import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.api.PluginConfig
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.common.MaskedString
 import org.ossreviewtoolkit.utils.common.Os
@@ -123,7 +124,8 @@ class OrtMain : CliktCommand(ORT_NAME) {
             helpFormatter = { MordantHelpFormatter(context = it, REQUIRED_OPTION_MARKER, showDefaultValues = true) }
         }
 
-        subcommands(OrtCommand.ALL.values)
+        // Pass an empty PluginConfig here as commands are not configurable.
+        subcommands(OrtCommandFactory.ALL.map { (_, factory) -> factory.create(PluginConfig()) })
 
         versionOption(
             version = env.ortVersion,

--- a/plugins/commands/advisor/build.gradle.kts
+++ b/plugins/commands/advisor/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.advisor)
     implementation(projects.model)

--- a/plugins/commands/advisor/src/main/kotlin/AdvisorCommand.kt
+++ b/plugins/commands/advisor/src/main/kotlin/AdvisorCommand.kt
@@ -45,7 +45,10 @@ import org.ossreviewtoolkit.advisor.Advisor
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStatsPrinter
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
@@ -57,10 +60,13 @@ import org.ossreviewtoolkit.utils.ort.ORT_FAILURE_STATUS_CODE
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class AdvisorCommand : OrtCommand(
-    name = "advise",
-    help = "Check dependencies for security vulnerabilities."
-) {
+@OrtPlugin(
+    id = "advise",
+    displayName = "advise command",
+    description = "Check dependencies for security vulnerabilities.",
+    factory = OrtCommandFactory::class
+)
+class AdvisorCommand(descriptor: PluginDescriptor = AdvisorCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "An ORT result file with an analyzer result to use."

--- a/plugins/commands/analyzer/build.gradle.kts
+++ b/plugins/commands/analyzer/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 

--- a/plugins/commands/analyzer/src/main/kotlin/AnalyzerCommand.kt
+++ b/plugins/commands/analyzer/src/main/kotlin/AnalyzerCommand.kt
@@ -47,7 +47,10 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.readValueOrNull
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStatsPrinter
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
@@ -62,10 +65,13 @@ import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class AnalyzerCommand : OrtCommand(
-    name = "analyze",
-    help = "Determine dependencies of a software project."
-) {
+@OrtPlugin(
+    id = "analyze",
+    displayName = "analyze command",
+    description = "Determine dependencies of a software project.",
+    factory = OrtCommandFactory::class
+)
+class AnalyzerCommand(descriptor: PluginDescriptor = AnalyzerCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val inputDir by option(
         "--input-dir", "-i",
         help = "The project directory to analyze. May point to a definition file if only a single package manager is " +

--- a/plugins/commands/api/src/main/kotlin/OrtCommand.kt
+++ b/plugins/commands/api/src/main/kotlin/OrtCommand.kt
@@ -27,23 +27,15 @@ import com.github.ajalt.clikt.core.requireObject
 import java.io.File
 
 import org.ossreviewtoolkit.model.config.OrtConfiguration
-import org.ossreviewtoolkit.utils.common.Plugin
+import org.ossreviewtoolkit.plugins.api.Plugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 
 /**
- * An interface for [CliktCommand]-based ORT commands that come as named plugins.
+ * An interface for [CliktCommand]-based ORT commands that come as [Plugin]s.
  */
-abstract class OrtCommand(name: String, private val help: String) : CliktCommand(name), Plugin {
-    companion object {
-        /**
-         * All [ORT commands][OrtCommand] available in the classpath, associated by their names.
-         */
-        val ALL by lazy { Plugin.getAll<OrtCommand>() }
-    }
-
-    override val type = commandName
-
-    override fun help(context: Context) = help
+abstract class OrtCommand(override val descriptor: PluginDescriptor) : CliktCommand(descriptor.id), Plugin {
+    override fun help(context: Context) = descriptor.description
 
     protected val ortConfig by requireObject<OrtConfiguration>()
 

--- a/plugins/commands/api/src/main/kotlin/OrtCommandFactory.kt
+++ b/plugins/commands/api/src/main/kotlin/OrtCommandFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,18 @@
  * License-Filename: LICENSE
  */
 
-plugins {
-    // Apply precompiled plugins.
-    id("ort-library-conventions")
-}
+package org.ossreviewtoolkit.plugins.commands.api
 
-dependencies {
-    api(projects.model)
-    api(projects.plugins.api)
+import org.ossreviewtoolkit.plugins.api.PluginFactory
 
-    api(libs.clikt)
-
-    implementation(projects.utils.ortUtils)
-
-    implementation(libs.jackson.core)
-    implementation(libs.jackson.databind)
+/**
+ * A factory interface for creating [OrtCommand] instances.
+ */
+interface OrtCommandFactory : PluginFactory<OrtCommand> {
+    companion object {
+        /**
+         * All [ORT command factories][OrtCommandFactory] available in the classpath, associated by their ids.
+         */
+        val ALL by lazy { PluginFactory.getAll<OrtCommandFactory, OrtCommand>() }
+    }
 }

--- a/plugins/commands/compare/build.gradle.kts
+++ b/plugins/commands/compare/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.model)
     implementation(projects.utils.commonUtils)

--- a/plugins/commands/compare/src/main/kotlin/CompareCommand.kt
+++ b/plugins/commands/compare/src/main/kotlin/CompareCommand.kt
@@ -43,15 +43,21 @@ import java.time.Instant
 
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.mapper
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.getCommonParentFile
 import org.ossreviewtoolkit.utils.ort.Environment
 
-class CompareCommand : OrtCommand(
-    name = "compare",
-    help = "Compare two ORT results with various methods."
-) {
+@OrtPlugin(
+    id = "compare",
+    displayName = "compare command",
+    description = "Compare two ORT results with various methods.",
+    factory = OrtCommandFactory::class
+)
+class CompareCommand(descriptor: PluginDescriptor = CompareCommandFactory.descriptor) : OrtCommand(descriptor) {
     private enum class CompareMethod { SEMANTIC_DIFF, TEXT_DIFF }
 
     private val fileA by argument(help = "The first ORT result file to compare.")

--- a/plugins/commands/config/build.gradle.kts
+++ b/plugins/commands/config/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.model)
     implementation(projects.utils.commonUtils)

--- a/plugins/commands/config/src/main/kotlin/ConfigCommand.kt
+++ b/plugins/commands/config/src/main/kotlin/ConfigCommand.kt
@@ -31,15 +31,21 @@ import com.github.ajalt.mordant.rendering.Theme
 
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfigurationWrapper
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.ORT_REFERENCE_CONFIG_FILENAME
 
-class ConfigCommand : OrtCommand(
-    name = "config",
-    help = "Show different ORT configurations."
-) {
+@OrtPlugin(
+    id = "config",
+    displayName = "config command",
+    description = "Show different ORT configurations.",
+    factory = OrtCommandFactory::class
+)
+class ConfigCommand(descriptor: PluginDescriptor = ConfigCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val showDefault by option(
         "--show-default",
         help = "Show the default configuration used when no custom configuration is present."

--- a/plugins/commands/downloader/build.gradle.kts
+++ b/plugins/commands/downloader/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.downloader)
     implementation(projects.model)

--- a/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
+++ b/plugins/commands/downloader/src/main/kotlin/DownloaderCommand.kt
@@ -82,7 +82,10 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.GroupTypes.FileType
 import org.ossreviewtoolkit.plugins.commands.api.utils.GroupTypes.StringType
 import org.ossreviewtoolkit.plugins.commands.api.utils.OPTION_GROUP_INPUT
@@ -102,10 +105,13 @@ import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
 
-class DownloaderCommand : OrtCommand(
-    name = "download",
-    help = "Fetch source code from a remote location."
-) {
+@OrtPlugin(
+    id = "download",
+    displayName = "download command",
+    description = "Fetch source code from a remote location.",
+    factory = OrtCommandFactory::class
+)
+class DownloaderCommand(descriptor: PluginDescriptor = DownloaderCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val input by mutuallyExclusiveOptions(
         option(
             "--ort-file", "-i",

--- a/plugins/commands/evaluator/build.gradle.kts
+++ b/plugins/commands/evaluator/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
     implementation(projects.plugins.packageCurationProviders.packageCurationProviderApi)

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluatorCommand.kt
@@ -57,7 +57,10 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStatsPrinter
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
@@ -81,10 +84,13 @@ import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class EvaluatorCommand : OrtCommand(
-    name = "evaluate",
-    help = "Evaluate ORT result files against policy rules."
-) {
+@OrtPlugin(
+    id = "evaluate",
+    displayName = "evaluate command",
+    description = "Evaluate ORT result files against policy rules.",
+    factory = OrtCommandFactory::class
+)
+class EvaluatorCommand(descriptor: PluginDescriptor = EvaluatorCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/plugins/commands/migrate/build.gradle.kts
+++ b/plugins/commands/migrate/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.plugins.packageCurationProviders.ortConfigPackageCurationProvider)
     implementation(projects.plugins.packageManagers.nugetPackageManager)

--- a/plugins/commands/migrate/src/main/kotlin/MigrateCommand.kt
+++ b/plugins/commands/migrate/src/main/kotlin/MigrateCommand.kt
@@ -33,17 +33,23 @@ import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.packagecurationproviders.ortconfig.toCurationPath
 import org.ossreviewtoolkit.plugins.packagemanagers.nuget.utils.getIdentifierWithNamespace
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.getCommonParentFile
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 
-class MigrateCommand : OrtCommand(
-    name = "migrate",
-    help = "Assist with migrating ORT configuration to newer ORT versions."
-) {
+@OrtPlugin(
+    id = "migrate",
+    displayName = "migrate command",
+    description = "Assist with migrating ORT configuration to newer ORT versions.",
+    factory = OrtCommandFactory::class
+)
+class MigrateCommand(descriptor: PluginDescriptor = MigrateCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val hoconToYaml by option(
         "--hocon-to-yaml",
         help = "Perform a simple conversion of the given HOCON configuration file to YAML and print the result."

--- a/plugins/commands/notifier/build.gradle.kts
+++ b/plugins/commands/notifier/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.model)
     implementation(projects.notifier)

--- a/plugins/commands/notifier/src/main/kotlin/NotifierCommand.kt
+++ b/plugins/commands/notifier/src/main/kotlin/NotifierCommand.kt
@@ -30,7 +30,10 @@ import com.github.ajalt.clikt.parameters.types.file
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
 import org.ossreviewtoolkit.notifier.Notifier
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
@@ -39,10 +42,13 @@ import org.ossreviewtoolkit.utils.ort.ORT_NOTIFIER_SCRIPT_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class NotifierCommand : OrtCommand(
-    name = "notify",
-    help = "Create notifications based on an ORT result."
-) {
+@OrtPlugin(
+    id = "notify",
+    displayName = "notify command",
+    description = "Create notifications based on an ORT result.",
+    factory = OrtCommandFactory::class
+)
+class NotifierCommand(descriptor: PluginDescriptor = NotifierCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/plugins/commands/reporter/build.gradle.kts
+++ b/plugins/commands/reporter/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.plugins.packageConfigurationProviders.packageConfigurationProviderApi)
 

--- a/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReporterCommand.kt
@@ -53,8 +53,11 @@ import org.ossreviewtoolkit.model.licenses.orEmpty
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginConfig
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
@@ -80,10 +83,13 @@ import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants.LICENSE_REF_PREFIX
 
-class ReporterCommand : OrtCommand(
-    name = "report",
-    help = "Present Analyzer, Scanner and Evaluator results in various formats."
-) {
+@OrtPlugin(
+    id = "report",
+    displayName = "report command",
+    description = "Present Analyzer, Scanner and Evaluator results in various formats.",
+    factory = OrtCommandFactory::class
+)
+class ReporterCommand(descriptor: PluginDescriptor = ReporterCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to use."

--- a/plugins/commands/requirements/build.gradle.kts
+++ b/plugins/commands/requirements/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.analyzer)
     implementation(projects.downloader)

--- a/plugins/commands/requirements/src/main/kotlin/RequirementsCommand.kt
+++ b/plugins/commands/requirements/src/main/kotlin/RequirementsCommand.kt
@@ -38,7 +38,10 @@ import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.scanner.ScannerWrapperConfig
 import org.ossreviewtoolkit.utils.common.CommandLineTool
@@ -55,10 +58,15 @@ private val DANGER_PREFIX = "\t${Theme.Default.danger("-")} "
 private val WARNING_PREFIX = "\t${Theme.Default.warning("+")} "
 private val SUCCESS_PREFIX = "\t${Theme.Default.success("*")} "
 
-class RequirementsCommand : OrtCommand(
-    name = "requirements",
-    help = "Check for the command line tools required by ORT."
-) {
+@OrtPlugin(
+    id = "requirements",
+    displayName = "requirements command",
+    description = "Check for the command line tools required by ORT.",
+    factory = OrtCommandFactory::class
+)
+class RequirementsCommand(
+    descriptor: PluginDescriptor = RequirementsCommandFactory.descriptor
+) : OrtCommand(descriptor) {
     private enum class RequirementsType { PLUGINS, COMMANDS }
 
     private enum class VersionStatus {

--- a/plugins/commands/scanner/build.gradle.kts
+++ b/plugins/commands/scanner/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.downloader)
     implementation(projects.model)

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -50,7 +50,10 @@ import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStatsPrinter
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
@@ -68,10 +71,13 @@ import org.ossreviewtoolkit.utils.ort.ORT_FAILURE_STATUS_CODE
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class ScannerCommand : OrtCommand(
-    name = "scan",
-    help = "Run external license / copyright scanners."
-) {
+@OrtPlugin(
+    id = "scan",
+    displayName = "scan command",
+    description = "Run external license / copyright scanners.",
+    factory = OrtCommandFactory::class
+)
+class ScannerCommand(descriptor: PluginDescriptor = ScannerCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val input by option(
         "--ort-file", "-i",
         help = "An ORT result file with an analyzer result to use. Source code is downloaded automatically if needed."

--- a/plugins/commands/upload-curations/build.gradle.kts
+++ b/plugins/commands/upload-curations/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.clients.clearlyDefinedClient)
     implementation(projects.model)

--- a/plugins/commands/upload-curations/src/main/kotlin/UploadCurationsCommand.kt
+++ b/plugins/commands/upload-curations/src/main/kotlin/UploadCurationsCommand.kt
@@ -50,16 +50,24 @@ import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.ossreviewtoolkit.utils.ort.runBlocking
 
-class UploadCurationsCommand : OrtCommand(
-    name = "upload-curations",
-    help = "Upload ORT package curations to ClearlyDefined."
-) {
+@OrtPlugin(
+    id = "upload-curations",
+    displayName = "upload-curations command",
+    description = "Upload ORT package curations to ClearlyDefined.",
+    factory = OrtCommandFactory::class
+)
+class UploadCurationsCommand(
+    descriptor: PluginDescriptor = UploadCurationsCommandFactory.descriptor
+) : OrtCommand(descriptor) {
     private val inputFile by option(
         "--input-file", "-i",
         help = "The file with package curations to upload."

--- a/plugins/commands/upload-result-to-postgres/build.gradle.kts
+++ b/plugins/commands/upload-result-to-postgres/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.model)
     implementation(projects.scanner)

--- a/plugins/commands/upload-result-to-postgres/src/main/kotlin/UploadResultToPostgresCommand.kt
+++ b/plugins/commands/upload-result-to-postgres/src/main/kotlin/UploadResultToPostgresCommand.kt
@@ -39,7 +39,10 @@ import org.ossreviewtoolkit.model.config.PostgresStorageConfiguration
 import org.ossreviewtoolkit.model.utils.DatabaseUtils
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.scanner.storages.utils.jsonb
@@ -47,10 +50,15 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
-class UploadResultToPostgresCommand : OrtCommand(
-    name = "upload-result-to-postgres",
-    help = "Upload an ORT result to a PostgreSQL database."
-) {
+@OrtPlugin(
+    id = "upload-result-to-postgres",
+    displayName = "upload-result-to-postgres command",
+    description = "Upload an ORT result to a PostgreSQL database.",
+    factory = OrtCommandFactory::class
+)
+class UploadResultToPostgresCommand(
+    descriptor: PluginDescriptor = UploadResultToPostgresCommandFactory.descriptor
+) : OrtCommand(descriptor) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/plugins/commands/upload-result-to-sw360/build.gradle.kts
+++ b/plugins/commands/upload-result-to-sw360/build.gradle.kts
@@ -19,11 +19,13 @@
 
 plugins {
     // Apply precompiled plugins.
-    id("ort-library-conventions")
+    id("ort-plugin-conventions")
 }
 
 dependencies {
     api(projects.plugins.commands.commandApi)
+
+    ksp(projects.plugins.commands.commandApi)
 
     implementation(projects.downloader)
     implementation(projects.model)

--- a/plugins/commands/upload-result-to-sw360/src/main/kotlin/UploadResultToSw360Command.kt
+++ b/plugins/commands/upload-result-to-sw360/src/main/kotlin/UploadResultToSw360Command.kt
@@ -43,7 +43,10 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
 import org.ossreviewtoolkit.model.utils.toPurl
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
+import org.ossreviewtoolkit.plugins.commands.api.OrtCommandFactory
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.scanner.storages.Sw360Storage
@@ -53,10 +56,15 @@ import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
-class UploadResultToSw360Command : OrtCommand(
-    name = "upload-result-to-sw360",
-    help = "Upload an ORT result to SW360."
-) {
+@OrtPlugin(
+    id = "upload-result-to-sw360",
+    displayName = "upload-result-to-sw360 command",
+    description = "Upload an ORT result to SW360.",
+    factory = OrtCommandFactory::class
+)
+class UploadResultToSw360Command(
+    descriptor: PluginDescriptor = UploadResultToSw360CommandFactory.descriptor
+) : OrtCommand(descriptor) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."


### PR DESCRIPTION
Migrate the command plugins to the new plugin API.

Relates to #9403.