### PR TITLE
build: Upgrade to Gradle 8.13 RC1

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -65,13 +65,7 @@ testing {
             }
         }
 
-        register<JvmTestSuite>("funTest") {
-            sources {
-                kotlin {
-                    testType = TestSuiteType.FUNCTIONAL_TEST
-                }
-            }
-        }
+        register<JvmTestSuite>("funTest")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionSha256Sum=3b3565efd2df2dd999774b6ef8ea571878c5532cbac6dbaaeb4b2731f42e6704
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-rc-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
While ORT usually sticks to final versions, this release candidate fixes a very annoying issue [1] where Gradle picks the wrong Java toolchain to run its daemon.

Also see the upgrade instructions [2] for the dropped `testType` property.

[1]: https://github.com/gradle/gradle/issues/30652
[2]: https://docs.gradle.org/8.13-rc-1/userguide/upgrading_version_8.html#changes_8.13