### PR TITLE
chore(advisor): Prefer `also` over `let` when not mapping

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -89,7 +89,7 @@ class Advisor(
                                 "vulnerabilities via ${provider.descriptor.displayName}. "
                         }
 
-                        providerResults.keys.takeIf { it.isNotEmpty() }?.let { pkgs ->
+                        providerResults.keys.takeIf { it.isNotEmpty() }?.also { pkgs ->
                             logger.debug {
                                 "Affected packages:\n\n${pkgs.joinToString("\n") { it.id.toCoordinates() }}\n"
                             }


### PR DESCRIPTION
It can be confusing to use `let` if the goal is not to map the (anyway discarded) return value, so use `also` instead to emphasize that just some additional work (logging in this case) is done.