### PR TITLE
docs(spdx-document): Fix-up a URL

### DIFF
--- a/utils/spdx-document/src/main/kotlin/model/SpdxExternalReference.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxExternalReference.kt
@@ -46,7 +46,7 @@ data class SpdxExternalReference(
 
     /**
      * The references type as specified by
-     * https://github.com/spdx/spdx-spec/blob/master/chapters/appendix-VI-external-repository-identifiers.md.
+     * https://github.com/spdx/spdx-spec/blob/v2.2.2/chapters/appendix-VI-external-repository-identifiers.md.
      */
     @JsonDeserialize(using = ReferenceTypeDeserializer::class)
     val referenceType: Type,


### PR DESCRIPTION
The existing URL pointed to the head of `main` in which the file path does not exist currently. Adjust the link to point to the analog page of the revision tagged with `v2.2.2`, for consistency with other references to these docs.
