### PR TITLE
Revert "fix(gradle): Be specific about using Adoptium / Temurin as the JDK"

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -112,7 +112,6 @@ detekt {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(javaLanguageVersion)
-        vendor = JvmVendorSpec.ADOPTIUM
     }
 }
 

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,4 +1,3 @@
 # The version of the JDK to use for building ORT.
 # Keep this aligned with `javaLanguageVersion` in `gradle.properties`.
 toolchainVersion = 21
-toolchainVendor = Adoptium


### PR DESCRIPTION
This reverts commit c9d114c as the issue cannot be reproduced anymore with Fedora 41 and Gradle 8.11.1.