### PR TITLE
style(node): Remove one level of nesting from tests

### DIFF
--- a/plugins/package-managers/node/src/funTest/kotlin/npm/NpmFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/npm/NpmFunTest.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.node.npm
 
-import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
@@ -43,116 +43,114 @@ import org.ossreviewtoolkit.utils.test.matchExpectedResult
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
-class NpmFunTest : WordSpec({
-    "NPM" should {
-        "resolve dependencies for a project with a 'shrinkwrap.json' correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/shrinkwrap/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/npm/shrinkwrap-expected-output.yml")
+class NpmFunTest : StringSpec({
+    "Resolve dependencies for a project with a 'shrinkwrap.json' correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/shrinkwrap/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/shrinkwrap-expected-output.yml")
 
-            val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            patchActualResult(result.toYaml()) should matchExpectedResult(
-                expectedResultFile,
-                definitionFile,
-                custom = mapOf(
-                    "<REPLACE_PROJECT_NAME>" to "npm-${definitionFile.parentFile.name}",
-                    "<REPLACE_LOCKFILE_NAME>" to "npm-shrinkwrap.json"
-                )
+        patchActualResult(result.toYaml()) should matchExpectedResult(
+            expectedResultFile,
+            definitionFile,
+            custom = mapOf(
+                "<REPLACE_PROJECT_NAME>" to "npm-${definitionFile.parentFile.name}",
+                "<REPLACE_LOCKFILE_NAME>" to "npm-shrinkwrap.json"
             )
+        )
+    }
+
+    "Exclude scopes if configured" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/shrinkwrap/package.json")
+        val expectedResultFile = getAssetFile(
+            "projects/synthetic/npm/shrinkwrap-skip-excluded-scopes-expected-output.yml"
+        )
+
+        val result = create("NPM", excludedScopes = setOf("devDependencies"))
+            .resolveSingleProject(definitionFile, resolveScopes = true)
+
+        patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
+    "Resolve dependencies for a project with lockfile correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/project-with-lockfile/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/project-with-lockfile-expected-output.yml")
+
+        val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
+
+        patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
+    "Show an error if no lockfile is present" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/no-lockfile/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/no-lockfile-expected-output.yml")
+
+        val result = create("NPM").resolveSingleProject(definitionFile)
+
+        patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
+    "Show an error if the 'package.json' file is invalid" {
+        val workingDir = tempdir()
+        val definitionFile = workingDir.resolve("package.json").apply { writeText("<>") }
+
+        val result = create("NPM", allowDynamicVersions = true).resolveSingleProject(definitionFile)
+
+        result.issues.forAtLeastOne {
+            it.source shouldBe "NPM"
+            it.severity shouldBe Severity.ERROR
+            it.message shouldContain "Unexpected token"
         }
+    }
 
-        "exclude scopes if configured" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/shrinkwrap/package.json")
-            val expectedResultFile = getAssetFile(
-                "projects/synthetic/npm/shrinkwrap-skip-excluded-scopes-expected-output.yml"
-            )
+    "Create issues for list errors" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/list-issues/package.json")
 
-            val result = create("NPM", excludedScopes = setOf("devDependencies"))
-                .resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("NPM", "legacyPeerDeps" to "true").resolveSingleProject(definitionFile)
 
-            patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.issues shouldNot beEmpty()
+        val elsproblems = result.issues.filter { it.message.startsWith("invalid: ") }
 
-        "resolve dependencies for a project with lockfile correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/project-with-lockfile/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/npm/project-with-lockfile-expected-output.yml")
+        elsproblems shouldHaveSize 2
+        elsproblems.forAll { it.severity shouldBe Severity.ERROR }
 
-            val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
+        elsproblems shouldHaveSingleElement { it.message.startsWith("invalid: react@18.2.0") }
+        elsproblems shouldHaveSingleElement { it.message.startsWith("invalid: react-dom@18.2.0") }
+    }
 
-            patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+    "Resolve dependencies even if the 'node_modules' directory already exists" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/node-modules/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/node-modules-expected-output.yml")
 
-        "show an error if no lockfile is present" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/no-lockfile/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/npm/no-lockfile-expected-output.yml")
+        val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            val result = create("NPM").resolveSingleProject(definitionFile)
+        patchActualResult(result.toYaml()) should matchExpectedResult(
+            expectedResultFile,
+            definitionFile,
+            custom = mapOf("<REPLACE_LOCKFILE_NAME>" to "package-lock.json")
+        )
+    }
 
-            patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+    "Resolve Babel dependencies correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/babel/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/babel-expected-output.yml")
+        val expectedResult = patchExpectedResult(expectedResultFile, definitionFile)
+            .fromYaml<ProjectAnalyzerResult>()
 
-        "show an error if the 'package.json' file is invalid" {
-            val workingDir = tempdir()
-            val definitionFile = workingDir.resolve("package.json").apply { writeText("<>") }
+        val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            val result = create("NPM", allowDynamicVersions = true).resolveSingleProject(definitionFile)
+        result.withInvariantIssues().toYaml() shouldBe expectedResult.withInvariantIssues().toYaml()
+    }
 
-            result.issues.forAtLeastOne {
-                it.source shouldBe "NPM"
-                it.severity shouldBe Severity.ERROR
-                it.message shouldContain "Unexpected token"
-            }
-        }
+    "Resolve dependencies with URLs as versions correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/version-urls/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/version-urls-expected-output.yml")
+        val expectedResult = patchExpectedResult(expectedResultFile, definitionFile)
+            .fromYaml<ProjectAnalyzerResult>()
 
-        "create issues for list errors" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/list-issues/package.json")
+        val result = create("NPM", allowDynamicVersions = true)
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
-            val result = create("NPM", "legacyPeerDeps" to "true").resolveSingleProject(definitionFile)
-
-            result.issues shouldNot beEmpty()
-            val elsproblems = result.issues.filter { it.message.startsWith("invalid: ") }
-
-            elsproblems shouldHaveSize 2
-            elsproblems.forAll { it.severity shouldBe Severity.ERROR }
-
-            elsproblems shouldHaveSingleElement { it.message.startsWith("invalid: react@18.2.0") }
-            elsproblems shouldHaveSingleElement { it.message.startsWith("invalid: react-dom@18.2.0") }
-        }
-
-        "resolve dependencies even if the 'node_modules' directory already exists" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/node-modules/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/npm/node-modules-expected-output.yml")
-
-            val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
-
-            patchActualResult(result.toYaml()) should matchExpectedResult(
-                expectedResultFile,
-                definitionFile,
-                custom = mapOf("<REPLACE_LOCKFILE_NAME>" to "package-lock.json")
-            )
-        }
-
-        "resolve Babel dependencies correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/babel/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/npm/babel-expected-output.yml")
-            val expectedResult = patchExpectedResult(expectedResultFile, definitionFile)
-                .fromYaml<ProjectAnalyzerResult>()
-
-            val result = create("NPM").resolveSingleProject(definitionFile, resolveScopes = true)
-
-            result.withInvariantIssues().toYaml() shouldBe expectedResult.withInvariantIssues().toYaml()
-        }
-
-        "resolve dependencies with URLs as versions correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/npm/version-urls/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/npm/version-urls-expected-output.yml")
-            val expectedResult = patchExpectedResult(expectedResultFile, definitionFile)
-                .fromYaml<ProjectAnalyzerResult>()
-
-            val result = create("NPM", allowDynamicVersions = true)
-                .resolveSingleProject(definitionFile, resolveScopes = true)
-
-            result.withInvariantIssues().toYaml() shouldBe expectedResult.withInvariantIssues().toYaml()
-        }
+        result.withInvariantIssues().toYaml() shouldBe expectedResult.withInvariantIssues().toYaml()
     }
 })

--- a/plugins/package-managers/node/src/funTest/kotlin/pnpm/PnpmFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/pnpm/PnpmFunTest.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm
 
-import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.analyzer.analyze
@@ -30,46 +30,44 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
 import org.ossreviewtoolkit.utils.test.patchActualResult
 
-class PnpmFunTest : WordSpec({
-    "Pnpm" should {
-        "resolve dependencies for a project with lockfile correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/pnpm/project-with-lockfile/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/pnpm/project-with-lockfile-expected-output.yml")
+class PnpmFunTest : StringSpec({
+    "Resolve dependencies for a project with lockfile correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/pnpm/project-with-lockfile/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/pnpm/project-with-lockfile-expected-output.yml")
 
-            val result = create("PNPM").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("PNPM").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "exclude scopes if configured" {
-            val definitionFile = getAssetFile("projects/synthetic/pnpm/project-with-lockfile/package.json")
-            val expectedResultFile = getAssetFile(
-                "projects/synthetic/pnpm/project-with-lockfile-skip-excluded-scopes-expected-output.yml"
-            )
+    "Exclude scopes if configured" {
+        val definitionFile = getAssetFile("projects/synthetic/pnpm/project-with-lockfile/package.json")
+        val expectedResultFile = getAssetFile(
+            "projects/synthetic/pnpm/project-with-lockfile-skip-excluded-scopes-expected-output.yml"
+        )
 
-            val result = create("PNPM", excludedScopes = setOf("devDependencies"))
-                .resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("PNPM", excludedScopes = setOf("devDependencies"))
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
-            patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "resolve dependencies for a project depending on Babel correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/pnpm/babel/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/pnpm/babel-expected-output.yml")
+    "Resolve dependencies for a project depending on Babel correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/pnpm/babel/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/pnpm/babel-expected-output.yml")
 
-            val result = create("PNPM").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("PNPM").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "resolve dependencies correctly in a workspaces project" {
-            val definitionFile = getAssetFile("projects/synthetic/pnpm/workspaces/packages.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/pnpm/workspaces-expected-output.yml")
+    "Resolve dependencies correctly in a workspaces project" {
+        val definitionFile = getAssetFile("projects/synthetic/pnpm/workspaces/packages.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/pnpm/workspaces-expected-output.yml")
 
-            val result = analyze(definitionFile.parentFile, packageManagers = setOf(Pnpm.Factory()))
+        val result = analyze(definitionFile.parentFile, packageManagers = setOf(Pnpm.Factory()))
 
-            patchActualResult(result.toYaml(), patchStartAndEndTime = true) should
-                matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        patchActualResult(result.toYaml(), patchStartAndEndTime = true) should
+            matchExpectedResult(expectedResultFile, definitionFile)
     }
 })

--- a/plugins/package-managers/node/src/funTest/kotlin/yarn/YarnFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/yarn/YarnFunTest.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.node.yarn
 
-import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.analyzer.collateMultipleProjects
@@ -29,35 +29,33 @@ import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
 
-class YarnFunTest : WordSpec({
-    "yarn" should {
-        "resolve dependencies for a project with lockfile correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/yarn/project-with-lockfile/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/yarn/project-with-lockfile-expected-output.yml")
+class YarnFunTest : StringSpec({
+    "Resolve dependencies for a project with lockfile correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/yarn/project-with-lockfile/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/yarn/project-with-lockfile-expected-output.yml")
 
-            val result = create("Yarn").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Yarn").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "resolve dependencies for a project depending on Babel correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/yarn/babel/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/yarn/babel-expected-output.yml")
+    "Resolve dependencies for a project depending on Babel correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/yarn/babel/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/yarn/babel-expected-output.yml")
 
-            val result = create("Yarn").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Yarn").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "resolve workspace dependencies correctly" {
-            // This test case illustrates the lack of Yarn workspaces support, in particular not all workspace
-            // dependencies get assigned to a scope.
-            val definitionFile = getAssetFile("projects/synthetic/yarn/workspaces/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/yarn/workspaces-expected-output.yml")
+    "Resolve workspace dependencies correctly" {
+        // This test case illustrates the lack of Yarn workspaces support, in particular not all workspace
+        // dependencies get assigned to a scope.
+        val definitionFile = getAssetFile("projects/synthetic/yarn/workspaces/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/yarn/workspaces-expected-output.yml")
 
-            val result = create("Yarn").collateMultipleProjects(definitionFile).withResolvedScopes()
+        val result = create("Yarn").collateMultipleProjects(definitionFile).withResolvedScopes()
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 })

--- a/plugins/package-managers/node/src/funTest/kotlin/yarn2/Yarn2FunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/yarn2/Yarn2FunTest.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.node.yarn2
 
-import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.analyzer.collateMultipleProjects
@@ -29,36 +29,34 @@ import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
 
-class Yarn2FunTest : WordSpec({
-    "Yarn 2" should {
-        "resolve dependencies for a project with lockfile correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/yarn2/project-with-lockfile/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/yarn2/project-with-lockfile-expected-output.yml")
+class Yarn2FunTest : StringSpec({
+    "Resolve dependencies for a project with lockfile correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/yarn2/project-with-lockfile/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/yarn2/project-with-lockfile-expected-output.yml")
 
-            val result = create("Yarn2").resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Yarn2").resolveSingleProject(definitionFile, resolveScopes = true)
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "resolved dependencies for a project with lockfile correctly and skip excluded scopes" {
-            val definitionFile = getAssetFile("projects/synthetic/yarn2/project-with-lockfile/package.json")
-            val expectedResultFile = getAssetFile(
-                "projects/synthetic/yarn2/project-with-lockfile-skip-excluded-scopes-expected-output.yml"
-            )
+    "Resolve dependencies for a project with lockfile correctly and skip excluded scopes" {
+        val definitionFile = getAssetFile("projects/synthetic/yarn2/project-with-lockfile/package.json")
+        val expectedResultFile = getAssetFile(
+            "projects/synthetic/yarn2/project-with-lockfile-skip-excluded-scopes-expected-output.yml"
+        )
 
-            val result = create("Yarn2", excludedScopes = setOf("devDependencies"))
-                .resolveSingleProject(definitionFile, resolveScopes = true)
+        val result = create("Yarn2", excludedScopes = setOf("devDependencies"))
+            .resolveSingleProject(definitionFile, resolveScopes = true)
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
 
-        "resolve dependencies for a workspaces project correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/yarn2/workspaces/package.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/yarn2/workspaces-expected-output.yml")
+    "Resolve dependencies for a workspaces project correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/yarn2/workspaces/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/yarn2/workspaces-expected-output.yml")
 
-            val result = create("Yarn2").collateMultipleProjects(definitionFile).withResolvedScopes()
+        val result = create("Yarn2").collateMultipleProjects(definitionFile).withResolvedScopes()
 
-            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
-        }
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 })


### PR DESCRIPTION
Use `StringSpec`s instead of `WordSpec`s as the latter were used to nest all tests as a whole only.