### PR TITLE
Test performance of `effectiveLicense()` and related function

### DIFF
--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -54,7 +54,6 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
-import org.ossreviewtoolkit.model.licenses.TestUtils.containLicensesExactly
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.FileProvenanceFileStorage
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -726,13 +726,6 @@ private fun createLicenseInfo(
     )
 )
 
-private class SimpleLicenseInfoProvider(licenseInfo: List<LicenseInfo>) : LicenseInfoProvider {
-    private val licenseInfoById = licenseInfo.associateBy { it.id }
-
-    override fun get(id: Identifier) =
-        licenseInfoById[id] ?: throw IllegalArgumentException("No license info for '${id.toCoordinates()}' available.")
-}
-
 private fun Map<String, List<TextLocation>>.toFindingsSet(): Set<LicenseFinding> =
     flatMap { (license, locations) ->
         locations.map { LicenseFinding(license, it) }

--- a/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
@@ -32,24 +32,19 @@ import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 class ResolvedLicenseInfoTest : WordSpec() {
-    private val mit = "MIT"
-    private val apache = "Apache-2.0 WITH LLVM-exception"
-    private val gpl = "GPL-2.0-only"
-    private val bsd = "0BSD"
-
     init {
         "effectiveLicense()" should {
             "apply choices for LicenseView.ALL on all resolved licenses" {
                 // All: (Apache-2.0 WITH LLVM-exception OR MIT) AND (MIT OR GPL-2.0-only) AND (0BSD OR GPL-2.0-only)
                 val choices = listOf(
-                    SpdxLicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx()),
-                    SpdxLicenseChoice("$mit OR $gpl".toSpdx(), mit.toSpdx()),
-                    SpdxLicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
+                    SpdxLicenseChoice("$MIT OR $GPL".toSpdx(), MIT.toSpdx()),
+                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
                 )
 
-                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(LicenseView.ALL, choices)
+                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(LicenseView.ALL, choices)
 
-                effectiveLicense shouldBe "$mit AND $bsd".toSpdx()
+                effectiveLicense shouldBe "$MIT AND $BSD".toSpdx()
             }
 
             "apply a choice for a sub-expression only" {
@@ -59,10 +54,10 @@ class ResolvedLicenseInfoTest : WordSpec() {
                     licenseInfo = mockk(),
                     licenses = listOf(
                         ResolvedLicense(
-                            license = apache.toSpdx() as SpdxSingleLicenseExpression,
-                            originalDeclaredLicenses = setOf("$apache OR $mit"),
+                            license = APACHE.toSpdx() as SpdxSingleLicenseExpression,
+                            originalDeclaredLicenses = setOf("$APACHE OR $MIT"),
                             originalExpressions = setOf(
-                                ResolvedOriginalExpression("$apache OR $mit OR $gpl".toSpdx(), LicenseSource.DECLARED)
+                                ResolvedOriginalExpression("$APACHE OR $MIT OR $GPL".toSpdx(), LicenseSource.DECLARED)
                             ),
                             locations = emptySet()
                         )
@@ -72,122 +67,125 @@ class ResolvedLicenseInfoTest : WordSpec() {
                 )
 
                 val choices = listOf(
-                    SpdxLicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx())
+                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx())
                 )
 
                 val effectiveLicense = resolvedLicenseInfo.effectiveLicense(LicenseView.ONLY_DECLARED, choices)
 
-                effectiveLicense shouldBe "$mit OR $gpl".toSpdx()
+                effectiveLicense shouldBe "$MIT OR $GPL".toSpdx()
             }
 
             "apply choices for LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED" {
                 // Concluded: 0BSD OR GPL-2.0-only
                 val choices = listOf(
-                    SpdxLicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
                 )
 
-                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(
+                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
                     LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
                     choices
                 )
 
-                effectiveLicense shouldBe bsd.toSpdx()
+                effectiveLicense shouldBe BSD.toSpdx()
             }
 
             "apply choices for LicenseView.ONLY_DECLARED" {
                 // Declared: Apache-2.0 WITH LLVM-exception OR MIT
                 val choices = listOf(
-                    SpdxLicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx())
+                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx())
                 )
 
-                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(
+                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
                     LicenseView.ONLY_DECLARED,
                     choices
                 )
 
-                effectiveLicense shouldBe mit.toSpdx()
+                effectiveLicense shouldBe MIT.toSpdx()
             }
 
             "apply package and repository license choice for LicenseView.ONLY_CONCLUDED in the correct order" {
                 val repositoryChoices = listOf(
-                    SpdxLicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx()),
-                    SpdxLicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
+                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
                 )
                 val packageChoices = listOf(
-                    SpdxLicenseChoice("$apache OR $mit".toSpdx(), apache.toSpdx())
+                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), APACHE.toSpdx())
                 )
 
-                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(
+                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
                     LicenseView.ALL,
                     packageChoices,
                     repositoryChoices
                 )
 
-                effectiveLicense shouldBe "$apache and ($mit or $gpl) and $bsd".toSpdx()
+                effectiveLicense shouldBe "$APACHE and ($MIT or $GPL) and $BSD".toSpdx()
             }
         }
 
         "applyChoices(licenseChoices)" should {
             "apply license choices on all licenses" {
-                val resolvedLicenseInfo = createResolvedLicenseInfo()
-
                 val choices = listOf(
-                    SpdxLicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx()),
-                    SpdxLicenseChoice("$mit OR $gpl".toSpdx(), mit.toSpdx()),
-                    SpdxLicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
+                    SpdxLicenseChoice("$MIT OR $GPL".toSpdx(), MIT.toSpdx()),
+                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
                 )
 
-                val filteredResolvedLicenseInfo = resolvedLicenseInfo.applyChoices(choices)
+                val filteredResolvedLicenseInfo = RESOLVED_LICENSE_INFO.applyChoices(choices)
 
-                filteredResolvedLicenseInfo.licenses should containLicensesExactly(mit, bsd)
+                filteredResolvedLicenseInfo.licenses should containLicensesExactly(MIT, BSD)
             }
         }
     }
+}
 
-    private fun createResolvedLicenseInfo(): ResolvedLicenseInfo {
-        val resolvedLicenses = listOf(
-            ResolvedLicense(
-                license = apache.toSpdx() as SpdxSingleLicenseExpression,
-                originalDeclaredLicenses = setOf("$apache OR $mit"),
-                originalExpressions = setOf(
-                    ResolvedOriginalExpression("$apache OR $mit".toSpdx(), LicenseSource.DECLARED)
-                ),
-                locations = emptySet()
-            ),
-            ResolvedLicense(
-                license = mit.toSpdx() as SpdxSingleLicenseExpression,
-                originalDeclaredLicenses = setOf("$apache OR $mit"),
-                originalExpressions = setOf(
-                    ResolvedOriginalExpression("$apache OR $mit".toSpdx(), LicenseSource.DECLARED),
-                    ResolvedOriginalExpression("$mit OR $gpl".toSpdx(), LicenseSource.DETECTED)
-                ),
-                locations = emptySet()
-            ),
-            ResolvedLicense(
-                license = gpl.toSpdx() as SpdxSingleLicenseExpression,
-                originalDeclaredLicenses = emptySet(),
-                originalExpressions = setOf(
-                    ResolvedOriginalExpression("$mit OR $gpl".toSpdx(), LicenseSource.DETECTED),
-                    ResolvedOriginalExpression("$bsd OR $gpl".toSpdx(), LicenseSource.CONCLUDED)
-                ),
-                locations = emptySet()
-            ),
-            ResolvedLicense(
-                license = bsd.toSpdx() as SpdxSingleLicenseExpression,
-                originalDeclaredLicenses = emptySet(),
-                originalExpressions = setOf(
-                    ResolvedOriginalExpression("$bsd OR $gpl".toSpdx(), LicenseSource.CONCLUDED)
-                ),
-                locations = emptySet()
-            )
-        )
+private const val MIT = "MIT"
+private const val APACHE = "Apache-2.0 WITH LLVM-exception"
+private const val GPL = "GPL-2.0-only"
+private const val BSD = "0BSD"
 
-        return ResolvedLicenseInfo(
-            id = Identifier.EMPTY,
-            licenseInfo = mockk(),
-            licenses = resolvedLicenses,
-            copyrightGarbage = emptyMap(),
-            unmatchedCopyrights = emptyMap()
+private val RESOLVED_LICENSE_INFO: ResolvedLicenseInfo by lazy {
+    val resolvedLicenses = listOf(
+        ResolvedLicense(
+            license = APACHE.toSpdx() as SpdxSingleLicenseExpression,
+            originalDeclaredLicenses = setOf("$APACHE OR $MIT"),
+            originalExpressions = setOf(
+                ResolvedOriginalExpression("$APACHE OR $MIT".toSpdx(), LicenseSource.DECLARED)
+            ),
+            locations = emptySet()
+        ),
+        ResolvedLicense(
+            license = MIT.toSpdx() as SpdxSingleLicenseExpression,
+            originalDeclaredLicenses = setOf("$APACHE OR $MIT"),
+            originalExpressions = setOf(
+                ResolvedOriginalExpression("$APACHE OR $MIT".toSpdx(), LicenseSource.DECLARED),
+                ResolvedOriginalExpression("$MIT OR $GPL".toSpdx(), LicenseSource.DETECTED)
+            ),
+            locations = emptySet()
+        ),
+        ResolvedLicense(
+            license = GPL.toSpdx() as SpdxSingleLicenseExpression,
+            originalDeclaredLicenses = emptySet(),
+            originalExpressions = setOf(
+                ResolvedOriginalExpression("$MIT OR $GPL".toSpdx(), LicenseSource.DETECTED),
+                ResolvedOriginalExpression("$BSD OR $GPL".toSpdx(), LicenseSource.CONCLUDED)
+            ),
+            locations = emptySet()
+        ),
+        ResolvedLicense(
+            license = BSD.toSpdx() as SpdxSingleLicenseExpression,
+            originalDeclaredLicenses = emptySet(),
+            originalExpressions = setOf(
+                ResolvedOriginalExpression("$BSD OR $GPL".toSpdx(), LicenseSource.CONCLUDED)
+            ),
+            locations = emptySet()
         )
-    }
+    )
+
+    ResolvedLicenseInfo(
+        id = Identifier.EMPTY,
+        licenseInfo = mockk(),
+        licenses = resolvedLicenses,
+        copyrightGarbage = emptyMap(),
+        unmatchedCopyrights = emptyMap()
+    )
 }

--- a/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
@@ -31,112 +31,110 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
-class ResolvedLicenseInfoTest : WordSpec() {
-    init {
-        "effectiveLicense()" should {
-            "apply choices for LicenseView.ALL on all resolved licenses" {
-                // All: (Apache-2.0 WITH LLVM-exception OR MIT) AND (MIT OR GPL-2.0-only) AND (0BSD OR GPL-2.0-only)
-                val choices = listOf(
-                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
-                    SpdxLicenseChoice("$MIT OR $GPL".toSpdx(), MIT.toSpdx()),
-                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
-                )
+class ResolvedLicenseInfoTest : WordSpec({
+    "effectiveLicense()" should {
+        "apply choices for LicenseView.ALL on all resolved licenses" {
+            // All: (Apache-2.0 WITH LLVM-exception OR MIT) AND (MIT OR GPL-2.0-only) AND (0BSD OR GPL-2.0-only)
+            val choices = listOf(
+                SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
+                SpdxLicenseChoice("$MIT OR $GPL".toSpdx(), MIT.toSpdx()),
+                SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
+            )
 
-                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(LicenseView.ALL, choices)
+            val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(LicenseView.ALL, choices)
 
-                effectiveLicense shouldBe "$MIT AND $BSD".toSpdx()
-            }
-
-            "apply a choice for a sub-expression only" {
-                // Declared: Apache-2.0 WITH LLVM-exception OR MIT OR GPL-2.0-only
-                val resolvedLicenseInfo = ResolvedLicenseInfo(
-                    id = Identifier.EMPTY,
-                    licenseInfo = mockk(),
-                    licenses = listOf(
-                        ResolvedLicense(
-                            license = APACHE.toSpdx() as SpdxSingleLicenseExpression,
-                            originalDeclaredLicenses = setOf("$APACHE OR $MIT"),
-                            originalExpressions = setOf(
-                                ResolvedOriginalExpression("$APACHE OR $MIT OR $GPL".toSpdx(), LicenseSource.DECLARED)
-                            ),
-                            locations = emptySet()
-                        )
-                    ),
-                    copyrightGarbage = emptyMap(),
-                    unmatchedCopyrights = emptyMap()
-                )
-
-                val choices = listOf(
-                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx())
-                )
-
-                val effectiveLicense = resolvedLicenseInfo.effectiveLicense(LicenseView.ONLY_DECLARED, choices)
-
-                effectiveLicense shouldBe "$MIT OR $GPL".toSpdx()
-            }
-
-            "apply choices for LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED" {
-                // Concluded: 0BSD OR GPL-2.0-only
-                val choices = listOf(
-                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
-                )
-
-                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
-                    LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
-                    choices
-                )
-
-                effectiveLicense shouldBe BSD.toSpdx()
-            }
-
-            "apply choices for LicenseView.ONLY_DECLARED" {
-                // Declared: Apache-2.0 WITH LLVM-exception OR MIT
-                val choices = listOf(
-                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx())
-                )
-
-                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
-                    LicenseView.ONLY_DECLARED,
-                    choices
-                )
-
-                effectiveLicense shouldBe MIT.toSpdx()
-            }
-
-            "apply package and repository license choice for LicenseView.ONLY_CONCLUDED in the correct order" {
-                val repositoryChoices = listOf(
-                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
-                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
-                )
-                val packageChoices = listOf(
-                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), APACHE.toSpdx())
-                )
-
-                val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
-                    LicenseView.ALL,
-                    packageChoices,
-                    repositoryChoices
-                )
-
-                effectiveLicense shouldBe "$APACHE and ($MIT or $GPL) and $BSD".toSpdx()
-            }
+            effectiveLicense shouldBe "$MIT AND $BSD".toSpdx()
         }
 
-        "applyChoices(licenseChoices)" should {
-            "apply license choices on all licenses" {
-                val choices = listOf(
-                    SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
-                    SpdxLicenseChoice("$MIT OR $GPL".toSpdx(), MIT.toSpdx()),
-                    SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
-                )
+        "apply a choice for a sub-expression only" {
+            // Declared: Apache-2.0 WITH LLVM-exception OR MIT OR GPL-2.0-only
+            val resolvedLicenseInfo = ResolvedLicenseInfo(
+                id = Identifier.EMPTY,
+                licenseInfo = mockk(),
+                licenses = listOf(
+                    ResolvedLicense(
+                        license = APACHE.toSpdx() as SpdxSingleLicenseExpression,
+                        originalDeclaredLicenses = setOf("$APACHE OR $MIT"),
+                        originalExpressions = setOf(
+                            ResolvedOriginalExpression("$APACHE OR $MIT OR $GPL".toSpdx(), LicenseSource.DECLARED)
+                        ),
+                        locations = emptySet()
+                    )
+                ),
+                copyrightGarbage = emptyMap(),
+                unmatchedCopyrights = emptyMap()
+            )
 
-                val filteredResolvedLicenseInfo = RESOLVED_LICENSE_INFO.applyChoices(choices)
+            val choices = listOf(
+                SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx())
+            )
 
-                filteredResolvedLicenseInfo.licenses should containLicensesExactly(MIT, BSD)
-            }
+            val effectiveLicense = resolvedLicenseInfo.effectiveLicense(LicenseView.ONLY_DECLARED, choices)
+
+            effectiveLicense shouldBe "$MIT OR $GPL".toSpdx()
+        }
+
+        "apply choices for LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED" {
+            // Concluded: 0BSD OR GPL-2.0-only
+            val choices = listOf(
+                SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
+            )
+
+            val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
+                LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+                choices
+            )
+
+            effectiveLicense shouldBe BSD.toSpdx()
+        }
+
+        "apply choices for LicenseView.ONLY_DECLARED" {
+            // Declared: Apache-2.0 WITH LLVM-exception OR MIT
+            val choices = listOf(
+                SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx())
+            )
+
+            val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
+                LicenseView.ONLY_DECLARED,
+                choices
+            )
+
+            effectiveLicense shouldBe MIT.toSpdx()
+        }
+
+        "apply package and repository license choice for LicenseView.ONLY_CONCLUDED in the correct order" {
+            val repositoryChoices = listOf(
+                SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
+                SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
+            )
+            val packageChoices = listOf(
+                SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), APACHE.toSpdx())
+            )
+
+            val effectiveLicense = RESOLVED_LICENSE_INFO.effectiveLicense(
+                LicenseView.ALL,
+                packageChoices,
+                repositoryChoices
+            )
+
+            effectiveLicense shouldBe "$APACHE and ($MIT or $GPL) and $BSD".toSpdx()
         }
     }
-}
+
+    "applyChoices(licenseChoices)" should {
+        "apply license choices on all licenses" {
+            val choices = listOf(
+                SpdxLicenseChoice("$APACHE OR $MIT".toSpdx(), MIT.toSpdx()),
+                SpdxLicenseChoice("$MIT OR $GPL".toSpdx(), MIT.toSpdx()),
+                SpdxLicenseChoice("$BSD OR $GPL".toSpdx(), BSD.toSpdx())
+            )
+
+            val filteredResolvedLicenseInfo = RESOLVED_LICENSE_INFO.applyChoices(choices)
+
+            filteredResolvedLicenseInfo.licenses should containLicensesExactly(MIT, BSD)
+        }
+    }
+})
 
 private const val MIT = "MIT"
 private const val APACHE = "Apache-2.0 WITH LLVM-exception"

--- a/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
@@ -27,7 +27,6 @@ import io.mockk.mockk
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
-import org.ossreviewtoolkit.model.licenses.TestUtils.containLicensesExactly
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx

--- a/model/src/test/kotlin/licenses/TestUtils.kt
+++ b/model/src/test/kotlin/licenses/TestUtils.kt
@@ -26,12 +26,10 @@ import io.kotest.matchers.neverNullMatcher
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
-object TestUtils {
-    fun containLicensesExactly(vararg licenses: String): Matcher<Iterable<ResolvedLicense>?> =
-        neverNullMatcher { value ->
-            val expected = licenses.map { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }.toSet()
-            val actual = value.map { it.license }.toSet()
+fun containLicensesExactly(vararg licenses: String): Matcher<Iterable<ResolvedLicense>?> =
+    neverNullMatcher { value ->
+        val expected = licenses.map { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }.toSet()
+        val actual = value.map { it.license }.toSet()
 
-            containExactly(expected).test(actual)
-        }
-}
+        containExactly(expected).test(actual)
+    }

--- a/model/src/test/kotlin/licenses/TestUtils.kt
+++ b/model/src/test/kotlin/licenses/TestUtils.kt
@@ -28,8 +28,8 @@ import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
 fun containLicensesExactly(vararg licenses: String): Matcher<Iterable<ResolvedLicense>?> =
     neverNullMatcher { value ->
-        val expected = licenses.map { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }.toSet()
-        val actual = value.map { it.license }.toSet()
+        val expected = licenses.mapTo(mutableSetOf()) { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }
+        val actual = value.mapTo(mutableSetOf()) { it.license }
 
         containExactly(expected).test(actual)
     }

--- a/model/src/test/kotlin/licenses/TestUtils.kt
+++ b/model/src/test/kotlin/licenses/TestUtils.kt
@@ -23,6 +23,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.neverNullMatcher
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
@@ -33,3 +34,10 @@ fun containLicensesExactly(vararg licenses: String): Matcher<Iterable<ResolvedLi
 
         containExactly(expected).test(actual)
     }
+
+class SimpleLicenseInfoProvider(licenseInfo: List<LicenseInfo>) : LicenseInfoProvider {
+    private val licenseInfoById = licenseInfo.associateBy { it.id }
+
+    override fun get(id: Identifier) =
+        licenseInfoById[id] ?: throw IllegalArgumentException("No license info for '${id.toCoordinates()}' available.")
+}


### PR DESCRIPTION
Ensure that the concatenation within the implementation runs reasonably fast.