### PR TITLE
fix(reporter): Change default FossID report type

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/report/Model.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/report/Model.kt
@@ -21,11 +21,17 @@ package org.ossreviewtoolkit.clients.fossid.model.report
 
 /**
  * Available FossID report types.
+ * FossID accepts the following report types:
+ * >= 24.2: SPDX, XLSX, STRING_MATCH, DYNAMIC_TOP_MATCHED_COMPONENTS, CYCLONE_DX, SPDX_LITE, HTML.
+ * < 24.2: HTML, STRING_MATCH, DYNAMIC_TOP_MATCHED_COMPONENTS, DYNAMIC_TOP_MATCHED_COMPONENTS,
+ * GENERATE_DYNAMIC_TOP_MATCHED_REPORT, CYCLONE_DX, SPDX_LITE, SPDX, SPDX_LITE, XLSX, DYNAMIC, BASIC, STRING_MATCH,
+ * PRELIMINARY, CYCLONE_DX
  */
 enum class ReportType(private val value: String) {
     /**
      * Interactive and self-contained HTML report providing advanced features for searching, filtering and investigating
-     * the results. Requires Javascript and corresponds to the UI report "Full FossID report".
+     * the results. Requires Javascript and corresponds to the UI report "Full FossID report". This report type has been
+     * removed with FossID 24.2.
      */
     HTML_DYNAMIC("dynamic"),
 
@@ -36,7 +42,8 @@ enum class ReportType(private val value: String) {
     HTML_STATIC("html"),
 
     /**
-     * Software Package Data Exchange (SPDX) conformant XML file. Corresponds to the UI report "SPDX".
+     * Software Package Data Exchange (SPDX) conformant XML file. Corresponds to the UI report "SPDX". This report type
+     * has been removed with FossID 24.2
      */
     SPDX_RDF("spdx"),
 

--- a/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
+++ b/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
@@ -62,7 +62,7 @@ data class FossIdReporterConfig(
     /**
      * The type of report to generate. Allowed values are "HTML_DYNAMIC", "HTML_STATIC", "SPDX_RDF", and "XLSX".
      */
-    @OrtPluginOption(defaultValue = "HTML_DYNAMIC")
+    @OrtPluginOption(defaultValue = "XLSX")
     val reportType: String,
 
     /**

--- a/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
+++ b/plugins/reporters/fossid/src/main/kotlin/FossIdReporter.kt
@@ -60,7 +60,7 @@ data class FossIdReporterConfig(
     val user: Secret,
 
     /**
-     * The type of report to generate. Allowed values are "HTML_DYNAMIC", "HTML_STATIC", "SPDX_RDF", and "XLSX".
+     * The type of report to generate. See [ReportType].
      */
     @OrtPluginOption(defaultValue = "XLSX")
     val reportType: String,


### PR DESCRIPTION
With version 24.2 of FossID, the full HTML report type is removed in favor of the Excel report type. Since the latter was already present in previous versions of FossID, it can safely be chosen for the default report type, preserving backward compatibility with previous FossID versions.