### PR TITLE
feat(cyclonedx): Change the default schema version to 1.6

### DIFF
--- a/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result-with-findings.json
+++ b/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result-with-findings.json
@@ -1,6 +1,6 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
+  "specVersion": "1.6",
   "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
   "version": 1,
   "metadata": {

--- a/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result-without-findings.json
+++ b/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result-without-findings.json
@@ -1,6 +1,6 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
+  "specVersion": "1.6",
   "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
   "version": 1,
   "metadata": {

--- a/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.json
+++ b/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.json
@@ -1,6 +1,6 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
+  "specVersion": "1.6",
   "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
   "version": 1,
   "metadata": {

--- a/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.xml
+++ b/plugins/reporters/cyclonedx/src/funTest/assets/cyclonedx-reporter-expected-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom serialNumber="urn:uuid:12345678-1234-1234-1234-123456789012" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
+<bom serialNumber="urn:uuid:12345678-1234-1234-1234-123456789012" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
   <metadata>
     <timestamp>1970-01-01T00:00:00Z</timestamp>
     <tools>

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -49,12 +49,12 @@ import org.ossreviewtoolkit.utils.common.alsoIfNull
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.ORT_FULL_NAME
 
-internal const val DEFAULT_SCHEMA_VERSION_NAME = "1.5" // Version.VERSION_15.versionString
+internal const val DEFAULT_SCHEMA_VERSION_NAME = "1.6" // Version.VERSION_16.versionString
 internal val DEFAULT_SCHEMA_VERSION = Version.entries.single { it.versionString == DEFAULT_SCHEMA_VERSION_NAME }
 
 data class CycloneDxReporterConfig(
     /**
-     * The CycloneDX schema version to use. Defaults to "1.5".
+     * The CycloneDX schema version to use. Defaults to "1.6".
      */
     @OrtPluginOption(
         defaultValue = DEFAULT_SCHEMA_VERSION_NAME,


### PR DESCRIPTION
Increase the default schema version from 1.5 to 1.6 which is currently the latest version [1]. For the release notes see [2].

[1]: https://cyclonedx.org/about/history/
[2]: https://cyclonedx.org/news/cyclonedx-v1.6-released/