### PR TITLE
fix(spdx): Use a single space after the person prefix for the supplier

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -217,9 +217,9 @@ internal fun Package.toSpdxPackage(
                 .sorted()
         },
         name = id.name,
-        originator = authors.takeUnless { it.isEmpty() }?.joinToString(prefix = SpdxConstants.PERSON),
+        originator = authors.takeUnless { it.isEmpty() }?.joinToString(prefix = "${SpdxConstants.PERSON} "),
         packageVerificationCode = packageVerificationCode,
-        supplier = authors.takeUnless { it.isEmpty() }?.joinToString(prefix = SpdxConstants.PERSON),
+        supplier = authors.takeUnless { it.isEmpty() }?.joinToString(prefix = "${SpdxConstants.PERSON} "),
         versionInfo = id.version
     )
 }


### PR DESCRIPTION
Same for the originator. This is a fixup for eead59c.