### PR TITLE
Identifier type aliases

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -125,3 +125,9 @@ data class Identifier(
     fun toPath(separator: String = "/", emptyValue: String = "unknown"): String =
         sanitizedProperties.joinToString(separator) { it.encodeOr(emptyValue) }
 }
+
+/**
+ * Return whether the [type][Identifier.type] of this [Identifier] matches the type of [other] by comparing them
+ * case-insensitively.
+ */
+fun Identifier.typeMatches(other: Identifier) = type.equals(other.type, ignoreCase = true)

--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -127,7 +127,21 @@ data class Identifier(
 }
 
 /**
- * Return whether the [type][Identifier.type] of this [Identifier] matches the type of [other] by comparing them
- * case-insensitively.
+ * A map of lowercase aliases for types that were renamed.
  */
-fun Identifier.typeMatches(other: Identifier) = type.equals(other.type, ignoreCase = true)
+private val typeAliases = mapOf(
+    "spdxdocument" to "spdxdocumentfile"
+)
+
+/**
+ * Return whether the [type][Identifier.type] of this [Identifier] matches the type of [other] by comparing them
+ * case-insensitively. Additionally, the [typeAliases] are considered.
+ */
+fun Identifier.typeMatches(other: Identifier): Boolean {
+    val thisType = type.lowercase()
+    val otherType = other.type.lowercase()
+
+    return thisType == otherType ||
+        typeAliases[thisType] == otherType ||
+        typeAliases[otherType] == thisType
+}

--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -58,7 +58,7 @@ data class PackageCuration(
      * disregarding the version.
      */
     private fun isApplicableDisregardingVersion(pkgId: Identifier) =
-        id.type.equals(pkgId.type, ignoreCase = true)
+        id.typeMatches(pkgId)
             && id.namespace == pkgId.namespace
             && id.name.equalsOrIsBlank(pkgId.name)
 

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -28,6 +28,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.typeMatches
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 
 /**
@@ -72,7 +73,7 @@ data class PackageConfiguration(
 
     fun matches(otherId: Identifier, provenance: Provenance): Boolean {
         @Suppress("ComplexCondition")
-        if (!id.type.equals(otherId.type, ignoreCase = true) ||
+        if (!id.typeMatches(otherId) ||
             id.namespace != otherId.namespace ||
             id.name != otherId.name ||
             id.version != otherId.version

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -71,7 +71,14 @@ data class PackageConfiguration(
     }
 
     fun matches(otherId: Identifier, provenance: Provenance): Boolean {
-        if (id != otherId) return false
+        @Suppress("ComplexCondition")
+        if (!id.type.equals(otherId.type, ignoreCase = true) ||
+            id.namespace != otherId.namespace ||
+            id.name != otherId.name ||
+            id.version != otherId.version
+        ) {
+            return false
+        }
 
         return when (provenance) {
             is UnknownProvenance -> false

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -135,4 +135,17 @@ class IdentifierTest : WordSpec({
             }
         }
     }
+
+    "typeMatches()" should {
+        "return true if the type is equal ignoring case" {
+            val id = Identifier.EMPTY.copy(type = "type")
+            id.typeMatches(id) shouldBe true
+            id.typeMatches(Identifier.EMPTY.copy(type = "TYPE")) shouldBe true
+        }
+
+        "return false if the type does not match" {
+            val id = Identifier.EMPTY.copy(type = "type")
+            id.typeMatches(Identifier.EMPTY.copy(type = "other")) shouldBe false
+        }
+    }
 })

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -147,5 +147,12 @@ class IdentifierTest : WordSpec({
             val id = Identifier.EMPTY.copy(type = "type")
             id.typeMatches(Identifier.EMPTY.copy(type = "other")) shouldBe false
         }
+
+        "return true if the type matches an alias" {
+            val id = Identifier.EMPTY.copy(type = "SpdxDocument")
+            val otherId = Identifier.EMPTY.copy(type = "spdxdocumentfile")
+            id.typeMatches(otherId) shouldBe true
+            otherId.typeMatches(id) shouldBe true
+        }
     }
 })

--- a/model/src/test/kotlin/config/PackageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/PackageConfigurationTest.kt
@@ -136,5 +136,24 @@ class PackageConfigurationTest : WordSpec({
                 )
             ) shouldBe false
         }
+
+        "return true if the identifier type is equal ignoring case" {
+            val config =
+                vcsPackageConfig(name = "some-name", revision = "12345678", url = "ssh://git@host/repo.git").let {
+                    it.copy(id = it.id.copy(type = "Gradle"))
+                }
+
+            config.matches(
+                config.id.copy(type = "gradle"),
+                RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "ssh://git@host/repo.git",
+                        revision = ""
+                    ),
+                    resolvedRevision = "12345678"
+                )
+            ) shouldBe true
+        }
     }
 })


### PR DESCRIPTION
Add a mechanism to define aliases for renamed identifier types to ensure package curations and package configurations can still be matched after a renaming. Please see the commit messages for details.