### PR TITLE
chore: Prefer the char-version of `split()` for single chars

### DIFF
--- a/helper-cli/src/main/kotlin/commands/dev/RewriteTestAssetsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/dev/RewriteTestAssetsCommand.kt
@@ -177,7 +177,7 @@ private fun JsonNode.replacePath(path: String, target: JsonNode) {
 }
 
 private fun JsonNode.getNodeAtPath(path: String): JsonNode? {
-    val keys = path.split("/").toMutableList()
+    val keys = path.split('/').toMutableList()
     var result: JsonNode? = this
 
     while (keys.isNotEmpty() && result != null) {

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -83,7 +83,7 @@ fun RepositoryProvenance.alignRevisions(): RepositoryProvenance =
 fun String.parseRepoManifestPath() =
     runCatching {
         URI(this).query.splitToSequence("&")
-            .map { it.split("=", limit = 2) }
+            .map { it.split('=', limit = 2) }
             .find { it.first() == "manifest" }
             ?.get(1)
             ?.takeUnless { it.isEmpty() }

--- a/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
+++ b/plugins/commands/scanner/src/main/kotlin/ScannerCommand.kt
@@ -250,7 +250,7 @@ class ScannerCommand(descriptor: PluginDescriptor = ScannerCommandFactory.descri
 
 private fun RawOption.convertToScannerWrapperFactories() =
     convert { scannerNames ->
-        scannerNames.split(",").map { name ->
+        scannerNames.split(',').map { name ->
             ScannerWrapperFactory.ALL[name]
                 ?: throw BadParameterValue("Scanner '$name' is not one of ${ScannerWrapperFactory.ALL.keys}.")
         }

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -145,7 +145,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
                         PluginOptionType.SECRET -> add("config.secrets[%S]?.let { %T(it) }", name, Secret::class)
                         PluginOptionType.STRING -> add("config.options[%S]", name)
                         PluginOptionType.STRING_LIST -> add(
-                            "config.options[%S]?.split(\",\")?.map { it.trim() }",
+                            "config.options[%S]?.split(',')?.map { it.trim() }",
                             name
                         )
                     }
@@ -170,7 +170,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
                         PluginOptionType.STRING_LIST -> {
                             add(" ?: listOf(")
 
-                            defaultValue.split(",").forEach { value ->
+                            defaultValue.split(',').forEach { value ->
                                 add("%S,", value.trim())
                             }
 
@@ -217,7 +217,7 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
                         PluginOptionType.STRING_LIST -> {
                             add("listOf(")
 
-                            defaultValue.split(",").forEach { value ->
+                            defaultValue.split(',').forEach { value ->
                                 add("%S,", value.trim())
                             }
 

--- a/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
@@ -477,7 +477,7 @@ private fun ModuleMetadata.toVcsInfo() =
 private fun ModuleSourceInfo.toRemoteArtifact(): RemoteArtifact? {
     when (this) {
         is ArchiveSourceInfo -> {
-            val (algo, b64digest) = integrity.split("-", limit = 2)
+            val (algo, b64digest) = integrity.split('-', limit = 2)
             val digest = Base64.decode(b64digest).toHexString()
 
             val hash = Hash(

--- a/plugins/package-managers/carthage/src/main/kotlin/Carthage.kt
+++ b/plugins/package-managers/carthage/src/main/kotlin/Carthage.kt
@@ -137,7 +137,7 @@ class Carthage(
             DependencyType.GITHUB -> {
                 // ID consists of GitHub username/project or a GitHub enterprise URL.
                 val projectUrl = if (id.split('/').size == 2) {
-                    val (username, project) = id.split("/", limit = 2)
+                    val (username, project) = id.split('/', limit = 2)
                     "https://github.com/$username/$project"
                 } else {
                     id

--- a/plugins/package-managers/maven/src/test/kotlin/utils/MavenDependencyHandlerTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/utils/MavenDependencyHandlerTest.kt
@@ -260,7 +260,7 @@ private fun toOrtIdentifier(mavenId: String): Identifier = Identifier("$PACKAGE_
  * `identifier()` extension function must have been mocked statically.
  */
 private fun createArtifact(id: String): Artifact {
-    val parts = id.split(":")
+    val parts = id.split(':')
     val artifact = mockk<Artifact>()
 
     every { artifact.identifier() } returns id

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
@@ -135,7 +135,7 @@ internal fun Collection<NuGetInspector.PackageData>.toOrtPackages(): Set<Package
         var vcsUrl = pkg.vcsUrl.orEmpty()
         var commit = ""
 
-        val segments = vcsUrl.split("@", limit = 2)
+        val segments = vcsUrl.split('@', limit = 2)
         if (segments.size == 2) {
             vcsUrl = segments[0]
             commit = segments[1]

--- a/plugins/package-managers/python/src/main/kotlin/Poetry.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Poetry.kt
@@ -174,7 +174,7 @@ internal fun getPythonVersionConstraint(pyprojectTomlFile: File): String? {
     val dependenciesSection = getTomlSectionContent(pyprojectTomlFile, "tool.poetry.dependencies")
         ?: return null
 
-    return dependenciesSection.split("\n").firstNotNullOfOrNull {
+    return dependenciesSection.split('\n').firstNotNullOfOrNull {
         it.trim().withoutPrefix("python = ")
     }?.removeSurrounding("\"")
 }

--- a/plugins/reporters/opossum/src/main/kotlin/OpossumModel.kt
+++ b/plugins/reporters/opossum/src/main/kotlin/OpossumModel.kt
@@ -89,7 +89,7 @@ internal data class OpossumResources(
     }
 
     fun addResource(path: String) {
-        val pathPieces = path.split("/").filter { it.isNotEmpty() }
+        val pathPieces = path.split('/').filter { it.isNotEmpty() }
 
         addResource(pathPieces)
     }
@@ -97,7 +97,7 @@ internal data class OpossumResources(
     fun isFile() = tree.isEmpty()
 
     fun isPathAFile(path: String): Boolean {
-        val pathPieces = path.split("/").filter { it.isNotEmpty() }
+        val pathPieces = path.split('/').filter { it.isNotEmpty() }
 
         return isPathAFile(pathPieces)
     }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -169,7 +169,7 @@ private fun getSnippets(details: ScanFileDetails): Set<Snippet> {
  */
 private fun convertLines(file: String, lineRanges: String): List<TextLocation> =
     lineRanges.split(',').map { lineRange ->
-        val splitLines = lineRange.split("-")
+        val splitLines = lineRange.split('-')
 
         when (splitLines.size) {
             1 -> TextLocation(file, splitLines.first().toInt())

--- a/utils/ort/src/funTest/kotlin/storage/S3FileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/S3FileStorageFunTest.kt
@@ -64,7 +64,7 @@ class S3FileStorageFunTest : WordSpec() {
 
                 "PUT" -> {
                     val key = exchange.requestURI.toString().removePrefix("/$bucket/")
-                    requests[key] = exchange.requestBody.reader().use { it.readText() }.split("\n")[1].trimEnd()
+                    requests[key] = exchange.requestBody.reader().use { it.readText() }.split('\n')[1].trimEnd()
                     exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0)
                 }
 

--- a/utils/ort/src/main/kotlin/UserInfoAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/UserInfoAuthenticator.kt
@@ -30,7 +30,7 @@ class UserInfoAuthenticator : Authenticator() {
     override fun getPasswordAuthentication(): PasswordAuthentication? {
         if (requestorType == RequestorType.SERVER) {
             requestingURL?.userInfo?.let {
-                val credentials = it.split(":", limit = 2)
+                val credentials = it.split(':', limit = 2)
                 if (credentials.size == 2) {
                     return PasswordAuthentication(credentials.first(), credentials.last().toCharArray())
                 }


### PR DESCRIPTION
If non-string types are not parsable but have a default value, do not throw but fall back to that value.