### PR TITLE
test(spdx-utils): Increase a test timeout a bit

### DIFF
--- a/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
@@ -346,7 +346,7 @@ class SpdxExpressionChoiceTest : WordSpec({
 
         "return in reasonable time for a complex AND expression".config(
             blockingTest = true,
-            timeout = 100.milliseconds
+            timeout = 150.milliseconds
         ) {
             val expression = "Apache-1.1 AND OFL-1.1 AND Apache-2.0 AND Apache-2.0 AND Artistic-1.0-Perl AND " +
                 "Artistic-2.0 AND BSD-2-Clause AND BSD-2-Clause-Darwin AND BSD-2-Clause-Views AND BSD-3-Clause AND " +


### PR DESCRIPTION
This test was observed to take longer on Windows, see e.g. [1].

[1]: https://github.com/oss-review-toolkit/ort/actions/runs/12388007556/job/34578512435#step:5:4691