### PR TITLE
docs: Clarify that repo config is specific to a "product"

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -56,7 +56,7 @@ typealias ProjectResults = Map<File, List<ProjectAnalyzerResult>>
 /**
  * A class to represent a package manager with the given [managerName] that handles projects of the given [projectType].
  * The analysis of any projects and their dependencies starts in the [analysisRoot] directory using the given
- * [analyzerConfig]. Any project-specific configuration stored in the repository is passed as [repoConfig].
+ * [analyzerConfig]. Any distribution-specific configuration stored in the repository is passed as [repoConfig].
  */
 abstract class PackageManager(
     val managerName: String,

--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.utils.ResolutionsFilter
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 
 /**
- * A project specific configuration for ORT which is usually stored in [ORT_REPO_CONFIG_FILENAME] at the root of a
+ * A distribution-specific configuration for ORT which is usually stored in [ORT_REPO_CONFIG_FILENAME] at the root of a
  * repository. It will be included in the analyzer result and can be further processed by the other tools.
  */
 data class RepositoryConfiguration(


### PR DESCRIPTION
While ORT does not really make use of the term "product" in its docs yet, start to use that term to clarify that repo config is not specific to a "project" in the ORT sense (i.e. something defined by a single definition file), but to the sum of the projects in a repository that form a "product" and that are captured by an analysis.