### PR TITLE
ci(renovate): Shorten the commit message for Gradle dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "matchManagers": ["gradle"],
+      "commitMessageTopic": "{{depName}}"
+    },
+    {
       "matchPackageNames": [
         "com.atlassian.jira:jira-rest-java-client-api",
         "com.atlassian.jira:jira-rest-java-client-app"


### PR DESCRIPTION
Change the commit message topic to `{{depName}}` instead of the default `dependency {{depName}}` [1]. "dependency" is redundant as the conventional commit type is already "deps".

[1]: https://docs.renovatebot.com/configuration-options/#commitmessagetopic