### PR TITLE
chore(DependencyGraphNavigator): Avoid relying on manager name prefixes

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -103,6 +103,15 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
             Pair(manager, mappedFiles).takeIf { mappedFiles.isNotEmpty() }
         }.toMap(mutableMapOf())
 
+        // Fail early if multiple managers for the same project type are enabled.
+        managedFiles.keys.groupBy { it.projectType }.forEach { (projectType, managers) ->
+            val managerNames = managers.map { it.managerName }
+            requireNotNull(managers.singleOrNull()) {
+                "All of the $managerNames managers are able to manage '$projectType' projects. Please enable only " +
+                    "one of them."
+            }
+        }
+
         // Check whether there are unmanaged files (because of deactivated, unsupported, or non-present package
         // managers) which need to get attached to an artificial "unmanaged" project.
         val managedDirs = managedFiles.values.flatten().mapNotNull { it.parentFile }


### PR DESCRIPTION
This removes the assumption that package manager names start with the name of the type of project they manage in favor of collecting all root indices that match the project and ensuring that they only stem from a single manager.