### PR TITLE
chore(common-utils):  Only decide once which `match()` to call

### DIFF
--- a/utils/common/src/main/kotlin/FileMatcher.kt
+++ b/utils/common/src/main/kotlin/FileMatcher.kt
@@ -54,8 +54,12 @@ class FileMatcher(
          * Return true if [path] is matched by any of [patterns], false otherwise. The [path] must use '/' as
          * separators, if it contains any.
          */
-        fun match(patterns: Collection<String>, path: String, ignoreCase: Boolean = false) =
-            patterns.any { pattern -> match(pattern, path, ignoreCase) }
+        fun match(patterns: Collection<String>, path: String, ignoreCase: Boolean = false): Boolean {
+            // Only decide once for all patterns which function to call.
+            val match = if (ignoreCase) matchCaseInsensitive else matchCaseSensitive
+
+            return patterns.any { pattern -> match(pattern, path) }
+        }
     }
 
     constructor(vararg patterns: String, ignoreCase: Boolean = false) : this(patterns.asList(), ignoreCase)


### PR DESCRIPTION
This is a fixup for 32ab460 which forgot about the intended optimization done by the previous implementation.