### PR TITLE
build(gradle): Remove an unneeded artifact version filter

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -32,7 +32,6 @@ repositories {
 
         filter {
             includeGroupByRegex("(com|io)\\.atlassian\\..*")
-            includeVersionByRegex("log4j", "log4j", ".*-atlassian-.*")
         }
     }
 


### PR DESCRIPTION
This is a fixup for 5dcde82.