### PR TITLE
fix(model): Keep the description when converting a project to a package

### DIFF
--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -181,7 +181,7 @@ data class Project(
             id = id,
             authors = authors,
             declaredLicenses = declaredLicenses,
-            description = "",
+            description = description,
             homepageUrl = homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = RemoteArtifact.EMPTY,


### PR DESCRIPTION
This is a fixup for 61a9846.