### PR TITLE
docs(schema): Fix the JSON schema for the repository configuration

### DIFF
--- a/integrations/schemas/package-manager-configuration-schema.json
+++ b/integrations/schemas/package-manager-configuration-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://oss-review-toolkit.org/package-manager-configuration.yml",
-    "title": "ORT configuration",
+    "title": "ORT package manager configurations",
     "description": "Configurations for package managers for the OSS-Review-Toolkit (ORT). A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/config/PackageManagerConfiguration.kt.",
     "type": "object",
     "propertyNames": {

--- a/integrations/schemas/repository-configurations/analyzer-configuration-schema.json
+++ b/integrations/schemas/repository-configurations/analyzer-configuration-schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://oss-review-toolkit.org/repository-configurations/analyzer-configuration.yml",
+  "title": "ORT repository analyzer configurations",
+  "description": "Configurations for the analyzer of the The OSS-Review-Toolkit (ORT). A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/config/AnalyzerConfiguration.kt.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "allow_dynamic_versions": {
+      "type": "boolean"
+    },
+    "enabled_package_managers": {
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-managers-schema.json"
+      }
+    },
+    "disabled_package_managers": {
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-managers-schema.json"
+      }
+    },
+    "package_managers": {
+      "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/repository-configurations/package-manager-configuration-schema.json"
+    },
+    "skip_excluded": {
+      "type": "boolean"
+    }
+  }
+}

--- a/integrations/schemas/repository-configurations/package-manager-configuration-schema.json
+++ b/integrations/schemas/repository-configurations/package-manager-configuration-schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://oss-review-toolkit.org/repository-configurations/package-manager-configuration.yml",
+    "title": "ORT repository package manager configuration",
+    "description": "Configurations for package managers for the OSS-Review-Toolkit (ORT). A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/config/PackageManagerConfiguration.kt.",
+    "type": "object",
+    "propertyNames": {
+        "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-managers-schema.json"
+    },
+    "additionalProperties": {
+        "type": "object",
+        "$ref": "#/definitions/PackageManagerConfigs"
+    },
+    "definitions": {
+        "PackageManagerConfigs": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "must_run_after": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-managers-schema.json"
+                    }
+                },
+                "options": {
+                    "additionalProperties": {
+                        "type": [
+                            "boolean",
+                            "number",
+                            "string"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/model/src/test/assets/analyzer-repository-configuration.ort.yml
+++ b/model/src/test/assets/analyzer-repository-configuration.ort.yml
@@ -1,0 +1,5 @@
+analyzer:
+  allow_dynamic_versions: false
+  enabled_package_managers:
+  - Gradle
+  - Maven

--- a/model/src/test/assets/package-manager-repository-configuration.ort.yml
+++ b/model/src/test/assets/package-manager-repository-configuration.ort.yml
@@ -1,0 +1,7 @@
+analyzer:
+  package_managers:
+    Gradle:
+      must_run_after:
+      - Maven
+      options:
+        foo: bar

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -60,6 +60,26 @@ class JsonSchemaTest : StringSpec({
         }
     }
 
+    "Analyzer configuration within a repository configuration validates successfully" {
+        val repositoryConfiguration = File("src/test/assets/analyzer-repository-configuration.ort.yml").toJsonNode()
+        val analyzerConfiguration = repositoryConfiguration.get("analyzer")
+
+        val errors = schemaV7.getSchema(repositoryConfigurationAnalyzerConfiguration).validate(analyzerConfiguration)
+
+        errors should beEmpty()
+    }
+
+    "Package manager configuration within a repository configuration validates successfully" {
+        val repositoryConfiguration =
+            File("src/test/assets/package-manager-repository-configuration.ort.yml").toJsonNode()
+        val packageManagerConfiguration = repositoryConfiguration.get("analyzer").get("package_managers")
+
+        val errors =
+            schemaV7.getSchema(repositoryConfigurationPackageManagerConfiguration).validate(packageManagerConfiguration)
+
+        errors should beEmpty()
+    }
+
     "The example package curations file validates successfully" {
         val curationsSchema = File("../integrations/schemas/curations-schema.json").toURI()
         val curationsExample = File("../examples/$ORT_PACKAGE_CURATIONS_FILENAME").toJsonNode()
@@ -115,5 +135,11 @@ private val schemaV7 = JsonSchemaFactory
 
 private val repositoryConfigurationSchema =
     File("../integrations/schemas/repository-configuration-schema.json").toURI()
+
+private val repositoryConfigurationAnalyzerConfiguration =
+    File("../integrations/schemas/repository-configurations/analyzer-configuration-schema.json").toURI()
+
+private val repositoryConfigurationPackageManagerConfiguration =
+    File("../integrations/schemas/repository-configurations/package-manager-configuration-schema.json").toURI()
 
 private fun File.toJsonNode() = yamlMapper.readTree(inputStream())


### PR DESCRIPTION
By reusing the analyzer configuration schema, the properties incorrectly used camel case notation, change it to snake case.

While at it, remove the `Sw360Configuration` from the schema, which is not part of the analyzer configuration model.

Resolves #7680

