### PR TITLE
Support FossID 2024.2

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/Project.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/Project.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.clients.fossid.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Project(
@@ -40,7 +41,9 @@ data class Project(
     val description: String?,
     val comment: String?,
 
-    val isArchived: Int,
+    @JsonDeserialize(using = IntBooleanDeserializer::class)
+    val isArchived: Boolean?,
+
     val jiraProjectKey: String?,
     val creationDate: String,
     val dateLimitDate: String?

--- a/clients/fossid-webapp/src/test/assets/2024.2/mappings/apiphp-get_project.json
+++ b/clients/fossid-webapp/src/test/assets/2024.2/mappings/apiphp-get_project.json
@@ -1,0 +1,26 @@
+{
+  "id" : "fabf2c26-e6b3-4a47-9e11-3bf3f19190c1",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"action\":\"get_information\",\"group\":\"projects\",\"data\":{\"username\":\"\",\"key\":\"\",\"project_code\":\"semver4j_2024\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{  \"operation\": \"projects_get_information\",  \"status\": \"1\",  \"data\": {    \"id\": 76,    \"creator\": 154,    \"project_code\": \"Test_project\",    \"project_name\": \"Test_project\",    \"limit_date\": null,    \"product_code\": \"\",    \"product_name\": \"\",    \"description\": \"\",    \"comment\": \"Created by ORT\",    \"is_archived\": false,    \"jira_project_key\": \"\",    \"created\": \"2025-02-05 07:20:43\",    \"updated\": \"2025-02-05 07:20:43\",    \"owner_username\": \"user\",    \"owner_name\": \"Infrastructure\",    \"owner_surname\": \"ORT user\",    \"owner_email\": \"ort@example.com\",    \"creation_date\": \"2025-02-05\",    \"date_limit_date\": null,    \"user_id\": 154  }}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 03 Dec 2020 08:03:42 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "fabf2c26-e6b3-4a47-9e11-3bf3f19190c1",
+  "persistent" : true,
+  "insertionIndex" : 2
+}

--- a/clients/fossid-webapp/src/test/kotlin/FossId2024dot2Test.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossId2024dot2Test.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.fossid
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockkObject
+
+private const val PROJECT_CODE_2024 = "semver4j_2024"
+
+/**
+ * This client test tests the calls that have been changed for FossID 2024.2.
+ */
+class FossId2024dot2Test : StringSpec({
+    val server = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderDirectory("src/test/assets/2024.2")
+    )
+    lateinit var service: FossIdServiceWithVersion
+
+    beforeSpec {
+        server.start()
+
+        mockkObject(FossIdServiceWithVersion)
+        coEvery { FossIdServiceWithVersion.create(any()) } answers {
+            VersionedFossIdService2021dot2(firstArg(), "2024.2.1")
+        }
+
+        service = FossIdRestService.create("http://localhost:${server.port()}")
+    }
+
+    afterSpec {
+        server.stop()
+        clearAllMocks()
+    }
+
+    beforeTest {
+        server.resetAll()
+    }
+
+    "Version can be parsed of login page (2024.2)" {
+        service.version shouldBe "2024.2.1"
+        service should beInstanceOf<VersionedFossIdService2021dot2>()
+    }
+
+    "Get project response can be parsed (2024.2)" {
+        // Recreate the version as the service caches it.
+        service = FossIdServiceWithVersion.create(service)
+
+        service.getProject("", "", PROJECT_CODE_2024) shouldNotBeNull {
+            checkResponse("get project")
+
+            data.shouldNotBeNull().isArchived shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
The `isArchived` property of a FossID Project had changed type with release 2024.2 from Integer to Boolean.

This commit fixes an `InvalidFormatException` from Jackson that occurs when deserializing scans returned by a FossID instance running the new version.

Please note that the new model support both property types thanks to the special deserializer `IntBooleanDeserializer`.
One of the test data in 'return-type/mappings' still contain the old data type to reflect this backward compatibility.
