### PR TITLE
docs(website): Remove the note about Bazel support being experimental

### DIFF
--- a/website/docs/tools/analyzer.md
+++ b/website/docs/tools/analyzer.md
@@ -18,7 +18,7 @@ It can be further processed or manually edited before passing it to one of the o
 Currently, the following package managers (grouped by the programming language they are most commonly used with) are supported:
 
 * C / C++
-  * [Bazel](https://bazel.build/) (**experimental**) (limitations: see [open tasks](https://github.com/oss-review-toolkit/ort/issues/264))
+  * [Bazel](https://bazel.build/) (limitations: see [open tasks](https://github.com/oss-review-toolkit/ort/issues/264))
   * [Conan 1.x](https://conan.io/)
   * Also see: [SPDX documents](#analyzer-for-spdx-documents)
 * Dart / Flutter


### PR DESCRIPTION
This is used in production and not experimental anymore, despite some missing features, see the open tasks at [1].

[1]: https://github.com/oss-review-toolkit/ort/issues/264