### PR TITLE
fix(scanners): Make the DOS `token` a secret again

### DIFF
--- a/plugins/scanners/dos/src/main/kotlin/DosScanner.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DosScanner.kt
@@ -88,7 +88,8 @@ class DosScanner(
     override val readFromStorage = false
     override val writeToStorage = config.writeToStorage
 
-    private val service = DosService.create(config.url, config.token, config.timeout?.let { Duration.ofSeconds(it) })
+    private val service =
+        DosService.create(config.url, config.token.value, config.timeout?.let { Duration.ofSeconds(it) })
     internal val client = DosClient(service)
 
     override fun scanPackage(nestedProvenance: NestedProvenance?, context: ScanContext): ScanResult {

--- a/plugins/scanners/dos/src/main/kotlin/DosScannerConfig.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DosScannerConfig.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.plugins.scanners.dos
 
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
+import org.ossreviewtoolkit.plugins.api.Secret
 
 /**
  * This is the configuration class for DOS Scanner.
@@ -29,7 +30,7 @@ data class DosScannerConfig(
     val url: String,
 
     /** The secret token to use with the DOS backend. */
-    val token: String,
+    val token: Secret,
 
     /** The timeout for communicating with the DOS backend, in seconds. */
     val timeout: Long?,

--- a/plugins/scanners/dos/src/test/kotlin/DosScannerTest.kt
+++ b/plugins/scanners/dos/src/test/kotlin/DosScannerTest.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.plugins.api.Secret
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.scanner.provenance.NestedProvenance
 
@@ -66,7 +67,7 @@ class DosScannerTest : StringSpec({
 
         scanner = DosScannerFactory.create(
             url = "http://localhost:${server.port()}/api/",
-            token = "",
+            token = Secret(""),
             timeout = 60L,
             pollInterval = 5L,
             fetchConcluded = false,


### PR DESCRIPTION
This is a fixup for 40fa386. Fixes #9957.