### PR TITLE
build(notifier): Make the Jakarta REST API dependency a constraint

### DIFF
--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -36,6 +36,12 @@ dependencies {
     // Required due to https://ecosystem.atlassian.net/browse/JRJC-262.
     implementation(libs.jakartaRestApi)
 
+    constraints {
+        implementation(libs.jakartaRestApi) {
+            because("the JIRA REST client still needs a 2.1.x version with the javax package namespace")
+        }
+    }
+
     implementation(libs.jiraRestClient.api)
     implementation(libs.jiraRestClient.app) {
         exclude("org.apache.logging.log4j", "log4j-slf4j2-impl")


### PR DESCRIPTION
Prevent consumers of the notifier to upgrade the Jakarta REST API because the Jira library requires version 2.1.x which still has the "javax" instead of the "jakarta" package namespace.