### PR TITLE
fix(maven): Avoid deduplication in Tycho dependency trees

### DIFF
--- a/plugins/package-managers/maven/src/funTest/assets/projects/synthetic/tycho-expected-output-scope-excludes.yml
+++ b/plugins/package-managers/maven/src/funTest/assets/projects/synthetic/tycho-expected-output-scope-excludes.yml
@@ -46,6 +46,8 @@ projects:
       - id: "Maven:commons-logging:commons-logging:1.3.2"
       - id: "Maven:org.apache.commons:commons-lang3:3.14.0"
       - id: "Maven:org.apache.commons:commons-text:1.12.0"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.14.0"
 packages:
 - id: "Maven:commons-logging:commons-logging:1.3.2"
   purl: "pkg:maven/commons-logging/commons-logging@1.3.2"

--- a/plugins/package-managers/maven/src/funTest/assets/projects/synthetic/tycho-expected-output.yml
+++ b/plugins/package-managers/maven/src/funTest/assets/projects/synthetic/tycho-expected-output.yml
@@ -46,6 +46,8 @@ projects:
       - id: "Maven:commons-logging:commons-logging:1.3.2"
       - id: "Maven:org.apache.commons:commons-lang3:3.14.0"
       - id: "Maven:org.apache.commons:commons-text:1.12.0"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.14.0"
   - name: "test"
     dependencies:
     - id: "Maven:junit:junit:4.13.2"

--- a/plugins/package-managers/maven/src/main/kotlin/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/Tycho.kt
@@ -258,6 +258,7 @@ class Tycho(
             add("-DoutputType=json")
             add("-DoutputFile=${dependencyTreeFile.absolutePath}")
             add("-DappendOutput=true")
+            add("-Dverbose=true")
 
             generateModuleExcludes(root)?.takeUnless { it.isEmpty() }?.let { excludedModules ->
                 add("-pl")


### PR DESCRIPTION
By default, the `maven-dependency-plugin` does not list dependencies (and their transitive dependencies) again if they have been listed before, effectively de-duplicating the dependency tree, also see #4720.

This de-duplication, however, is something that ORT's `DependencyGraph` should handle on its own. So, disable this de-duplication by running in `verbose` mode [1].

[1]: https://maven.apache.org/plugins/maven-dependency-plugin/tree-mojo.html#verbose