### PR TITLE
feat(spdx): Add file level information to SPDX projects

### DIFF
--- a/plugins/reporters/spdx/src/funTest/assets/disclosure-cli-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/disclosure-cli-expected-output.spdx.yml
@@ -30,7 +30,7 @@ packages:
     \ 2023 Mercedes-Benz Tech Innovation GmbH\nCopyright 2009-2010, 2012 The Go Authors\n\
     Copyright 2011-2016 Canonical Ltd.\nCopyright 2022 Alan Shreve\nCopyright 2023-2024\
     \ Mercedes-Benz Tech Innovation GmbH"
-  downloadLocation: "NONE"
+  downloadLocation: "https://github.com/mercedes-benz/disclosure-cli.git"
   filesAnalyzed: false
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -22,7 +22,7 @@
   "packages" : [ {
     "SPDXID" : "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1",
     "copyrightText" : "NONE",
-    "downloadLocation" : "NONE",
+    "downloadLocation" : "https://github.com/path/first-project.git",
     "filesAnalyzed" : false,
     "homepage" : "first project's homepage",
     "licenseConcluded" : "NOASSERTION",

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -34,7 +34,7 @@ documentDescribes:
 packages:
 - SPDXID: "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1"
   copyrightText: "NONE"
-  downloadLocation: "NONE"
+  downloadLocation: "https://github.com/path/first-project.git"
   filesAnalyzed: false
   homepage: "first project's homepage"
   licenseConcluded: "NOASSERTION"


### PR DESCRIPTION
In an SPDX report, the information of the project itself is converted to an SPDX package entity as it is done for external dependencies as well. However, this project entity does neither contain the attribute `licenseInfoFromFiles` nor does it contain file-level information even though the scanner found (and e.g. the web app report contains) licenses. Only detected copyright statements are included in the field `copyrightText`.

~If the property `file.information.enabled` is set, file-level information for the scanned project is included.~
If the property `fileInformationEnabled` is set to true in the `SpdxDocumentReporter`, file-level information for the scanned project is included.

I would like some feedback on this addition, which is linked to #8485 :) Thanks

These are the minimum set of changes required to make our use case work.

P.S. @daniel-kr I have set you as author of this PR because these are all your changes. 
