### PR TITLE
feat(spdx)!: Revert renaming of `SpdxDocumentFile` to `SpdxDocument`

### DIFF
--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/spdx-project-cyclic-expected-output.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/spdx-project-cyclic-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "SpdxDocument::xyz:0.1.0"
+  id: "SpdxDocumentFile::xyz:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   authors:
   - "Thomas Steenbergen"
@@ -22,19 +22,19 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "SpdxDocument::abc:0.1.1"
+    - id: "SpdxDocumentFile::abc:0.1.1"
       dependencies:
-      - id: "SpdxDocument::def:0.1.0"
+      - id: "SpdxDocumentFile::def:0.1.0"
         dependencies:
-        - id: "SpdxDocument::xyz:0.1.0"
-    - id: "SpdxDocument::zlib:1.2.11"
+        - id: "SpdxDocumentFile::xyz:0.1.0"
+    - id: "SpdxDocumentFile::zlib:1.2.11"
       linkage: "STATIC"
-    - id: "SpdxDocument:OpenSSL Development Team:openssl:1.1.1g"
+    - id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   - name: "test"
     dependencies:
-    - id: "SpdxDocument::curl:7.70.0"
+    - id: "SpdxDocumentFile::curl:7.70.0"
 packages:
-- id: "SpdxDocument::abc:0.1.1"
+- id: "SpdxDocumentFile::abc:0.1.1"
   purl: "pkg:generic/abc@0.1.1"
   authors:
   - "Thomas Steenbergen"
@@ -64,7 +64,7 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/cyclic-references"
-- id: "SpdxDocument::curl:7.70.0"
+- id: "SpdxDocumentFile::curl:7.70.0"
   purl: "pkg:generic/curl@7.70.0?download_url=https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
   cpe: "cpe:2.3:a:http:curl:7.70.0:*:*:*:*:*:*:*"
   authors:
@@ -98,7 +98,7 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/curl"
-- id: "SpdxDocument::def:0.1.0"
+- id: "SpdxDocumentFile::def:0.1.0"
   purl: "pkg:generic/def@0.1.0"
   authors:
   - "Thomas Steenbergen"
@@ -128,7 +128,7 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/cyclic-references"
-- id: "SpdxDocument::zlib:1.2.11"
+- id: "SpdxDocumentFile::zlib:1.2.11"
   purl: "pkg:generic/zlib@1.2.11?download_url=http://zlib.net/zlib-1.2.11.tar.gz"
   cpe: "cpe:/a:compress:zlib:1.2.11:::en-us"
   authors:
@@ -160,7 +160,7 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/zlib"
-- id: "SpdxDocument:OpenSSL Development Team:openssl:1.1.1g"
+- id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   purl: "pkg:a-name/openssl@1.1.1g"
   cpe: "cpe:2.3:a:a-name:openssl:1.1.1g:*:*:*:*:*:*:*"
   authors:

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml
@@ -26,7 +26,7 @@ projects:
     - id: "Conan::openssl:3.0.0"
       dependencies:
       - id: "Conan::zlib:1.2.12"
-- id: "SpdxDocument::xyz:0.1.0"
+- id: "SpdxDocumentFile::xyz:0.1.0"
   definition_file_path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-conan/project-xyz.spdx.yml"
   authors:
   - "Thomas Steenbergen"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "SpdxDocument::xyz:0.1.0"
+  id: "SpdxDocumentFile::xyz:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   authors:
   - "Thomas Steenbergen"
@@ -22,14 +22,14 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "SpdxDocument::zlib:1.2.11"
+    - id: "SpdxDocumentFile::zlib:1.2.11"
       linkage: "STATIC"
-    - id: "SpdxDocument:OpenSSL Development Team:openssl:1.1.1g"
+    - id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   - name: "test"
     dependencies:
-    - id: "SpdxDocument::curl:7.70.0"
+    - id: "SpdxDocumentFile::curl:7.70.0"
 packages:
-- id: "SpdxDocument::curl:7.70.0"
+- id: "SpdxDocumentFile::curl:7.70.0"
   purl: "pkg:generic/curl@7.70.0?download_url=https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
   cpe: "cpe:2.3:a:http:curl:7.70.0:*:*:*:*:*:*:*"
   authors:
@@ -63,7 +63,7 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/curl"
-- id: "SpdxDocument::zlib:1.2.11"
+- id: "SpdxDocumentFile::zlib:1.2.11"
   purl: "pkg:generic/zlib@1.2.11?download_url=http://zlib.net/zlib-1.2.11.tar.gz"
   cpe: "cpe:/a:compress:zlib:1.2.11:::en-us"
   authors:
@@ -95,7 +95,7 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/zlib"
-- id: "SpdxDocument:OpenSSL Development Team:openssl:1.1.1g"
+- id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   purl: "pkg:a-name/openssl@1.1.1g"
   cpe: "cpe:2.3:a:a-name:openssl:1.1.1g:*:*:*:*:*:*:*"
   authors:

--- a/plugins/package-managers/spdx/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
+++ b/plugins/package-managers/spdx/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
@@ -67,13 +67,13 @@ class SpdxDocumentFileFunTest : WordSpec({
 
         "succeed if no project is provided" {
             val curlPackageFile = projectDir.resolve("libs/curl/package.spdx.yml")
-            val curlId = Identifier("SpdxDocument::curl:7.70.0")
+            val curlId = Identifier("SpdxDocumentFile::curl:7.70.0")
 
             val opensslPackageFile = projectDir.resolve("libs/openssl/package.spdx.yml")
-            val opensslId = Identifier("SpdxDocument:OpenSSL Development Team:openssl:1.1.1g")
+            val opensslId = Identifier("SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g")
 
             val zlibPackageFile = projectDir.resolve("libs/zlib/package.spdx.yml")
-            val zlibId = Identifier("SpdxDocument::zlib:1.2.11")
+            val zlibId = Identifier("SpdxDocumentFile::zlib:1.2.11")
 
             val definitionFiles = listOf(curlPackageFile, opensslPackageFile, zlibPackageFile)
             val actualResult = create("SpdxDocumentFile").resolveDependencies(definitionFiles, emptyMap())
@@ -148,10 +148,10 @@ class SpdxDocumentFileFunTest : WordSpec({
         }
 
         "retrieve transitive dependencies" {
-            val idCurl = Identifier("SpdxDocument::curl:7.70.0")
-            val idOpenSsl = Identifier("SpdxDocument:OpenSSL Development Team:openssl:1.1.1g")
-            val idZlib = Identifier("SpdxDocument::zlib:1.2.11")
-            val idMyLib = Identifier("SpdxDocument::my-lib:8.88.8")
+            val idCurl = Identifier("SpdxDocumentFile::curl:7.70.0")
+            val idOpenSsl = Identifier("SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g")
+            val idZlib = Identifier("SpdxDocumentFile::zlib:1.2.11")
+            val idMyLib = Identifier("SpdxDocumentFile::my-lib:8.88.8")
 
             val projectFile = projectDir.resolve("transitive-dependencies/project-xyz.spdx.yml")
             val definitionFiles = listOf(projectFile)
@@ -177,9 +177,9 @@ class SpdxDocumentFileFunTest : WordSpec({
         }
 
         "retrieve nested DEPENDS_ON dependencies" {
-            val idCurl = Identifier("SpdxDocument::curl:7.70.0")
-            val idOpenSsl = Identifier("SpdxDocument:OpenSSL Development Team:openssl:1.1.1g")
-            val idZlib = Identifier("SpdxDocument::zlib:1.2.11")
+            val idCurl = Identifier("SpdxDocumentFile::curl:7.70.0")
+            val idOpenSsl = Identifier("SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g")
+            val idZlib = Identifier("SpdxDocumentFile::zlib:1.2.11")
 
             val projectFile = projectDir.resolve("DEPENDS_ON-packages/project-xyz.spdx.yml")
             val definitionFiles = listOf(projectFile)
@@ -258,13 +258,13 @@ class SpdxDocumentFileFunTest : WordSpec({
             val packageIds = projectResults.flatMap { projResult -> projResult.packages.map { it.id } }
 
             projectIds shouldContainExactlyInAnyOrder listOf(
-                Identifier("SpdxDocument::xyz:0.1.0"),
-                Identifier("SpdxDocument::subproject-xyz:0.1.0")
+                Identifier("SpdxDocumentFile::xyz:0.1.0"),
+                Identifier("SpdxDocumentFile::subproject-xyz:0.1.0")
             )
             packageIds shouldContainExactlyInAnyOrder listOf(
-                Identifier("SpdxDocument::curl:7.70.0"),
-                Identifier("SpdxDocument::my-lib:8.88.8"),
-                Identifier("SpdxDocument:OpenSSL Development Team:openssl:1.1.1g")
+                Identifier("SpdxDocumentFile::curl:7.70.0"),
+                Identifier("SpdxDocumentFile::my-lib:8.88.8"),
+                Identifier("SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g")
             )
         }
 

--- a/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
+++ b/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
@@ -259,7 +259,7 @@ class SpdxDocumentFile(
     analysisRoot: File,
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
-) : PackageManager(managerName, "SpdxDocument", analysisRoot, analyzerConfig, repoConfig) {
+) : PackageManager(managerName, "SpdxDocumentFile", analysisRoot, analyzerConfig, repoConfig) {
     class Factory : AbstractPackageManagerFactory<SpdxDocumentFile>("SpdxDocumentFile") {
         override val globsForDefinitionFiles = listOf("*.spdx.yml", "*.spdx.yaml", "*.spdx.json")
 


### PR DESCRIPTION
In 01f1930 the identifier type used for projects and packages created by the `SpdxDocumentFile` package manager was renamed from `SdpxDocumentFile` to `SpdxDocument`. This breaks all existing package curations and package configurations which is especially problematic when they are contained in `.ort.yml` files of repositories which cannot be centrally managed.

Revert the renaming until a solution is found to make such renamings backward compatible.