### PR TITLE
fix(reporter): Fix aliases for renamed reporter options

### DIFF
--- a/plugins/reporters/asciidoc/src/main/kotlin/AsciiDocTemplateReporter.kt
+++ b/plugins/reporters/asciidoc/src/main/kotlin/AsciiDocTemplateReporter.kt
@@ -39,13 +39,13 @@ data class AsciiDocTemplateReporterConfig(
      * If no template id or path is provided, the "disclosure_document" template is used, and if the ORT result contains
      * an advisor run, the "vulnerability_report" and "defect_report" templates are used as well.
      */
-    @OrtPluginOption(aliases = ["templateId"])
+    @OrtPluginOption(aliases = ["template.id"])
     val templateIds: List<String>?,
 
     /**
      * A comma-separated list of paths to template files provided by the user.
      */
-    @OrtPluginOption(aliases = ["templatePath"])
+    @OrtPluginOption(aliases = ["template.path"])
     val templatePaths: List<String>?
 )
 

--- a/plugins/reporters/asciidoc/src/main/kotlin/PdfTemplateReporter.kt
+++ b/plugins/reporters/asciidoc/src/main/kotlin/PdfTemplateReporter.kt
@@ -35,13 +35,13 @@ data class PdfTemplateReporterConfig(
      * If no template id or path is provided, the "disclosure_document" template is used, and if the ORT result contains
      * an advisor run, the "vulnerability_report" and "defect_report" templates are used as well.
      */
-    @OrtPluginOption(aliases = ["templateId"])
+    @OrtPluginOption(aliases = ["template.id"])
     val templateIds: List<String>?,
 
     /**
      * A comma-separated list of paths to template files provided by the user.
      */
-    @OrtPluginOption(aliases = ["templatePath"])
+    @OrtPluginOption(aliases = ["template.path"])
     val templatePaths: List<String>?,
 
     /**

--- a/plugins/reporters/freemarker/src/main/kotlin/PlainTextTemplateReporter.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/PlainTextTemplateReporter.kt
@@ -34,13 +34,13 @@ data class PlainTextTemplateReporterConfig(
      * "NOTICE_SUMMARY" templates are available.
      * If no template id or path is provided, the "NOTICE_DEFAULT" template is used.
      */
-    @OrtPluginOption(aliases = ["templateId"])
+    @OrtPluginOption(aliases = ["template.id"])
     val templateIds: List<String>?,
 
     /**
      * A comma-separated list of paths to template files provided by the user.
      */
-    @OrtPluginOption(aliases = ["templatePath"])
+    @OrtPluginOption(aliases = ["template.path"])
     val templatePaths: List<String>?
 ) {
     companion object {


### PR DESCRIPTION
This is a fixup for 27f0dae and 88aa4a0. In those commits the reporter options `template.id` and `template.path` were renamed to `templateIds` and `templatePaths` but the aliases for backward compatibility have been set wrongly.