### PR TITLE
feat(Provenance): Add a `RemoteProvenance` sub-interface

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -43,6 +43,8 @@ data object UnknownProvenance : Provenance {
 
 sealed interface KnownProvenance : Provenance
 
+sealed interface RemoteProvenance : KnownProvenance
+
 /**
  * Provenance information for a source artifact.
  */
@@ -51,7 +53,7 @@ data class ArtifactProvenance(
      * The source artifact that was downloaded.
      */
     val sourceArtifact: RemoteArtifact
-) : KnownProvenance {
+) : RemoteProvenance {
     override fun matches(pkg: Package): Boolean = sourceArtifact == pkg.sourceArtifact
 }
 
@@ -70,7 +72,7 @@ data class RepositoryProvenance(
      * like a branch or tag name, but a fixed revision (e.g. the SHA1 of a Git commit).
      */
     val resolvedRevision: String
-) : KnownProvenance {
+) : RemoteProvenance {
     init {
         require(resolvedRevision.isNotBlank()) { "The resolved revision must not be blank." }
     }


### PR DESCRIPTION
In preparation to split the `KnownProvenance` hierarchy further, for now introduce a `RemoteProvenance` that bundles the `RepositoryProvenance` and `ArtifactProvance`. Later an additional `LocalProvance` will be introduced.

For more context see https://github.com/oss-review-toolkit/ort/issues/8803#issuecomment-2236958430.

This PR succeeds #9476.

Signed-off-by: Jens Keim <jens.keim@forvia.com>