### PR TITLE
fix(cyclonedx): Improve mapping of vulnerability methods

### DIFF
--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -296,15 +296,15 @@ class CycloneDxReporter(
     }
 
     private fun addVulnerabilitiesToBom(advisorVulnerabilities: Map<Identifier, List<Vulnerability>>, bom: Bom) {
-        val vulnerabilities = mutableListOf<org.cyclonedx.model.vulnerability.Vulnerability>()
-        advisorVulnerabilities.forEach {
-            val vulnerabilityBomRef = it.key.toCoordinates()
-            it.value.forEach {
-                val vulnerability = org.cyclonedx.model.vulnerability.Vulnerability().apply {
-                    id = it.id
-                    description = it.description
-                    detail = it.summary
-                    ratings = it.references.map { reference ->
+        val allVulnerabilities = mutableListOf<org.cyclonedx.model.vulnerability.Vulnerability>()
+
+        advisorVulnerabilities.forEach { (id, vulnerabilities) ->
+            vulnerabilities.forEach { ortVulnerability ->
+                val cdxVulnerability = org.cyclonedx.model.vulnerability.Vulnerability().apply {
+                    this.id = ortVulnerability.id
+                    description = ortVulnerability.description
+                    detail = ortVulnerability.summary
+                    ratings = ortVulnerability.references.map { reference ->
                         org.cyclonedx.model.vulnerability.Vulnerability.Rating().apply {
                             source = org.cyclonedx.model.vulnerability.Vulnerability.Source()
                                 .apply { url = reference.url.toString() }
@@ -318,14 +318,14 @@ class CycloneDxReporter(
 
                     affects = mutableListOf(
                         org.cyclonedx.model.vulnerability.Vulnerability.Affect()
-                            .apply { ref = vulnerabilityBomRef }
+                            .apply { ref = id.toCoordinates() }
                     )
                 }
 
-                vulnerabilities.add(vulnerability)
+                allVulnerabilities.add(cdxVulnerability)
             }
 
-            bom.vulnerabilities = vulnerabilities
+            bom.vulnerabilities = allVulnerabilities
         }
     }
 

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -338,6 +338,7 @@ class CycloneDxReporter(
                             severity = org.cyclonedx.model.vulnerability.Vulnerability.Rating.Severity
                                 .fromString(reference.severity?.lowercase())
                             this.method = method
+                            vector = reference.vector
                         }
                     }
 


### PR DESCRIPTION
Do not require an exact match of method names, but map according to CVSS prefixes known to ORT.

Resolves #9556.