### PR TITLE
chore(scancode): Print JSON raw results non-pretty

### DIFF
--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -76,7 +76,7 @@ class ScanCode internal constructor(
         const val SCANNER_NAME = "ScanCode"
 
         private const val LICENSE_REFERENCES_OPTION_VERSION = "32.0.0"
-        private const val OUTPUT_FORMAT_OPTION = "--json-pp"
+        private const val OUTPUT_FORMAT_OPTION = "--json"
     }
 
     class Factory : ScannerWrapperFactory<ScanCodeConfig>(SCANNER_NAME) {

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -44,7 +44,7 @@ class ScanCodeTest : WordSpec({
 
     "configuration" should {
         "return the default values if the scanner configuration is empty" {
-            scanner.configuration shouldBe "--copyright --license --info --strip-root --timeout 300 --json-pp"
+            scanner.configuration shouldBe "--copyright --license --info --strip-root --timeout 300 --json"
         }
 
         "return the non-config values from the scanner configuration" {
@@ -57,7 +57,7 @@ class ScanCodeTest : WordSpec({
 
             val scannerWithConfig = ScanCode("ScanCode", config, ScannerWrapperConfig.EMPTY)
 
-            scannerWithConfig.configuration shouldBe "--command --line --json-pp"
+            scannerWithConfig.configuration shouldBe "--command --line --json"
         }
     }
 


### PR DESCRIPTION
ScanCode's raw JSON results are not exposed by ORT and thus not looked at by humans. So disable pretty-printing for the chance of a tad quicker result generation.