### PR TITLE
fix(Git): Work around a bug with JGit vs MINA

### DIFF
--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -104,6 +104,11 @@ class Git(
 ) : VersionControlSystem() {
     companion object {
         init {
+            if (Os.isLinux) {
+                // Work around a bug in Apache MINA sshd, see https://github.com/eclipse-jgit/jgit/issues/135.
+                System.setProperty("java.security.egd", "file:/dev/./urandom")
+            }
+
             // Make sure that JGit uses the exact same authentication information as ORT itself. This addresses
             // discrepancies in the way .netrc files are interpreted between JGit's and ORT's implementation.
             CredentialsProvider.setDefault(AuthenticatorCredentialsProvider)


### PR DESCRIPTION
Also see [1] for some more background information about why SSH connections can otherwise block "if there is less entropy available than requested".

[1]: https://stackoverflow.com/a/59097932/1127485