### PR TITLE
chore: Avoid the use of `toRelativeString()`

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -258,7 +258,7 @@ class LicenseInfoResolver(
             val directory = (provenance as? RepositoryProvenance)?.vcsInfo?.path.orEmpty()
             val rootLicenseFiles = pathLicenseMatcher.getApplicableLicenseFilesForDirectories(
                 relativeFilePaths = archiveDir.walk().filter { it.isFile }.mapTo(mutableSetOf()) {
-                    it.toRelativeString(archiveDir)
+                    it.relativeTo(archiveDir).invariantSeparatorsPath
                 },
                 directories = listOf(directory)
             ).getValue(directory)

--- a/scanner/src/main/kotlin/utils/Utils.kt
+++ b/scanner/src/main/kotlin/utils/Utils.kt
@@ -80,7 +80,7 @@ private fun getVcsPathForRepositoryOrNull(vcsPath: String, repositoryPath: Strin
     return if (repoPathFile.startsWith(vcsPathFile)) {
         ""
     } else {
-        runCatching { vcsPathFile.toRelativeString(repoPathFile) }.getOrNull()
+        runCatching { vcsPathFile.relativeTo(repoPathFile).invariantSeparatorsPath }.getOrNull()
     }
 }
 

--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -339,7 +339,8 @@ fun File.packZip(
         }.filter {
             Files.isRegularFile(it.toPath(), LinkOption.NOFOLLOW_LINKS) && fileFilter(it) && it != targetFile
         }.forEach { file ->
-            val packPath = prefix + file.toRelativeString(takeUnless { it.isFile } ?: parentFile)
+            val base = takeUnless { it.isFile } ?: parentFile
+            val packPath = prefix + file.relativeTo(base).invariantSeparatorsPath
             val entry = ZipArchiveEntry(file, packPath)
             output.putArchiveEntry(entry)
             file.inputStream().use { input -> input.copyTo(output) }


### PR DESCRIPTION
In all cases except for user-facing console output, string representations for paths should be invariant to the OS, as ORT is often comparing paths by string, e.g. VCS paths for repository provenances.