### PR TITLE
docs(analyzer): Improve `PackageManager` class documentation

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -54,9 +54,9 @@ typealias ManagedProjectFiles = Map<PackageManagerFactory, List<File>>
 typealias ProjectResults = Map<File, List<ProjectAnalyzerResult>>
 
 /**
- * A class to represent a package manager of the given [managerName] that handles dependencies for the given
- * [projectType]. The analysis of any projects and their dependencies starts in the [analysisRoot] directory using the
- * given general [analyzerConfig]. Per-repository configuration is passed in [repoConfig].
+ * A class to represent a package manager with the given [managerName] that handles projects of the given [projectType].
+ * The analysis of any projects and their dependencies starts in the [analysisRoot] directory using the given
+ * [analyzerConfig]. Any project-specific configuration stored in the repository is passed as [repoConfig].
  */
 abstract class PackageManager(
     val managerName: String,


### PR DESCRIPTION
Specifically, clarify that the `projectType` does not refer to dependencies.