### PR TITLE
docs(Composer): Improve the comment about filtering vendored dependencies

### DIFF
--- a/plugins/package-managers/composer/src/main/kotlin/Composer.kt
+++ b/plugins/package-managers/composer/src/main/kotlin/Composer.kt
@@ -112,7 +112,8 @@ class Composer(
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> {
         val projectFiles = definitionFiles.toMutableList()
 
-        // Ignore definition files from vendored dependencies to avoid them being recognized as projects.
+        // Ignore definition files from vendor directories that reside next to other definition files, to avoid the
+        // former from being recognized as projects.
         var index = 0
         while (index < projectFiles.size - 1) {
             val projectFile = projectFiles[index++]


### PR DESCRIPTION
Better explain the idea behind the algorithm, also to highlight the difference to similar code in the `GoMod` analyzer [1], which omits definition files also from "vendor" directories that do not have another definition file as a sibling.

[1]: https://github.com/oss-review-toolkit/ort/blob/01f19307c486f63012ad8b86c08f323622d87abd/plugins/package-managers/go/src/main/kotlin/GoMod.kt#L104-L111