### PR TITLE
chore(node): Rename the typealias to get package details

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/NpmSupport.kt
+++ b/plugins/package-managers/node/src/main/kotlin/NpmSupport.kt
@@ -137,13 +137,13 @@ internal fun parseVcsInfo(packageJson: PackageJson): VcsInfo {
     )
 }
 
-typealias PackageDetailsFunction = (packageName: String) -> PackageJson?
+typealias GetPackageDetailsFun = (packageName: String) -> PackageJson?
 
 /**
  * Construct a [Package] by parsing its _package.json_ file and - if applicable - querying additional
  * content via the `npm view` command. The result is a [Pair] with the raw identifier and the new package.
  */
-internal fun parsePackage(packageJsonFile: File, getPackageDetails: PackageDetailsFunction): Package {
+internal fun parsePackage(packageJsonFile: File, getPackageDetails: GetPackageDetailsFun): Package {
     val packageJson = parsePackageJson(packageJsonFile)
 
     // The "name" and "version" fields are only required if the package is going to be published, otherwise they are

--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
@@ -26,8 +26,8 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.utils.DependencyHandler
+import org.ossreviewtoolkit.plugins.packagemanagers.node.GetPackageDetailsFun
 import org.ossreviewtoolkit.plugins.packagemanagers.node.NodePackageManager
-import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageDetailsFunction
 import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageJson
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackage
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackageJson
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.utils.common.realFile
 
 internal class NpmDependencyHandler(
     private val projectType: String,
-    private val getPackageDetails: PackageDetailsFunction
+    private val getPackageDetails: GetPackageDetailsFun
 ) : DependencyHandler<ModuleInfo> {
     private val packageJsonCache = mutableMapOf<File, PackageJson>()
 

--- a/plugins/package-managers/node/src/main/kotlin/pnpm/PnpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/pnpm/PnpmDependencyHandler.kt
@@ -26,8 +26,8 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.utils.DependencyHandler
+import org.ossreviewtoolkit.plugins.packagemanagers.node.GetPackageDetailsFun
 import org.ossreviewtoolkit.plugins.packagemanagers.node.NodePackageManager
-import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageDetailsFunction
 import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageJson
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackage
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackageJson
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.utils.common.realFile
 
 internal class PnpmDependencyHandler(
     private val projectType: String,
-    private val getPackageDetails: PackageDetailsFunction
+    private val getPackageDetails: GetPackageDetailsFun
 ) : DependencyHandler<Dependency> {
     private val workspaceModuleDirs = mutableSetOf<File>()
     private val packageJsonCache = mutableMapOf<File, PackageJson>()


### PR DESCRIPTION
Make more clear that this is about *getting* package details, and use only "Fun" to resemble the corresponding Kotlin keyword.