### PR TITLE
feat(spdx): Expose the validation of license text files' existence

### DIFF
--- a/utils/spdx/src/test/kotlin/UtilsTest.kt
+++ b/utils/spdx/src/test/kotlin/UtilsTest.kt
@@ -198,6 +198,22 @@ class UtilsTest : WordSpec() {
             }
         }
 
+        "getLicenseTextReader provided a custom dir" should {
+            "call the custom validation lambda if provided" {
+                val id = "LicenseRef-ort-abc"
+                val text = "a\nb\nc"
+                val candidateFilenames = mutableListOf<String>()
+
+                setupTempFile(id, text)
+
+                getLicenseTextReader(id, true, listOf(tempDir)) { directory, filename ->
+                    candidateFilenames += filename
+                    directory.resolve(filename).takeIf { it.isFile }
+                }?.invoke() shouldBe text
+                candidateFilenames shouldBe listOf("LicenseRef-ort-abc")
+            }
+        }
+
         "removeYamlFrontMatter" should {
             "remove a YAML front matter" {
                 val text = """


### PR DESCRIPTION
ORT has a complicate logic to search for a file containing the full license text of a given license: several search paths are tried. Unfortunately, the latter are not exposed, making it hard for an alternative `LicenseTextProvider` to have the same logic. Additionally, the current code assumes that the license files are on a local storage and the I/Os are therefore cheap. To allow the current utility function to be used with a `LicenseTextProvider` that works with license text files stored on a network storage, this commit exposes the validation function.
