### PR TITLE
PNPM: Handle projects with nested subprojects

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project-expected-output.yml
@@ -1,0 +1,1289 @@
+---
+projects:
+- id: "PNPM::pnpm-nested-sub-project:1.0.0"
+  definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/sub/package.json"
+  authors:
+  - "The Author"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  vcs:
+    type: "Git"
+    url: "https://github.com/oss-review-toolkit/ort.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>/sub"
+  description: "A sub project nested in another one"
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "NPM::proxy-from-env:1.1.0"
+- id: "PNPM::pnpm-package-with-nested-project:1.0.0"
+  definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/package.json"
+  authors:
+  - "The Author"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  vcs:
+    type: "Git"
+    url: "https://github.com/oss-review-toolkit/ort.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  description: "PNPM project with a nested sub project."
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "NPM::cheerio:1.0.0-rc.1"
+      dependencies:
+      - id: "NPM::css-select:1.2.0"
+        dependencies:
+        - id: "NPM::boolbase:1.0.0"
+        - id: "NPM::css-what:2.1.3"
+        - id: "NPM::domutils:1.5.1"
+          dependencies:
+          - id: "NPM::dom-serializer:0.1.1"
+            dependencies:
+            - id: "NPM::domelementtype:1.3.1"
+            - id: "NPM::entities:1.1.2"
+          - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::nth-check:1.0.2"
+          dependencies:
+          - id: "NPM::boolbase:1.0.0"
+      - id: "NPM::dom-serializer:0.1.1"
+        dependencies:
+        - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::entities:1.1.2"
+      - id: "NPM::entities:1.1.2"
+      - id: "NPM::htmlparser2:3.10.1"
+        dependencies:
+        - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::domhandler:2.4.2"
+          dependencies:
+          - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::domutils:1.7.0"
+          dependencies:
+          - id: "NPM::dom-serializer:0.1.1"
+            dependencies:
+            - id: "NPM::domelementtype:1.3.1"
+            - id: "NPM::entities:1.1.2"
+          - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::entities:1.1.2"
+        - id: "NPM::inherits:2.0.4"
+        - id: "NPM::readable-stream:3.6.2"
+          dependencies:
+          - id: "NPM::inherits:2.0.4"
+          - id: "NPM::string_decoder:1.3.0"
+            dependencies:
+            - id: "NPM::safe-buffer:5.2.1"
+          - id: "NPM::util-deprecate:1.0.2"
+      - id: "NPM::lodash:4.17.21"
+      - id: "NPM::parse5:3.0.3"
+        dependencies:
+        - id: "NPM:@types:node:22.9.0"
+          dependencies:
+          - id: "NPM::undici-types:6.19.8"
+    - id: "NPM::long:3.2.0"
+    - id: "NPM::promise:7.3.1"
+      dependencies:
+      - id: "NPM::asap:2.0.6"
+    - id: "NPM::web-animations-js:2.3.2"
+  - name: "devDependencies"
+    dependencies:
+    - id: "NPM::cson:4.1.0"
+      dependencies:
+      - id: "NPM::coffee-script:1.12.7"
+      - id: "NPM::cson-parser:1.3.5"
+        dependencies:
+        - id: "NPM::coffee-script:1.12.7"
+      - id: "NPM::extract-opts:3.4.0"
+        dependencies:
+        - id: "NPM::eachr:3.3.0"
+          dependencies:
+          - id: "NPM::editions:2.3.1"
+            dependencies:
+            - id: "NPM::errlop:2.2.0"
+            - id: "NPM::semver:6.3.1"
+          - id: "NPM::typechecker:4.11.0"
+            dependencies:
+            - id: "NPM::editions:2.3.1"
+              dependencies:
+              - id: "NPM::errlop:2.2.0"
+              - id: "NPM::semver:6.3.1"
+        - id: "NPM::editions:2.3.1"
+          dependencies:
+          - id: "NPM::errlop:2.2.0"
+          - id: "NPM::semver:6.3.1"
+        - id: "NPM::typechecker:4.11.0"
+          dependencies:
+          - id: "NPM::editions:2.3.1"
+            dependencies:
+            - id: "NPM::errlop:2.2.0"
+            - id: "NPM::semver:6.3.1"
+      - id: "NPM::requirefresh:2.3.0"
+        dependencies:
+        - id: "NPM::editions:2.3.1"
+          dependencies:
+          - id: "NPM::errlop:2.2.0"
+          - id: "NPM::semver:6.3.1"
+      - id: "NPM::safefs:4.2.0"
+        dependencies:
+        - id: "NPM::editions:2.3.1"
+          dependencies:
+          - id: "NPM::errlop:2.2.0"
+          - id: "NPM::semver:6.3.1"
+        - id: "NPM::graceful-fs:4.2.11"
+packages:
+- id: "NPM::asap:2.0.6"
+  purl: "pkg:npm/asap@2.0.6"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "High-priority task queue for Node.js and browsers"
+  homepage_url: "https://github.com/kriskowal/asap#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+    hash:
+      value: "e50347611d7e690943208bbdafebcbc2fb866d46"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/kriskowal/asap.git"
+    revision: "3e3d99381444379bb0483cb9216caa39ac67bebb"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/kriskowal/asap.git"
+    revision: "3e3d99381444379bb0483cb9216caa39ac67bebb"
+    path: ""
+- id: "NPM::boolbase:1.0.0"
+  purl: "pkg:npm/boolbase@1.0.0"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "two functions: One that returns true, one that returns false"
+  homepage_url: "https://github.com/fb55/boolbase"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+    hash:
+      value: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/fb55/boolbase"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/boolbase.git"
+    revision: ""
+    path: ""
+- id: "NPM::cheerio:1.0.0-rc.1"
+  purl: "pkg:npm/cheerio@1.0.0-rc.1"
+  authors:
+  - "Matt Mueller"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Tiny, fast, and elegant implementation of core jQuery designed specifically\
+    \ for the server"
+  homepage_url: "https://github.com/cheeriojs/cheerio#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.1.tgz"
+    hash:
+      value: "2af37339eab713ef6b72cde98cefa672b87641fe"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/cheeriojs/cheerio.git"
+    revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/cheeriojs/cheerio.git"
+    revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
+    path: ""
+- id: "NPM::coffee-script:1.12.7"
+  purl: "pkg:npm/coffee-script@1.12.7"
+  authors:
+  - "Jeremy Ashkenas"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Unfancy JavaScript"
+  homepage_url: "http://coffeescript.org"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
+    hash:
+      value: "c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/jashkenas/coffeescript.git"
+    revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jashkenas/coffeescript.git"
+    revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
+    path: ""
+- id: "NPM::cson:4.1.0"
+  purl: "pkg:npm/cson@4.1.0"
+  authors:
+  - "2012+ Bevry Pty Ltd"
+  - "Benjamin Lupton"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "CoffeeScript-Object-Notation Parser. Same as JSON but for CoffeeScript\
+    \ objects."
+  homepage_url: "https://github.com/bevry/cson"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz"
+    hash:
+      value: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/cson.git"
+    revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/cson.git"
+    revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
+    path: ""
+- id: "NPM::cson-parser:1.3.5"
+  purl: "pkg:npm/cson-parser@1.3.5"
+  authors:
+  - "Groupon"
+  declared_licenses:
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+  description: "Safe parsing of CSON files"
+  homepage_url: "https://github.com/groupon/cson-parser"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
+    hash:
+      value: "7ec675e039145533bf2a6a856073f1599d9c2d24"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+ssh://git@github.com/groupon/cson-parser"
+    revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "ssh://git@github.com/groupon/cson-parser.git"
+    revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
+    path: ""
+- id: "NPM::css-select:1.2.0"
+  purl: "pkg:npm/css-select@1.2.0"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-like"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD-like: "BSD-3-Clause"
+  description: "a CSS selector compiler/engine"
+  homepage_url: "https://github.com/fb55/css-select#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
+    hash:
+      value: "2b3a110539c5355f1cd8d314623e870b121ec858"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/css-select.git"
+    revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/css-select.git"
+    revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
+    path: ""
+- id: "NPM::css-what:2.1.3"
+  purl: "pkg:npm/css-what@2.1.3"
+  authors:
+  - "Felix Böhm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "a CSS selector parser"
+  homepage_url: "https://github.com/fb55/css-what#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz"
+    hash:
+      value: "a6d7604573365fe74686c3f311c56513d88285f2"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: "https://github.com/fb55/css-what"
+    revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/css-what.git"
+    revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
+    path: ""
+- id: "NPM::dom-serializer:0.1.1"
+  purl: "pkg:npm/dom-serializer@0.1.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "render dom nodes to string"
+  homepage_url: "https://github.com/cheeriojs/dom-renderer#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz"
+    hash:
+      value: "1ec4059e284babed36eec2941d4a970a189ce7c0"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/cheeriojs/dom-renderer.git"
+    revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/cheeriojs/dom-renderer.git"
+    revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
+    path: ""
+- id: "NPM::domelementtype:1.3.1"
+  purl: "pkg:npm/domelementtype@1.3.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "all the types of nodes in htmlparser2's dom"
+  homepage_url: "https://github.com/fb55/domelementtype#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz"
+    hash:
+      value: "d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/domelementtype.git"
+    revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/domelementtype.git"
+    revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
+    path: ""
+- id: "NPM::domhandler:2.4.2"
+  purl: "pkg:npm/domhandler@2.4.2"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "handler for htmlparser2 that turns pages into a dom"
+  homepage_url: "https://github.com/fb55/DomHandler#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz"
+    hash:
+      value: "8805097e933d65e85546f726d60f5eb88b44f803"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/DomHandler.git"
+    revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/DomHandler.git"
+    revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
+    path: ""
+- id: "NPM::domutils:1.5.1"
+  purl: "pkg:npm/domutils@1.5.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: "utilities for working with htmlparser2's dom"
+  homepage_url: "https://github.com/FB55/domutils"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+    hash:
+      value: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/FB55/domutils.git"
+    revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/FB55/domutils.git"
+    revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
+    path: ""
+- id: "NPM::domutils:1.7.0"
+  purl: "pkg:npm/domutils@1.7.0"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "utilities for working with htmlparser2's dom"
+  homepage_url: "https://github.com/FB55/domutils#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz"
+    hash:
+      value: "56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/FB55/domutils.git"
+    revision: "34f193ca17d11a98d9310b1965efe5f73d32d79f"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/FB55/domutils.git"
+    revision: "34f193ca17d11a98d9310b1965efe5f73d32d79f"
+    path: ""
+- id: "NPM::eachr:3.3.0"
+  purl: "pkg:npm/eachr@3.3.0"
+  authors:
+  - "2011+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Give eachr an item to iterate (array, object or map) and an iterator,\
+    \ then in return eachr gives iterator the value and key of each item, and will\
+    \ stop if the iterator returned false."
+  homepage_url: "https://github.com/bevry/eachr"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/eachr/-/eachr-3.3.0.tgz"
+    hash:
+      value: "11f7287be7d31d6b99947fe0d8a79de99ac2a469"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/eachr.git"
+    revision: "0d1b43cc12c83f9ddb8d49a1acaf8718a026f863"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/eachr.git"
+    revision: "0d1b43cc12c83f9ddb8d49a1acaf8718a026f863"
+    path: ""
+- id: "NPM::editions:2.3.1"
+  purl: "pkg:npm/editions@2.3.1"
+  authors:
+  - "2016+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Publish multiple editions for your JavaScript packages consistently\
+    \ and easily (e.g. source edition, esnext edition, es2015 edition)"
+  homepage_url: "https://github.com/bevry/editions"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz"
+    hash:
+      value: "3bc9962f1978e801312fbd0aebfed63b49bfe698"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/editions.git"
+    revision: "b03745b7cd5a09a6fb4984dcab9544f20a794078"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/editions.git"
+    revision: "b03745b7cd5a09a6fb4984dcab9544f20a794078"
+    path: ""
+- id: "NPM::entities:1.1.2"
+  purl: "pkg:npm/entities@1.1.2"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "Encode & decode XML/HTML entities with ease"
+  homepage_url: "https://github.com/fb55/entities#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz"
+    hash:
+      value: "bdfa735299664dfafd34529ed4f8522a275fea56"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/entities.git"
+    revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/entities.git"
+    revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
+    path: ""
+- id: "NPM::errlop:2.2.0"
+  purl: "pkg:npm/errlop@2.2.0"
+  authors:
+  - "2018+ Benjamin Lupton"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "An extended Error class that envelops a parent error, such that the\
+    \ stack trace contains the causation"
+  homepage_url: "https://github.com/bevry/errlop"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz"
+    hash:
+      value: "1ff383f8f917ae328bebb802d6ca69666a42d21b"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/errlop.git"
+    revision: "df73707a467967d1da36176e9199f2c98a314220"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/errlop.git"
+    revision: "df73707a467967d1da36176e9199f2c98a314220"
+    path: ""
+- id: "NPM::extract-opts:3.4.0"
+  purl: "pkg:npm/extract-opts@3.4.0"
+  authors:
+  - "2011+ Benjamin Lupton"
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Extract the options and callback from a function's arguments easily"
+  homepage_url: "https://github.com/bevry/extract-opts"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/extract-opts/-/extract-opts-3.4.0.tgz"
+    hash:
+      value: "ab07a7873896a1a7e350f27e2d52645c2ceba9ac"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/extract-opts.git"
+    revision: "be6ba5f1d865d3d547350fe3f379251792936ed8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/extract-opts.git"
+    revision: "be6ba5f1d865d3d547350fe3f379251792936ed8"
+    path: ""
+- id: "NPM::graceful-fs:4.2.11"
+  purl: "pkg:npm/graceful-fs@4.2.11"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "A drop-in replacement for fs, making various improvements."
+  homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
+    hash:
+      value: "4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/isaacs/node-graceful-fs"
+    revision: "514861c372899df14beb7aaecca4cdbb498d7d11"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/isaacs/node-graceful-fs.git"
+    revision: "514861c372899df14beb7aaecca4cdbb498d7d11"
+    path: ""
+- id: "NPM::htmlparser2:3.10.1"
+  purl: "pkg:npm/htmlparser2@3.10.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fast & forgiving HTML/XML/RSS parser"
+  homepage_url: "https://github.com/fb55/htmlparser2#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz"
+    hash:
+      value: "bd679dc3f59897b6a34bb10749c855bb53a9392f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/htmlparser2.git"
+    revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/htmlparser2.git"
+    revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
+    path: ""
+- id: "NPM::inherits:2.0.4"
+  purl: "pkg:npm/inherits@2.0.4"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "Browser-friendly inheritance fully compatible with standard node.js\
+    \ inherits()"
+  homepage_url: "https://github.com/isaacs/inherits#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
+    hash:
+      value: "0fa2c64f932917c3433a0ded55363aae37416b7c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/isaacs/inherits"
+    revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/isaacs/inherits.git"
+    revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
+    path: ""
+- id: "NPM::lodash:4.17.21"
+  purl: "pkg:npm/lodash@4.17.21"
+  authors:
+  - "John-David Dalton"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Lodash modular utilities."
+  homepage_url: "https://lodash.com/"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+    hash:
+      value: "679591c564c3bffaae8454cf0b3df370c3d6911c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/lodash/lodash.git"
+    revision: "c6e281b878b315c7a10d90f9c2af4cdb112d9625"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lodash/lodash.git"
+    revision: "c6e281b878b315c7a10d90f9c2af4cdb112d9625"
+    path: ""
+- id: "NPM::long:3.2.0"
+  purl: "pkg:npm/long@3.2.0"
+  authors:
+  - "Daniel Wirtz"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  description: "A Long class for representing a 64-bit two's-complement integer value."
+  homepage_url: "https://github.com/dcodeIO/long.js#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/long/-/long-3.2.0.tgz"
+    hash:
+      value: "d821b7138ca1cb581c172990ef14db200b5c474b"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/dcodeIO/long.js.git"
+    revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/dcodeIO/long.js.git"
+    revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
+    path: ""
+- id: "NPM::nth-check:1.0.2"
+  purl: "pkg:npm/nth-check@1.0.2"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "performant nth-check parser & compiler"
+  homepage_url: "https://github.com/fb55/nth-check"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz"
+    hash:
+      value: "b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/fb55/nth-check"
+    revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/nth-check.git"
+    revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
+    path: ""
+- id: "NPM::parse5:3.0.3"
+  purl: "pkg:npm/parse5@3.0.3"
+  authors:
+  - "Ivan Nikulin"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "HTML parsing/serialization toolset for Node.js. WHATWG HTML Living\
+    \ Standard (aka HTML5)-compliant."
+  homepage_url: "https://github.com/inikulin/parse5"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz"
+    hash:
+      value: "042f792ffdd36851551cf4e9e066b3874ab45b5c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/inikulin/parse5.git"
+    revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inikulin/parse5.git"
+    revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
+    path: ""
+- id: "NPM::promise:7.3.1"
+  purl: "pkg:npm/promise@7.3.1"
+  authors:
+  - "ForbesLindesay"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Bare bones Promises/A+ implementation"
+  homepage_url: "https://github.com/then/promise#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
+    hash:
+      value: "064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/then/promise.git"
+    revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/then/promise.git"
+    revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
+    path: ""
+- id: "NPM::proxy-from-env:1.1.0"
+  purl: "pkg:npm/proxy-from-env@1.1.0"
+  authors:
+  - "Rob Wu"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Offers getProxyForUrl to get the proxy URL for a URL, respecting the\
+    \ *_PROXY (e.g. HTTP_PROXY) and NO_PROXY environment variables."
+  homepage_url: "https://github.com/Rob--W/proxy-from-env#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
+    hash:
+      value: "e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/Rob--W/proxy-from-env.git"
+    revision: "96d01f8fcfdccfb776735751132930bbf79c4a3a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/Rob--W/proxy-from-env.git"
+    revision: "96d01f8fcfdccfb776735751132930bbf79c4a3a"
+    path: ""
+- id: "NPM::readable-stream:3.6.2"
+  purl: "pkg:npm/readable-stream@3.6.2"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Streams3, a user-land copy of the stream library from Node.js"
+  homepage_url: "https://github.com/nodejs/readable-stream#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
+    hash:
+      value: "56a9b36ea965c00c5a93ef31eb111a0f11056967"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/nodejs/readable-stream"
+    revision: "6c32003bd8607da54f8ca1b096c4411778b060bc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/nodejs/readable-stream.git"
+    revision: "6c32003bd8607da54f8ca1b096c4411778b060bc"
+    path: ""
+- id: "NPM::requirefresh:2.3.0"
+  purl: "pkg:npm/requirefresh@2.3.0"
+  authors:
+  - "2011+ Benjamin Lupton"
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Require a file without adding it into the require cache"
+  homepage_url: "https://github.com/bevry/requirefresh"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/requirefresh/-/requirefresh-2.3.0.tgz"
+    hash:
+      value: "fb09387b57f5ed335ff4a4beea3d8c0bf2367306"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/requirefresh.git"
+    revision: "aecc77a6b41d1486ca63b317cb31dd07b4f56629"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/requirefresh.git"
+    revision: "aecc77a6b41d1486ca63b317cb31dd07b4f56629"
+    path: ""
+- id: "NPM::safe-buffer:5.2.1"
+  purl: "pkg:npm/safe-buffer@5.2.1"
+  authors:
+  - "Feross Aboukhadijeh"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Safer Node.js Buffer API"
+  homepage_url: "https://github.com/feross/safe-buffer"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+    hash:
+      value: "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/feross/safe-buffer.git"
+    revision: "89d3d5b4abd6308c6008499520373d204ada694b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/feross/safe-buffer.git"
+    revision: "89d3d5b4abd6308c6008499520373d204ada694b"
+    path: ""
+- id: "NPM::safefs:4.2.0"
+  purl: "pkg:npm/safefs@4.2.0"
+  authors:
+  - "2011-2012 Benjamin Lupton"
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Stop getting EMFILE errors! Open only as many files as the operating\
+    \ system supports."
+  homepage_url: "https://github.com/bevry/safefs"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/safefs/-/safefs-4.2.0.tgz"
+    hash:
+      value: "6d60d3aecc47c3d02b0ecf39ee0a3798cb363218"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/safefs.git"
+    revision: "f57353e1353147252e8c306eb5f06321631ea46a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/safefs.git"
+    revision: "f57353e1353147252e8c306eb5f06321631ea46a"
+    path: ""
+- id: "NPM::semver:6.3.1"
+  purl: "pkg:npm/semver@6.3.1"
+  authors:
+  - "GitHub Inc."
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "The semantic version parser used by npm."
+  homepage_url: "https://github.com/npm/node-semver#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+    hash:
+      value: "556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/npm/node-semver.git"
+    revision: "b717044e57bd132c7e5aa50e9af9a03f10d4655a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/npm/node-semver.git"
+    revision: "b717044e57bd132c7e5aa50e9af9a03f10d4655a"
+    path: ""
+- id: "NPM::string_decoder:1.3.0"
+  purl: "pkg:npm/string_decoder@1.3.0"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "The string_decoder module from Node core"
+  homepage_url: "https://github.com/nodejs/string_decoder"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+    hash:
+      value: "42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/nodejs/string_decoder.git"
+    revision: "60db81e031c126112039157ba9437484b1329dff"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/nodejs/string_decoder.git"
+    revision: "60db81e031c126112039157ba9437484b1329dff"
+    path: ""
+- id: "NPM::typechecker:4.11.0"
+  purl: "pkg:npm/typechecker@4.11.0"
+  authors:
+  - "2011-2012 Benjamin Lupton"
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Utilities to get and check variable types (isString, isPlainObject,\
+    \ isRegExp, etc)"
+  homepage_url: "https://github.com/bevry/typechecker"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/typechecker/-/typechecker-4.11.0.tgz"
+    hash:
+      value: "8219cd90d2f7b585a3f5af9c146c8a23891f1eac"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/bevry/typechecker.git"
+    revision: "3a3868d30834a52522ecb1032dc475af5e8ecc2c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/typechecker.git"
+    revision: "3a3868d30834a52522ecb1032dc475af5e8ecc2c"
+    path: ""
+- id: "NPM::undici-types:6.19.8"
+  purl: "pkg:npm/undici-types@6.19.8"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "A stand-alone types package for Undici"
+  homepage_url: "https://undici.nodejs.org"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
+    hash:
+      value: "35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/nodejs/undici.git"
+    revision: "3d3ce0695c8c3f9a8f3c8af90dd42d0569d3f0bb"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/nodejs/undici.git"
+    revision: "3d3ce0695c8c3f9a8f3c8af90dd42d0569d3f0bb"
+    path: ""
+- id: "NPM::util-deprecate:1.0.2"
+  purl: "pkg:npm/util-deprecate@1.0.2"
+  authors:
+  - "Nathan Rajlich"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "The Node.js `util.deprecate()` function with browser support"
+  homepage_url: "https://github.com/TooTallNate/util-deprecate"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    hash:
+      value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/TooTallNate/util-deprecate.git"
+    revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/TooTallNate/util-deprecate.git"
+    revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
+    path: ""
+- id: "NPM::web-animations-js:2.3.2"
+  purl: "pkg:npm/web-animations-js@2.3.2"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  description: "JavaScript implementation of the Web Animations API"
+  homepage_url: "https://github.com/web-animations"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.2.tgz"
+    hash:
+      value: "a51963a359c543f97b47c7d4bc2d811f9fc9e153"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/web-animations/web-animations-js.git"
+    revision: "64d83730282fdbce733460d44be52c132d6c04e9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/web-animations/web-animations-js.git"
+    revision: "64d83730282fdbce733460d44be52c132d6c04e9"
+    path: ""
+- id: "NPM:@types:node:22.9.0"
+  purl: "pkg:npm/%40types/node@22.9.0"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "TypeScript definitions for node"
+  homepage_url: "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz"
+    hash:
+      value: "b7f16e5c3384788542c72dc3d561a7ceae2c0365"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    revision: ""
+    path: "types/node"
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    revision: ""
+    path: "types/node"

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pnpm-package-with-nested-project",
+  "version": "1.0.0",
+  "description": "PNPM project with a nested sub project.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oss-review-toolkit/ort.git"
+  },
+  "license": "Apache-2.0",
+  "author": "The Author <the.author@mail.example> (https://www.the.author.example/index.html)",
+  "private": true,
+  "dependencies": {
+    "cheerio": "1.0.0-rc.1",
+    "long": "^3.2.0",
+    "web-animations-js": "github:web-animations/web-animations-js#2.3.2"
+  },
+  "devDependencies": {
+    "cson": "~4.1.0"
+  },
+  "optionalDependencies": {
+    "promise": "~7.3.1"
+  }
+}

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/pnpm-lock.yaml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/pnpm-lock.yaml
@@ -1,0 +1,304 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      cheerio:
+        specifier: 1.0.0-rc.1
+        version: 1.0.0-rc.1
+      long:
+        specifier: ^3.2.0
+        version: 3.2.0
+      web-animations-js:
+        specifier: github:web-animations/web-animations-js#2.3.2
+        version: https://codeload.github.com/web-animations/web-animations-js/tar.gz/64d83730282fdbce733460d44be52c132d6c04e9
+    optionalDependencies:
+      promise:
+        specifier: ~7.3.1
+        version: 7.3.1
+    devDependencies:
+      cson:
+        specifier: ~4.1.0
+        version: 4.1.0
+
+packages:
+
+  '@types/node@22.9.0':
+    resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  cheerio@1.0.0-rc.1:
+    resolution: {integrity: sha512-f9fNo3JP239BmXoZM2afbybS8CSm9fPyrTSH1UbQCQaaMeL0bRfbpAvYMbKOvy0y9tSho/coEdwBvYWx8hemDg==}
+    engines: {node: '>= 0.6'}
+
+  coffee-script@1.12.7:
+    resolution: {integrity: sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==}
+    engines: {node: '>=0.8.0'}
+    deprecated: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
+    hasBin: true
+
+  cson-parser@1.3.5:
+    resolution: {integrity: sha512-Pchz4dDkyafUL4V3xBuP9Os8Hu9VU96R+MxuTKh7NR+D866UiWrhBiSLbfuvwApEaJzpXhXTr3iPe4lFtXLzcQ==}
+
+  cson@4.1.0:
+    resolution: {integrity: sha512-WJE4sajPn19i2NVs7PUjODPoEcwE7NEmVDsXYxyYca7UOcWcGIZM7xPtI0VQeOWxNbCLI+uvuP0BetJJfsspxQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  css-select@1.2.0:
+    resolution: {integrity: sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==}
+
+  css-what@2.1.3:
+    resolution: {integrity: sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==}
+
+  dom-serializer@0.1.1:
+    resolution: {integrity: sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==}
+
+  domelementtype@1.3.1:
+    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
+
+  domhandler@2.4.2:
+    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
+
+  domutils@1.5.1:
+    resolution: {integrity: sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==}
+
+  domutils@1.7.0:
+    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
+
+  eachr@3.3.0:
+    resolution: {integrity: sha512-yKWuGwOE283CTgbEuvqXXusLH4VBXnY2nZbDkeWev+cpAXY6zCIADSPLdvfkAROc0t8S4l07U1fateCdEDuuvg==}
+    engines: {node: '>=0.10'}
+
+  editions@2.3.1:
+    resolution: {integrity: sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==}
+    engines: {node: '>=0.8'}
+
+  entities@1.1.2:
+    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+
+  errlop@2.2.0:
+    resolution: {integrity: sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==}
+    engines: {node: '>=0.8'}
+
+  extract-opts@3.4.0:
+    resolution: {integrity: sha512-M7Y+1cJDkzOWqvGH5F/V2qgkD6+uitW3NV9rQGl+pLSVuXZ4IDDQgxxMeLPKcWUyfypBWczIILiroSuhXG7Ytg==}
+    engines: {node: '>=0.10'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  htmlparser2@3.10.1:
+    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  long@3.2.0:
+    resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
+    engines: {node: '>=0.6'}
+
+  nth-check@1.0.2:
+    resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
+
+  parse5@3.0.3:
+    resolution: {integrity: sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==}
+
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  requirefresh@2.3.0:
+    resolution: {integrity: sha512-oskKAg0pSlPnJAkFMrcqrHeCGzYunl4Hkl+N/NW3nnFWDHRg97yb475HtF5ax8LP9i8QvVkenVIhjNb+h+P7nA==}
+    engines: {node: '>=0.12'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safefs@4.2.0:
+    resolution: {integrity: sha512-1amPBO92jw/hWS+gH/u7z7EL7YxaJ8WecBQl49tMQ6Y6EQfndxNNKwlPqDOcwpUetdmK6nKLoVdjybVScRwq5A==}
+    engines: {node: '>=0.12'}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  typechecker@4.11.0:
+    resolution: {integrity: sha512-lz39Mc/d1UBcF/uQFL5P8L+oWdIn/stvkUgHf0tPRW4aEwGGErewNXo2Nb6We2WslWifn00rhcHbbRWRcTGhuw==}
+    engines: {node: '>=0.8'}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  web-animations-js@https://codeload.github.com/web-animations/web-animations-js/tar.gz/64d83730282fdbce733460d44be52c132d6c04e9:
+    resolution: {tarball: https://codeload.github.com/web-animations/web-animations-js/tar.gz/64d83730282fdbce733460d44be52c132d6c04e9}
+    version: 2.3.2
+
+snapshots:
+
+  '@types/node@22.9.0':
+    dependencies:
+      undici-types: 6.19.8
+
+  asap@2.0.6:
+    optional: true
+
+  boolbase@1.0.0: {}
+
+  cheerio@1.0.0-rc.1:
+    dependencies:
+      css-select: 1.2.0
+      dom-serializer: 0.1.1
+      entities: 1.1.2
+      htmlparser2: 3.10.1
+      lodash: 4.17.21
+      parse5: 3.0.3
+
+  coffee-script@1.12.7: {}
+
+  cson-parser@1.3.5:
+    dependencies:
+      coffee-script: 1.12.7
+
+  cson@4.1.0:
+    dependencies:
+      coffee-script: 1.12.7
+      cson-parser: 1.3.5
+      extract-opts: 3.4.0
+      requirefresh: 2.3.0
+      safefs: 4.2.0
+
+  css-select@1.2.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 2.1.3
+      domutils: 1.5.1
+      nth-check: 1.0.2
+
+  css-what@2.1.3: {}
+
+  dom-serializer@0.1.1:
+    dependencies:
+      domelementtype: 1.3.1
+      entities: 1.1.2
+
+  domelementtype@1.3.1: {}
+
+  domhandler@2.4.2:
+    dependencies:
+      domelementtype: 1.3.1
+
+  domutils@1.5.1:
+    dependencies:
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
+
+  domutils@1.7.0:
+    dependencies:
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
+
+  eachr@3.3.0:
+    dependencies:
+      editions: 2.3.1
+      typechecker: 4.11.0
+
+  editions@2.3.1:
+    dependencies:
+      errlop: 2.2.0
+      semver: 6.3.1
+
+  entities@1.1.2: {}
+
+  errlop@2.2.0: {}
+
+  extract-opts@3.4.0:
+    dependencies:
+      eachr: 3.3.0
+      editions: 2.3.1
+      typechecker: 4.11.0
+
+  graceful-fs@4.2.11: {}
+
+  htmlparser2@3.10.1:
+    dependencies:
+      domelementtype: 1.3.1
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  inherits@2.0.4: {}
+
+  lodash@4.17.21: {}
+
+  long@3.2.0: {}
+
+  nth-check@1.0.2:
+    dependencies:
+      boolbase: 1.0.0
+
+  parse5@3.0.3:
+    dependencies:
+      '@types/node': 22.9.0
+
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
+    optional: true
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  requirefresh@2.3.0:
+    dependencies:
+      editions: 2.3.1
+
+  safe-buffer@5.2.1: {}
+
+  safefs@4.2.0:
+    dependencies:
+      editions: 2.3.1
+      graceful-fs: 4.2.11
+
+  semver@6.3.1: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typechecker@4.11.0:
+    dependencies:
+      editions: 2.3.1
+
+  undici-types@6.19.8: {}
+
+  util-deprecate@1.0.2: {}
+
+  web-animations-js@https://codeload.github.com/web-animations/web-animations-js/tar.gz/64d83730282fdbce733460d44be52c132d6c04e9: {}

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/sub/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/sub/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pnpm-nested-sub-project",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oss-review-toolkit/ort.git"
+  },
+  "license": "Apache-2.0",
+  "author": "The Author <the.author@mail.example> (https://www.the.author.example/index.html)",
+  "description": "A sub project nested in another one",
+  "dependencies": {
+    "proxy-from-env": "~1.1.0"
+  }
+}

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/sub/pnpm-lock.yaml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/sub/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      proxy-from-env:
+        specifier: ~1.1.0
+        version: 1.1.0
+
+packages:
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+snapshots:
+
+  proxy-from-env@1.1.0: {}

--- a/plugins/package-managers/node/src/funTest/kotlin/pnpm/PnpmFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/pnpm/PnpmFunTest.kt
@@ -23,6 +23,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.analyzer.analyze
+import org.ossreviewtoolkit.analyzer.collateMultipleProjects
 import org.ossreviewtoolkit.analyzer.create
 import org.ossreviewtoolkit.analyzer.resolveSingleProject
 import org.ossreviewtoolkit.model.toYaml
@@ -69,5 +70,15 @@ class PnpmFunTest : StringSpec({
 
         patchActualResult(result.toYaml(), patchStartAndEndTime = true) should
             matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
+    "Resolve dependencies correctly for a nested project" {
+        val definitionFile = getAssetFile("projects/synthetic/pnpm/nested-project/package.json")
+        val nestedDefinitionFile = definitionFile.parentFile.resolve("sub/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/pnpm/nested-project-expected-output.yml")
+
+        val result = create("PNPM").collateMultipleProjects(definitionFile, nestedDefinitionFile).withResolvedScopes()
+
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 })

--- a/plugins/package-managers/node/src/test/assets/pnpm-list.json
+++ b/plugins/package-managers/node/src/test/assets/pnpm-list.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "some-project",
+    "version": "1.0.0",
+    "path": "/tmp/work/root",
+    "private": false,
+    "dependencies": {
+      "eslint-scope": {
+        "from": "eslint-scope",
+        "version": "link:node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope",
+        "path": "/tmp/work/root/node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope"
+      }
+    }
+  },
+  {
+    "name": "other-project",
+    "version": "1.0.1",
+    "path": "/tmp/work/other_root",
+    "private": false,
+    "dependencies": {
+      "@types/eslint": {
+        "from": "@types/eslint",
+        "version": "link:node_modules/.pnpm/@types+eslint@8.56.2/node_modules/@types/eslint",
+        "path": "/tmp/work/other_root/node_modules/.pnpm/@types+eslint@8.56.2/node_modules/@types/eslint"
+      }
+    }
+  }
+]

--- a/plugins/package-managers/node/src/test/assets/pnpm-multi-list.json
+++ b/plugins/package-managers/node/src/test/assets/pnpm-multi-list.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "outer-project",
+    "version": "1.0.0",
+    "path": "/tmp/work/top",
+    "private": false,
+    "dependencies": {
+      "eslint-scope": {
+        "from": "eslint-scope",
+        "version": "link:node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope",
+        "path": "/tmp/work/top/node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope"
+      }
+    }
+  }
+]
+
+[
+  {
+    "name": "nested-project",
+    "version": "1.0.0",
+    "path": "/tmp/work/top/nested",
+    "private": false
+  }
+]

--- a/plugins/package-managers/node/src/test/kotlin/NpmDetectionTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/NpmDetectionTest.kt
@@ -200,7 +200,9 @@ class NpmDetectionTest : WordSpec({
                 "pnpm/babel/package.json",
                 "pnpm/project-with-lockfile/package.json",
                 "pnpm/workspaces/package.json",
-                "pnpm/workspaces/src/non-workspace/package-c/package.json"
+                "pnpm/workspaces/src/non-workspace/package-c/package.json",
+                "pnpm/nested-project/package.json",
+                "pnpm/nested-project/sub/package.json"
             )
         }
     }

--- a/plugins/package-managers/node/src/test/kotlin/pnpm/ModuleInfoTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/pnpm/ModuleInfoTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.node.pnpm
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.sequences.shouldContainExactly
+
+import java.io.File
+
+class ModuleInfoTest : WordSpec({
+    "parsePnpmList()" should {
+        "handle normal PNPM output" {
+            val input = File("src/test/assets/pnpm-list.json").readText()
+
+            val expectedResults = sequenceOf(
+                listOf(
+                    ModuleInfo(
+                        name = "some-project",
+                        version = "1.0.0",
+                        path = "/tmp/work/root",
+                        private = false,
+                        dependencies = mapOf(
+                            "eslint-scope" to ModuleInfo.Dependency(
+                                from = "eslint-scope",
+                                version = "link:node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope",
+                                path = "/tmp/work/root/node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope"
+                            )
+                        )
+                    ),
+                    ModuleInfo(
+                        name = "other-project",
+                        version = "1.0.1",
+                        path = "/tmp/work/other_root",
+                        private = false,
+                        dependencies = mapOf(
+                            "@types/eslint" to ModuleInfo.Dependency(
+                                from = "@types/eslint",
+                                version = "link:node_modules/.pnpm/@types+eslint@8.56.2/node_modules/@types/eslint",
+                                path = "/tmp/work/other_root/node_modules/.pnpm/@types+eslint@8.56.2" +
+                                    "/node_modules/@types/eslint"
+                            )
+                        )
+                    )
+                )
+            )
+
+            val moduleInfos = parsePnpmList(input)
+
+            moduleInfos shouldContainExactly expectedResults
+        }
+
+        "handle multiple JSON arrays" {
+            val input = File("src/test/assets/pnpm-multi-list.json").readText()
+
+            val expectedResults = sequenceOf(
+                listOf(
+                    ModuleInfo(
+                        name = "outer-project",
+                        version = "1.0.0",
+                        path = "/tmp/work/top",
+                        private = false,
+                        dependencies = mapOf(
+                            "eslint-scope" to ModuleInfo.Dependency(
+                                from = "eslint-scope",
+                                version = "link:node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope",
+                                path = "/tmp/work/top/node_modules/.pnpm/eslint-scope@5.1.1/node_modules/eslint-scope"
+                            )
+                        )
+                    )
+                ),
+                listOf(
+                    ModuleInfo(
+                        name = "nested-project",
+                        version = "1.0.0",
+                        path = "/tmp/work/top/nested",
+                        private = false
+                    )
+                )
+            )
+
+            val moduleInfos = parsePnpmList(input)
+
+            moduleInfos shouldContainExactly expectedResults
+        }
+    }
+})


### PR DESCRIPTION
This PR changes the parsing of the PNPM `list` output to handle the special case of nested projects; here the command does not produce syntactically correct JSON. This is related to #9784.

I ran a scan with these changes on an internal project that was failing before, and the generated reports looked at least reasonable. However, I am no expert for PNPM and thus cannot be sure whether the nested project is actually handled correctly. The successful fun tests should prove that no unrelated functionality was broken.