### PR TITLE
deps: Upgrade the JIRA REST client to version 6.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,8 +29,9 @@ hikari = "6.2.1"
 hoplite = "2.9.0"
 jackson = "2.18.2"
 jakartaMail = "2.0.1"
+jakartaRestApi = "2.1.6"
 jgit = "7.1.0.202411261347-r"
-jiraRestClient = "5.2.7"
+jiraRestClient = "6.0.1"
 jruby = "9.4.9.0"
 jslt = "0.1.14"
 jsonSchemaValidator = "1.5.4"
@@ -115,6 +116,7 @@ jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-d
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jakartaMail = { module = "com.sun.mail:jakarta.mail", version.ref = "jakartaMail" }
+jakartaRestApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "jakartaRestApi" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 jgit-ssh-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit" }
 jgit-ssh-apache-agent = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent", version.ref = "jgit" }

--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -30,10 +30,15 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-scripting-common")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm-host")
+
     implementation(libs.jakartaMail)
+
+    // Required due to https://ecosystem.atlassian.net/browse/JRJC-262.
+    implementation(libs.jakartaRestApi)
+
     implementation(libs.jiraRestClient.api)
     implementation(libs.jiraRestClient.app) {
-        exclude("org.slf4j", "slf4j-log4j12")
+        exclude("org.apache.logging.log4j", "log4j-slf4j2-impl")
             .because("the SLF4J implementation from Log4j 2 is used")
     }
 


### PR DESCRIPTION
Probably because the latest version of `jira-rest-java-client-app` is not hosted on Maven Central [1], Renovate seems to have missed this.

As the client relies on `jakarta.ws.rs:jakarta.ws.rs-api:2.1.6` to be available transitively, which is not the case anymore with `org.glassfish.jersey.core:jersey-common:2.42`, add that dependency directly until [2] is resolved.

[1]: https://mvnrepository.com/artifact/com.atlassian.jira/jira-rest-java-client-app
[2]: https://ecosystem.atlassian.net/browse/JRJC-262