### PR TITLE
fix(PackageManager)!: Use the `projectType` also when resultion failed

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -298,7 +298,7 @@ abstract class PackageManager(
                 }.onFailure {
                     it.showStackTrace()
 
-                    val id = Identifier.EMPTY.copy(type = managerName, name = relativePath)
+                    val id = Identifier.EMPTY.copy(type = projectType, name = relativePath)
 
                     val projectWithIssues = Project.EMPTY.copy(
                         id = id,


### PR DESCRIPTION
This is a fixup for 01f1930.