### PR TITLE
chore(fossid): Add file path with invalid licenses to the error messages

### DIFF
--- a/model/src/main/kotlin/Issue.kt
+++ b/model/src/main/kotlin/Issue.kt
@@ -77,9 +77,14 @@ class NormalizeLineBreaksSerializer : StdSerializer<String>(String::class.java) 
 /**
  * Create an [Issue] and log the message. The log level is aligned with the [severity].
  */
-inline fun <reified T : Any> T.createAndLogIssue(source: String, message: String, severity: Severity? = null): Issue {
-    val issue = severity?.let { Issue(source = source, message = message, severity = it) }
-        ?: Issue(source = source, message = message)
+inline fun <reified T : Any> T.createAndLogIssue(
+    source: String,
+    message: String,
+    severity: Severity? = null,
+    affectedPath: String? = null
+): Issue {
+    val issue = severity?.let { Issue(source = source, message = message, severity = it, affectedPath = affectedPath) }
+        ?: Issue(source = source, message = message, affectedPath = affectedPath)
     logger.log(issue.severity.toLog4jLevel()) { message }
     return issue
 }

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -156,7 +156,8 @@ private fun mapLicense(
     }.onFailure { spdxException ->
         issues += FossId.createAndLogIssue(
             source = "FossId",
-            message = "Failed to parse license '$license' as an SPDX expression: ${spdxException.collectMessages()}"
+            message = "Failed to parse license '$license' as an SPDX expression: ${spdxException.collectMessages()}",
+            affectedPath = location.path
         )
     }.getOrNull()
 }


### PR DESCRIPTION
When FossID reports non-SPDX licenses, it is hard to find the file that initially contained this invalid license.
Improve the user experience by adding the file path to the issue message.

