### PR TITLE
build(advisors): Do not explicitly depend on `testUtils`

### DIFF
--- a/plugins/advisors/oss-index/build.gradle.kts
+++ b/plugins/advisors/oss-index/build.gradle.kts
@@ -33,5 +33,4 @@ dependencies {
     ksp(projects.advisor)
 
     testImplementation(libs.wiremock)
-    testImplementation(projects.utils.testUtils)
 }


### PR DESCRIPTION
This is already done globally via test suite conventions [1] (in order to always have `kotest.properties` on the test classpath).

[1]: https://github.com/oss-review-toolkit/ort/blob/cd855bef34c68613d1b33601130678b39ce912e3/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts#L61