### PR TITLE
fix(helper-cli): Add a default value for `Dependency.purl`

### DIFF
--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -147,7 +147,7 @@ private data class PackageList(
 
 private data class Dependency(
     val id: Identifier,
-    val purl: String?,
+    val purl: String? = null,
     val vcs: Vcs? = null,
     val sourceArtifact: SourceArtifact? = null,
     val isExcluded: Boolean = false,


### PR DESCRIPTION
The recent addition of `dependency.purl` [1] made providing that `purl` mandatory. That should have been optional so that the change is non-breaking. Fix that by adding a default value.

[1] b1a157d7dfa8889cc1a7d143f04ee514e58443da

