### PR TITLE
feat(model): Add a generic labeling mechanism for packages

### DIFF
--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -75,3 +75,9 @@
   curations:
     comment: "Scan the source artifact, because the VCS revision and path are hard to figure out."
     source_code_origins: [ARTIFACT]
+
+- id: "Maven:androidx.collection:collection:"
+  curations:
+    comment: "Specify the platform for use within policy rules."
+    labels:
+      platform: "android"

--- a/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -107,6 +107,8 @@ analyzer:
         url: "https://github.com/example/depedency-1.git"
         revision: "1111111111111111111111111111111111111111"
         path: "vcs-path/dependency-two"
+      labels:
+        key: "value"
 scanner: null
 advisor: null
 evaluator: null

--- a/helper-cli/src/funTest/assets/package-list.yml
+++ b/helper-cli/src/funTest/assets/package-list.yml
@@ -27,3 +27,5 @@ dependencies:
       url: "https://example.org/example-dependency-two.zip"
     isExcluded: false
     isDynamicallyLinked: false
+    labels:
+      key: "value"

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -151,7 +151,8 @@ private data class Dependency(
     val vcs: Vcs? = null,
     val sourceArtifact: SourceArtifact? = null,
     val isExcluded: Boolean = false,
-    val isDynamicallyLinked: Boolean = false
+    val isDynamicallyLinked: Boolean = false,
+    val labels: Map<String, String> = emptyMap()
 )
 
 private data class SourceArtifact(
@@ -200,6 +201,7 @@ private fun Dependency.toPackage(): Package {
         declaredLicenses = emptySet(),
         description = "",
         homepageUrl = "",
-        binaryArtifact = RemoteArtifact.EMPTY
+        binaryArtifact = RemoteArtifact.EMPTY,
+        labels = labels
     )
 }

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 import org.ossreviewtoolkit.model.utils.requireNotEmptyNoDuplicates
@@ -137,7 +138,15 @@ data class Package(
      * default is used. If not null, this must not be empty and not contain any duplicates.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val sourceCodeOrigins: List<SourceCodeOrigin>? = null
+    val sourceCodeOrigins: List<SourceCodeOrigin>? = null,
+
+    /**
+     * User defined labels associated with this package. The labels are not interpreted by the core of ORT itself, but
+     * can be used in parts of ORT such as plugins, in evaluator rules, or in reporter templates.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder(alphabetic = true)
+    val labels: Map<String, String> = emptyMap()
 ) {
     companion object {
         /**

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 
 import org.ossreviewtoolkit.utils.common.zip
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -107,7 +108,15 @@ data class PackageCurationData(
      * duplicates.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val sourceCodeOrigins: List<SourceCodeOrigin>? = null
+    val sourceCodeOrigins: List<SourceCodeOrigin>? = null,
+
+    /**
+     * User defined labels associated with this package. The labels are not interpreted by the core of ORT itself, but
+     * can be used in parts of ORT such as plugins, in evaluator rules, or in reporter templates.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder(alphabetic = true)
+    val labels: Map<String, String> = emptyMap()
 ) {
     init {
         declaredLicenseMapping.forEach { (key, value) ->
@@ -156,7 +165,8 @@ data class PackageCurationData(
             vcsProcessed = vcsProcessed,
             isMetadataOnly = isMetadataOnly ?: original.isMetadataOnly,
             isModified = isModified ?: original.isModified,
-            sourceCodeOrigins = sourceCodeOrigins ?: original.sourceCodeOrigins
+            sourceCodeOrigins = sourceCodeOrigins ?: original.sourceCodeOrigins,
+            labels = original.labels + labels
         )
 
         return CuratedPackage(pkg, targetPackage.curations + this)
@@ -185,7 +195,8 @@ data class PackageCurationData(
                 @Suppress("UnsafeCallOnNullableType")
                 (value ?: otherValue)!!
             },
-            sourceCodeOrigins = sourceCodeOrigins ?: other.sourceCodeOrigins
+            sourceCodeOrigins = sourceCodeOrigins ?: other.sourceCodeOrigins,
+            labels = labels + other.labels
         )
 }
 

--- a/model/src/test/kotlin/PackageCurationDataTest.kt
+++ b/model/src/test/kotlin/PackageCurationDataTest.kt
@@ -50,7 +50,11 @@ class PackageCurationDataTest : WordSpec({
         isMetadataOnly = true,
         isModified = true,
         declaredLicenseMapping = mapOf("original" to "LicenseRef-original".toSpdx()),
-        sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
+        sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS),
+        labels = mapOf(
+            "k1" to "v1-original",
+            "k2" to "v2-original"
+        )
     )
 
     val other = PackageCurationData(
@@ -78,7 +82,11 @@ class PackageCurationDataTest : WordSpec({
         isMetadataOnly = false,
         isModified = false,
         declaredLicenseMapping = mapOf("other" to "LicenseRef-other".toSpdx()),
-        sourceCodeOrigins = listOf(SourceCodeOrigin.VCS)
+        sourceCodeOrigins = listOf(SourceCodeOrigin.VCS),
+        labels = mapOf(
+            "k2" to "v2-other",
+            "k3" to "v3-other"
+        )
     )
 
     "Merging" should {
@@ -95,7 +103,8 @@ class PackageCurationDataTest : WordSpec({
                 vcs = null,
                 isMetadataOnly = null,
                 declaredLicenseMapping = emptyMap(),
-                sourceCodeOrigins = null
+                sourceCodeOrigins = null,
+                labels = emptyMap()
             )
 
             originalWithSomeUnsetData.merge(other) shouldBe originalWithSomeUnsetData.copy(
@@ -106,7 +115,8 @@ class PackageCurationDataTest : WordSpec({
                 vcs = other.vcs,
                 isMetadataOnly = other.isMetadataOnly,
                 declaredLicenseMapping = other.declaredLicenseMapping,
-                sourceCodeOrigins = other.sourceCodeOrigins
+                sourceCodeOrigins = other.sourceCodeOrigins,
+                labels = other.labels
             )
         }
 
@@ -118,6 +128,11 @@ class PackageCurationDataTest : WordSpec({
                 declaredLicenseMapping = mapOf(
                     "original" to "LicenseRef-original".toSpdx(),
                     "other" to "LicenseRef-other".toSpdx()
+                ),
+                labels = mapOf(
+                    "k1" to "v1-original",
+                    "k2" to "v2-other",
+                    "k3" to "v3-other"
                 )
             )
         }
@@ -128,7 +143,8 @@ class PackageCurationDataTest : WordSpec({
                 authors = original.authors,
                 concludedLicense = original.concludedLicense,
                 declaredLicenseMapping = original.declaredLicenseMapping,
-                sourceCodeOrigins = original.sourceCodeOrigins
+                sourceCodeOrigins = original.sourceCodeOrigins,
+                labels = original.labels
             )
 
             val mergedData = original.merge(otherWithSomeOriginalData)

--- a/website/docs/configuration/package-curations.md
+++ b/website/docs/configuration/package-curations.md
@@ -31,6 +31,9 @@ Curations can be used to:
 * set the *source_code_origins* property:
   * Override the source code origins priority configured in the downloader configuration by the given one.
     Possible values: VCS, ARTIFACT.
+* set labels:
+  * Add key-value pairs to the package in order to inject custom per-package data into, for example, policy
+    rules, reporter templates, or custom ORT plugins.
 
 The sections below explain how to create curations in the `curations.yml` file which, if passed to the *analyzer*, is applied to all package metadata found in the analysis.
 If a license detected in the source code of a package needs to be corrected, add a license finding curation in the [.ort.yml](ort-yml.md#curations) file for the project.
@@ -84,6 +87,8 @@ A curation file consists of one or more `id` entries:
     is_metadata_only: true
     is_modified: true
     source_code_origins: [ARTIFACT, VCS]
+    labels:
+      my-key: "my-value"
 ```
 
 Where the list of available options for curations is defined in [PackageCurationData.kt](https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/PackageCurationData.kt).


### PR DESCRIPTION
Allow setting arbitrary key-value pairs on a `Package`, which is not interpreted by ORT's core.
The property can be useful for ORT plugins (not necessarily public), policy rules, notice templates and so forth.

Also, in cases where introducing a dedicated property under `Package` makes sense, this mechanism can be used as a temporary work-around to remove the introduction of the dedicated property from any critical development path.

Fixes #8725.