### PR TITLE
fix(website): Move a link out of the tagline variable

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = themes.dracula;
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'OSS Review Toolkit',
-  tagline: 'A suite of CLI tools to automate software compliance checks. Also available as a <a href="https://eclipse-apoapsis.github.io/ort-server/">server</a>.',
+  tagline: 'A suite of CLI tools to automate software compliance checks.',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -32,7 +32,11 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <p className="hero__subtitle">
+          {siteConfig.tagline}
+          <br/>
+          Also available as a <a href="https://eclipse-apoapsis.github.io/ort-server/">server</a>.
+        </p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg margin-right--lg"


### PR DESCRIPTION
This is a fixup for 547c295.