### PR TITLE
docs(schema): Use reference to correct analyzer configuration schema

### DIFF
--- a/integrations/schemas/repository-configuration-schema.json
+++ b/integrations/schemas/repository-configuration-schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "analyzer": {
-      "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/analyzer-configuration-schema.json"
+      "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/repository-configurations/analyzer-configuration-schema.json"
     },
     "excludes": {
       "type": "object",


### PR DESCRIPTION
This is a fixup for 8dbd4258f37e74cef86c8dfb5afe88852e184a8c.

Unfortunately I missed to correct the actual reference 🙄