### PR TITLE
helper-cli: Allow to specify purls in package lists used for creating analyzer results

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,6 +10,7 @@ dependabot[bot] <dependabot[bot]@users.noreply.github.com> <49699333+dependabot[
 Frank Viernau <frank_viernau@epam.com> <42963794+fviernau@users.noreply.github.com>
 Frank Viernau <frank_viernau@epam.com> <frank.viernau@gmail.com>
 Frank Viernau <frank_viernau@epam.com> <frank.viernau@here.com>
+Frank Viernau <frank_viernau@epam.com> <x9fviern@zeiss.com>
 François Barbe <f.barbe@lectra.com>
 François Barbe <f.barbe@lectra.com> <fb33@users.noreply.github.com>
 François Barbe <f.barbe@lectra.com> <fbarbe@yahoo.fr>

--- a/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -56,7 +56,7 @@ analyzer:
           linkage: "STATIC"
     packages:
     - id: "NPM::example-dependency-one:1.0.0"
-      purl: ""
+      purl: "pkg:npm/example-dependency-one@1.0.0"
       declared_licenses: []
       declared_licenses_processed: {}
       description: ""
@@ -82,7 +82,7 @@ analyzer:
         revision: "0000000000000000000000000000000000000000"
         path: "vcs-path/dependency-one"
     - id: "NPM::example-dependency-two:2.0.0"
-      purl: ""
+      purl: "pkg:npm/example-dependency-two@2.0.0"
       declared_licenses: []
       declared_licenses_processed: {}
       description: ""

--- a/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -82,7 +82,7 @@ analyzer:
         revision: "0000000000000000000000000000000000000000"
         path: "vcs-path/dependency-one"
     - id: "NPM::example-dependency-two:2.0.0"
-      purl: "pkg:npm/example-dependency-two@2.0.0"
+      purl: "pkg:github/example-org/example-dependency-two@v2.0.0"
       declared_licenses: []
       declared_licenses_processed: {}
       description: ""

--- a/helper-cli/src/funTest/assets/package-list.yml
+++ b/helper-cli/src/funTest/assets/package-list.yml
@@ -17,6 +17,7 @@ dependencies:
     isExcluded: true
     isDynamicallyLinked: true
   - id: "NPM::example-dependency-two:2.0.0"
+    purl: "pkg:github/example-org/example-dependency-two@v2.0.0"
     vcs:
       type: "Git"
       url: "https://github.com/example/depedency-1.git"

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -51,6 +51,7 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.config.setPackageCurations
@@ -146,6 +147,7 @@ private data class PackageList(
 
 private data class Dependency(
     val id: Identifier,
+    val purl: String?,
     val vcs: Vcs? = null,
     val sourceArtifact: SourceArtifact? = null,
     val isExcluded: Boolean = false,
@@ -192,6 +194,7 @@ private fun Dependency.toPackage(): Package {
 
     return Package(
         id = id,
+        purl = purl ?: id.toPurl(),
         sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash ?: Hash.NONE) }.orEmpty(),
         vcs = vcsInfo,
         declaredLicenses = emptySet(),

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -190,10 +190,13 @@ private fun Collection<Dependency>.toScope(name: String): Scope =
 private fun Dependency.toPackage(): Package {
     val vcsInfo = vcs.toVcsInfo()
 
-    return Package.EMPTY.copy(
+    return Package(
         id = id,
         sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash ?: Hash.NONE) }.orEmpty(),
         vcs = vcsInfo,
-        vcsProcessed = vcsInfo.normalize()
+        declaredLicenses = emptySet(),
+        description = "",
+        homepageUrl = "",
+        binaryArtifact = RemoteArtifact.EMPTY
     )
 }


### PR DESCRIPTION
Support injecting `purls` for packages when creating an analyzer result from a `PackageList`, to allow using the analyzer results as-is with purl-based advisors, such as OSV and (the upcoming) BlackDuck.

Related to: #8739.
