### PR TITLE
feat(model): Match the type case insensitive in package configurations

### DIFF
--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -71,7 +71,14 @@ data class PackageConfiguration(
     }
 
     fun matches(otherId: Identifier, provenance: Provenance): Boolean {
-        if (id != otherId) return false
+        @Suppress("ComplexCondition")
+        if (!id.type.equals(otherId.type, ignoreCase = true) ||
+            id.namespace != otherId.namespace ||
+            id.name != otherId.name ||
+            id.version != otherId.version
+        ) {
+            return false
+        }
 
         return when (provenance) {
             is UnknownProvenance -> false

--- a/model/src/test/kotlin/config/PackageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/PackageConfigurationTest.kt
@@ -136,5 +136,24 @@ class PackageConfigurationTest : WordSpec({
                 )
             ) shouldBe false
         }
+
+        "return true if the identifier type is equal ignoring case" {
+            val config =
+                vcsPackageConfig(name = "some-name", revision = "12345678", url = "ssh://git@host/repo.git").let {
+                    it.copy(id = it.id.copy(type = "Gradle"))
+                }
+
+            config.matches(
+                config.id.copy(type = "gradle"),
+                RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "ssh://git@host/repo.git",
+                        revision = ""
+                    ),
+                    resolvedRevision = "12345678"
+                )
+            ) shouldBe true
+        }
     }
 })


### PR DESCRIPTION
Make the matching of the identifier type in package configurations case insensitive to align with package curations.
