### PR TITLE
feat(cocoapods): Add custom error message

### DIFF
--- a/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
@@ -252,7 +252,9 @@ private fun parseLockfile(podfileLock: File): LockfileData {
         // The version written to the lockfile matches the version specified in the project's ".podspec" file at the
         // given revision, so the same version might be used in different revisions. To still get a unique identifier,
         // append the revision to the version.
-        val versionFromPodspec = checkNotNull(resolvedVersions[name])
+        val versionFromPodspec = checkNotNull(resolvedVersions[name]) {
+            "No version found for '$name' in resolved versions $resolvedVersions."
+        }
         val uniqueVersion = "$versionFromPodspec-$revision"
         val id = Identifier("Pod", "", name, uniqueVersion)
 


### PR DESCRIPTION
Add a custom error message for the case that a build target cannot be found in the resolved versions from the lockfile. Give context information what resolved versions were found.

This improves the current situation where just an
IllegalStateException is thrown without any further context.
