### PR TITLE
refactor(version-control-systems): Reduce visibility of `CommandLineTool`s

### DIFF
--- a/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
@@ -71,7 +71,7 @@ private data class Include(
     val name: String
 )
 
-object GitRepoCommand : CommandLineTool {
+internal object GitRepoCommand : CommandLineTool {
     override fun command(workingDir: File?) = "repo"
 
     override fun transformVersion(output: String): String {

--- a/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
+++ b/plugins/version-control-systems/mercurial/src/main/kotlin/Mercurial.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 const val MERCURIAL_LARGE_FILES_EXTENSION = "largefiles = "
 const val MERCURIAL_SPARSE_EXTENSION = "sparse = "
 
-object MercurialCommand : CommandLineTool {
+internal object MercurialCommand : CommandLineTool {
     private val versionRegex = Regex("Mercurial .*\\([Vv]ersion (?<version>[\\d.]+)\\)")
 
     override fun command(workingDir: File?) = "hg"


### PR DESCRIPTION
The fact that CLIs are used is an implementation detail that should be hidden away as much as possible.

Note that because these changes are in plugins (and not in public API of core modules), they should not be regarded as breaking changes.