### PR TITLE
fix(cargo): Add lockfile version 4 to allow-list

### DIFF
--- a/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
@@ -115,7 +115,7 @@ class Cargo(
         }
 
         return when (contents.version) {
-            null, 2, 3 -> {
+            null, 2, 3, 4 -> {
                 contents.packages.mapNotNull { pkg ->
                     pkg.checksum?.let { checksum ->
                         // Use the same key format as for version 1, see above.


### PR DESCRIPTION
a7078fe updated Cargo to support lockfile version 4, however we also maintain an allow-list of lockfile versions for which we understand the checksum computation. Add version 4 to this allow-list.