### PR TITLE
Introduce a Project description property and support for it in node

### DIFF
--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -86,6 +86,12 @@ data class Project(
     val vcsProcessed: VcsInfo = vcs.normalize(),
 
     /**
+     * The description of project.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val description: String = "",
+
+    /**
      * The URL to the project's homepage.
      */
     val homepageUrl: String,

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/babel-expected-output.yml
@@ -15,7 +15,7 @@ project:
     type: "Git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/babel"
+    path: "<REPLACE_PATH>"
   description: "A dummy NPM project that depends on Babel"
   homepage_url: ""
   scopes:

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/babel-expected-output.yml
@@ -16,6 +16,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/babel"
+  description: "A dummy NPM project that depends on Babel"
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/node-modules-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/node-modules-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "NPM test project with existing node_modules directory."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/project-with-lockfile-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/project-with-lockfile-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "NPM test project with package-lock.json."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/shrinkwrap-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/shrinkwrap-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "NPM test project with npm-shrinkwrap.json."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/shrinkwrap-skip-excluded-scopes-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/shrinkwrap-skip-excluded-scopes-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "NPM test project with npm-shrinkwrap.json."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/version-urls-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/version-urls-expected-output.yml
@@ -16,6 +16,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "An NPM project that uses URLs as versions of dependencies."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel-expected-output.yml
@@ -16,6 +16,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel"
+  description: "A dummy NPM project that depends on Babel"
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel-expected-output.yml
@@ -15,7 +15,7 @@ project:
     type: "Git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel"
+    path: "<REPLACE_PATH>"
   description: "A dummy NPM project that depends on Babel"
   homepage_url: ""
   scopes:

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "PNPM project with pnpm-lock.yaml."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile-skip-excluded-scopes-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile-skip-excluded-scopes-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "PNPM project with pnpm-lock.yaml."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces-expected-output.yml
@@ -82,6 +82,7 @@ analyzer:
         url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces"
+      description: "PNPM workspaces test"
       homepage_url: ""
       scopes:
       - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/babel-expected-output.yml
@@ -16,6 +16,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/babel"
+  description: "A dummy NPM project that depends on Babel"
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/babel-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/babel-expected-output.yml
@@ -15,7 +15,7 @@ project:
     type: "Git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
-    path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/babel"
+    path: "<REPLACE_PATH>"
   description: "A dummy NPM project that depends on Babel"
   homepage_url: ""
   scopes:

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/project-with-lockfile-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/project-with-lockfile-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "Yarn test project with yarn.lock."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces-expected-output.yml
@@ -39,6 +39,7 @@ projects:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn/workspaces"
+  description: "Yarn test project using Yarn workspaces."
   homepage_url: ""
   scopes: []
 - id: "Yarn:@scope1:pkg1:1.0.0"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/project-with-lockfile-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/project-with-lockfile-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "Yarn test project with yarn.lock."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/project-with-lockfile-skip-excluded-scopes-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/project-with-lockfile-skip-excluded-scopes-expected-output.yml
@@ -18,6 +18,7 @@ project:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
+  description: "Yarn test project with yarn.lock."
   homepage_url: ""
   scopes:
   - name: "dependencies"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/workspaces-expected-output.yml
@@ -39,6 +39,7 @@ projects:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/yarn2/workspaces"
+  description: "Yarn test project using Yarn workspaces."
   homepage_url: ""
   scopes: []
 - id: "Yarn2:@scope1:pkg1:1.0.0"

--- a/plugins/package-managers/node/src/main/kotlin/NpmSupport.kt
+++ b/plugins/package-managers/node/src/main/kotlin/NpmSupport.kt
@@ -251,6 +251,7 @@ internal fun parseProject(packageJsonFile: File, analysisRoot: File, managerName
 
     val declaredLicenses = packageJson.licenses.mapLicenses()
     val authors = packageJson.authors.flatMap { parseAuthorString(it.name) }.mapNotNullTo(mutableSetOf()) { it.name }
+    val description = packageJson.description.orEmpty()
     val homepageUrl = packageJson.homepage.orEmpty()
     val projectDir = packageJsonFile.parentFile.realFile()
     val vcsFromPackage = parseVcsInfo(packageJson)
@@ -267,6 +268,7 @@ internal fun parseProject(packageJsonFile: File, analysisRoot: File, managerName
         declaredLicenses = declaredLicenses,
         vcs = vcsFromPackage,
         vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),
+        description = description,
         homepageUrl = homepageUrl
     )
 }

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -414,6 +414,7 @@ class Yarn2(
                 declaredLicenses = declaredLicenses,
                 vcs = additionalData.vcsFromPackage,
                 vcsProcessed = processProjectVcs(definitionFile.parentFile, additionalData.vcsFromPackage, homepageUrl),
+                description = additionalData.description,
                 homepageUrl = homepageUrl,
                 authors = authors
             )


### PR DESCRIPTION
Add the `description` property to project's, analog to the one in packages and implement support in all node package managers.

Fixes #9443.