### PR TITLE
chore(gradle-inspector): Lower logging of missing checkums to debug

### DIFF
--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleDependencyHandler.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleDependencyHandler.kt
@@ -255,7 +255,7 @@ private fun createRemoteArtifact(
                 }
             }
         }.getOrElse {
-            logger.warn {
+            logger.debug {
                 "Unable to get a valid '$algorithm' checksum for the artifact at $artifactUrl: ${it.collectMessages()}"
             }
 


### PR DESCRIPTION
At this point ORT does not know if the belonging artifact actually exists, and for non-existing artifacts it is natural to not have a checksum file published, so lower this to only a debug log.