### PR TITLE
test(model): Increase timeout for performance tests

### DIFF
--- a/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
@@ -137,7 +137,7 @@ class ResolvedLicenseInfoTest : WordSpec({
 
         "execute in reasonable time for large license info with several OR operators".config(
             blockingTest = true,
-            timeout = 1.seconds
+            timeout = 2.seconds
         ) {
             runCancellable {
                 COMPUTATION_HEAVY_RESOLVED_LICENSE_INFO.effectiveLicense(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
@@ -148,7 +148,7 @@ class ResolvedLicenseInfoTest : WordSpec({
     "toCompoundExpression()" should {
         "execute in reasonable time for large license info with several OR operators".config(
             blockingTest = true,
-            timeout = 1.seconds
+            timeout = 2.seconds
         ) {
             runCancellable {
                 COMPUTATION_HEAVY_RESOLVED_LICENSE_INFO.toCompoundExpression()


### PR DESCRIPTION
Double the timeout for the two performance related tests for SPDX expressions because they often time out on the GitHub Windows runners. Increasing the timeout should be fine because the tests are supposed to prevent performance regressions on a much larger scale.