### PR TITLE
black-duck: Properly de-duplicate vulnerability references

### DIFF
--- a/plugins/advisors/black-duck/build.gradle.kts
+++ b/plugins/advisors/black-duck/build.gradle.kts
@@ -35,5 +35,7 @@ dependencies {
 
     funTestImplementation(libs.gson)
 
+    testImplementation(libs.gson)
+
     ksp(projects.advisor)
 }

--- a/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
@@ -198,7 +198,7 @@ class BlackDuck(
 }
 
 internal fun VulnerabilityView.toOrtVulnerability(): Vulnerability {
-    val referenceUris = listOf(meta.href.uri(), *meta.links.map { it.href.uri() }.toTypedArray())
+    val referenceUris = setOf(meta.href.uri(), *meta.links.map { it.href.uri() }.toTypedArray())
 
     val references = referenceUris.map { uri ->
         val cvssVector = cvss3?.vector ?: cvss2?.vector

--- a/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
@@ -197,7 +197,7 @@ class BlackDuck(
         }
 }
 
-private fun VulnerabilityView.toOrtVulnerability(): Vulnerability {
+internal fun VulnerabilityView.toOrtVulnerability(): Vulnerability {
     val referenceUris = listOf(meta.href.uri(), *meta.links.map { it.href.uri() }.toTypedArray())
 
     val references = referenceUris.map { uri ->

--- a/plugins/advisors/black-duck/src/test/assets/.gitattributes
+++ b/plugins/advisors/black-duck/src/test/assets/.gitattributes
@@ -1,0 +1,2 @@
+# Use Unix line endings for expected test results for consistency across platforms.
+*-parsed.yml	text eol=lf

--- a/plugins/advisors/black-duck/src/test/assets/BDSA-2024-5272-parsed.yml
+++ b/plugins/advisors/black-duck/src/test/assets/BDSA-2024-5272-parsed.yml
@@ -44,11 +44,6 @@ references:
   severity: "MEDIUM"
   score: 4.8
   vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
-- url: "https://gitlab.com/libtiff/libtiff/-/issues/624"
-  scoring_system: "CVSS:3.1"
-  severity: "MEDIUM"
-  score: 4.8
-  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
 - url: "https://gitlab.com/libtiff/libtiff/-/tags/v4.7.0rc1"
   scoring_system: "CVSS:3.1"
   severity: "MEDIUM"

--- a/plugins/advisors/black-duck/src/test/assets/BDSA-2024-5272-parsed.yml
+++ b/plugins/advisors/black-duck/src/test/assets/BDSA-2024-5272-parsed.yml
@@ -1,0 +1,56 @@
+---
+id: "BDSA-2024-5272"
+description: "Libtiff is vulnerable to a null pointer dereference issue due to a problem\
+  \ in its `_TIFFMergeFields` function. This could allow an attacker to trigger memory\
+  \ allocation failures, causing a segmentation fault and leading to a crash."
+references:
+- url: "https://zeiss.app.blackduck.com/api/vulnerabilities/BDSA-2024-5272"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://zeiss.app.blackduck.com/api/cwes/CWE-476"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://zeiss.app.blackduck.com/api/vulnerabilities/CVE-2024-7006"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://zeiss.app.blackduck.com/api/vulnerabilities/BDSA-2024-5272/ranges"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://access.redhat.com/security/cve/CVE-2024-7006"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://bugzilla.redhat.com/show_bug.cgi?id=2302996"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://gitlab.com/libtiff/libtiff/-/commit/818fb8ce"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://gitlab.com/libtiff/libtiff/-/issues/624"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://gitlab.com/libtiff/libtiff/-/issues/624"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+- url: "https://gitlab.com/libtiff/libtiff/-/tags/v4.7.0rc1"
+  scoring_system: "CVSS:3.1"
+  severity: "MEDIUM"
+  score: 4.8
+  vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"

--- a/plugins/advisors/black-duck/src/test/assets/BDSA-2024-5272.json
+++ b/plugins/advisors/black-duck/src/test/assets/BDSA-2024-5272.json
@@ -1,0 +1,106 @@
+{
+  "source": "BDSA",
+  "name": "BDSA-2024-5272",
+  "title": "Libtiff Vulnerable to Denial-of-Service (DoS) via Null Pointer Dereference Caused by '_TIFFCreateAnonField' Return Value",
+  "description": "Libtiff is vulnerable to a null pointer dereference issue due to a problem in its `_TIFFMergeFields` function. This could allow an attacker to trigger memory allocation failures, causing a segmentation fault and leading to a crash.",
+  "technicalDescription": "The vulnerability resides within the `tif_dirinfo.c` file. The issue arises from a null pointer dereference in the `_TIFFMergeFields` function, which directly uses the return value of `_TIFFCreateAnonField` as the second parameter, without checking whether it might be NULL. This could lead to a segmentation fault and a potential denial-of-service situation. The vulnerability was fixed by adding a check for the return value of `_TIFFCreateAnonField`. If the return value is NULL, the `_TIFFMergeFields()` function will not proceed. This change was implemented in both the `TIFFReadDirectory` and `TIFFReadCustomDirectory` functions within the `tif_dirread.c` file.",
+  "publishedDate": "2024-08-09T13:47:27.503Z",
+  "updatedDate": "2024-10-08T12:52:29.767Z",
+  "disclosureDate": "2024-08-05T00:00:00.000Z",
+  "exploitPublishDate": "2023-11-23T00:00:00.000Z",
+  "solution": "Fixed in [**v4.7.0rc1**](https://gitlab.com/libtiff/libtiff/-/tags/v4.7.0rc1) by [this](https://gitlab.com/libtiff/libtiff/-/commit/818fb8ce) commit.",
+  "severity": "MEDIUM",
+  "cvss2": {
+    "baseScore": 0,
+    "impactSubscore": 0,
+    "exploitabilitySubscore": 1.2,
+    "severity": "LOW",
+    "accessVector": "LOCAL",
+    "accessComplexity": "HIGH",
+    "authentication": "MULTIPLE",
+    "confidentialityImpact": "NONE",
+    "integrityImpact": "NONE",
+    "availabilityImpact": "NONE",
+    "vector": "(AV:L/AC:H/Au:M/C:N/I:N/A:N)"
+  },
+  "cvss3": {
+    "baseScore": 5.3,
+    "impactSubscore": 1.4,
+    "exploitabilitySubscore": 3.9,
+    "severity": "MEDIUM",
+    "attackVector": "NETWORK",
+    "attackComplexity": "LOW",
+    "confidentialityImpact": "NONE",
+    "integrityImpact": "NONE",
+    "availabilityImpact": "LOW",
+    "privilegesRequired": "NONE",
+    "scope": "UNCHANGED",
+    "userInteraction": "NONE",
+    "temporalMetrics": {
+      "exploitability": "PROOF_OF_CONCEPT",
+      "remediationLevel": "OFFICIAL_FIX",
+      "reportConfidence": "CONFIRMED",
+      "score": 4.8
+    },
+    "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C"
+  },
+  "useCvss3": true,
+  "classifications": [],
+  "zeroDay": false,
+  "underReview": false,
+  "parentAdvisory": false,
+  "workaround": "",
+  "vendorFixDate": "2023-12-09T00:00:00.000Z",
+  "vendorNotifiedDate": "2023-11-23T00:00:00.000Z",
+  "bdsaTags": [],
+  "overallScore": 4.8,
+  "_meta": {
+    "allow": [],
+    "href": "https://zeiss.app.blackduck.com/api/vulnerabilities/BDSA-2024-5272",
+    "links": [
+      {
+        "rel": "cwes",
+        "href": "https://zeiss.app.blackduck.com/api/cwes/CWE-476"
+      },
+      {
+        "rel": "related-vulnerability",
+        "href": "https://zeiss.app.blackduck.com/api/vulnerabilities/CVE-2024-7006",
+        "label": "NVD"
+      },
+      {
+        "rel": "bdsa-ranges",
+        "href": "https://zeiss.app.blackduck.com/api/vulnerabilities/BDSA-2024-5272/ranges"
+      },
+      {
+        "rel": "reference",
+        "href": "https://access.redhat.com/security/cve/CVE-2024-7006",
+        "label": "ADVISORY"
+      },
+      {
+        "rel": "reference",
+        "href": "https://bugzilla.redhat.com/show_bug.cgi?id=2302996",
+        "label": "ADVISORY"
+      },
+      {
+        "rel": "reference",
+        "href": "https://gitlab.com/libtiff/libtiff/-/commit/818fb8ce",
+        "label": "PATCH"
+      },
+      {
+        "rel": "reference",
+        "href": "https://gitlab.com/libtiff/libtiff/-/issues/624",
+        "label": "ADVISORY"
+      },
+      {
+        "rel": "reference",
+        "href": "https://gitlab.com/libtiff/libtiff/-/issues/624",
+        "label": "POC"
+      },
+      {
+        "rel": "reference",
+        "href": "https://gitlab.com/libtiff/libtiff/-/tags/v4.7.0rc1",
+        "label": "VENDOR_UPGRADE"
+      }
+    ]
+  }
+}

--- a/plugins/advisors/black-duck/src/test/kotlin/BlackDuckTest.kt
+++ b/plugins/advisors/black-duck/src/test/kotlin/BlackDuckTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.blackduck
+
+import com.blackduck.integration.blackduck.api.generated.view.VulnerabilityView
+
+import com.google.gson.GsonBuilder
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.utils.test.matchExpectedResult
+
+class BlackDuckTest : WordSpec({
+    "toOrtVulnerability()" should {
+        "parse a vulnerability with CVSS 3.1 and with duplicate links as expected" {
+            val expectedResult = getAssetFile("BDSA-2024-5272-parsed.yml")
+            val vulnerabilityView = readVulnerabilityViewAssetFile("BDSA-2024-5272.json")
+
+            val vulnerability = vulnerabilityView.toOrtVulnerability()
+
+            vulnerability.toYaml() shouldBe matchExpectedResult(expectedResult)
+        }
+    }
+})
+
+private fun readVulnerabilityViewAssetFile(path: String): VulnerabilityView =
+    GSON.fromJson(getAssetFile(path).readText(), VulnerabilityView::class.java)
+
+private val GSON by lazy { GsonBuilder().setPrettyPrinting().create() }
+
+private fun getAssetFile(path: String): File = File("src/test/assets", path).absoluteFile


### PR DESCRIPTION
See individual commits.

Part of: #8739.