### PR TITLE
Refactor FossID config

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -254,7 +254,7 @@ ort:
         options:
           serverUrl: 'https://fossid.example.com/instance/'
 
-          namingProjectPattern: '$Var1_$Var2'
+          projectName: 'My Project'
           namingScanPattern: '$Var1_#projectBaseCode_$Var3'
           namingVariableVar1: myOrg
           namingVariableVar2: myTeam

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -268,7 +268,7 @@ ort:
 
           timeout: 60
 
-          urlMappingExample: "https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}"
+          urlMappings: "https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}"
 
           sensitivity: 10
 

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -255,10 +255,7 @@ ort:
           serverUrl: 'https://fossid.example.com/instance/'
 
           projectName: 'My Project'
-          namingScanPattern: '$Var1_#projectBaseCode_$Var3'
-          namingVariableVar1: myOrg
-          namingVariableVar2: myTeam
-          namingVariableVar3: myUnit
+          namingScanPattern: '#projectName_#repositoryName_#currentTimestamp_#deltaTag_#branch'
 
           waitForResult: false
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -264,7 +264,7 @@ class OrtConfigurationTest : WordSpec({
                             "detectLicenseDeclarations" to "true",
                             "detectCopyrightStatements" to "true",
                             "timeout" to "60",
-                            "urlMappingExample" to urlMapping,
+                            "urlMappings" to urlMapping,
                             "sensitivity" to "10"
                         )
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -256,10 +256,7 @@ class OrtConfigurationTest : WordSpec({
                         options shouldContainExactly mapOf(
                             "serverUrl" to "https://fossid.example.com/instance/",
                             "projectName" to "My Project",
-                            "namingScanPattern" to "\$Var1_#projectBaseCode_\$Var3",
-                            "namingVariableVar1" to "myOrg",
-                            "namingVariableVar2" to "myTeam",
-                            "namingVariableVar3" to "myUnit",
+                            "namingScanPattern" to "#projectName_#repositoryName_#currentTimestamp_#deltaTag_#branch",
                             "waitForResult" to "false",
                             "keepFailedScans" to "false",
                             "deltaScans" to "true",

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -255,7 +255,7 @@ class OrtConfigurationTest : WordSpec({
 
                         options shouldContainExactly mapOf(
                             "serverUrl" to "https://fossid.example.com/instance/",
-                            "namingProjectPattern" to "\$Var1_\$Var2",
+                            "projectName" to "My Project",
                             "namingScanPattern" to "\$Var1_#projectBaseCode_\$Var3",
                             "namingVariableVar1" to "myOrg",
                             "namingVariableVar2" to "myTeam",

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -292,7 +292,7 @@ class FossId internal constructor(
 
         val result = runBlocking {
             try {
-                val projectCode = namingProvider.createProjectCode(repositoryName)
+                val projectCode = config.projectName ?: repositoryName
 
                 if (getProject(projectCode) == null) {
                     logger.info { "Creating project '$projectCode'..." }

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -45,12 +45,8 @@ import org.ossreviewtoolkit.utils.common.Options
  *   license declarations.
  * * **"options.detectCopyrightStatements":** When set, the FossID scan is configured to automatically detect copyright
  *   statements.
- *
- * Naming conventions options. If they are not set, default naming conventions are used.
- * * **"options.namingProjectPattern":** A pattern for project names when projects are created on the FossID instance.
- *   Contains variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
- *   [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
- * * **"options.namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
+ * * **"options.namingScanPattern":** A pattern for scan names when scans are created on the FossID instance. If not
+ *   set, a default pattern is used.
  *
  * URL mapping options. These options allow transforming the URLs of specific repositories before they are passed to
  * the FossID service. This may be necessary if FossID uses a different mechanism to clone a repository, e.g. via SSH
@@ -167,11 +163,6 @@ data class FossIdConfig(
         private const val PROP_SENSITIVITY = "sensitivity"
 
         /**
-         * The scanner options beginning with this prefix will be used to parameterize project and scan names.
-         */
-        private const val NAMING_CONVENTION_VARIABLE_PREFIX = "namingVariable"
-
-        /**
          * Default timeout in minutes for communication with FossID.
          */
         @JvmStatic
@@ -255,11 +246,7 @@ data class FossIdConfig(
             logger.info { "Naming pattern for scans is $it." }
         }
 
-        val namingConventionVariables = options
-            .filterKeys { it.startsWith(NAMING_CONVENTION_VARIABLE_PREFIX) }
-            .mapKeys { it.key.substringAfter(NAMING_CONVENTION_VARIABLE_PREFIX) }
-
-        return FossIdNamingProvider(namingScanPattern, namingConventionVariables, projectName)
+        return FossIdNamingProvider(namingScanPattern, projectName)
     }
 
     /**

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -259,7 +259,7 @@ data class FossIdConfig(
             .filterKeys { it.startsWith(NAMING_CONVENTION_VARIABLE_PREFIX) }
             .mapKeys { it.key.substringAfter(NAMING_CONVENTION_VARIABLE_PREFIX) }
 
-        return FossIdNamingProvider(namingScanPattern, namingConventionVariables)
+        return FossIdNamingProvider(namingScanPattern, namingConventionVariables, projectName)
     }
 
     /**

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -115,6 +115,9 @@ data class FossIdConfig(
     /** The sensitivity of the scan. */
     val sensitivity: Int,
 
+    /** A comma-separated list of URL mappings. */
+    val urlMappings: String?,
+
     /** Stores the map with FossID-specific configuration options. */
     private val options: Map<String, String>
 ) {
@@ -162,6 +165,9 @@ data class FossIdConfig(
         /** Name of the configuration property defining the sensitivity of the scan. */
         private const val PROP_SENSITIVITY = "sensitivity"
 
+        /** Name of the configuration property defining the URL mappings. */
+        private const val PROP_URL_MAPPINGS = "urlMappings"
+
         /**
          * Default timeout in minutes for communication with FossID.
          */
@@ -208,6 +214,8 @@ data class FossIdConfig(
 
             val sensitivity = options[PROP_SENSITIVITY]?.toInt() ?: DEFAULT_SENSITIVITY
 
+            val urlMappings = options[PROP_URL_MAPPINGS]
+
             require(deltaScanLimit > 0) {
                 "deltaScanLimit must be > 0, current value is $deltaScanLimit."
             }
@@ -233,7 +241,8 @@ data class FossIdConfig(
                 fetchSnippetMatchedLines = fetchSnippetMatchedLines,
                 options = options,
                 snippetsLimit = snippetsLimit,
-                sensitivity = sensitivity
+                sensitivity = sensitivity,
+                urlMappings = urlMappings,
             )
         }
     }
@@ -252,5 +261,5 @@ data class FossIdConfig(
     /**
      * Create a [FossIdUrlProvider] helper object based on the configuration stored in this object.
      */
-    fun createUrlProvider() = FossIdUrlProvider.create(options)
+    fun createUrlProvider() = FossIdUrlProvider.create(urlMappings?.split(',').orEmpty())
 }

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -84,6 +84,9 @@ data class FossIdConfig(
     /** The API key to access the FossID server. */
     val apiKey: String,
 
+    /** The name of the FossID project. If `null`, the name will be determined from the repository URL. */
+    val projectName: String?,
+
     /** Flag whether the scanner should wait for the completion of FossID scans. */
     val waitForResult: Boolean,
 
@@ -129,11 +132,11 @@ data class FossIdConfig(
         /** Name of the configuration property for the API key. */
         private const val PROP_API_KEY = "apiKey"
 
+        /** Name of the configuration property to set the project name. */
+        private const val PROP_PROJECT_NAME = "projectName"
+
         /** Name of the configuration property controlling whether ORT should wait for FossID results. */
         private const val PROP_WAIT_FOR_RESULT = "waitForResult"
-
-        /** Name of the configuration property defining the naming convention for projects. */
-        private const val PROP_NAMING_PROJECT_PATTERN = "namingProjectPattern"
 
         /** Name of the configuration property defining the naming convention for scans. */
         private const val PROP_NAMING_SCAN_PATTERN = "namingScanPattern"
@@ -196,6 +199,8 @@ data class FossIdConfig(
             val apiKey = secrets[PROP_API_KEY]
                 ?: throw IllegalArgumentException("No FossID API Key configuration found.")
 
+            val projectName = options[PROP_PROJECT_NAME]
+
             val waitForResult = options[PROP_WAIT_FOR_RESULT]?.toBooleanStrict() ?: true
 
             val keepFailedScans = options[PROP_KEEP_FAILED_SCANS]?.toBooleanStrict() ?: false
@@ -226,6 +231,7 @@ data class FossIdConfig(
                 serverUrl = serverUrl,
                 user = user,
                 apiKey = apiKey,
+                projectName = projectName,
                 waitForResult = waitForResult,
                 keepFailedScans = keepFailedScans,
                 deltaScans = deltaScans,
@@ -245,10 +251,6 @@ data class FossIdConfig(
      * Create a [FossIdNamingProvider] helper object based on the configuration stored in this object.
      */
     fun createNamingProvider(): FossIdNamingProvider {
-        val namingProjectPattern = options[PROP_NAMING_PROJECT_PATTERN]?.also {
-            logger.info { "Naming pattern for projects is $it." }
-        }
-
         val namingScanPattern = options[PROP_NAMING_SCAN_PATTERN]?.also {
             logger.info { "Naming pattern for scans is $it." }
         }
@@ -257,7 +259,7 @@ data class FossIdConfig(
             .filterKeys { it.startsWith(NAMING_CONVENTION_VARIABLE_PREFIX) }
             .mapKeys { it.key.substringAfter(NAMING_CONVENTION_VARIABLE_PREFIX) }
 
-        return FossIdNamingProvider(namingProjectPattern, namingScanPattern, namingConventionVariables)
+        return FossIdNamingProvider(namingScanPattern, namingConventionVariables)
     }
 
     /**

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -83,6 +83,9 @@ data class FossIdConfig(
     /** The name of the FossID project. If `null`, the name will be determined from the repository URL. */
     val projectName: String?,
 
+    /** The pattern for scan names when scans are created on the FossID instance. If null, a default pattern is used. */
+    val namingScanPattern: String?,
+
     /** Flag whether the scanner should wait for the completion of FossID scans. */
     val waitForResult: Boolean,
 
@@ -116,10 +119,7 @@ data class FossIdConfig(
     val sensitivity: Int,
 
     /** A comma-separated list of URL mappings. */
-    val urlMappings: String?,
-
-    /** Stores the map with FossID-specific configuration options. */
-    private val options: Map<String, String>
+    val urlMappings: String?
 ) {
     companion object {
         /** Name of the configuration property for the server URL. */
@@ -197,6 +197,7 @@ data class FossIdConfig(
                 ?: throw IllegalArgumentException("No FossID API Key configuration found.")
 
             val projectName = options[PROP_PROJECT_NAME]
+            val namingScanPattern = options[PROP_NAMING_SCAN_PATTERN]
 
             val waitForResult = options[PROP_WAIT_FOR_RESULT]?.toBooleanStrict() ?: true
 
@@ -231,6 +232,7 @@ data class FossIdConfig(
                 user = user,
                 apiKey = apiKey,
                 projectName = projectName,
+                namingScanPattern = namingScanPattern,
                 waitForResult = waitForResult,
                 keepFailedScans = keepFailedScans,
                 deltaScans = deltaScans,
@@ -239,10 +241,9 @@ data class FossIdConfig(
                 detectCopyrightStatements = detectCopyrightStatements,
                 timeout = timeout,
                 fetchSnippetMatchedLines = fetchSnippetMatchedLines,
-                options = options,
                 snippetsLimit = snippetsLimit,
                 sensitivity = sensitivity,
-                urlMappings = urlMappings,
+                urlMappings = urlMappings
             )
         }
     }
@@ -250,13 +251,7 @@ data class FossIdConfig(
     /**
      * Create a [FossIdNamingProvider] helper object based on the configuration stored in this object.
      */
-    fun createNamingProvider(): FossIdNamingProvider {
-        val namingScanPattern = options[PROP_NAMING_SCAN_PATTERN]?.also {
-            logger.info { "Naming pattern for scans is $it." }
-        }
-
-        return FossIdNamingProvider(namingScanPattern, projectName)
-    }
+    fun createNamingProvider() = FossIdNamingProvider(namingScanPattern, projectName)
 
     /**
      * Create a [FossIdUrlProvider] helper object based on the configuration stored in this object.

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.kotlin.logger
  *
  * There are also built-in variables. Built-in variables are prefixed in the pattern with "#" e.g. "$var1_#builtin".
  * Available built-in variables:
+ * * **projectName**: The project name, if configured in the scanner options.
  * * **repositoryName**: The name of the repository (i.e., the part of the URL before .git).
  * * **currentTimestamp**: The current time.
  * * **deltaTag** (scan code only): If delta scans are enabled, this qualifies the scan as an *origin* scan or a *delta*
@@ -42,7 +43,8 @@ import org.apache.logging.log4j.kotlin.logger
  */
 class FossIdNamingProvider(
     private val namingScanPattern: String?,
-    private val namingConventionVariables: Map<String, String>
+    private val namingConventionVariables: Map<String, String>,
+    private val projectName: String?
 ) {
     companion object {
         val ALLOWED_CHARACTERS_REGEX = Regex("[^\\w-]")
@@ -61,6 +63,7 @@ class FossIdNamingProvider(
         }
 
         val builtins = mutableMapOf(
+            "#projectName" to projectName.orEmpty(),
             "#repositoryName" to repositoryName,
             "#deltaTag" to deltaTag?.name?.lowercase().orEmpty()
         )

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
@@ -25,10 +25,10 @@ import java.time.format.DateTimeFormatter
 import org.apache.logging.log4j.kotlin.logger
 
 /**
- * This class provides names for projects and scans when the FossID scanner creates them, following a given pattern.
- * If one or both patterns is null, a default naming convention is used.
+ * This class provides names for scans when the FossID scanner creates them, based on the provided [namingScanPattern].
+ * If the pattern is null, a default pattern is used.
  *
- * [namingScanPattern] and [namingProjectPattern] are patterns describing the name using variables, e.g. "$var1_$var2".
+ * The pattern can contain variables prefixed with "$", for example, "$var1_$var2".
  * Variable values are given in the map [namingConventionVariables].
  *
  * There are also built-in variables. Built-in variables are prefixed in the pattern with "#" e.g. "$var1_#builtin".
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.kotlin.logger
  *   other characters are replaced with underscores. Might be shortened to fit the scan code length limit.
  */
 class FossIdNamingProvider(
-    private val namingProjectPattern: String?,
     private val namingScanPattern: String?,
     private val namingConventionVariables: Map<String, String>
 ) {
@@ -53,14 +52,6 @@ class FossIdNamingProvider(
 
         const val MAX_SCAN_CODE_LEN = 254
     }
-
-    fun createProjectCode(repositoryName: String): String =
-        namingProjectPattern?.let {
-            val builtins = mapOf(
-                "#repositoryName" to repositoryName
-            )
-            replaceNamingConventionVariables(namingProjectPattern, builtins, namingConventionVariables)
-        } ?: repositoryName
 
     fun createScanCode(repositoryName: String, deltaTag: FossId.DeltaTag? = null, branch: String = ""): String {
         val pattern = namingScanPattern ?: buildString {

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
@@ -74,13 +74,6 @@ class FossIdUrlProvider private constructor(
         }
 
         /**
-         * Create a new instance of [FossIdUrlProvider] and configure the URL mappings from the given configuration
-         * [options].
-         */
-        fun create(options: Map<String, String>): FossIdUrlProvider =
-            create(options.filter { it.key.startsWith(PREFIX_URL_MAPPING) }.values)
-
-        /**
          * Try to fetch credentials for [repoUrl] from the current [Authenticator]. Return *null* if no matching host
          * is found.
          */

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
@@ -166,9 +166,7 @@ class FossIdConfigTest : WordSpec({
         "create a naming provider with a correct scan naming convention" {
             val options = mapOf(
                 "serverUrl" to SERVER_URL,
-                "namingScanPattern" to "#repositoryName_\$Org_\$Unit_#deltaTag",
-                "namingVariableOrg" to "TestOrganization",
-                "namingVariableUnit" to "TestUnit"
+                "namingScanPattern" to "#repositoryName_#deltaTag"
             )
 
             val secrets = mapOf(
@@ -181,7 +179,7 @@ class FossIdConfigTest : WordSpec({
 
             val scanCode = namingProvider.createScanCode("TestProject", FossId.DeltaTag.DELTA)
 
-            scanCode shouldBe "TestProject_TestOrganization_TestUnit_delta"
+            scanCode shouldBe "TestProject_delta"
         }
     }
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
@@ -52,7 +52,8 @@ class FossIdConfigTest : WordSpec({
                 "detectCopyrightStatements" to "true",
                 "timeout" to "300",
                 "fetchSnippetMatchedLines" to "true",
-                "snippetsLimit" to "1000"
+                "snippetsLimit" to "1000",
+                "urlMappings" to "https://example.org(?<repoPath>.*) -> ssh://example.org\${repoPath}"
             )
 
             val secrets = mapOf(
@@ -77,7 +78,8 @@ class FossIdConfigTest : WordSpec({
                 fetchSnippetMatchedLines = true,
                 options = options,
                 snippetsLimit = 1000,
-                sensitivity = 10
+                sensitivity = 10,
+                urlMappings = "https://example.org(?<repoPath>.*) -> ssh://example.org\${repoPath}"
             )
         }
 
@@ -106,7 +108,8 @@ class FossIdConfigTest : WordSpec({
                 fetchSnippetMatchedLines = false,
                 options = options,
                 snippetsLimit = 500,
-                sensitivity = 10
+                sensitivity = 10,
+                urlMappings = null
             )
         }
 
@@ -188,7 +191,7 @@ class FossIdConfigTest : WordSpec({
             val url = "https://changeit.example.org/foo"
             val options = mapOf(
                 "serverUrl" to SERVER_URL,
-                "urlMappingChangeHost" to "$url -> $SERVER_URL"
+                "urlMappings" to "$url -> $SERVER_URL"
             )
 
             val secrets = mapOf(

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
@@ -44,6 +44,7 @@ class FossIdConfigTest : WordSpec({
             val options = mapOf(
                 "serverUrl" to SERVER_URL,
                 "projectName" to PROJECT,
+                "namingScanPattern" to "#repositoryName_#deltaTag",
                 "waitForResult" to "false",
                 "keepFailedScans" to "true",
                 "deltaScans" to "true",
@@ -68,6 +69,7 @@ class FossIdConfigTest : WordSpec({
                 user = USER,
                 apiKey = API_KEY,
                 projectName = PROJECT,
+                namingScanPattern = "#repositoryName_#deltaTag",
                 waitForResult = false,
                 keepFailedScans = true,
                 deltaScans = true,
@@ -76,7 +78,6 @@ class FossIdConfigTest : WordSpec({
                 detectCopyrightStatements = true,
                 timeout = 300,
                 fetchSnippetMatchedLines = true,
-                options = options,
                 snippetsLimit = 1000,
                 sensitivity = 10,
                 urlMappings = "https://example.org(?<repoPath>.*) -> ssh://example.org\${repoPath}"
@@ -98,6 +99,7 @@ class FossIdConfigTest : WordSpec({
                 user = USER,
                 apiKey = API_KEY,
                 projectName = null,
+                namingScanPattern = null,
                 waitForResult = true,
                 keepFailedScans = false,
                 deltaScans = false,
@@ -106,7 +108,6 @@ class FossIdConfigTest : WordSpec({
                 detectCopyrightStatements = false,
                 timeout = 60,
                 fetchSnippetMatchedLines = false,
-                options = options,
                 snippetsLimit = 500,
                 sensitivity = 10,
                 urlMappings = null

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdConfigTest.kt
@@ -43,6 +43,7 @@ class FossIdConfigTest : WordSpec({
         "read all properties from the scanner configuration" {
             val options = mapOf(
                 "serverUrl" to SERVER_URL,
+                "projectName" to PROJECT,
                 "waitForResult" to "false",
                 "keepFailedScans" to "true",
                 "deltaScans" to "true",
@@ -65,6 +66,7 @@ class FossIdConfigTest : WordSpec({
                 serverUrl = SERVER_URL,
                 user = USER,
                 apiKey = API_KEY,
+                projectName = PROJECT,
                 waitForResult = false,
                 keepFailedScans = true,
                 deltaScans = true,
@@ -93,6 +95,7 @@ class FossIdConfigTest : WordSpec({
                 serverUrl = SERVER_URL,
                 user = USER,
                 apiKey = API_KEY,
+                projectName = null,
                 waitForResult = true,
                 keepFailedScans = false,
                 deltaScans = false,
@@ -160,27 +163,6 @@ class FossIdConfigTest : WordSpec({
     }
 
     "createNamingProvider" should {
-        "create a naming provider with a correct project naming convention" {
-            val options = mapOf(
-                "serverUrl" to SERVER_URL,
-                "namingProjectPattern" to "#repositoryName_\$Org_\$Unit",
-                "namingVariableOrg" to "TestOrganization",
-                "namingVariableUnit" to "TestUnit"
-            )
-
-            val secrets = mapOf(
-                "user" to USER,
-                "apiKey" to API_KEY
-            )
-
-            val fossIdConfig = FossIdConfig.create(options, secrets)
-            val namingProvider = fossIdConfig.createNamingProvider()
-
-            val projectName = namingProvider.createProjectCode("TestProject")
-
-            projectName shouldBe "TestProject_TestOrganization_TestUnit"
-        }
-
         "create a naming provider with a correct scan naming convention" {
             val options = mapOf(
                 "serverUrl" to SERVER_URL,

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdNamingProviderTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdNamingProviderTest.kt
@@ -43,7 +43,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
     init {
         "createScanCode" should {
-            val namingProvider = FossIdNamingProvider(null, emptyMap())
+            val namingProvider = FossIdNamingProvider(null, emptyMap(), null)
 
             val mockedDateTime = LocalDateTime.of(2024, 4, 1, 10, 0)
             val expectedTimestamp = "20240401_100000"
@@ -114,10 +114,23 @@ class FossIdNamingProviderTest : WordSpec() {
                 }
             }
 
+            "replace all built-in variables" {
+                val customScanPattern = "#projectName_#repositoryName_#currentTimestamp_#deltaTag_#branch"
+                val customNamingProvider = FossIdNamingProvider(customScanPattern, emptyMap(), "projectName")
+
+                mockkStatic(LocalDateTime::class) {
+                    every { LocalDateTime.now() } returns mockedDateTime
+
+                    customNamingProvider.createScanCode(
+                        "repositoryName", FossId.DeltaTag.DELTA, "branch"
+                    ) shouldBeEqual "projectName_repositoryName_${expectedTimestamp}_delta_branch"
+                }
+            }
+
             "create code without branch name form custom naming pattern" {
                 val customScanPattern = "#repositoryName_#currentTimestamp"
 
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap(), null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -130,7 +143,7 @@ class FossIdNamingProviderTest : WordSpec() {
             "create code without branch name form custom naming pattern when branch name is provided" {
                 val customScanPattern = "#repositoryName_#currentTimestamp"
 
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap(), null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -142,7 +155,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
             "create code without branch name form custom naming pattern when too long branch name is provided" {
                 val customScanPattern = "#repositoryName_#currentTimestamp_#branch"
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap(), null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -153,7 +166,7 @@ class FossIdNamingProviderTest : WordSpec() {
             }
 
             "throw an exception if scan code pattern is too long" {
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(longScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(longScanPattern, emptyMap(), null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdNamingProviderTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdNamingProviderTest.kt
@@ -43,7 +43,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
     init {
         "createScanCode" should {
-            val namingProvider = FossIdNamingProvider(null, emptyMap(), null)
+            val namingProvider = FossIdNamingProvider(null, null)
 
             val mockedDateTime = LocalDateTime.of(2024, 4, 1, 10, 0)
             val expectedTimestamp = "20240401_100000"
@@ -116,7 +116,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
             "replace all built-in variables" {
                 val customScanPattern = "#projectName_#repositoryName_#currentTimestamp_#deltaTag_#branch"
-                val customNamingProvider = FossIdNamingProvider(customScanPattern, emptyMap(), "projectName")
+                val customNamingProvider = FossIdNamingProvider(customScanPattern, "projectName")
 
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
@@ -130,7 +130,7 @@ class FossIdNamingProviderTest : WordSpec() {
             "create code without branch name form custom naming pattern" {
                 val customScanPattern = "#repositoryName_#currentTimestamp"
 
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap(), null)
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -143,7 +143,7 @@ class FossIdNamingProviderTest : WordSpec() {
             "create code without branch name form custom naming pattern when branch name is provided" {
                 val customScanPattern = "#repositoryName_#currentTimestamp"
 
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap(), null)
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -155,7 +155,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
             "create code without branch name form custom naming pattern when too long branch name is provided" {
                 val customScanPattern = "#repositoryName_#currentTimestamp_#branch"
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap(), null)
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -166,7 +166,7 @@ class FossIdNamingProviderTest : WordSpec() {
             }
 
             "throw an exception if scan code pattern is too long" {
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(longScanPattern, emptyMap(), null)
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(longScanPattern, null)
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdNamingProviderTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdNamingProviderTest.kt
@@ -43,7 +43,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
     init {
         "createScanCode" should {
-            val namingProvider = FossIdNamingProvider(null, null, emptyMap())
+            val namingProvider = FossIdNamingProvider(null, emptyMap())
 
             val mockedDateTime = LocalDateTime.of(2024, 4, 1, 10, 0)
             val expectedTimestamp = "20240401_100000"
@@ -117,7 +117,7 @@ class FossIdNamingProviderTest : WordSpec() {
             "create code without branch name form custom naming pattern" {
                 val customScanPattern = "#repositoryName_#currentTimestamp"
 
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(null, customScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap())
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -130,7 +130,7 @@ class FossIdNamingProviderTest : WordSpec() {
             "create code without branch name form custom naming pattern when branch name is provided" {
                 val customScanPattern = "#repositoryName_#currentTimestamp"
 
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(null, customScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap())
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -142,7 +142,7 @@ class FossIdNamingProviderTest : WordSpec() {
 
             "create code without branch name form custom naming pattern when too long branch name is provided" {
                 val customScanPattern = "#repositoryName_#currentTimestamp_#branch"
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(null, customScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(customScanPattern, emptyMap())
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 
@@ -153,7 +153,7 @@ class FossIdNamingProviderTest : WordSpec() {
             }
 
             "throw an exception if scan code pattern is too long" {
-                val namingProviderWithLongScanPattern = FossIdNamingProvider(null, longScanPattern, emptyMap())
+                val namingProviderWithLongScanPattern = FossIdNamingProvider(longScanPattern, emptyMap())
                 mockkStatic(LocalDateTime::class) {
                     every { LocalDateTime.now() } returns mockedDateTime
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
@@ -102,7 +102,7 @@ class FossIdSnippetChoiceTest : WordSpec({
 
     "scanPackages()" should {
         "not report a snippet that has been chosen" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -147,7 +147,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "not report a snippet when there is a chosen snippet for its location" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -194,7 +194,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "not report a snippet when there are false positives for its location" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -243,7 +243,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "mark a file with all snippets chosen as identified" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -300,7 +300,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "mark a file with only non relevant snippets for a given snippet location as identified" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -346,7 +346,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "not mark a file with some non relevant snippets for a given snippet location as identified" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -401,7 +401,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "mark a file with only chosen and non relevant snippets for a given snippet location as identified" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -446,7 +446,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "add the license of a chosen snippet to the license findings" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -491,7 +491,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "create an issue if the chosen snippet is not in the snippet results" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -535,7 +535,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "add the license of already marked as identified file with a snippet choice to the license findings" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -576,7 +576,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "add the license of marked as identified files that have been manually marked in the UI (legacy behavior)" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -611,7 +611,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "put a marked as identified file back to pending if it has no snippet choice" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -672,7 +672,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "put a marked as identified file back to pending if some of its snippet choices have been deleted" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -734,7 +734,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "respect the snippet limit when listing snippets (single snippet per finding)" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true, snippetsLimit = 2)
             val vcsInfo = createVcsInfo()
@@ -779,7 +779,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "respect the snippet limit when listing snippets (multiple snippets per finding)" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true, snippetsLimit = 2)
             val vcsInfo = createVcsInfo()
@@ -824,7 +824,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "list all the snippets of a file even if if goes over the snippets limit" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true, snippetsLimit = 2)
             val vcsInfo = createVcsInfo()
@@ -867,7 +867,7 @@ class FossIdSnippetChoiceTest : WordSpec({
         }
 
         "not count the chosen snippet when enforcing the snippet limits" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true, snippetsLimit = 2)
             val vcsInfo = createVcsInfo()

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -119,7 +119,7 @@ class FossIdTest : WordSpec({
 
     "scanPackages()" should {
         "create issues for packages not hosted in Git" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo(type = VcsType.UNKNOWN)
@@ -144,7 +144,7 @@ class FossIdTest : WordSpec({
         }
 
         "create a new scan for an existing project" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -174,7 +174,7 @@ class FossIdTest : WordSpec({
         }
 
         "throw an exception if the scan download failed" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -206,7 +206,7 @@ class FossIdTest : WordSpec({
         }
 
         "return copyright and license findings from a new scan" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -238,7 +238,7 @@ class FossIdTest : WordSpec({
         }
 
         "take ignored files into account" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -267,7 +267,7 @@ class FossIdTest : WordSpec({
         }
 
         "fallback to identified files if no marked identified files are available" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -299,7 +299,7 @@ class FossIdTest : WordSpec({
         }
 
         "create an issue if there are files pending identification" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -331,7 +331,7 @@ class FossIdTest : WordSpec({
         }
 
         "report snippets of pending files" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -359,7 +359,7 @@ class FossIdTest : WordSpec({
         }
 
         "list matched lines of snippets" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, fetchSnippetMatchedLines = true)
             val vcsInfo = createVcsInfo()
@@ -414,7 +414,7 @@ class FossIdTest : WordSpec({
         }
 
         "create a new project if none exists yet" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -440,7 +440,7 @@ class FossIdTest : WordSpec({
         }
 
         "explicitly start a scan if necessary" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -484,7 +484,7 @@ class FossIdTest : WordSpec({
         }
 
         "works if scan was queued in FossID older than 2021.2" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -534,7 +534,7 @@ class FossIdTest : WordSpec({
         }
 
         "wait for a scan to complete" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val pkgId = createIdentifier(index = 1)
@@ -576,7 +576,7 @@ class FossIdTest : WordSpec({
 
         "support triggering asynchronous scans" {
             val pkgId = createIdentifier(index = 1)
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false, waitForResult = false)
             val vcsInfo = createVcsInfo()
@@ -611,7 +611,7 @@ class FossIdTest : WordSpec({
         }
 
         "create a delta scan for an existing scan" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = "originalScanCode"
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig()
@@ -657,7 +657,7 @@ class FossIdTest : WordSpec({
         "create a delta scan for a branch (no fallback)" {
             val branchName = "aTestBranch"
 
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = "originalScanCode"
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig()
@@ -706,7 +706,7 @@ class FossIdTest : WordSpec({
         "create a delta scan for a branch (fallback to default branch)" {
             val branchName = "aTestBranch"
 
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = "originalScanCode"
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig()
@@ -755,7 +755,7 @@ class FossIdTest : WordSpec({
         "create a delta scan for a branch (fallback to latest scan)" {
             val branchName = "aTestBranch"
 
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = "originalScanCode"
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig()
@@ -802,7 +802,7 @@ class FossIdTest : WordSpec({
         }
 
         "carry exclusion rules to a delta scan from an existing scan (legacy behavior)" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = "originalScanCode"
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig()
@@ -856,7 +856,7 @@ class FossIdTest : WordSpec({
         }
 
         "carry exclusion rules to a delta scan from path excludes" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = "originalScanCode"
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig()
@@ -911,7 +911,7 @@ class FossIdTest : WordSpec({
         }
 
         "create an origin scan if no scan exists yet" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.ORIGIN)
             val config = createConfig()
             val vcsInfo = createVcsInfo()
@@ -950,7 +950,7 @@ class FossIdTest : WordSpec({
         }
 
         "apply exclusion rules to a non-delta scan" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()
@@ -990,50 +990,53 @@ class FossIdTest : WordSpec({
         }
 
         "delete newly triggered scans if a package cannot be scanned" {
+            val projectCode = PROJECT
+
             val id1 = createIdentifier(index = 1)
             val vcsInfo1 = createVcsInfo()
             val pkg1 = createPackage(id1, vcsInfo1)
-            val projectCode1 = projectCode(PROJECT)
-            val scanCode1 = scanCode(PROJECT, FossId.DeltaTag.ORIGIN)
+            val scanCode1 = scanCode(projectCode, FossId.DeltaTag.ORIGIN)
 
             val failedProject = "failedProject"
             val id2 = createIdentifier(index = 2)
             val failedVcsInfo = createVcsInfo(projectName = failedProject)
             val pkg2 = createPackage(id2, failedVcsInfo)
-            val failedProjectCode = projectCode(failedProject)
 
             val project3 = "project3"
             val id3 = createIdentifier(index = 3)
             val vcsInfo3 = createVcsInfo(projectName = project3)
             val pkg3 = createPackage(id3, vcsInfo3)
-            val projectCode3 = projectCode(project3)
             val scanCode3 = scanCode(project3, FossId.DeltaTag.ORIGIN, index = 2)
 
-            val config = createConfig()
+            val config = createConfig(projectName = null)
 
             val service = FossIdRestService.create(config.serverUrl)
-                .expectProjectRequest(projectCode1)
-                .expectListScans(projectCode1, emptyList())
+                .expectProjectRequest(projectCode)
+                .expectListScans(projectCode, emptyList())
                 .expectCheckScanStatus(scanCode1, ScanStatus.FINISHED)
-                .expectCreateScan(projectCode1, scanCode1, vcsInfo1, "")
+                .expectCreateScan(projectCode, scanCode1, vcsInfo1, "")
                 .expectDownload(scanCode1)
                 .mockFiles(scanCode1, markedRange = 1..2)
 
-            service.expectProjectRequest(failedProjectCode)
-            coEvery { service.listScansForProject(USER, API_KEY, failedProjectCode) } throws IllegalStateException()
+            service.expectProjectRequest(failedProject)
+            coEvery { service.listScansForProject(USER, API_KEY, failedProject) } throws IllegalStateException()
             coEvery { service.deleteScan(any()) } returns EntityResponseBody(status = 1)
 
-            service.expectProjectRequest(projectCode3)
-                .expectListScans(projectCode3, emptyList())
+            service.expectProjectRequest(project3)
+                .expectListScans(project3, emptyList())
                 .expectCheckScanStatus(scanCode3, ScanStatus.FINISHED)
-                .expectCreateScan(projectCode3, scanCode3, vcsInfo3, "")
+                .expectCreateScan(project3, scanCode3, vcsInfo3, "")
                 .expectDownload(scanCode3)
                 .mockFiles(scanCode3, markedRange = 1..2)
 
             val fossId = createFossId(config)
 
             fossId.scan(pkg1)
+
+            coEvery { service.listScansForProject(USER, API_KEY, projectCode) } throws IllegalStateException()
+
             val result = fossId.scan(pkg2)
+
             fossId.scan(pkg3)
 
             result.summary.issues shouldHaveSize 1
@@ -1055,7 +1058,7 @@ class FossIdTest : WordSpec({
         "enforce a limit on the number of delta scans" {
             val numberOfDeltaScans = 8
             val deltaScanLimit = 4
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val originCode = scanCode(PROJECT, FossId.DeltaTag.ORIGIN, index = 0)
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig(deltaScanLimit = deltaScanLimit)
@@ -1114,7 +1117,7 @@ class FossIdTest : WordSpec({
         }
 
         "return scan code of a scan" {
-            val projectCode = projectCode(PROJECT)
+            val projectCode = PROJECT
             val scanCode = scanCode(PROJECT, null)
             val config = createConfig(deltaScans = false)
             val vcsInfo = createVcsInfo()

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -140,7 +140,8 @@ internal fun createConfig(
         fetchSnippetMatchedLines = fetchSnippetMatchedLines,
         options = emptyMap(),
         snippetsLimit = snippetsLimit,
-        sensitivity = 10
+        sensitivity = 10,
+        urlMappings = null
     )
 
     val namingProvider = createNamingProviderMock()

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -130,6 +130,7 @@ internal fun createConfig(
         user = USER,
         apiKey = API_KEY,
         projectName = projectName,
+        namingScanPattern = null,
         waitForResult = waitForResult,
         keepFailedScans = false,
         deltaScans = deltaScans,
@@ -138,7 +139,6 @@ internal fun createConfig(
         detectCopyrightStatements = false,
         timeout = 60,
         fetchSnippetMatchedLines = fetchSnippetMatchedLines,
-        options = emptyMap(),
         snippetsLimit = snippetsLimit,
         sensitivity = 10,
         urlMappings = null

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -118,6 +118,7 @@ internal fun createFossId(config: FossIdConfig): FossId = FossId("FossId", confi
  * Create a standard [FossIdConfig] whose properties can be partly specified.
  */
 internal fun createConfig(
+    projectName: String? = PROJECT,
     waitForResult: Boolean = true,
     deltaScans: Boolean = true,
     deltaScanLimit: Int = Int.MAX_VALUE,
@@ -128,6 +129,7 @@ internal fun createConfig(
         serverUrl = "https://www.example.org/fossid",
         user = USER,
         apiKey = API_KEY,
+        projectName = projectName,
         waitForResult = waitForResult,
         keepFailedScans = false,
         deltaScans = deltaScans,
@@ -155,10 +157,6 @@ internal fun createConfig(
 private fun createNamingProviderMock(): FossIdNamingProvider {
     val counter = AtomicInteger()
     val provider = mockk<FossIdNamingProvider>()
-
-    every { provider.createProjectCode(any()) } answers {
-        projectCode(firstArg())
-    }
 
     every { provider.createScanCode(any(), any(), any()) } answers {
         scanCode(firstArg(), secondArg(), index = counter.incrementAndGet())
@@ -190,11 +188,6 @@ internal fun createVersionControlSystemMock(): VersionControlSystem {
 
     return vcs
 }
-
-/**
- * Generate a project code for the project with the given [name].
- */
-internal fun projectCode(name: String): String = "$name:projectCode"
 
 /**
  * Generate a synthetic scan code for the project with the given [name], [tag], and [index].


### PR DESCRIPTION
Refactor the FossID config to prepare for migrating scanners to the new plugin API. See the commit messages for details.