### PR TITLE
helper-cli: Test that curations are added when creating an analyzer results from package lists

### DIFF
--- a/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -110,4 +110,13 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "File"
+    curations:
+    - id: "NPM::example-dependency-one:1.0.0"
+      curations:
+        comment: "Example curation."
+        vcs:
+          revision: "v1.0.0"

--- a/helper-cli/src/funTest/kotlin/commands/CreateAnalyzerResultFromPackageListCommandFunTest.kt
+++ b/helper-cli/src/funTest/kotlin/commands/CreateAnalyzerResultFromPackageListCommandFunTest.kt
@@ -99,7 +99,4 @@ private fun createOrtConfig(): File {
     return ortConfigFile
 }
 
-private fun OrtResult.patchAnalyzerResult(): OrtResult =
-    copy(
-        analyzer = analyzer?.copy(environment = Environment())
-    )
+private fun OrtResult.patchAnalyzerResult(): OrtResult = copy(analyzer = analyzer?.copy(environment = Environment()))


### PR DESCRIPTION
The test has been missing back when the functionality was added.

Done in context of: #8739.