### PR TITLE
fix(scancode): No ScanCode license texts in disclosure document

### DIFF
--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -49,7 +49,8 @@ val scanCodeLicenseTextDir by lazy {
     val pythonBinDir = listOf("bin", "Scripts")
     val scanCodeBaseDir = scanCodeExeDir?.takeUnless { it.name in pythonBinDir } ?: scanCodeExeDir?.parentFile
 
-    scanCodeBaseDir?.walkTopDown()?.find { it.isDirectory && it.endsWith("licensedcode/data/licenses") }
+    scanCodeBaseDir?.walkTopDown()?.find { it.isDirectory && it.endsWith("licensedcode/data/licenses") } ?:
+        File("/opt/scancode-license-data").takeIf { it.isDirectory }
 }
 
 /**


### PR DESCRIPTION
Dump the ScanCode license texts to directory _/opt/scancode-license-data_ when creating the ORT docker container. Use this directory as fallback option if the ScanCode license texts cannot be located by the existing heuristic algorithm.


Fixes #8147.
