### PR TITLE
fix(bazel): Correctly get the Buildozer version

### DIFF
--- a/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
@@ -97,6 +97,9 @@ internal object BazelCommand : CommandLineTool {
 
 internal object BuildozerCommand : CommandLineTool {
     override fun command(workingDir: File?) = "buildozer"
+
+    override fun transformVersion(output: String) =
+        output.lineSequence().first().trim().removePrefix("buildozer version: ")
 }
 
 class Bazel(


### PR DESCRIPTION
This is a fixup for 8516d2a. However, note [1] about the version always saying "redacted".

[1]: https://github.com/bazelbuild/buildtools/issues/831
