### PR TITLE
feat(Provenance): Add `DirectoryProvenance` as a `LocalProvenance`

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.treeToValue
 
+import java.io.File
+
 /**
  * Provenance information about the origin of source code.
  */
@@ -44,6 +46,8 @@ data object UnknownProvenance : Provenance {
 sealed interface KnownProvenance : Provenance
 
 sealed interface RemoteProvenance : KnownProvenance
+
+sealed interface LocalProvenance : KnownProvenance
 
 /**
  * Provenance information for a source artifact.
@@ -81,6 +85,19 @@ data class RepositoryProvenance(
      * Return true if this provenance matches the processed VCS information of the [package][pkg].
      */
     override fun matches(pkg: Package): Boolean = vcsInfo == pkg.vcsProcessed
+}
+
+/**
+ * Provenance information for a local directory path.
+ */
+data class DirectoryProvenance(
+    val canonicalPath: File
+) : LocalProvenance {
+    /**
+     * Return false for any [pkg] as a [Package] by definition is coming from a remote, and is not stored in a local
+     * directory path (which would be a [Project]).
+     */
+    override fun matches(pkg: Package): Boolean = false
 }
 
 /**

--- a/model/src/main/kotlin/ProvenanceResolutionResult.kt
+++ b/model/src/main/kotlin/ProvenanceResolutionResult.kt
@@ -37,7 +37,7 @@ data class ProvenanceResolutionResult(
      * The resolved provenance of the package. Can only be null if a [packageProvenanceResolutionIssue] occurred.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val packageProvenance: KnownProvenance? = null,
+    val packageProvenance: RemoteProvenance? = null,
 
     /**
      * The (recursive) sub-repositories of [packageProvenance]. The map can only be empty if a

--- a/model/src/main/kotlin/utils/FileProvenanceFileStorage.kt
+++ b/model/src/main/kotlin/utils/FileProvenanceFileStorage.kt
@@ -24,6 +24,7 @@ import java.io.InputStream
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.DirectoryProvenance
 import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -81,6 +82,7 @@ private fun KnownProvenance.hash(): String {
     val key = when (this) {
         is ArtifactProvenance -> "${sourceArtifact.url}${sourceArtifact.hash.value}"
         is RepositoryProvenance -> "${vcsInfo.type}${vcsInfo.url}$resolvedRevision"
+        is DirectoryProvenance -> "$canonicalPath"
     }
 
     return HashAlgorithm.SHA1.calculate(key.toByteArray())

--- a/model/src/main/kotlin/utils/PostgresProvenanceFileStorage.kt
+++ b/model/src/main/kotlin/utils/PostgresProvenanceFileStorage.kt
@@ -36,6 +36,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.DirectoryProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
@@ -121,4 +122,5 @@ private fun KnownProvenance.storageKey(): String =
         is ArtifactProvenance -> "source-artifact|${sourceArtifact.url}|${sourceArtifact.hash}"
         // The trailing "|" is kept for backward compatibility because there used to be an additional parameter.
         is RepositoryProvenance -> "vcs|${vcsInfo.type}|${vcsInfo.url}|$resolvedRevision|"
+        is DirectoryProvenance -> "directory|$canonicalPath"
     }

--- a/model/src/main/kotlin/utils/PurlExtensions.kt
+++ b/model/src/main/kotlin/utils/PurlExtensions.kt
@@ -27,6 +27,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
@@ -101,7 +102,11 @@ fun Provenance.toPurlExtras(): PurlExtras =
             )
         }
 
-        is UnknownProvenance -> PurlExtras()
+        /**
+         * Purls refer to packages that have been published and thus always have a remove provenance. So just return
+         * empty extras in all other cases.
+         */
+        !is RemoteProvenance -> PurlExtras()
     }
 
 /**

--- a/scanner/src/funTest/kotlin/provenance/AbstractNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/provenance/AbstractNestedProvenanceStorageFunTest.kt
@@ -23,7 +23,7 @@ import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -78,6 +78,6 @@ private fun createRepositoryProvenance(
 ) = RepositoryProvenance(vcsInfo, resolvedRevision)
 
 private fun createNestedProvenance(
-    root: KnownProvenance,
+    root: RemoteProvenance,
     subRepositories: Map<String, RepositoryProvenance> = emptyMap()
 ) = NestedProvenance(root, subRepositories)

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -245,8 +245,8 @@ internal class ScanController(
      * 'components/conanfile.txt'. This is because scanner interfaces receive packages as input, and this aims at
      * providing a deterministic ordering when choosing a reference package for packages with the same provenance.
      */
-    fun getPackagesConsolidatedByProvenance(): Map<KnownProvenance, List<Package>> {
-        val packagesByProvenance = mutableMapOf<KnownProvenance, MutableSet<Package>>()
+    fun getPackagesConsolidatedByProvenance(): Map<RemoteProvenance, List<Package>> {
+        val packagesByProvenance = mutableMapOf<RemoteProvenance, MutableSet<Package>>()
         val comparator = compareBy<Package, String>(PATH_STRING_COMPARATOR) { it.id.name }.thenBy { it.id }
 
         packages.forEach { pkg ->

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -24,6 +24,7 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
@@ -79,7 +80,7 @@ internal class ScanController(
      * A map of package [Identifier]s to their resolved [KnownProvenance]s. These provenances are used to filter the
      * scan results for a package based on the VCS path.
      */
-    private val packageProvenances = mutableMapOf<Identifier, KnownProvenance>()
+    private val packageProvenances = mutableMapOf<Identifier, RemoteProvenance>()
 
     /**
      * A map of package [Identifier]s to their resolved [KnownProvenance]s with the VCS path removed. These provenances
@@ -130,7 +131,7 @@ internal class ScanController(
     /**
      * Set the [provenance] for the package denoted by [id], overwriting any existing values.
      */
-    fun putPackageProvenance(id: Identifier, provenance: KnownProvenance) {
+    fun putPackageProvenance(id: Identifier, provenance: RemoteProvenance) {
         packageProvenances[id] = provenance
         packageProvenancesWithoutVcsPath[id] = when (provenance) {
             is RepositoryProvenance -> provenance.copy(vcsInfo = provenance.vcsInfo.copy(path = ""))
@@ -267,7 +268,7 @@ internal class ScanController(
     fun getPackagesForProvenanceWithoutVcsPath(provenance: KnownProvenance): Set<Identifier> =
         packageProvenancesWithoutVcsPath.filter { (_, packageProvenance) -> packageProvenance == provenance }.keys
 
-    fun getPackageProvenance(id: Identifier): KnownProvenance? = packageProvenances[id]
+    fun getPackageProvenance(id: Identifier): RemoteProvenance? = packageProvenances[id]
 
     /**
      * Return the package provenanceResolutionIssue associated with the given [id].

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -74,7 +74,7 @@ internal class ScanController(
     /**
      * A map of [KnownProvenance]s to their resolved [NestedProvenance]s.
      */
-    private val nestedProvenances = mutableMapOf<KnownProvenance, NestedProvenance>()
+    private val nestedProvenances = mutableMapOf<RemoteProvenance, NestedProvenance>()
 
     /**
      * A map of package [Identifier]s to their resolved [KnownProvenance]s. These provenances are used to filter the
@@ -86,7 +86,7 @@ internal class ScanController(
      * A map of package [Identifier]s to their resolved [KnownProvenance]s with the VCS path removed. These provenances
      * are used during scanning to make sure that always the full repositories are scanned.
      */
-    private val packageProvenancesWithoutVcsPath = mutableMapOf<Identifier, KnownProvenance>()
+    private val packageProvenancesWithoutVcsPath = mutableMapOf<Identifier, RemoteProvenance>()
 
     /**
      * The [ScanResult]s for each [KnownProvenance] and [ScannerWrapper].
@@ -143,7 +143,7 @@ internal class ScanController(
      * Set the [nestedProvenance] corresponding to the given [package provenance][root], overwriting any existing
      * values.
      */
-    fun putNestedProvenance(root: KnownProvenance, nestedProvenance: NestedProvenance) {
+    fun putNestedProvenance(root: RemoteProvenance, nestedProvenance: NestedProvenance) {
         nestedProvenances[root] = nestedProvenance
     }
 
@@ -166,7 +166,7 @@ internal class ScanController(
     /**
      * Return all [KnownProvenance]s contained in [nestedProvenances].
      */
-    fun getAllProvenances(): Set<KnownProvenance> =
+    fun getAllProvenances(): Set<RemoteProvenance> =
         nestedProvenances.values.flatMapTo(mutableSetOf()) { it.allProvenances }
 
     /**
@@ -178,7 +178,7 @@ internal class ScanController(
     /**
      * Return all provenances including sub-repositories associated with the identifiers of the packages they belong to.
      */
-    fun getIdsByProvenance(): Map<KnownProvenance, Set<Identifier>> =
+    fun getIdsByProvenance(): Map<RemoteProvenance, Set<Identifier>> =
         buildMap<_, MutableSet<Identifier>> {
             getNestedProvenancesByPackage().forEach { (pkg, nestedProvenance) ->
                 nestedProvenance.allProvenances.forEach { provenance ->
@@ -278,7 +278,7 @@ internal class ScanController(
     /**
      * Return all [KnownProvenance]s for the [packages] with the VCS path removed.
      */
-    fun getPackageProvenancesWithoutVcsPath(): Set<KnownProvenance> = packageProvenancesWithoutVcsPath.values.toSet()
+    fun getPackageProvenancesWithoutVcsPath(): Set<RemoteProvenance> = packageProvenancesWithoutVcsPath.values.toSet()
 
     /**
      * Return all [PackageScannerWrapper]s.

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -236,7 +236,7 @@ class Scanner(
                 }.awaitAll()
             }.forEach { (pkg, result) ->
                 result.onSuccess { provenance ->
-                    controller.putPackageProvenance(pkg.id, provenance as RemoteProvenance)
+                    controller.putPackageProvenance(pkg.id, provenance)
                 }.onFailure {
                     controller.putPackageProvenanceResolutionIssue(
                         pkg.id,
@@ -257,7 +257,7 @@ class Scanner(
                 controller.getPackageProvenancesWithoutVcsPath().map { provenance ->
                     async {
                         provenance to runCatching {
-                            nestedProvenanceResolver.resolveNestedProvenance(provenance as RemoteProvenance)
+                            nestedProvenanceResolver.resolveNestedProvenance(provenance)
                         }.onFailure {
                             if (it is CancellationException) currentCoroutineContext().ensureActive()
                         }
@@ -586,13 +586,13 @@ class Scanner(
     }
 
     private fun scanPath(
-        provenance: KnownProvenance,
+        provenance: RemoteProvenance,
         scanners: List<PathScannerWrapper>,
         context: ScanContext,
         controller: ScanController
     ): Map<PathScannerWrapper, ScanResult> {
         val downloadDir = try {
-            provenanceDownloader.download(provenance as RemoteProvenance)
+            provenanceDownloader.download(provenance)
         } catch (e: DownloadException) {
             val issue = createAndLogIssue(
                 "Downloader", "Could not download provenance $provenance: ${e.collectMessages()}"

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -44,6 +44,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.TextLocation
@@ -235,7 +236,7 @@ class Scanner(
                 }.awaitAll()
             }.forEach { (pkg, result) ->
                 result.onSuccess { provenance ->
-                    controller.putPackageProvenance(pkg.id, provenance)
+                    controller.putPackageProvenance(pkg.id, provenance as RemoteProvenance)
                 }.onFailure {
                     controller.putPackageProvenanceResolutionIssue(
                         pkg.id,
@@ -256,7 +257,7 @@ class Scanner(
                 controller.getPackageProvenancesWithoutVcsPath().map { provenance ->
                     async {
                         provenance to runCatching {
-                            nestedProvenanceResolver.resolveNestedProvenance(provenance)
+                            nestedProvenanceResolver.resolveNestedProvenance(provenance as RemoteProvenance)
                         }.onFailure {
                             if (it is CancellationException) currentCoroutineContext().ensureActive()
                         }
@@ -591,7 +592,7 @@ class Scanner(
         controller: ScanController
     ): Map<PathScannerWrapper, ScanResult> {
         val downloadDir = try {
-            provenanceDownloader.download(provenance)
+            provenanceDownloader.download(provenance as RemoteProvenance)
         } catch (e: DownloadException) {
             val issue = createAndLogIssue(
                 "Downloader", "Could not download provenance $provenance: ${e.collectMessages()}"

--- a/scanner/src/main/kotlin/provenance/NestedProvenance.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenance.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 
 /**
@@ -32,7 +33,7 @@ data class NestedProvenance(
     /**
      * The root provenance that contains the [nested provenances][subRepositories].
      */
-    val root: KnownProvenance,
+    val root: RemoteProvenance,
 
     /**
      * If [root] is a [RepositoryProvenance] this map contains all paths which contain nested repositories associated
@@ -45,7 +46,7 @@ data class NestedProvenance(
      * The set of all contained [KnownProvenance]s.
      */
     @JsonIgnore
-    val allProvenances: Set<KnownProvenance> =
+    val allProvenances: Set<RemoteProvenance> =
         buildSet {
             add(root)
             addAll(subRepositories.values)

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceResolver.kt
@@ -23,8 +23,8 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.downloader.WorkingTreeCache
 import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 
 /**
@@ -36,7 +36,7 @@ interface NestedProvenanceResolver {
      * [NestedProvenance] always contains only the provided [ArtifactProvenance]. For a [RepositoryProvenance] the
      * resolver looks for nested repositories, for example Git submodules or Mercurial subrepositories.
      */
-    suspend fun resolveNestedProvenance(provenance: KnownProvenance): NestedProvenance
+    suspend fun resolveNestedProvenance(provenance: RemoteProvenance): NestedProvenance
 }
 
 /**
@@ -46,7 +46,7 @@ class DefaultNestedProvenanceResolver(
     private val storage: NestedProvenanceStorage,
     private val workingTreeCache: WorkingTreeCache
 ) : NestedProvenanceResolver {
-    override suspend fun resolveNestedProvenance(provenance: KnownProvenance): NestedProvenance {
+    override suspend fun resolveNestedProvenance(provenance: RemoteProvenance): NestedProvenance {
         return when (provenance) {
             is ArtifactProvenance -> NestedProvenance(root = provenance, subRepositories = emptyMap())
             is RepositoryProvenance -> resolveNestedRepository(provenance)

--- a/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceScanResult.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.scanner.provenance
 
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
@@ -38,7 +39,7 @@ data class NestedProvenanceScanResult(
     /**
      * A map of [KnownProvenance]s from [nestedProvenance] associated with lists of [ScanResult]s.
      */
-    val scanResults: Map<KnownProvenance, List<ScanResult>>
+    val scanResults: Map<RemoteProvenance, List<ScanResult>>
 ) {
     /**
      * Return true if [scanResults] contains at least one scan result for each of the [KnownProvenance]s contained in
@@ -107,7 +108,7 @@ data class NestedProvenanceScanResult(
             }
         }
 
-        fun KnownProvenance.withVcsPath() =
+        fun RemoteProvenance.withVcsPath() =
             when (this) {
                 is RepositoryProvenance -> {
                     val pathWithinProvenance = pathsWithinProvenances.getValue(this)

--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -33,10 +33,10 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.downloader.WorkingTreeCache
 import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.VcsInfo
@@ -54,7 +54,7 @@ interface PackageProvenanceResolver {
      *
      * Throws an [IOException] if the provenance cannot be resolved.
      */
-    suspend fun resolveProvenance(pkg: Package, defaultSourceCodeOrigins: List<SourceCodeOrigin>): KnownProvenance
+    suspend fun resolveProvenance(pkg: Package, defaultSourceCodeOrigins: List<SourceCodeOrigin>): RemoteProvenance
 }
 
 /**
@@ -74,7 +74,7 @@ class DefaultPackageProvenanceResolver(
     override suspend fun resolveProvenance(
         pkg: Package,
         defaultSourceCodeOrigins: List<SourceCodeOrigin>
-    ): KnownProvenance {
+    ): RemoteProvenance {
         val errors = mutableMapOf<SourceCodeOrigin, Throwable>()
         val sourceCodeOrigins = pkg.sourceCodeOrigins ?: defaultSourceCodeOrigins
 

--- a/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
@@ -64,7 +64,7 @@ fun interface ProvenanceDownloader {
         // Use the provenanceDownloader to download each provenance from nestedProvenance separately, because they are
         // likely already cached if a path scanner wrapper is used.
 
-        val root = download(nestedProvenance.root as RemoteProvenance)
+        val root = download(nestedProvenance.root)
 
         nestedProvenance.subRepositories.forEach { (path, provenance) ->
             val tempDir = download(provenance)

--- a/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
@@ -32,8 +32,8 @@ import org.ossreviewtoolkit.downloader.DownloadException
 import org.ossreviewtoolkit.downloader.Downloader
 import org.ossreviewtoolkit.downloader.WorkingTreeCache
 import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
@@ -51,7 +51,7 @@ fun interface ProvenanceDownloader {
      *
      * Throws a [DownloadException] if the download fails.
      */
-    fun download(provenance: KnownProvenance): File
+    fun download(provenance: RemoteProvenance): File
 
     /**
      * Download the source code specified by the provided [nestedProvenance] incl. sub-repositories and return the path
@@ -64,7 +64,7 @@ fun interface ProvenanceDownloader {
         // Use the provenanceDownloader to download each provenance from nestedProvenance separately, because they are
         // likely already cached if a path scanner wrapper is used.
 
-        val root = download(nestedProvenance.root)
+        val root = download(nestedProvenance.root as RemoteProvenance)
 
         nestedProvenance.subRepositories.forEach { (path, provenance) ->
             val tempDir = download(provenance)
@@ -86,7 +86,7 @@ class DefaultProvenanceDownloader(
 ) : ProvenanceDownloader {
     private val downloader = Downloader(config)
 
-    override fun download(provenance: KnownProvenance): File {
+    override fun download(provenance: RemoteProvenance): File {
         val downloadDir = createOrtTempDir()
 
         when (provenance) {

--- a/scanner/src/main/kotlin/storages/ProvenanceBasedFileStorage.kt
+++ b/scanner/src/main/kotlin/storages/ProvenanceBasedFileStorage.kt
@@ -46,7 +46,11 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
     override fun read(provenance: KnownProvenance, scannerMatcher: ScannerMatcher?): List<ScanResult> {
         requireEmptyVcsPath(provenance)
 
-        val path = storagePath(provenance as RemoteProvenance)
+        if (provenance !is RemoteProvenance) {
+            throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
+        }
+
+        val path = storagePath(provenance)
 
         return runCatching {
             backend.read(path).use { input ->
@@ -81,7 +85,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
 
         requireEmptyVcsPath(provenance)
 
-        if (provenance !is KnownProvenance) {
+        if (provenance !is RemoteProvenance) {
             throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
         }
 
@@ -98,7 +102,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
 
         val scanResults = existingScanResults + scanResult
 
-        val path = storagePath(provenance as RemoteProvenance)
+        val path = storagePath(provenance)
         val yamlBytes = yamlMapper.writeValueAsBytes(scanResults)
         val input = ByteArrayInputStream(yamlBytes)
 

--- a/scanner/src/main/kotlin/storages/ProvenanceBasedFileStorage.kt
+++ b/scanner/src/main/kotlin/storages/ProvenanceBasedFileStorage.kt
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.yamlMapper
@@ -45,7 +46,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
     override fun read(provenance: KnownProvenance, scannerMatcher: ScannerMatcher?): List<ScanResult> {
         requireEmptyVcsPath(provenance)
 
-        val path = storagePath(provenance)
+        val path = storagePath(provenance as RemoteProvenance)
 
         return runCatching {
             backend.read(path).use { input ->
@@ -97,7 +98,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
 
         val scanResults = existingScanResults + scanResult
 
-        val path = storagePath(provenance)
+        val path = storagePath(provenance as RemoteProvenance)
         val yamlBytes = yamlMapper.writeValueAsBytes(scanResults)
         val input = ByteArrayInputStream(yamlBytes)
 
@@ -123,7 +124,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
     }
 }
 
-private fun storagePath(provenance: KnownProvenance) =
+private fun storagePath(provenance: RemoteProvenance) =
     when (provenance) {
         is ArtifactProvenance -> "artifact/${provenance.sourceArtifact.url.fileSystemEncode()}/$SCAN_RESULTS_FILE_NAME"
         is RepositoryProvenance -> {

--- a/scanner/src/main/kotlin/storages/ProvenanceBasedPostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/ProvenanceBasedPostgresStorage.kt
@@ -37,6 +37,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
@@ -86,6 +87,10 @@ class ProvenanceBasedPostgresStorage(
         try {
             return database.transaction {
                 val query = table.selectAll()
+
+                if (provenance !is RemoteProvenance) {
+                    throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
+                }
 
                 when (provenance) {
                     is ArtifactProvenance -> {
@@ -138,7 +143,7 @@ class ProvenanceBasedPostgresStorage(
 
         requireEmptyVcsPath(provenance)
 
-        if (provenance !is KnownProvenance) {
+        if (provenance !is RemoteProvenance) {
             throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
         }
 

--- a/scanner/src/main/kotlin/utils/FileListResolver.kt
+++ b/scanner/src/main/kotlin/utils/FileListResolver.kt
@@ -26,6 +26,7 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.utils.ProvenanceFileStorage
 import org.ossreviewtoolkit.model.yamlMapper
@@ -58,7 +59,7 @@ class FileListResolver(
     fun resolve(provenance: KnownProvenance): FileList {
         storage.getFileList(provenance)?.let { return it }
 
-        val dir = provenanceDownloader.download(provenance)
+        val dir = provenanceDownloader.download(provenance as RemoteProvenance)
 
         return createFileList(dir).also {
             try {

--- a/scanner/src/main/kotlin/utils/FileListResolver.kt
+++ b/scanner/src/main/kotlin/utils/FileListResolver.kt
@@ -56,10 +56,10 @@ class FileListResolver(
      * Get the [FileList] associated with the provided [provenance]. If it is not available in the [storage], download
      * the provenance and create the [FileList] from it.
      */
-    fun resolve(provenance: KnownProvenance): FileList {
+    fun resolve(provenance: RemoteProvenance): FileList {
         storage.getFileList(provenance)?.let { return it }
 
-        val dir = provenanceDownloader.download(provenance as RemoteProvenance)
+        val dir = provenanceDownloader.download(provenance)
 
         return createFileList(dir).also {
             try {

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -1183,7 +1183,7 @@ private class FakePackageProvenanceResolver : PackageProvenanceResolver {
     override suspend fun resolveProvenance(
         pkg: Package,
         defaultSourceCodeOrigins: List<SourceCodeOrigin>
-    ): KnownProvenance {
+    ): RemoteProvenance {
         defaultSourceCodeOrigins.forEach { sourceCodeOrigin ->
             when (sourceCodeOrigin) {
                 SourceCodeOrigin.ARTIFACT -> {
@@ -1298,7 +1298,7 @@ private fun createScanResult(
 )
 
 private fun createNestedScanResult(
-    provenance: KnownProvenance,
+    provenance: RemoteProvenance,
     scannerDetails: ScannerDetails,
     subRepositories: Map<String, RepositoryProvenance> = emptyMap()
 ) = NestedProvenanceScanResult(
@@ -1320,7 +1320,7 @@ private fun createStoredScanResult(provenance: Provenance, scannerDetails: Scann
     )
 
 private fun createStoredNestedScanResult(
-    provenance: KnownProvenance,
+    provenance: RemoteProvenance,
     scannerDetails: ScannerDetails,
     subRepositories: Map<String, RepositoryProvenance> = emptyMap()
 ) = NestedProvenanceScanResult(

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -57,6 +57,7 @@ import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
@@ -1168,7 +1169,7 @@ private class FakePathScannerWrapper : PathScannerWrapper {
  * provenance, instead of actually downloading the source code.
  */
 private class FakeProvenanceDownloader(val filename: String = "fake.txt") : ProvenanceDownloader {
-    override fun download(provenance: KnownProvenance): File =
+    override fun download(provenance: RemoteProvenance): File =
         createOrtTempDir().apply {
             resolve(filename).writeText(provenance.toYaml())
         }
@@ -1207,7 +1208,7 @@ private class FakePackageProvenanceResolver : PackageProvenanceResolver {
  * An implementation of [NestedProvenanceResolver] that always returns a non-nested provenance.
  */
 private class FakeNestedProvenanceResolver : NestedProvenanceResolver {
-    override suspend fun resolveNestedProvenance(provenance: KnownProvenance): NestedProvenance =
+    override suspend fun resolveNestedProvenance(provenance: RemoteProvenance): NestedProvenance =
         NestedProvenance(root = provenance, subRepositories = emptyMap())
 }
 

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RemoteProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScannerRun
@@ -193,7 +194,7 @@ fun scannerRunOf(vararg pkgScanResults: Pair<Identifier, List<ScanResult>>): Sca
         provenances = pkgScanResultsWithKnownProvenance.mapTo(mutableSetOf()) { (id, scanResultsForId) ->
             ProvenanceResolutionResult(
                 id = id,
-                packageProvenance = scanResultsForId.firstOrNull()?.provenance as KnownProvenance
+                packageProvenance = scanResultsForId.firstOrNull()?.provenance as RemoteProvenance
             )
         },
         scanResults = scanResults,


### PR DESCRIPTION
In contrast to the previously added `RemoteProvenance` stands the `LocalProvenance`, which has no remote source, but instead references a local input of some kind.
The `DirectoryProvenance` references a local project directory, which is lacking supported (remote) version control. It is defined by its local directory path only.

Since ORT needs further refactoring until `DirectoryProvenance` can be fully utilized, it the new class can not be used right now. However the presence of a new `KnownProvenance` class, results in `when` conditional cases not being exhaustive anymore.

To circumvent this issue, the following changes were made:
1. Whereever possible `RemoteProvenance` is used as parameter type instead of `KnownProvenance`.
2. When necessary `KnownProvenance`s are cast to `RemoteProvenance`.
3. If `Provenance` is expected, `DirectoryProvenance` is handled like `UnknownProvenance`.

The excaption being `hash` and `storageKey`, which both default to an empty string. However, since the rest of the code does not handle `DirectoryProvenance`, this should not become an issue.

For more context on the new Provenance Hierarchy, see: https://github.com/oss-review-toolkit/ort/issues/8803#issuecomment-2236958430

Signed-off-by: Jens Keim <jens.keim@forvia.com>