### PR TITLE
fix(web-app-template): Fix concluded license in table view

### DIFF
--- a/plugins/reporters/web-app-template/src/components/ResultsTable.jsx
+++ b/plugins/reporters/web-app-template/src/components/ResultsTable.jsx
@@ -57,7 +57,7 @@ const ResultsTable = ({ webAppOrtResult }) => {
             return webAppOrtResult.packages
                 .map(
                     (webAppPackage) => ({
-                        concludedLicenses: webAppPackage.concludedLicense || '',
+                        concludedLicense: webAppPackage.concludedLicense || '',
                         declaredLicenses: webAppPackage.declaredLicenses,
                         declaredLicensesText: Array.from(webAppPackage.declaredLicenses).join(', '),
                         declaredLicensesMapped: webAppPackage.declaredLicensesMapped,


### PR DESCRIPTION
This is a fix-up for 403d1bc where due to copy-paste mistake the concluded license for a package is not shown in the table view.

Closes #9980.
