### PR TITLE
feat(advisor): Add BlackDuck as advisor

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -44,6 +44,27 @@ repositories {
             includeGroup("org.gradle")
         }
     }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://repo.blackduck.com/bds-integrations-release")
+        }
+
+        filter {
+            includeGroup("com.blackduck.integration")
+            includeGroup("com.blackducksoftware.magpie")
+        }
+    }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://sig-repo.synopsys.com/bds-bdio-release")
+        }
+
+        filter {
+            includeGroup("com.blackducksoftware.bdio")
+        }
+    }
 }
 
 tasks.withType<Jar>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ versionsPlugin = "0.51.0"
 aeSecurity = "0.132.0"
 asciidoctorj = "3.0.0"
 asciidoctorjPdf = "2.3.19"
+blackduckCommon = "67.0.3"
+blackduckCommonApi = "2023.10.0.6"
 clikt = "5.0.2"
 commonsCompress = "1.27.1"
 cyclonedx = "10.1.0"
@@ -25,6 +27,7 @@ exposed = "0.57.0"
 flexmark = "0.64.8"
 freemarker = "2.3.34"
 greenmail = "2.1.2"
+gson = "2.11.0"
 hikari = "6.2.1"
 hoplite = "2.9.0"
 jackson = "2.18.2"
@@ -90,6 +93,8 @@ aeSecurity = { module = "org.metaeffekt.core:ae-security", version.ref = "aeSecu
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
 asciidoctorj-pdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = "asciidoctorjPdf" }
 awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
+blackduck-common = { module = "com.blackduck.integration:blackduck-common", version.ref = "blackduckCommon" }
+blackduck-common-api = { module = "com.blackduck.integration:blackduck-common-api", version.ref = "blackduckCommonApi" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 cyclonedx = { module = "org.cyclonedx:cyclonedx-core-java", version.ref = "cyclonedx" }
@@ -106,6 +111,7 @@ exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "e
 flexmark = { module = "com.vladsch.flexmark:flexmark", version.ref = "flexmark" }
 freemarker = { module = "org.freemarker:freemarker", version.ref = "freemarker" }
 greenmail = { module = "com.icegreen:greenmail", version.ref = "greenmail" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 hoplite-core = { module = "com.sksamuel.hoplite:hoplite-core", version.ref = "hoplite" }
 hoplite-yaml = { module = "com.sksamuel.hoplite:hoplite-yaml", version.ref = "hoplite" }

--- a/integrations/completions/ort-completion.fish
+++ b/integrations/completions/ort-completion.fish
@@ -25,7 +25,7 @@ complete -c ort -n "__fish_seen_subcommand_from advise" -l output-dir -s o -r -F
 complete -c ort -n "__fish_seen_subcommand_from advise" -l output-formats -s f -r -fa "JSON YAML" -d 'The list of output formats to be used for the ORT result file(s).'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l label -s l -r -d 'Set a label in the ORT result, overwriting any existing label of the same name. Can be used multiple times. For example: --label distribution=external'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l resolutions-file -r -F -d 'A file containing issue and rule violation resolutions.'
-complete -c ort -n "__fish_seen_subcommand_from advise" -l advisors -s a -r -d 'The comma-separated advisors to use, any of [OSSIndex, OSV, VulnerableCode].'
+complete -c ort -n "__fish_seen_subcommand_from advise" -l advisors -s a -r -d 'The comma-separated advisors to use, any of [BlackDuck, OSSIndex, OSV, VulnerableCode].'
 complete -c ort -n "__fish_seen_subcommand_from advise" -l skip-excluded -d 'Do not check excluded projects or packages.'
 complete -c ort -n "__fish_seen_subcommand_from advise" -s h -l help -d 'Show this message and exit'
 

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -127,6 +127,12 @@ ort:
     skipExcluded: true
 
     config:
+      BlackDuck:
+        options:
+          serverUrl: 'server-url'
+        secrets:
+          apiToken: 'token'
+
       GitHubDefects:
         options:
           endpointUrl: 'https://api.github.com/graphql'

--- a/plugins/advisors/black-duck/build.gradle.kts
+++ b/plugins/advisors/black-duck/build.gradle.kts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-plugin-conventions")
+}
+
+dependencies {
+    api(libs.blackduck.common.api)
+
+    api(projects.advisor)
+    api(projects.model)
+
+    implementation(libs.blackduck.common)
+    implementation(libs.kotlinx.coroutines)
+
+    implementation(projects.utils.commonUtils)
+
+    funTestImplementation(libs.gson)
+
+    ksp(projects.advisor)
+}

--- a/plugins/advisors/black-duck/src/funTest/assets/recorded-responses.json
+++ b/plugins/advisors/black-duck/src/funTest/assets/recorded-responses.json
@@ -1,0 +1,5521 @@
+{
+  "componentsViewsForPurl": {
+    "pkg:nuget/Bunkum@4.0.0": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3",
+        "componentName": "Bunkum",
+        "originId": "Bunkum/4.0.0",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origins/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983",
+        "versionName": "4.0.0"
+      }
+    ],
+    "pkg:cargo/sys-info@0.7.0": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133",
+        "componentName": "sys-info",
+        "originId": "sys-info/0.7.0",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origins/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad",
+        "versionName": "0.7.0"
+      }
+    ],
+    "pkg:maven/com.jfinal/jfinal@1.4": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671",
+        "componentName": "jfinal",
+        "originId": "com.jfinal:jfinal:1.4",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origins/bb54ad3a-6605-4455-8d6e-11ce7639ff7e",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f",
+        "versionName": "1.4"
+      }
+    ],
+    "pkg:npm/rebber@1.0.0": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404",
+        "componentName": "zmarkdown",
+        "originId": "rebber/1.0.0",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origins/96aa1969-e052-4206-a2e3-76436abecf72",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d",
+        "versionName": "1.0.0"
+      }
+    ],
+    "pkg:gem/rack@2.0.4": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550",
+        "componentName": "Rack",
+        "originId": "rack/2.0.4",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origins/9630addb-363c-4413-9b72-147f0d3cb2d6",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af",
+        "versionName": "2.0.4"
+      }
+    ],
+    "pkg:pypi/django@3.2": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3",
+        "componentName": "Django",
+        "originId": "Django/3.2",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origins/77ef257f-0925-462b-b7b7-392b37a25772",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267",
+        "versionName": "3.2"
+      }
+    ],
+    "pkg:pub/http@0.13.1": [
+      {
+        "component": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d",
+        "componentName": "http",
+        "originId": "http/0.13.1",
+        "variant": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origins/c946dbc1-368f-46cf-9a42-64cf8beef6a8",
+        "version": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3",
+        "versionName": "0.13.1"
+      }
+    ]
+  },
+  "originViewForComponentsViewKey": {
+    "67572a44-f8ee-4a45-8e21-69f56db86d5d/origins/96aa1969-e052-4206-a2e3-76436abecf72": {
+      "externalId": "rebber/1.0.0",
+      "externalNamespace": "npmjs",
+      "license": {
+        "licenseDisplay": "MIT License",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/ad705c59-6893-4980-bdbf-0837f1823cc4",
+            "licenseDisplay": "MIT License",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/1",
+              "name": "Permissive"
+            },
+            "licenses": [],
+            "name": "MIT License",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "DISJUNCTIVE"
+      },
+      "originId": "rebber/1.0.0",
+      "originName": "npmjs",
+      "originUrl": "https://www.npmjs.org/package/rebber#1.0.0",
+      "packageUrl": "pkg:npm/rebber@1.0.0",
+      "releasedOn": "Jul 29, 2017, 11:55:21 AM",
+      "source": "KB",
+      "versionName": "1.0.0",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origins/96aa1969-e052-4206-a2e3-76436abecf72",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origin/96aa1969-e052-4206-a2e3-76436abecf72/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origin/96aa1969-e052-4206-a2e3-76436abecf72/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origin/96aa1969-e052-4206-a2e3-76436abecf72/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origin/96aa1969-e052-4206-a2e3-76436abecf72/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origins/96aa1969-e052-4206-a2e3-76436abecf72/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origins/96aa1969-e052-4206-a2e3-76436abecf72/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/eb04cfa0-093b-4b88-8236-3ed3f597c404/versions/67572a44-f8ee-4a45-8e21-69f56db86d5d/origins/96aa1969-e052-4206-a2e3-76436abecf72/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    },
+    "19d4ea91-e696-44c9-a3f4-cf751be63dad/origins/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5": {
+      "externalId": "sys-info/0.7.0",
+      "externalNamespace": "crates",
+      "license": {
+        "licenseDisplay": "MIT License",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/ad705c59-6893-4980-bdbf-0837f1823cc4",
+            "licenseDisplay": "MIT License",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/1",
+              "name": "Permissive"
+            },
+            "licenses": [],
+            "name": "MIT License",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "DISJUNCTIVE"
+      },
+      "originId": "sys-info/0.7.0",
+      "originName": "crates",
+      "originUrl": "https://crates.io/crates/sys-info/0.7.0",
+      "packageUrl": "pkg:cargo/sys-info@0.7.0",
+      "releasedOn": "May 29, 2020, 5:58:10 AM",
+      "source": "KB",
+      "versionName": "0.7.0",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origins/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origin/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origin/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origin/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origin/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origins/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origins/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/26967cbe-6a8d-44a6-bea3-c882176af133/versions/19d4ea91-e696-44c9-a3f4-cf751be63dad/origins/d5a17d3b-1a24-4ad6-b4a2-7c969f15a6b5/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    },
+    "e11db4c2-b23c-4e21-88d3-149accf7f6af/origins/9630addb-363c-4413-9b72-147f0d3cb2d6": {
+      "externalId": "rack/2.0.4",
+      "externalNamespace": "rubygems",
+      "license": {
+        "licenseDisplay": "MIT License",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/ad705c59-6893-4980-bdbf-0837f1823cc4",
+            "licenseDisplay": "MIT License",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/1",
+              "name": "Permissive"
+            },
+            "licenses": [],
+            "name": "MIT License",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "DISJUNCTIVE"
+      },
+      "originId": "rack/2.0.4",
+      "originName": "rubygems",
+      "originUrl": "https://rubygems.org/gems/rack/versions/2.0.4",
+      "packageUrl": "pkg:gem/rack@2.0.4",
+      "releasedOn": "Feb 1, 2018, 12:30:03 AM",
+      "source": "KB",
+      "versionName": "2.0.4",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origins/9630addb-363c-4413-9b72-147f0d3cb2d6",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origin/9630addb-363c-4413-9b72-147f0d3cb2d6/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origin/9630addb-363c-4413-9b72-147f0d3cb2d6/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origin/9630addb-363c-4413-9b72-147f0d3cb2d6/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origin/9630addb-363c-4413-9b72-147f0d3cb2d6/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origins/9630addb-363c-4413-9b72-147f0d3cb2d6/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origins/9630addb-363c-4413-9b72-147f0d3cb2d6/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6adfc5b7-92fb-46c4-b5b6-8b06cc7d6550/versions/e11db4c2-b23c-4e21-88d3-149accf7f6af/origins/9630addb-363c-4413-9b72-147f0d3cb2d6/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    },
+    "60c9a5f2-25a3-4525-bee8-4056c9d6397f/origins/bb54ad3a-6605-4455-8d6e-11ce7639ff7e": {
+      "externalId": "com.jfinal:jfinal:1.4",
+      "externalNamespace": "maven",
+      "license": {
+        "licenseDisplay": "Apache License 2.0",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/7cae335f-1193-421e-92f1-8802b4243e93",
+            "licenseDisplay": "Apache License 2.0",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/1",
+              "name": "Permissive"
+            },
+            "licenses": [],
+            "name": "Apache License 2.0",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "DISJUNCTIVE"
+      },
+      "originId": "com.jfinal:jfinal:1.4",
+      "originName": "maven",
+      "originUrl": "http://repo1.maven.org/maven2/com/jfinal/jfinal/1.4/",
+      "packageUrl": "pkg:maven/com.jfinal/jfinal@1.4",
+      "releasedOn": "Sep 8, 2013, 6:26:17 PM",
+      "source": "KB",
+      "versionName": "1.4",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origins/bb54ad3a-6605-4455-8d6e-11ce7639ff7e",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origin/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origin/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origin/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origin/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origins/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origins/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/6dd46c55-176f-47fe-bf04-d4b0b94bd671/versions/60c9a5f2-25a3-4525-bee8-4056c9d6397f/origins/bb54ad3a-6605-4455-8d6e-11ce7639ff7e/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    },
+    "6e56af11-fecc-4d26-9c3b-44bed45b70c3/origins/c946dbc1-368f-46cf-9a42-64cf8beef6a8": {
+      "externalId": "http/0.13.1",
+      "externalNamespace": "dart",
+      "license": {
+        "licenseDisplay": "BSD 3-clause \"New\" or \"Revised\" License",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/3d238144-44e6-450e-b523-3defbdaed9dc",
+            "licenseDisplay": "BSD 3-clause \"New\" or \"Revised\" License",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/1",
+              "name": "Permissive"
+            },
+            "licenses": [],
+            "name": "BSD 3-clause \"New\" or \"Revised\" License",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "DISJUNCTIVE"
+      },
+      "originId": "http/0.13.1",
+      "originName": "dart",
+      "originUrl": "https://pub.dev/packages/http/versions/0.13.1",
+      "packageUrl": "pkg:pub/http@0.13.1",
+      "releasedOn": "May 22, 2015, 2:30:39 AM",
+      "source": "KB",
+      "versionName": "0.13.1",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origins/c946dbc1-368f-46cf-9a42-64cf8beef6a8",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origin/c946dbc1-368f-46cf-9a42-64cf8beef6a8/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origin/c946dbc1-368f-46cf-9a42-64cf8beef6a8/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origin/c946dbc1-368f-46cf-9a42-64cf8beef6a8/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origin/c946dbc1-368f-46cf-9a42-64cf8beef6a8/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origins/c946dbc1-368f-46cf-9a42-64cf8beef6a8/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origins/c946dbc1-368f-46cf-9a42-64cf8beef6a8/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/227df150-1760-486e-afdc-93b1aefd5f4d/versions/6e56af11-fecc-4d26-9c3b-44bed45b70c3/origins/c946dbc1-368f-46cf-9a42-64cf8beef6a8/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    },
+    "ef8a7df6-7ee9-41ff-93cd-e2242c273983/origins/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c": {
+      "externalId": "Bunkum/4.0.0",
+      "externalNamespace": "nuget",
+      "license": {
+        "licenseDisplay": "(GNU Affero General Public License v3.0 AND GNU General Public License v3.0 or later)",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/394cd54e-2263-4005-ac0b-2c080a383d84",
+            "licenseDisplay": "GNU Affero General Public License v3.0",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/4",
+              "name": "AGPL"
+            },
+            "licenses": [],
+            "name": "GNU Affero General Public License v3.0",
+            "ownership": "OPEN_SOURCE"
+          },
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/f80fb9a9-5329-47c2-864d-00ed5cf744bf",
+            "licenseDisplay": "GNU General Public License v3.0 or later",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/2",
+              "name": "Reciprocal"
+            },
+            "licenses": [],
+            "name": "GNU General Public License v3.0 or later",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "CONJUNCTIVE"
+      },
+      "originId": "Bunkum/4.0.0",
+      "originName": "nuget",
+      "originUrl": "https://www.nuget.org/packages/Bunkum/4.0.0",
+      "packageUrl": "pkg:nuget/Bunkum@4.0.0",
+      "releasedOn": "Oct 1, 2023, 5:35:27 AM",
+      "source": "KB",
+      "versionName": "4.0.0",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origins/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origin/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origin/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origin/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origin/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origins/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origins/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/3174353e-ed05-4baa-8bab-232b68b697f3/versions/ef8a7df6-7ee9-41ff-93cd-e2242c273983/origins/8cd81233-9ebb-4c22-a1dc-e6ac0d9ee78c/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    },
+    "0dbe6949-559a-4d20-8408-16ce700a7267/origins/77ef257f-0925-462b-b7b7-392b37a25772": {
+      "externalId": "Django/3.2",
+      "externalNamespace": "pypi",
+      "license": {
+        "licenseDisplay": "BSD 3-clause \"New\" or \"Revised\" License",
+        "licenses": [
+          {
+            "license": "https://BLACK_DUCK_SERVER_HOST/api/licenses/3d238144-44e6-450e-b523-3defbdaed9dc",
+            "licenseDisplay": "BSD 3-clause \"New\" or \"Revised\" License",
+            "licenseFamilySummary": {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/license-families/1",
+              "name": "Permissive"
+            },
+            "licenses": [],
+            "name": "BSD 3-clause \"New\" or \"Revised\" License",
+            "ownership": "OPEN_SOURCE"
+          }
+        ],
+        "type": "DISJUNCTIVE"
+      },
+      "originId": "Django/3.2",
+      "originName": "pypi",
+      "originUrl": "https://pypi.org/project/Django/3.2",
+      "packageUrl": "pkg:pypi/django@3.2",
+      "releasedOn": "Apr 6, 2021, 3:33:15 PM",
+      "source": "KB",
+      "versionName": "3.2",
+      "_meta": {
+        "allow": [
+          "GET"
+        ],
+        "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origins/77ef257f-0925-462b-b7b7-392b37a25772",
+        "links": [
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267",
+            "rel": "version"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origin/77ef257f-0925-462b-b7b7-392b37a25772/vulnerabilities",
+            "rel": "vulnerabilities"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origin/77ef257f-0925-462b-b7b7-392b37a25772/file-licenses",
+            "rel": "file-licenses"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origin/77ef257f-0925-462b-b7b7-392b37a25772/file-licenses-fuzzy",
+            "rel": "file-licenses-fuzzy"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origin/77ef257f-0925-462b-b7b7-392b37a25772/file-copyrights",
+            "rel": "file-copyrights"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origins/77ef257f-0925-462b-b7b7-392b37a25772/upgrade-guidance",
+            "rel": "upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origins/77ef257f-0925-462b-b7b7-392b37a25772/transitive-upgrade-guidance",
+            "rel": "transitive-upgrade-guidance"
+          },
+          {
+            "href": "https://BLACK_DUCK_SERVER_HOST/api/components/1a52678e-8cbf-403c-81e4-976a5cdedbc3/versions/0dbe6949-559a-4d20-8408-16ce700a7267/origins/77ef257f-0925-462b-b7b7-392b37a25772/copyrights",
+            "rel": "component-origin-copyrights"
+          }
+        ]
+      }
+    }
+  },
+  "vulnerabilityViewsForOriginViewKey": {
+    "crates:sys-info/0.7.0": [
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "An issue was discovered in the sys-info crate before 0.8.0 for Rust. sys_info::disk_info calls can trigger a double free.",
+        "name": "CVE-2020-36434",
+        "overallScore": 9.8,
+        "publishedDate": "Aug 8, 2021, 8:15:06 AM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Aug 13, 2021, 7:22:10 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2020-36434",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-415",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2020-4804",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            }
+          ]
+        }
+      }
+    ],
+    "maven:com.jfinal:jfinal:1.4": [
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "temporalMetrics": {
+            "exploitability": "PROOF_OF_CONCEPT",
+            "remediationLevel": "UNAVAILABLE",
+            "reportConfidence": "REASONABLE",
+            "score": 8.9
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:R"
+        },
+        "description": "JFinal CMS 5.1.0 is vulnerable to Command Execution via unauthorized execution of deserialization in the file ApiForm.java\n\n**Note: CVE details have been utilized in generating this advisory. The details of the vulnerability have not been independently verified by Black Duck CyRC.**",
+        "name": "BDSA-2024-9352",
+        "overallScore": 8.9,
+        "publishedDate": "Dec 3, 2024, 3:59:01 PM",
+        "severity": "HIGH",
+        "source": "BDSA",
+        "updatedDate": "Dec 3, 2024, 3:59:01 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-9352",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-77",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-53477",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-9352/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.2,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "HIGH",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "PROOF_OF_CONCEPT",
+            "remediationLevel": "UNAVAILABLE",
+            "reportConfidence": "REASONABLE",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:R"
+        },
+        "description": "A vulnerability has been found in heyewei JFinalCMS 5.0.0 and classified as critical. Affected by this vulnerability is an unknown functionality of the file `/admin/div_data/delete?divId\u003d9` of the component Custom Data Page. The manipulation leads to SQL injection. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-257071.\n\n**Note: CVE details have been utilized in generating this advisory. The details of the vulnerability have not been independently verified by Synopsys CyRC.**",
+        "name": "BDSA-2024-1748",
+        "overallScore": 6.5,
+        "publishedDate": "Apr 19, 2024, 5:03:50 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Apr 19, 2024, 5:03:50 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-1748",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-2568",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-1748/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "Cross Site Scripting (XSS) vulnerability in /admin/login password parameter in JFinalcms 5.0.0 allows attackers to run arbitrary code via crafted URL.",
+        "name": "CVE-2024-22497",
+        "overallScore": 6.1,
+        "publishedDate": "Jan 23, 2024, 8:15:08 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Jan 29, 2024, 6:38:24 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-22497",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "Cross Site Scripting (XSS) vulnerability in JFinalcms 5.0.0 allows attackers to run arbitrary code via the /admin/login username parameter.",
+        "name": "CVE-2024-22496",
+        "overallScore": 6.1,
+        "publishedDate": "Jan 23, 2024, 6:15:10 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Jan 29, 2024, 6:38:30 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-22496",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "A stored XSS vulnerability exists in JFinalcms 5.0.0 via the /gusetbook/save content parameter, which allows remote attackers to inject arbitrary web script or HTML.",
+        "name": "CVE-2024-22493",
+        "overallScore": 5.4,
+        "publishedDate": "Jan 12, 2024, 5:15:52 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Sep 10, 2024, 11:35:08 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-22493",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "A stored XSS vulnerability exists in JFinalcms 5.0.0 via the /gusetbook/save contact parameter, which allows remote attackers to inject arbitrary web script or HTML.",
+        "name": "CVE-2024-22492",
+        "overallScore": 5.4,
+        "publishedDate": "Jan 12, 2024, 5:15:52 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Jan 20, 2024, 7:42:47 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-22492",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalcms 5.0.0 is vulnerable to Cross Site Scripting (XSS) in the site management office.",
+        "name": "CVE-2023-50137",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 14, 2023, 5:15:52 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 16, 2023, 2:41:27 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-50137",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalcms 5.0.0 is vulnerable to Cross Site Scripting (XSS).",
+        "name": "CVE-2023-50102",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 14, 2023, 5:15:52 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 16, 2023, 2:41:22 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-50102",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalcms 5.0.0 is vulnerable to Cross Site Scripting (XSS) via Label management editing.",
+        "name": "CVE-2023-50101",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 14, 2023, 5:15:52 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 16, 2023, 2:41:17 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-50101",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalcms 5.0.0 is vulnerable to Cross Site Scripting (XSS) via carousel image editing.",
+        "name": "CVE-2023-50100",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 14, 2023, 5:15:52 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 16, 2023, 2:10:05 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-50100",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 7.5,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        "description": "JFinalCMS 5.0.0 could allow a remote attacker to read files via ../ Directory Traversal in the /common/down/file fileKey parameter.",
+        "name": "CVE-2023-50449",
+        "overallScore": 7.5,
+        "publishedDate": "Dec 10, 2023, 7:15:07 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 13, 2023, 5:02:58 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-50449",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a cross-site scripting (XSS) vulnerability in the navigation management department.",
+        "name": "CVE-2023-49487",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 8, 2023, 4:15:07 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 12, 2023, 6:19:08 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49487",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a cross-site scripting (XSS) vulnerability in the model management department.",
+        "name": "CVE-2023-49486",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 8, 2023, 4:15:07 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 12, 2023, 6:19:42 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49486",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a cross-site scripting (XSS) vulnerability in the column management department.",
+        "name": "CVE-2023-49485",
+        "overallScore": 5.4,
+        "publishedDate": "Dec 8, 2023, 4:15:07 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Dec 12, 2023, 6:19:56 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49485",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via admin/nav/delete.",
+        "name": "CVE-2023-49448",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:49:37 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49448",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/nav/update.",
+        "name": "CVE-2023-49447",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:34 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49447",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/nav/save.",
+        "name": "CVE-2023-49446",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:26 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49446",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/category/delete.",
+        "name": "CVE-2023-49398",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:23 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49398",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/category/updateStatus.",
+        "name": "CVE-2023-49397",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:20 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49397",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/category/save.",
+        "name": "CVE-2023-49396",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:04 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49396",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/category/update.",
+        "name": "CVE-2023-49395",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:02 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49395",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/tag/save.",
+        "name": "CVE-2023-49383",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:49:57 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49383",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/div/delete.",
+        "name": "CVE-2023-49382",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:49:53 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49382",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/div/update.",
+        "name": "CVE-2023-49381",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:49:48 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49381",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/friend_link/delete.",
+        "name": "CVE-2023-49380",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:49:44 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49380",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via the component /admin/friend_link/save.",
+        "name": "CVE-2023-49379",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:10 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49379",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/form/save.",
+        "name": "CVE-2023-49378",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:07 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49378",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/tag/update.",
+        "name": "CVE-2023-49377",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:12 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49377",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/tag/delete.",
+        "name": "CVE-2023-49376",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:07 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:15 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49376",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/friend_link/update.",
+        "name": "CVE-2023-49375",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:07 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:18 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49375",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/slide/update.",
+        "name": "CVE-2023-49374",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:07 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:28 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49374",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) via /admin/slide/delete.",
+        "name": "CVE-2023-49373",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:07 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:31 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49373",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "JFinalCMS v5.0.0 was discovered to contain a Cross-Site Request Forgery (CSRF) vulnerability via /admin/slide/save.",
+        "name": "CVE-2023-49372",
+        "overallScore": 8.8,
+        "publishedDate": "Dec 5, 2023, 4:15:07 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 9, 2023, 5:50:38 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-49372",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-352",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "Server-Side Template Injection (SSTI) vulnerability in jFinal v.4.9.08 allows a remote attacker to execute arbitrary code via the template function.",
+        "name": "CVE-2021-31635",
+        "overallScore": 9.8,
+        "publishedDate": "Jun 26, 2023, 9:15:09 PM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Dec 5, 2024, 5:15:19 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-31635",
+          "links": []
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "SINGLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 3.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 6.8,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "LOW",
+          "vector": "(AV:N/AC:M/Au:S/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.4,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.3,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "LOW",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "Jfinal CMS v5.1.0 allows attackers to execute arbitrary web scripts or HTML via a crafted payload injected into the keyword text field under the publish blog module.",
+        "name": "CVE-2022-33113",
+        "overallScore": 5.4,
+        "publishedDate": "Jun 23, 2022, 7:15:14 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Jun 29, 2022, 5:04:40 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-33113",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "In applications using jfinal 4.9.08 and below, there is a deserialization vulnerability when using redis,may be vulnerable to remote code execute",
+        "name": "CVE-2021-31649",
+        "overallScore": 9.8,
+        "publishedDate": "Jun 24, 2021, 6:15:08 PM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Jul 1, 2021, 3:25:11 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-31649",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-502",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 8.6,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:M/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "An issue was discovered in JFinal framework v4.9.10 and below. The \"set\" method of the \"Controller\" class of jfinal framework is not strictly filtered, which will lead to XSS vulnerabilities in some cases.",
+        "name": "CVE-2021-33348",
+        "overallScore": 6.1,
+        "publishedDate": "Jun 24, 2021, 5:15:08 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Jun 30, 2021, 10:29:33 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-33348",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+        },
+        "description": "In JFinal cos before 2019-08-13, as used in JFinal 4.4, there is a vulnerability that can bypass the isSafeFile() function: one can upload any type of file. For example, a .jsp file may be stored and almost immediately deleted, but this deletion step does not occur for certain exceptions.",
+        "name": "CVE-2019-17352",
+        "overallScore": 7.5,
+        "publishedDate": "Oct 8, 2019, 3:15:15 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Oct 15, 2019, 7:20:28 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2019-17352",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-434",
+              "rel": "cwes"
+            }
+          ]
+        }
+      }
+    ],
+    "pypi:Django/3.2": [
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 8.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django contains an SQL injection (SQLi) in the `django.db.models.fields.json.HasKey` lookup routine on Oracle databases. Malicious input to the routine could allow an attacker to execute arbitrary commands on the database, resulting in potentially high confidentiality, integrity and availability impacts.",
+        "name": "BDSA-2024-9419",
+        "overallScore": 8.5,
+        "publishedDate": "Dec 5, 2024, 6:24:00 PM",
+        "severity": "HIGH",
+        "source": "BDSA",
+        "updatedDate": "Dec 5, 2024, 6:24:00 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-9419",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-53908",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-9419/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to denial-of-service (DoS) in its `django.utils.html.strip_tags()` method. An attacker could exploit this vulnerability via inputs containing large sequences of nested incomplete HTML entities.",
+        "name": "BDSA-2024-9408",
+        "overallScore": 6.5,
+        "publishedDate": "Dec 5, 2024, 4:14:51 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Dec 5, 2024, 4:15:17 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-9408",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-20",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-53907",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-9408/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+        },
+        "description": "An issue was discovered in Django v5.1.1, v5.0.9, and v4.2.16. The django.contrib.auth.forms.PasswordResetForm class, when used in a view implementing password reset flows, allows remote attackers to enumerate user e-mail addresses by sending password reset requests and observing the outcome (only when e-mail sending is consistently failing).",
+        "name": "CVE-2024-45231",
+        "overallScore": 5.3,
+        "publishedDate": "Oct 8, 2024, 6:15:11 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Oct 30, 2024, 6:35:10 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-45231",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5968",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5968",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to denial-of-service (DoS) via the `urlize()` and `urlizetrunc()` functions when calling the `trim_punctuation()` function. An attacker could cause DoS conditions by supplying very large inputs with a specific sequence of characters.",
+        "name": "BDSA-2024-5966",
+        "overallScore": 6.5,
+        "publishedDate": "Sep 4, 2024, 5:56:59 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Sep 4, 2024, 5:56:59 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5966",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-45230",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5966/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 8.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to SQL injection due to improper validation of input supplied to column aliases via JSON object keys in the `QuerySet.values()` and `QuerySet.values_list()` functions. This could allow an attacker to obtain or modify sensitive information from application databases.",
+        "name": "BDSA-2024-5261",
+        "overallScore": 8.5,
+        "publishedDate": "Aug 8, 2024, 6:25:04 PM",
+        "severity": "HIGH",
+        "source": "BDSA",
+        "updatedDate": "Aug 8, 2024, 6:25:04 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5261",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-42005",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5261/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to denial-of-service (DoS) due to improper string validation in the `floatformat` template filter. This could allow an attacker to cause excessive memory consumption by supplying an application with maliciously crafted input.",
+        "name": "BDSA-2024-5260",
+        "overallScore": 6.5,
+        "publishedDate": "Aug 8, 2024, 6:24:59 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Aug 8, 2024, 6:24:59 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5260",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-41989",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5260/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to a potential denial-of-service (DoS) attack due to a flaw in the `django.utils.html.urlize` function and `AdminURLFieldWidget`. An attacker could cause service disruption by exploiting the vulnerability with certain inputs containing a very large number of Unicode characters.",
+        "name": "BDSA-2024-5207",
+        "overallScore": 6.5,
+        "publishedDate": "Aug 8, 2024, 9:47:29 AM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Nov 6, 2024, 10:20:48 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5207",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-41991",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5207/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to a potential denial-of-service (DoS) attack due to an issue in its `urlize` and `urlizetrunc` template filters. This could allow an attacker to cause a service disruption by inputting very large sequences of specific characters.",
+        "name": "BDSA-2024-5212",
+        "overallScore": 6.5,
+        "publishedDate": "Aug 8, 2024, 9:41:51 AM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Aug 8, 2024, 9:41:51 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5212",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-41990",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-5212/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "HIGH",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 3.7,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.2,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "LOW",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 3.2
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to information disclosure due to inconsistent login validation. An attacker could enumerate, and infer, the validity of usernames by measuring how long the login response takes.",
+        "name": "BDSA-2024-4238",
+        "overallScore": 3.2,
+        "publishedDate": "Jul 10, 2024, 6:26:56 PM",
+        "severity": "LOW",
+        "source": "BDSA",
+        "updatedDate": "Sep 6, 2024, 5:12:43 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4238",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-208",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-39329",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4238/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to denial-of-service (DoS) via the `urlize()` and `urlizetrunc()` functions. An attack can craft an input with a large number of brackets leading to DOS conditions. This could highly compromise the availability on any data which uses the affected functionality.",
+        "name": "BDSA-2024-4239",
+        "overallScore": 6.5,
+        "publishedDate": "Jul 10, 2024, 6:22:06 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Dec 5, 2024, 4:51:44 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4239",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-38875",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4239/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 4.6
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to directory traversal due to path validation which is overwritten when using `generate_filename()`. This could allow an attacker to traverse restricted directories by calling the `save()` command with specific inputs.",
+        "name": "BDSA-2024-4236",
+        "overallScore": 4.6,
+        "publishedDate": "Jul 10, 2024, 6:13:14 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Dec 5, 2024, 4:50:46 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4236",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-39330",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4236/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to denial-of-service (DoS) via the `get_supported_language_variant()` function. An attacker could craft a very long language name string in order to cause memory exhaustion leading to DoS conditions. This could compromise the availability of any data which uses the affected functionality.",
+        "name": "BDSA-2024-4233",
+        "overallScore": 6.5,
+        "publishedDate": "Jul 10, 2024, 5:28:52 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Dec 5, 2024, 4:51:27 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4233",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-39614",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-4233/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "PROOF_OF_CONCEPT",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.7
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to a regular expression denial-of-service (ReDoS) issue due to how the `Truncator.words()` method handles some inputs as a result of a flawed regular expression.\n\nWhere an application uses this method with `html\u003dTrue`, or the `truncatewords_html` template filter, an attacker may be able to submit a crafted input containing a series of less-than (`\u003c`) characters that, when truncated, triggers an excessive use of resources that results in availability issues.\n\n**Note**: This issue exists as a result of incomplete fixes for the previously reported ReDoS issues **CVE-2019-14232** (**BDSA-2019-2490**) and **CVE-2023-43665** (**BDSA-2023-2657**).",
+        "name": "BDSA-2024-0515",
+        "overallScore": 6.7,
+        "publishedDate": "Mar 5, 2024, 5:04:39 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Mar 5, 2024, 5:04:39 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0515",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-27351",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0515/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "An issue was discovered in Django 3.2 before 3.2.24, 4.2 before 4.2.10, and Django 5.0 before 5.0.2. The intcomma template filter was subject to a potential denial-of-service attack when used with very long strings.",
+        "name": "CVE-2024-24680",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 6, 2024, 11:16:15 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Apr 20, 2024, 5:15:06 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-24680",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0283",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0283",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "In Django 3.2 before 3.2.22, 4.1 before 4.1.12, and 4.2 before 4.2.6, the django.utils.text.Truncator chars() and words() methods (when used with html\u003dTrue) are subject to a potential DoS (denial of service) attack via certain inputs with very long, potentially malformed HTML text. The chars() and words() methods are used to implement the truncatechars_html and truncatewords_html template filters, which are thus also vulnerable. NOTE: this issue exists because of an incomplete fix for CVE-2019-14232.",
+        "name": "CVE-2023-43665",
+        "overallScore": 7.5,
+        "publishedDate": "Nov 3, 2023, 6:15:30 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "May 1, 2024, 7:15:25 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-43665",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1284",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-2657",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-2657",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "In Django 3.2 before 3.2.21, 4.1 before 4.1.11, and 4.2 before 4.2.5, django.utils.encoding.uri_to_iri() is subject to a potential DoS (denial of service) attack via certain inputs with a very large number of Unicode characters.",
+        "name": "CVE-2023-41164",
+        "overallScore": 7.5,
+        "publishedDate": "Nov 3, 2023, 6:15:29 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Apr 20, 2024, 5:15:06 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-41164",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1284",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-2334",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-2334",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "An issue was discovered in Django 3.2 before 3.2.23, 4.1 before 4.1.13, and 4.2 before 4.2.7. The NFKC normalization is slow on Windows. As a consequence, django.contrib.auth.forms.UsernameField is subject to a potential DoS (denial of service) attack via certain inputs with a very large number of Unicode characters.",
+        "name": "CVE-2023-46695",
+        "overallScore": 7.5,
+        "publishedDate": "Nov 2, 2023, 7:15:08 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 14, 2023, 11:15:08 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-46695",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-770",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-3013",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-3013",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "In Django 3.2 before 3.2.20, 4 before 4.1.10, and 4.2 before 4.2.3, EmailValidator and URLValidator are subject to a potential ReDoS (regular expression denial of service) attack via a very large number of domain name labels of emails and URLs.",
+        "name": "CVE-2023-36053",
+        "overallScore": 7.5,
+        "publishedDate": "Jul 3, 2023, 3:15:09 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Jul 3, 2024, 3:40:24 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-36053",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1333",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-1682",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-1682",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "In Django 3.2 before 3.2.19, 4.x before 4.1.9, and 4.2 before 4.2.1, it was possible to bypass validation when using one form field to upload multiple files. This multiple upload has never been supported by forms.FileField or forms.ImageField (only the last uploaded file was validated). However, Django\u0027s \"Uploading multiple files\" documentation suggested otherwise.",
+        "name": "CVE-2023-31047",
+        "overallScore": 9.8,
+        "publishedDate": "May 7, 2023, 4:15:08 AM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 5:14:10 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-31047",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-20",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-1084",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-1084",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "An issue was discovered in the Multipart Request Parser in Django 3.2 before 3.2.18, 4.0 before 4.0.10, and 4.1 before 4.1.7. Passing certain inputs (e.g., an excessive number of parts) to multipart forms could result in too many open files or memory exhaustion, and provided a potential vector for a denial-of-service attack.",
+        "name": "CVE-2023-24580",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 15, 2023, 2:15:10 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 5:08:33 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-24580",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0295",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0295",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "In Django 3.2 before 3.2.17, 4.0 before 4.0.9, and 4.1 before 4.1.6, the parsed values of Accept-Language headers are cached in order to avoid repetitive parsing. This leads to a potential denial-of-service vector via excessive memory usage if the raw value of Accept-Language headers is very large.",
+        "name": "CVE-2023-23969",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 1, 2023, 8:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 5:08:08 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-23969",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-770",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0199",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0199",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "In Django 3.2 before 3.2.16, 4.0 before 4.0.8, and 4.1 before 4.1.2, internationalized URLs were subject to a potential denial of service attack via the locale parameter, which is treated as a regular expression.",
+        "name": "CVE-2022-41323",
+        "overallScore": 7.5,
+        "publishedDate": "Oct 16, 2022, 8:15:09 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 4:52:46 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-41323",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-2820",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-2820",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 8.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        "description": "An issue was discovered in the HTTP FileResponse class in Django 3.2 before 3.2.15 and 4.0 before 4.0.7. An application is vulnerable to a reflected file download (RFD) attack that sets the Content-Disposition header of a FileResponse when the filename is derived from user-supplied input.",
+        "name": "CVE-2022-36359",
+        "overallScore": 8.8,
+        "publishedDate": "Aug 3, 2022, 4:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 4:49:36 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-36359",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-494",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-2166",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-2166",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "An issue was discovered in Django 3.2 before 3.2.14 and 4.0 before 4.0.6. The Trunc() and Extract() database functions are subject to SQL injection if untrusted data is used as a kind/lookup_name value. Applications that constrain the lookup name and kind choice to a known safe list are unaffected.",
+        "name": "CVE-2022-34265",
+        "overallScore": 9.8,
+        "publishedDate": "Jul 4, 2022, 6:15:09 PM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 4:48:31 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-34265",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-1849",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-1849",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "A SQL injection issue was discovered in QuerySet.explain() in Django 2.2 before 2.2.28, 3.2 before 3.2.13, and 4.0 before 4.0.4. This occurs by passing a crafted dictionary (with dictionary expansion) as the **options argument, and placing the injection payload in an option name.",
+        "name": "CVE-2022-28347",
+        "overallScore": 9.8,
+        "publishedDate": "Apr 12, 2022, 7:15:07 AM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:57:11 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-28347",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0989",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0989",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "An issue was discovered in Django 2.2 before 2.2.28, 3.2 before 3.2.13, and 4.0 before 4.0.4. QuerySet.annotate(), aggregate(), and extra() methods are subject to SQL injection in column aliases via a crafted dictionary (with dictionary expansion) as the passed **kwargs.",
+        "name": "CVE-2022-28346",
+        "overallScore": 9.8,
+        "publishedDate": "Apr 12, 2022, 7:15:06 AM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:57:11 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-28346",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0987",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0987",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:N/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "An issue was discovered in MultiPartParser in Django 2.2 before 2.2.27, 3.2 before 3.2.12, and 4.0 before 4.0.2. Passing certain inputs to multipart forms could result in an infinite loop when parsing files.",
+        "name": "CVE-2022-23833",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 3, 2022, 3:15:07 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:49:20 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-23833",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-835",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0315",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0315",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 8.6,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:M/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "The {% debug %} template tag in Django 2.2 before 2.2.27, 3.2 before 3.2.12, and 4.0 before 4.0.2 does not properly encode the current context. This may lead to XSS.",
+        "name": "CVE-2022-22818",
+        "overallScore": 6.1,
+        "publishedDate": "Feb 3, 2022, 3:15:07 AM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:47:30 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-22818",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0295",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0295",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+        },
+        "description": "Storage.save in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before 4.0.1 allows directory traversal if crafted filenames are directly passed to it.",
+        "name": "CVE-2021-45452",
+        "overallScore": 5.3,
+        "publishedDate": "Jan 5, 2022, 1:15:07 AM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:32:14 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-45452",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0002",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0002",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 7.5,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        "description": "An issue was discovered in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before 4.0.1. Due to leveraging the Django Template Language\u0027s variable resolution logic, the dictsort template filter was potentially vulnerable to information disclosure, or an unintended method call, if passed a suitably crafted key.",
+        "name": "CVE-2021-45116",
+        "overallScore": 7.5,
+        "publishedDate": "Jan 5, 2022, 1:15:07 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:31:59 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-45116",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-20",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0003",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0003",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:N/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "An issue was discovered in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before 4.0.1. UserAttributeSimilarityValidator incurred significant overhead in evaluating a submitted password that was artificially large in relation to the comparison values. In a situation where access to user registration was unrestricted, this provided a potential vector for a denial-of-service attack.",
+        "name": "CVE-2021-45115",
+        "overallScore": 7.5,
+        "publishedDate": "Jan 5, 2022, 1:15:07 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:31:59 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-45115",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0005",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-0005",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "LOW",
+          "baseScore": 7.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.4,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+        },
+        "description": "In Django 2.2 before 2.2.25, 3.1 before 3.1.14, and 3.2 before 3.2.10, HTTP requests for URLs with trailing newlines could bypass upstream access control based on URL paths.",
+        "name": "CVE-2021-44420",
+        "overallScore": 7.3,
+        "publishedDate": "Dec 8, 2021, 1:15:07 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 7:30:56 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-44420",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-3666",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-3666",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "HIGH",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "description": "Django 3.1.x before 3.1.13 and 3.2.x before 3.2.5 allows QuerySet.order_by SQL injection if order_by is untrusted input from a client of a web application.",
+        "name": "CVE-2021-35042",
+        "overallScore": 9.8,
+        "publishedDate": "Jul 2, 2021, 12:15:07 PM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 4:36:29 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-35042",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-89",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1994",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1994",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+        },
+        "description": "In Django 2.2 before 2.2.24, 3.x before 3.1.12, and 3.2 before 3.2.4, URLValidator, validate_ipv4_address, and validate_ipv46_address do not prohibit leading zero characters in octal literals. This may allow a bypass of access control that is based on IP addresses. (validate_ipv4_address and validate_ipv46_address are unaffected with Python 3.9.5+..) .",
+        "name": "CVE-2021-33571",
+        "overallScore": 7.5,
+        "publishedDate": "Jun 8, 2021, 8:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 7, 2023, 11:15:08 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-33571",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-918",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1670",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1670",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "SINGLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 8.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:S/C:P/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.9,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "HIGH",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N"
+        },
+        "description": "Django before 2.2.24, 3.x before 3.1.12, and 3.2.x before 3.2.4 has a potential directory traversal via django.contrib.admindocs. Staff members could use the TemplateDetailView view to check the existence of arbitrary files. Additionally, if (and only if) the default admindocs templates have been customized by application developers to also show file contents, then not only the existence but also the file contents would have been exposed. In other words, there is directory traversal outside of the template root directories.",
+        "name": "CVE-2021-33203",
+        "overallScore": 4.9,
+        "publishedDate": "Jun 8, 2021, 8:15:08 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 4:35:49 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-33203",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1666",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1666",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 8.6,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:M/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "In Django 2.2 before 2.2.22, 3.1 before 3.1.10, and 3.2 before 3.2.2 (with Python 3.9.5+), URLValidator does not prohibit newlines and tabs (unless the URLField form field is used). If an application uses values with newlines in an HTTP response, header injection can occur. Django itself is unaffected because HttpResponse prohibits newlines in HTTP headers.",
+        "name": "CVE-2021-32052",
+        "overallScore": 6.1,
+        "publishedDate": "May 6, 2021, 6:15:07 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 4:35:12 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-32052",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1271",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1271",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 7.5,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        "description": "In Django 2.2 before 2.2.21, 3.1 before 3.1.9, and 3.2 before 3.2.1, MultiPartParser, UploadedFile, and FieldFile allowed directory traversal via uploaded files with suitably crafted file names.",
+        "name": "CVE-2021-31542",
+        "overallScore": 7.5,
+        "publishedDate": "May 5, 2021, 5:15:08 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 7, 2023, 11:15:07 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-31542",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1238",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-1238",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "SINGLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 8.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 3.0
+          },
+          "vector": "(AV:N/AC:L/Au:S/C:P/I:N/A:N/E:U/RL:OF/RC:C)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "LOW",
+          "scope": "UNCHANGED",
+          "severity": "LOW",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 3.8
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C"
+        },
+        "description": "Django contains a directory traversal vulnerability because of improper sanitization measures. An attacker could exploit this flaw and gain access to restricted files or directories.",
+        "name": "BDSA-2021-0876",
+        "overallScore": 3.8,
+        "publishedDate": "Apr 7, 2021, 3:55:16 PM",
+        "severity": "LOW",
+        "source": "BDSA",
+        "updatedDate": "Apr 7, 2021, 3:55:16 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-0876",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-28658",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-0876/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 3.7
+          },
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:N/A:N/E:U/RL:OF/RC:C)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 4.6
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:C"
+        },
+        "description": "Django contains a directory traversal vulnerability. Successfully exploiting this could allow an attacker access to files they do not have permission to view.",
+        "name": "BDSA-2021-0269",
+        "overallScore": 4.6,
+        "publishedDate": "Feb 1, 2021, 6:12:50 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Aug 10, 2021, 11:24:33 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-0269",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2021-3281",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-0269/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 3.7
+          },
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:N/A:P/E:U/RL:OF/RC:C)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Django is vulnerable to a regular expression blowup. An attacker able to supply specially crafted input to the `Truncator` functionality could consume excessive CPU resources, resulting in a denial-of-service (DoS).",
+        "name": "BDSA-2019-2490",
+        "overallScore": 6.5,
+        "publishedDate": "Aug 8, 2019, 1:48:54 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Mar 5, 2024, 4:59:33 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2019-2490",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2019-14232",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2019-2490/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      }
+    ],
+    "npmjs:rebber/1.0.0": [
+      {
+        "bdsaTags": [
+          "RCE"
+        ],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 6.4,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "PROOF_OF_CONCEPT",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 5.9
+          },
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:P/A:P/E:POC/RL:OF/RC:C)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 5.9,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "temporalMetrics": {
+            "exploitability": "PROOF_OF_CONCEPT",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 8.8
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C"
+        },
+        "description": "Rebber is vulnerable to OS command injection due to the unsafe generation of `CodeBlock` elements. A remote attacker could execute arbitrary commands on a vulnerable system by causing the application to process input containing a crafted markdown payload.",
+        "name": "BDSA-2021-2907",
+        "overallScore": 8.8,
+        "publishedDate": "Oct 12, 2021, 4:55:01 PM",
+        "severity": "HIGH",
+        "source": "BDSA",
+        "updatedDate": "Aug 31, 2022, 5:50:25 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-2907",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-78",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2021-2907/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      }
+    ],
+    "dart:http/0.13.1": [
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 8.6,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:M/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "An issue was discovered in the http package through 0.12.2 for Dart. If the attacker controls the HTTP method and the app is using Request directly, it\u0027s possible to achieve CRLF injection in an HTTP request.",
+        "name": "CVE-2020-35669",
+        "overallScore": 6.1,
+        "publishedDate": "Dec 24, 2020, 4:15:12 AM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Jul 19, 2022, 1:02:05 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2020-35669",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-74",
+              "rel": "cwes"
+            }
+          ]
+        }
+      }
+    ],
+    "rubygems:rack/2.0.4": [
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 6.5
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+        },
+        "description": "Rack is vulnerable to denial-of-service (DoS) via the media type parsing component. An attacker could exploit this by leveraging a specially designed HTTP `Content-Type` header that could result in the media type parsing process to exceed the expected time frame, potentially causing a denial-of-service.",
+        "name": "BDSA-2024-0568",
+        "overallScore": 6.5,
+        "publishedDate": "Mar 11, 2024, 10:57:09 AM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Mar 11, 2024, 10:57:09 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0568",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-25126",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0568/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "LOW",
+          "baseScore": 5.8,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 5.1
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L/E:U/RL:O/RC:C"
+        },
+        "description": "Rack was found to be susceptible to a denial-of-service (DoS) condition via the Range request header. A remote attacker could exploit this by sending a crafted Range headar in order to cause the server to respond with an excessively large response. Applications that use the `Rack::File` middleware or the `Rack::Utils.byte_ranges` methods (including Rails applications) are vulnerable.",
+        "name": "BDSA-2024-0549",
+        "overallScore": 5.1,
+        "publishedDate": "Mar 7, 2024, 3:00:43 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Mar 7, 2024, 3:00:43 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0549",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-26141",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0549/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "HIGH",
+          "accessVector": "LOCAL",
+          "authentication": "MULTIPLE",
+          "availabilityImpact": "NONE",
+          "baseScore": 0.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 1.2,
+          "impactSubscore": 0.0,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "LOW",
+          "baseScore": 5.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 4.6
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:C"
+        },
+        "description": "An issue was discovered in the header parsing routine within Rack. A remote attacker could exploit this using a carefully crafted header in order to cause a denial-of-service (DoS) condition. This issue affects both \u0027Accept\u0027 and \u0027Forwarded\u0027 headers.",
+        "name": "BDSA-2024-0544",
+        "overallScore": 4.6,
+        "publishedDate": "Mar 7, 2024, 2:53:30 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Mar 7, 2024, 2:53:30 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0544",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2024-26146",
+              "label": "NVD",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2024-0544/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "LOW",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 3.7
+          },
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:N/A:P/E:U/RL:OF/RC:C)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "LOW",
+          "baseScore": 5.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "temporalMetrics": {
+            "exploitability": "UNPROVEN",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "score": 4.6
+          },
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:C"
+        },
+        "description": "Rack is vulnerable to regular expression denial-of-service (ReDoS) due to a flaw in the header parsing functionality. A remote unauthenticated attacker could exploit this vulnerability by using a crafted URL.",
+        "name": "BDSA-2023-1001",
+        "overallScore": 4.6,
+        "publishedDate": "Apr 26, 2023, 5:12:01 PM",
+        "severity": "MEDIUM",
+        "source": "BDSA",
+        "updatedDate": "Apr 26, 2023, 5:12:01 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-1001",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-1001/ranges",
+              "rel": "bdsa-ranges"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "A DoS vulnerability exists in Rack \u003cv3.0.4.2, \u003cv2.2.6.3, \u003cv2.1.4.3 and \u003cv2.0.9.3 within in the Multipart MIME parsing code in which could allow an attacker to craft requests that can be abuse to cause multipart parsing to take longer than expected.",
+        "name": "CVE-2023-27530",
+        "overallScore": 7.5,
+        "publishedDate": "Mar 10, 2023, 11:15:10 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Oct 15, 2024, 9:35:28 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-27530",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-770",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0452",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0452",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "A denial of service vulnerability in the multipart parsing component of Rack fixed in 2.0.9.2, 2.1.4.2, 2.2.4.1 and 3.0.0.1 could allow an attacker tocraft input that can cause RFC2183 multipart boundary parsing in Rack to take an unexpected amount of time, possibly resulting in a denial of service attack vector. Any applications that parse multipart posts using Rack (virtually all Rails applications) are impacted.",
+        "name": "CVE-2022-44572",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 9, 2023, 9:15:11 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 8, 2023, 11:15:07 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-44572",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1333",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0097",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0097",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "There is a denial of service vulnerability in the Content-Disposition parsingcomponent of Rack fixed in 2.0.9.2, 2.1.4.2, 2.2.4.1, 3.0.0.1. This could allow an attacker to craft an input that can cause Content-Disposition header parsing in Rackto take an unexpected amount of time, possibly resulting in a denial ofservice attack vector. This header is used typically used in multipartparsing. Any applications that parse multipart posts using Rack (virtuallyall Rails applications) are impacted.",
+        "name": "CVE-2022-44571",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 9, 2023, 9:15:11 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 8, 2023, 11:15:07 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-44571",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1333",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0099",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0099",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "A denial of service vulnerability in the Range header parsing component of Rack \u003e\u003d 1.5.0. A Carefully crafted input can cause the Range header parsing component in Rack to take an unexpected amount of time, possibly resulting in a denial of service attack vector. Any applications that deal with Range requests (such as streaming applications, or applications that serve files) may be impacted.",
+        "name": "CVE-2022-44570",
+        "overallScore": 7.5,
+        "publishedDate": "Feb 9, 2023, 9:15:11 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 8, 2023, 11:15:07 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-44570",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1333",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0095",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2023-0095",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 10.0,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 6.0,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "CRITICAL",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+        },
+        "description": "A sequence injection vulnerability exists in Rack \u003c2.0.9.1, \u003c2.1.4.1 and \u003c2.2.3.1 which could allow is a possible shell escape in the Lint and CommonLogger components of Rack.",
+        "name": "CVE-2022-30123",
+        "overallScore": 10.0,
+        "publishedDate": "Dec 5, 2022, 11:15:10 PM",
+        "severity": "CRITICAL",
+        "source": "NVD",
+        "updatedDate": "Dec 8, 2023, 11:15:07 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-30123",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-1495",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-1495",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "A possible denial of service vulnerability exists in Rack \u003c2.0.9.1, \u003c2.1.4.1 and \u003c2.2.3.1 in the multipart parsing component of Rack.",
+        "name": "CVE-2022-30122",
+        "overallScore": 7.5,
+        "publishedDate": "Dec 5, 2022, 11:15:10 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Dec 20, 2023, 4:02:05 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2022-30122",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-1333",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-1492",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2022-1492",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:P/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 8.6,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 4.0,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+        },
+        "description": "A directory traversal vulnerability exists in rack \u003c 2.2.0 that allows an attacker perform directory traversal vulnerability in the Rack::Directory app that is bundled with Rack which could result in information disclosure.",
+        "name": "CVE-2020-8161",
+        "overallScore": 8.6,
+        "publishedDate": "Jul 2, 2020, 9:15:12 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 6:38:24 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2020-8161",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-22",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2020-1615",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2020-1615",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "HIGH",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+        },
+        "description": "A reliance on cookies without validation/integrity check security vulnerability exists in rack \u003c 2.2.3, rack \u003c 2.1.4 that makes it is possible for an attacker to forge a secure or host-only cookie prefix.",
+        "name": "CVE-2020-8184",
+        "overallScore": 7.5,
+        "publishedDate": "Jun 19, 2020, 7:15:18 PM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 21, 2024, 6:38:27 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2020-8184",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-20",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2020-1429",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2020-1429",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "PARTIAL",
+          "exploitabilitySubscore": 8.6,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:M/Au:N/C:P/I:N/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "HIGH",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.9,
+          "confidentialityImpact": "HIGH",
+          "exploitabilitySubscore": 2.2,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        "description": "There\u0027s a possible information leak / session hijack vulnerability in Rack (RubyGem rack). This vulnerability is patched in versions 1.6.12 and 2.0.8. Attackers may be able to find and hijack sessions by using timing attacks targeting the session id. Session ids are usually stored and indexed in a database that uses some kind of scheme for speeding up lookups of that session id. By carefully measuring the amount of time it takes to look up a session, an attacker may be able to find a valid session id and hijack the session. The session id itself may be generated randomly, but the way the session is indexed by the backing store does not use a secure comparison.",
+        "name": "CVE-2019-16782",
+        "overallScore": 5.9,
+        "publishedDate": "Dec 18, 2019, 9:15:16 PM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Nov 2, 2021, 7:04:03 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2019-16782",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-203",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2019-4012",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2019-4012",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "MEDIUM",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "NONE",
+          "baseScore": 4.3,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 8.6,
+          "impactSubscore": 2.9,
+          "integrityImpact": "PARTIAL",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:M/Au:N/C:N/I:P/A:N)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 6.1,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 2.8,
+          "impactSubscore": 2.7,
+          "integrityImpact": "LOW",
+          "privilegesRequired": "NONE",
+          "scope": "CHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "REQUIRED",
+          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+        },
+        "description": "There is a possible XSS vulnerability in Rack before 2.0.6 and 1.6.11. Carefully crafted requests can impact the data returned by the `scheme` method on `Rack::Request`. Applications that expect the scheme to be limited to \u0027http\u0027 or \u0027https\u0027 and do not escape the return value could be vulnerable to an XSS attack. Note that applications using the normal escaping mechanisms provided by Rails may not impacted, but applications that bypass the escaping mechanisms, or do not use them may be vulnerable.",
+        "name": "CVE-2018-16471",
+        "overallScore": 6.1,
+        "publishedDate": "Nov 14, 2018, 12:29:00 AM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 3:53:46 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2018-16471",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-79",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2018-3915",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2018-3915",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      },
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {
+          "accessComplexity": "LOW",
+          "accessVector": "NETWORK",
+          "authentication": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 5.0,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 10.0,
+          "impactSubscore": 2.9,
+          "integrityImpact": "NONE",
+          "severity": "MEDIUM",
+          "vector": "(AV:N/AC:L/Au:N/C:N/I:N/A:P)"
+        },
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "confidentialityImpact": "NONE",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 3.6,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "HIGH",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        "description": "There is a possible DoS vulnerability in the multipart parser in Rack before 2.0.6. Specially crafted requests can cause the multipart parser to enter a pathological state, causing the parser to use CPU resources disproportionate to the request size.",
+        "name": "CVE-2018-16470",
+        "overallScore": 7.5,
+        "publishedDate": "Nov 14, 2018, 12:29:00 AM",
+        "severity": "HIGH",
+        "source": "NVD",
+        "updatedDate": "Nov 7, 2023, 3:53:46 AM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2018-16470",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-400",
+              "rel": "cwes"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2018-3914",
+              "label": "BDSA",
+              "rel": "related-vulnerabilities"
+            },
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2018-3914",
+              "label": "BDSA",
+              "rel": "related-affecting-vulnerability"
+            }
+          ]
+        }
+      }
+    ],
+    "nuget:Bunkum/4.0.0": [
+      {
+        "bdsaTags": [],
+        "classifications": [],
+        "cvss2": {},
+        "cvss3": {
+          "attackComplexity": "LOW",
+          "attackVector": "NETWORK",
+          "availabilityImpact": "NONE",
+          "baseScore": 5.3,
+          "confidentialityImpact": "LOW",
+          "exploitabilitySubscore": 3.9,
+          "impactSubscore": 1.4,
+          "integrityImpact": "NONE",
+          "privilegesRequired": "NONE",
+          "scope": "UNCHANGED",
+          "severity": "MEDIUM",
+          "userInteraction": "NONE",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+        },
+        "description": "Bunkum is an open-source protocol-agnostic request server for custom game servers. First, a little bit of background. So, in the beginning, Bunkum\u0027s `AuthenticationService` only supported injecting `IUser`s. However, as Refresh and SoundShapesServer implemented permissions systems support for injecting `IToken`s into endpoints was added. All was well until 4.0. Bunkum 4.0 then changed to enforce relations between `IToken`s and `IUser`s. This wasn\u0027t implemented in a very good way in the `AuthenticationService`, and ended up breaking caching in such a way that cached tokens would persist after the lifetime of the request - since we tried to cache both tokens and users. From that point until now, from what I understand, Bunkum was attempting to use that cached token at the start of the next request once cached. Naturally, when that token expired, downstream projects like Refresh would remove the object from Realm - and cause the object in the cache to be in a detached state, causing an exception from invalid use of `IToken.User`. So in other words, a use-after-free since Realm can\u0027t manage the lifetime of the cached token. Security-wise, the scope is fairly limited, can only be pulled off on a couple endpoints given a few conditions, and you can\u0027t guarantee which token you\u0027re going to get. Also, the token *would* get invalidated properly if the endpoint had either a `IToken` usage or a `IUser` usage. The fix is to just wipe the token cache after the request was handled, which is now in `4.2.1`. Users are advised to upgrade. There are no known workarounds for this vulnerability.",
+        "name": "CVE-2023-45814",
+        "overallScore": 5.3,
+        "publishedDate": "Oct 19, 2023, 12:15:09 AM",
+        "severity": "MEDIUM",
+        "source": "NVD",
+        "updatedDate": "Oct 30, 2023, 6:16:15 PM",
+        "useCvss3": true,
+        "_meta": {
+          "allow": [],
+          "href": "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2023-45814",
+          "links": [
+            {
+              "href": "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-772",
+              "rel": "cwes"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/plugins/advisors/black-duck/src/funTest/assets/retrieve-package-findings-expected-result.yml
+++ b/plugins/advisors/black-duck/src/funTest/assets/retrieve-package-findings-expected-result.yml
@@ -1,0 +1,29 @@
+---
+Crate::sys-info:0.7.0:
+  advisor:
+    name: "BlackDuck"
+    capabilities:
+    - "VULNERABILITIES"
+  summary:
+    start_time: "1970-01-01T00:00:00Z"
+    end_time: "1970-01-01T00:00:00Z"
+  vulnerabilities:
+  - id: "CVE-2020-36434"
+    description: "An issue was discovered in the sys-info crate before 0.8.0 for Rust.\
+      \ sys_info::disk_info calls can trigger a double free."
+    references:
+    - url: "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/CVE-2020-36434"
+      scoring_system: "CVSS:3.1"
+      severity: "CRITICAL"
+      score: 9.8
+      vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    - url: "https://BLACK_DUCK_SERVER_HOST/api/cwes/CWE-415"
+      scoring_system: "CVSS:3.1"
+      severity: "CRITICAL"
+      score: 9.8
+      vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    - url: "https://BLACK_DUCK_SERVER_HOST/api/vulnerabilities/BDSA-2020-4804"
+      scoring_system: "CVSS:3.1"
+      severity: "CRITICAL"
+      score: 9.8
+      vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"

--- a/plugins/advisors/black-duck/src/funTest/kotlin/BlackDuckFunTest.kt
+++ b/plugins/advisors/black-duck/src/funTest/kotlin/BlackDuckFunTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+
+import java.time.Instant
+
+import org.ossreviewtoolkit.advisor.normalizeVulnerabilityData
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.utils.common.Os
+import org.ossreviewtoolkit.utils.test.getAssetFile
+import org.ossreviewtoolkit.utils.test.identifierToPackage
+
+class BlackDuckFunTest : WordSpec({
+    /**
+     * To run the test against a real instance, and / or to re-record the responses:
+     *
+     * 1. Set the BLACK_DUCK_SERVER_URL and BLACK_DUCK_API_TOKEN environment variables.
+     * 2. Delete 'recorded-responses.json'.
+     * 3. Run the functional test.
+     */
+    val serverUrl = Os.env["BLACK_DUCK_SERVER_URL"]
+    val apiToken = Os.env["BLACK_DUCK_API_TOKEN"]
+    val componentServiceClient = ResponseCachingComponentServiceClient(
+        overrideFile = getAssetFile("recorded-responses.json"),
+        serverUrl = serverUrl,
+        apiToken = apiToken
+    )
+
+    val blackDuck = BlackDuck(BlackDuckFactory.descriptor, componentServiceClient)
+
+    afterEach { componentServiceClient.flush() }
+
+    "retrievePackageFindings()" should {
+        "return the vulnerabilities for the supported ecosystems" {
+            val packages = setOf(
+                // TODO: Add hackage / pod
+                "Crate::sys-info:0.7.0",
+                "Gem::rack:2.0.4",
+                "Maven:com.jfinal:jfinal:1.4",
+                "NPM::rebber:1.0.0",
+                "NuGet::Bunkum:4.0.0",
+                "Pub::http:0.13.1",
+                "PyPI::django:3.2"
+            ).mapTo(mutableSetOf()) {
+                identifierToPackage(it)
+            }
+
+            val packageFindings = blackDuck.retrievePackageFindings(packages).mapKeys { it.key.id.toCoordinates() }
+
+            packageFindings.keys shouldContainExactlyInAnyOrder packages.map { it.id.toCoordinates() }
+            packageFindings.keys.forAll { id ->
+                packageFindings.getValue(id).vulnerabilities shouldNot beEmpty()
+            }
+        }
+
+        "return the expected result for the given package(s)" {
+            val expectedResult = getAssetFile("retrieve-package-findings-expected-result.yml")
+                .readValue<Map<Identifier, AdvisorResult>>()
+            val packages = setOf(
+                // Package using CVSS 3.1 vector:
+                "Crate::sys-info:0.7.0"
+                // Todo: Add a package using CVSS 2 vector:
+            ).mapTo(mutableSetOf()) {
+                identifierToPackage(it)
+            }
+
+            val packageFindings = blackDuck.retrievePackageFindings(packages).mapKeys { it.key.id }
+
+            packageFindings.patchTimes().toYaml().patchServerUrl(serverUrl) shouldBe
+                expectedResult.patchTimes().toYaml()
+        }
+    }
+})
+
+internal fun String.patchServerUrl(serverUrl: String?) =
+    serverUrl?.let { replace(it, "https://BLACK_DUCK_SERVER_HOST") } ?: this
+
+private fun Map<Identifier, AdvisorResult>.patchTimes(): Map<Identifier, AdvisorResult> =
+    mapValues { (_, advisorResult) ->
+        advisorResult.normalizeVulnerabilityData().copy(
+            summary = advisorResult.summary.copy(
+                startTime = Instant.EPOCH,
+                endTime = Instant.EPOCH
+            )
+        )
+    }

--- a/plugins/advisors/black-duck/src/funTest/kotlin/ResponseCachingComponentServiceClient.kt
+++ b/plugins/advisors/black-duck/src/funTest/kotlin/ResponseCachingComponentServiceClient.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import com.blackduck.integration.blackduck.api.generated.response.ComponentsView
+import com.blackduck.integration.blackduck.api.generated.view.OriginView
+import com.blackduck.integration.blackduck.api.generated.view.VulnerabilityView
+
+import com.google.gson.GsonBuilder
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * This [ComponentServiceClient] uses a cache for responses. The cache is initialized with the content from a preceding
+ * run in the given overrideFile.
+ *
+ * Note: In case the cache initially contains all responses for a particular test, an instance of this class can be used
+ * as a fake [ComponentServiceClient].
+ */
+internal class ResponseCachingComponentServiceClient(
+    private val overrideFile: File,
+    private val serverUrl: String?,
+    apiToken: String?
+) : ComponentServiceClient {
+    // The BlackDuck library uses GSON to serialize its POJOs. So use GSON, too, because this is the simplest option.
+    private val gson = GsonBuilder().setPrettyPrinting().create()
+
+    private val cache = if (overrideFile.isFile) {
+        gson.fromJson(overrideFile.readText(), ResponseCache::class.java)
+    } else {
+        ResponseCache()
+    }
+
+    private val delegate = if (serverUrl != null && apiToken != null) {
+        ExtendedComponentService.create(serverUrl, apiToken)
+    } else {
+        null
+    }
+
+    override fun searchKbComponentsByPurl(purl: String): List<ComponentsView> =
+        cache.componentsViewsForPurl.getOrPut(purl) {
+            delegate?.searchKbComponentsByPurl(purl).orEmpty()
+        }
+
+    override fun getOriginView(searchResult: ComponentsView): OriginView? =
+        cache.originViewForComponentsViewKey.getOrPut(searchResult.key) {
+            delegate?.getOriginView(searchResult)
+        }
+
+    override fun getVulnerabilities(originView: OriginView): List<VulnerabilityView> =
+        cache.vulnerabilityViewsForOriginViewKey.getOrPut(originView.key) {
+            delegate?.getVulnerabilities(originView).orEmpty()
+        }
+
+    fun flush() {
+        if (delegate != null) {
+            val json = gson.toJson(cache).patchServerUrl(serverUrl)
+            overrideFile.writeText(json)
+        }
+    }
+}
+
+private class ResponseCache {
+    val componentsViewsForPurl = ConcurrentHashMap<String, List<ComponentsView>>()
+    val originViewForComponentsViewKey = ConcurrentHashMap<String, OriginView?>()
+    val vulnerabilityViewsForOriginViewKey = ConcurrentHashMap<String, List<VulnerabilityView>>()
+}
+
+private val OriginView.key: String get() = "$externalNamespace:$externalId"
+private val ComponentsView.key: String
+    // Only take the UUID of the version and variant, to avoid including the server URL into the key, to avoid
+    // complexities related to replacement of the server URL.
+    get() = variant.substringAfter("/versions/")

--- a/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import com.blackduck.integration.blackduck.api.generated.view.OriginView
+import com.blackduck.integration.blackduck.api.generated.view.VulnerabilityView
+
+import java.time.Instant
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.advisor.AdviceProvider
+import org.ossreviewtoolkit.advisor.AdviceProviderFactory
+import org.ossreviewtoolkit.model.AdvisorCapability
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorSummary
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.vulnerabilities.Cvss2Rating
+import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.utils.common.collectMessages
+import org.ossreviewtoolkit.utils.common.enumSetOf
+
+@OrtPlugin(
+    id = "BlackDuck",
+    displayName = "BlackDuck",
+    description = "An advisor that retrieves vulnerability information from a BlackDuck instance.",
+    factory = AdviceProviderFactory::class
+)
+class BlackDuck(
+    override val descriptor: PluginDescriptor,
+    private val blackDuckApi: ComponentServiceClient
+) : AdviceProvider {
+    override val details = AdvisorDetails(descriptor.id, enumSetOf(AdvisorCapability.VULNERABILITIES))
+
+    constructor(descriptor: PluginDescriptor, config: BlackDuckConfiguration) : this(
+        descriptor, ExtendedComponentService.create(config.serverUrl, config.apiToken.value)
+    )
+
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
+        val startTime = Instant.now()
+        val issuesForId = packages.associate { it.id to mutableListOf<Issue>() }
+
+        logger.info { "Obtaining origins for ${packages.size} package(s)..." }
+
+        val originsForId = withContext(Dispatchers.IO.limitedParallelism(20)) {
+            packages.associate { pkg ->
+                pkg.id to async { getOrigins(pkg, issuesForId.getValue(pkg.id)) }
+            }
+        }.mapValues { it.value.await() }
+
+        logger.info { "Obtaining vulnerabilities for ${originsForId.entries.sumOf { it.value.size } } origins..." }
+
+        val vulnerabilitiesForId = withContext(Dispatchers.IO.limitedParallelism(20)) {
+            originsForId.mapValues { (id, origins) ->
+                async { getVulnerabilities(origins, issuesForId.getValue(id)) }
+            }
+        }.mapValues { it.value.await() }
+
+        logger.info { originsForId.getSummary() }
+
+        return packages.associateWith { pkg ->
+            AdvisorResult(
+                details,
+                summary = AdvisorSummary(
+                    startTime,
+                    Instant.now(),
+                    issuesForId.getValue(pkg.id)
+                ),
+                vulnerabilities = vulnerabilitiesForId.getValue(pkg.id).map { it.toOrtVulnerability() }
+            )
+        }
+    }
+
+    private fun getOrigins(pkg: Package, issues: MutableList<Issue>): List<OriginView> {
+        val searchResults = runCatching {
+            blackDuckApi.searchKbComponentsByPurl(pkg.purl)
+        }.getOrElse {
+            issues += createAndLogIssue(
+                source = descriptor.displayName,
+                message = "Requesting origins for purl ${pkg.purl} failed: ${it.collectMessages()}"
+            )
+            return emptyList()
+        }
+
+        val origins = searchResults.mapNotNull { searchResult ->
+            runCatching {
+                blackDuckApi.getOriginView(searchResult)
+            }.onFailure {
+                issues += createAndLogIssue(
+                    source = descriptor.displayName,
+                    message = "Requesting origin details failed: ${it.collectMessages()}"
+                )
+            }.getOrNull()
+        }
+
+        if (origins.isEmpty()) {
+            logger.info { "No origin found for package '${pkg.id.toCoordinates()}'." }
+        } else {
+            logger.info {
+                "Found ${origins.size} origin(s) for package '${pkg.id.toCoordinates()}': " +
+                    "${origins.joinToString { it.identifier }}."
+            }
+        }
+
+        return origins
+    }
+
+    private fun getVulnerabilities(
+        origins: Collection<OriginView>,
+        issues: MutableList<Issue>
+    ): List<VulnerabilityView> =
+        origins.flatMap { origin ->
+            runCatching {
+                blackDuckApi.getVulnerabilities(origin)
+            }.onSuccess {
+                logger.info { "Found ${it.size} vulnerabilities for origin ${origin.identifier}." }
+            }.onFailure {
+                issues += createAndLogIssue(
+                    source = descriptor.displayName,
+                    message = "Requesting vulnerabilities for origin ${origin.identifier} failed: " +
+                        it.collectMessages()
+                )
+            }.getOrDefault(emptyList())
+        }
+}
+
+private fun VulnerabilityView.toOrtVulnerability(): Vulnerability {
+    val referenceUris = listOf(meta.href.uri(), *meta.links.map { it.href.uri() }.toTypedArray())
+
+    val references = referenceUris.map { uri ->
+        val cvssVector = cvss3?.vector ?: cvss2?.vector
+        // Only CVSS version 2 vectors do not contain the "CVSS:" label and version prefix
+        val scoringSystem = cvssVector?.substringBefore('/', Cvss2Rating.PREFIXES.first())
+
+        VulnerabilityReference(
+            url = uri,
+            scoringSystem = scoringSystem,
+            severity = severity.toString(),
+            score = overallScore.toFloat(),
+            vector = cvssVector
+        )
+    }
+
+    return Vulnerability(
+        id = name,
+        description = description,
+        references = references
+    )
+}
+
+private val OriginView.identifier get() = "$externalNamespace:$externalId"
+
+private fun Map<Identifier, List<OriginView>>.getSummary(): String =
+    buildString {
+        val idsWithMultipleOrigins = entries.filter { it.value.size > 1 }.sortedBy { it.key }
+        if (idsWithMultipleOrigins.isNotEmpty()) {
+            appendLine("The following ${idsWithMultipleOrigins.size} packages have multiple matching origins:")
+            idsWithMultipleOrigins.forEach { (id, origins) ->
+                appendLine("  $id -> ${origins.joinToString { it.identifier }}")
+            }
+        }
+
+        val idsWithoutOrigins = entries.filter { it.value.isEmpty() }.map { it.key }.sorted()
+        if (idsWithoutOrigins.isNotEmpty()) {
+            appendLine("The following ${idsWithoutOrigins.size} packages do not have any matching origin:")
+            idsWithoutOrigins.forEach {
+                appendLine("  ${it.toCoordinates()}")
+            }
+        }
+    }

--- a/plugins/advisors/black-duck/src/main/kotlin/BlackDuckConfiguration.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/BlackDuckConfiguration.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import org.ossreviewtoolkit.plugins.api.Secret
+
+/**
+ * The configuration for the BlackDuck vulnerability provider.
+ */
+data class BlackDuckConfiguration(
+    /**
+     * The base URL of the BlackDuck REST API.
+     */
+    val serverUrl: String,
+
+    /**
+     * The API token to use for authentication.
+     */
+    val apiToken: Secret
+)

--- a/plugins/advisors/black-duck/src/main/kotlin/ComponentServiceClient.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/ComponentServiceClient.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import com.blackduck.integration.blackduck.api.generated.response.ComponentsView
+import com.blackduck.integration.blackduck.api.generated.view.OriginView
+import com.blackduck.integration.blackduck.api.generated.view.VulnerabilityView
+
+interface ComponentServiceClient {
+    fun getOriginView(searchResult: ComponentsView): OriginView?
+
+    fun getVulnerabilities(originView: OriginView): List<VulnerabilityView>
+
+    fun searchKbComponentsByPurl(purl: String): List<ComponentsView>
+}

--- a/plugins/advisors/black-duck/src/main/kotlin/ExtendedComponentService.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/ExtendedComponentService.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import com.blackduck.integration.blackduck.api.core.BlackDuckPath
+import com.blackduck.integration.blackduck.api.core.response.LinkMultipleResponses
+import com.blackduck.integration.blackduck.api.generated.discovery.ApiDiscovery
+import com.blackduck.integration.blackduck.api.generated.response.ComponentsView
+import com.blackduck.integration.blackduck.api.generated.view.ComponentView
+import com.blackduck.integration.blackduck.api.generated.view.OriginView
+import com.blackduck.integration.blackduck.api.generated.view.VulnerabilityView
+import com.blackduck.integration.blackduck.configuration.BlackDuckServerConfigBuilder
+import com.blackduck.integration.blackduck.configuration.BlackDuckServerConfigKeys.KEYS
+import com.blackduck.integration.blackduck.http.BlackDuckRequestBuilder
+import com.blackduck.integration.blackduck.service.BlackDuckApiClient
+import com.blackduck.integration.blackduck.service.BlackDuckServicesFactory
+import com.blackduck.integration.blackduck.service.dataservice.ComponentService
+import com.blackduck.integration.log.IntLogger
+import com.blackduck.integration.log.SilentIntLogger
+import com.blackduck.integration.rest.HttpUrl
+import com.blackduck.integration.util.IntEnvironmentVariables
+
+import java.util.Optional
+import java.util.concurrent.Executors
+
+// Parameter for BlackDuck services factory, see also
+// https://github.com/blackducksoftware/blackduck-common/blob/67.0.2/src/main/java/com/blackduck/integration/blackduck/service/BlackDuckServicesFactory.java#L82-L84
+private const val BLACK_DUCK_SERVICES_THREAD_POOL_SIZE = 30
+
+private val KB_COMPONENTS_SEARCH_PATH = BlackDuckPath(
+    "/api/search/kb-purl-component",
+    // Use ComponentsView even though SearchKbPurlComponentView is probably the class dedicated to this result,
+    // to avoid any conversion to the needed ComponentsView.
+    ComponentsView::class.java,
+    /* isMultiple = */ true
+)
+
+/**
+ * This class adds a couple of functions which are missing in the super class and fixes an issue with an override.
+ */
+internal class ExtendedComponentService(
+    blackDuckApiClient: BlackDuckApiClient,
+    apiDiscovery: ApiDiscovery,
+    logger: IntLogger
+) : ComponentService(blackDuckApiClient, apiDiscovery, logger), ComponentServiceClient {
+    companion object {
+        fun create(serverUrl: String, apiToken: String): ExtendedComponentService {
+            val logger = SilentIntLogger()
+            val factory = createBlackDuckServicesFactory(serverUrl, apiToken, logger)
+            return ExtendedComponentService(factory.blackDuckApiClient, factory.apiDiscovery, factory.logger)
+        }
+    }
+
+    override fun searchKbComponentsByPurl(purl: String): List<ComponentsView> {
+        // See https://community.blackduck.com/s/article/Searching-Black-Duck-KnowledgeBase-using-Package-URLs.
+        val responses = apiDiscovery.metaMultipleResponses(KB_COMPONENTS_SEARCH_PATH)
+
+        val request = BlackDuckRequestBuilder()
+            .commonGet()
+            .addQueryParameter("purl", purl)
+            .buildBlackDuckRequest(responses)
+
+        return blackDuckApiClient.getAllResponses(request)
+    }
+
+    override fun getComponentView(searchResult: ComponentsView): Optional<ComponentView> {
+        // The super function accidentally uses the URL to the version view, while it should use the URL to the
+        // component view. This override fixes that.
+        if (searchResult.component.isNotBlank()) {
+            val url = HttpUrl(searchResult.component)
+            return Optional.ofNullable(blackDuckApiClient.getResponse(url, ComponentView::class.java))
+        } else {
+            return Optional.empty()
+        }
+    }
+
+    override fun getOriginView(searchResult: ComponentsView): OriginView? {
+        if (searchResult.variant.isNullOrBlank()) return null
+
+        val url = HttpUrl(searchResult.variant)
+        return blackDuckApiClient.getResponse(url, OriginView::class.java)
+    }
+
+    override fun getVulnerabilities(originView: OriginView): List<VulnerabilityView> {
+        val link = LinkMultipleResponses("vulnerabilities", VulnerabilityView::class.java)
+        val metaVulnerabilitiesLinked = originView.metaMultipleResponses(link)
+
+        return blackDuckApiClient.getAllResponses(metaVulnerabilitiesLinked)
+    }
+}
+
+private fun createBlackDuckServicesFactory(
+    serverUrl: String,
+    apiToken: String,
+    logger: IntLogger
+): BlackDuckServicesFactory {
+    val serverConfig = BlackDuckServerConfigBuilder(KEYS.apiToken).apply {
+        url = serverUrl
+        this.apiToken = apiToken
+    }.build()
+
+    val httpClient = serverConfig.createBlackDuckHttpClient(logger)
+    val environmentVariables = IntEnvironmentVariables.empty()
+    val executorService = Executors.newFixedThreadPool(BLACK_DUCK_SERVICES_THREAD_POOL_SIZE)
+
+    return BlackDuckServicesFactory(environmentVariables, executorService, logger, httpClient)
+}

--- a/website/docs/tools/advisor.md
+++ b/website/docs/tools/advisor.md
@@ -14,6 +14,30 @@ The providers require specific configuration in the [ORT configuration file](htt
 When executing the advisor, the providers to enable are selected with the `--advisors` option (or its short alias `-a`); here a comma-separated list with provider IDs is expected.
 The following sections describe the providers supported by the advisor:
 
+## Black Duck
+
+This vulnerability provider obtains information about security vulnerabilities from the Black Duck instance specified in the configuration.
+The configuration is mandatory, because authentication is required.
+
+:::note
+The implementation is in *experimental* state.
+:::
+
+Initial experiments indicate that it works with the ecosystems mentioned [over here](https://github.com/oss-review-toolkit/ort/issues/9638).
+
+```yaml
+ort:
+  advisor:
+    config:
+      BlackDuck:
+        options:
+          serverUrl: 'server-url'
+        secrets:
+          apiToken: 'token'
+```
+
+To enable this provider, pass `-a BlackDuck` on the command line.
+
 ## OSS Index
 
 This vulnerability provider does not require any further configuration as it uses the public service at https://ossindex.sonatype.org/.


### PR DESCRIPTION
Add an initial version of the integration of BlackDuck as security vulnerability provider.

Note: The implementation will be iterated upon, e.g. a curation mechanism to manually specify an origin will
           be added in a following PR.

Part of: #8739.