### PR TITLE
fix(spdx-utils): Fix a performance issue in `SpdxExpression::and()`

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -205,14 +205,12 @@ sealed class SpdxExpression {
     /**
      * Concatenate [this][SpdxExpression] and [other] using [SpdxOperator.AND].
      */
-    infix fun and(other: SpdxExpression) =
-        takeIf { this == other } ?: SpdxCompoundExpression(SpdxOperator.AND, listOf(this, other))
+    infix fun and(other: SpdxExpression) = SpdxCompoundExpression(SpdxOperator.AND, listOf(this, other))
 
     /**
      * Concatenate [this][SpdxExpression] and [other] using [SpdxOperator.OR].
      */
-    infix fun or(other: SpdxExpression) =
-        takeIf { this == other } ?: SpdxCompoundExpression(SpdxOperator.OR, listOf(this, other))
+    infix fun or(other: SpdxExpression) = SpdxCompoundExpression(SpdxOperator.OR, listOf(this, other))
 }
 
 /**

--- a/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
@@ -342,9 +342,9 @@ class SpdxExpressionChoiceTest : WordSpec({
             val choices = "(a OR b) AND (a OR b)".toSpdx().validChoices()
 
             choices.map { it.toString() } should containExactlyInAnyOrder(
-                "a",
+                "a AND a",
                 "b AND a",
-                "b"
+                "b AND b"
             )
         }
 


### PR DESCRIPTION
31b9be8 introduced an `equals()` into `SpdxCompoundExpression::and`. For packages with large amounts of detected licenses including ones with `OR` operators, the performance of the `and` function becomes so poor that the evaluator runs for 3 days (with the open source `ort-config` rules, without terminating. Also the reporter performance degrades from less than 30 seconds to 3 hours.

Unfortunately the call tree involved is so complicated that there is no simple fix for this. `equals()` involves recursive `validChoices()` calls which in turn call `equals()` again when computing distinctness or inserting further `SpdxExpressions` into sets.

Revert the change to fix the problem in a timely manner. Note that it makes sense to bring back the now reverted functionality, but the code should be refactored first to produce more managable call trees.

Fixes: #9902.

This reverts commit 31b9be83c5793954a7d052a0f1e7e3ca4d9384bd.

