### PR TITLE
refactor(package-managers): Prefer composition for `CommandLineTool`s

### DIFF
--- a/plugins/package-managers/bower/src/main/kotlin/Bower.kt
+++ b/plugins/package-managers/bower/src/main/kotlin/Bower.kt
@@ -46,6 +46,12 @@ import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
+internal object BowerCommand : CommandLineTool {
+    override fun command(workingDir: File?) = if (Os.isWindows) "bower.cmd" else "bower"
+
+    override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.8.8")
+}
+
 /**
  * The [Bower](https://bower.io/) package manager for JavaScript.
  */
@@ -54,7 +60,7 @@ class Bower(
     analysisRoot: File,
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
-) : PackageManager(name, "Bower", analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
+) : PackageManager(name, "Bower", analysisRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<Bower>("Bower") {
         override val globsForDefinitionFiles = listOf("bower.json")
 
@@ -65,11 +71,7 @@ class Bower(
         ) = Bower(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    override fun command(workingDir: File?) = if (Os.isWindows) "bower.cmd" else "bower"
-
-    override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.8.8")
-
-    override fun beforeResolution(definitionFiles: List<File>) = checkVersion()
+    override fun beforeResolution(definitionFiles: List<File>) = BowerCommand.checkVersion()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
@@ -99,8 +101,8 @@ class Bower(
     }
 
     private fun getProjectPackageInfo(workingDir: File): PackageInfo {
-        run(workingDir, "--allow-root", "install").requireSuccess()
-        val json = run(workingDir, "--allow-root", "list", "--json").requireSuccess().stdout
+        BowerCommand.run(workingDir, "--allow-root", "install").requireSuccess()
+        val json = BowerCommand.run(workingDir, "--allow-root", "list", "--json").requireSuccess().stdout
         return parsePackageInfoJson(json)
     }
 }

--- a/plugins/package-managers/stack/src/test/kotlin/StackTest.kt
+++ b/plugins/package-managers/stack/src/test/kotlin/StackTest.kt
@@ -20,24 +20,18 @@
 package org.ossreviewtoolkit.plugins.packagemanagers.stack
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
-
-import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
-import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 
 class StackTest : WordSpec({
     "transformVersion()" should {
         "return the transformed version" {
-            val stack = Stack("Stack", tempdir(), AnalyzerConfiguration(), RepositoryConfiguration())
-
             mapOf(
                 "Version 1.7.1 x86_64" to "1.7.1",
                 "Version 1.7.1 x86_64" to "1.7.1",
                 "Version 2.1.1, Git revision f612ea8 (7648 commits) x86_64 hpack-0.31.2" to "2.1.1"
             ).forAll { (input, expectedVersion) ->
-                stack.transformVersion(input) shouldBe expectedVersion
+                StackCommand.transformVersion(input) shouldBe expectedVersion
             }
         }
     }

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -51,6 +51,12 @@ private const val PACKAGE_TYPE = "Swift"
 
 private const val DEPENDENCIES_SCOPE_NAME = "dependencies"
 
+internal object SwiftCommand : CommandLineTool {
+    override fun command(workingDir: File?) = if (Os.isWindows) "swift.exe" else "swift"
+
+    override fun transformVersion(output: String) = output.substringAfter("version ").substringBefore(" (")
+}
+
 /**
  * The [Swift Package Manager](https://github.com/apple/swift-package-manager).
  */
@@ -59,7 +65,7 @@ class SwiftPm(
     analysisRoot: File,
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
-) : PackageManager(name, "SwiftPM", analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
+) : PackageManager(name, "SwiftPM", analysisRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<SwiftPm>("SwiftPM") {
         override val globsForDefinitionFiles = listOf(PACKAGE_SWIFT_NAME, PACKAGE_RESOLVED_NAME)
 
@@ -69,10 +75,6 @@ class SwiftPm(
             repoConfig: RepositoryConfiguration
         ) = SwiftPm(type, analysisRoot, analyzerConfig, repoConfig)
     }
-
-    override fun command(workingDir: File?) = if (Os.isWindows) "swift.exe" else "swift"
-
-    override fun transformVersion(output: String) = output.substringAfter("version ").substringBefore(" (")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> {
         return definitionFiles.filterNot { file -> file.path.contains(".build/checkouts") }
@@ -158,7 +160,7 @@ class SwiftPm(
 
     private fun getSwiftPackage(packageSwiftFile: File): SwiftPackage {
         // TODO: Handle errors from stderr.
-        val result = run(
+        val result = SwiftCommand.run(
             packageSwiftFile.parentFile,
             "package",
             "show-dependencies",


### PR DESCRIPTION
Make more clear that package manager implementation *are* not CLIs, but eventually *use* CLIs. This is a better separation of concerns and reduces the sizes of the main classes.

Do the refactoring for all but `Pub` and `Yarn2` for now as these require more work.

Note that `CommandLineTool` implementations in plugins can at maximum be `internal` for the `ort requirements` command to work.