### PR TITLE
fix(reporter): Add authors to concluded license

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -98,23 +98,7 @@ class LicenseInfoResolver(
                 }.keys
 
                 licenseInfo.declaredLicenseInfo.authors.takeIf { it.isNotEmpty() && addAuthorsToCopyrights }?.also {
-                    locations += ResolvedLicenseLocation(
-                        provenance = UnknownProvenance,
-                        location = UNDEFINED_TEXT_LOCATION,
-                        appliedCuration = null,
-                        matchingPathExcludes = emptyList(),
-                        copyrights = it.mapTo(mutableSetOf()) { author ->
-                            val statement = "Copyright (C) $author".takeUnless {
-                                author.contains("Copyright", ignoreCase = true)
-                            } ?: author
-
-                            ResolvedCopyrightFinding(
-                                statement = statement,
-                                location = UNDEFINED_TEXT_LOCATION,
-                                matchingPathExcludes = emptyList()
-                            )
-                        }
-                    )
+                    locations += resolveCopyrightFromAuthors(it)
                 }
             }
         }
@@ -287,6 +271,25 @@ class LicenseInfoResolver(
 
         return ResolvedLicenseFileInfo(id, licenseFiles)
     }
+
+    private fun resolveCopyrightFromAuthors(authors: Set<String>): ResolvedLicenseLocation =
+        ResolvedLicenseLocation(
+            provenance = UnknownProvenance,
+            location = UNDEFINED_TEXT_LOCATION,
+            appliedCuration = null,
+            matchingPathExcludes = emptyList(),
+            copyrights = authors.mapTo(mutableSetOf()) { author ->
+                val statement = "Copyright (C) $author".takeUnless {
+                    author.contains("Copyright", ignoreCase = true)
+                } ?: author
+
+                ResolvedCopyrightFinding(
+                    statement = statement,
+                    location = UNDEFINED_TEXT_LOCATION,
+                    matchingPathExcludes = emptyList()
+                )
+            }
+        )
 }
 
 private class ResolvedLicenseBuilder(val license: SpdxSingleLicenseExpression) {

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -83,6 +83,10 @@ class LicenseInfoResolver(
                 licenseInfo.concludedLicenseInfo.concludedLicense?.also {
                     originalExpressions += ResolvedOriginalExpression(expression = it, source = LicenseSource.CONCLUDED)
                 }
+
+                licenseInfo.declaredLicenseInfo.authors.takeIf { it.isNotEmpty() && addAuthorsToCopyrights }?.also {
+                    locations += resolveCopyrightFromAuthors(it)
+                }
             }
         }
 


### PR DESCRIPTION
Include authors for package dependencies when both `concluded_license` and `authors` are curated, and ORT is configured with the `addAuthorsToCopyrights` option enabled. This ensures that package authors appear under the respective concluded license in the Disclosure Document.

This behaviour applies when the Scanner option `skipConcluded` is enabled, having the effect that the scan stage is skipped for the particular package dependency in this case, and if either the _concluded_ license is different from the _declared_ license or if no license is _declared_ at all.

Fixes #9599.
