### PR TITLE
fix(scanoss): Make the API key optional again

### DIFF
--- a/plugins/scanners/scanoss/build.gradle.kts
+++ b/plugins/scanners/scanoss/build.gradle.kts
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     // Apply precompiled plugins.
     id("ort-plugin-conventions")
@@ -32,7 +30,6 @@ dependencies {
     implementation(projects.utils.commonUtils)
     implementation(projects.utils.spdxUtils)
 
-    implementation(libs.kotlinx.coroutines)
     implementation(libs.scanoss) {
         exclude(group = "org.slf4j", module = "slf4j-simple")
             .because("the logging provider conflicts with ORT's")
@@ -42,14 +39,6 @@ dependencies {
 
     funTestApi(testFixtures(projects.scanner))
 
-    testImplementation(libs.kotlinx.serialization.core)
-    testImplementation(libs.kotlinx.serialization.json)
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)
-}
-
-tasks.named<KotlinCompile>("compileTestKotlin") {
-    compilerOptions {
-        optIn = listOf("kotlinx.serialization.ExperimentalSerializationApi")
-    }
 }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -54,7 +54,7 @@ class ScanOss(
     private val service = ScanApi.builder()
         // As there is only a single endpoint, the SCANOSS API client expects the path to be part of the API URL.
         .url(config.apiUrl.removeSuffix("/") + "/scan/direct")
-        .apiKey(config.apiKey)
+        .apiKey(config.apiKey.value)
         .build()
 
     override val version: String by lazy {

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -20,14 +20,16 @@
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
+import org.ossreviewtoolkit.plugins.api.Secret
 
 data class ScanOssConfig(
     /** The URL of the ScanOSS server. */
     @OrtPluginOption(defaultValue = "https://api.osskb.org/")
     val apiUrl: String,
 
-    /** The API key required to authenticate with the ScanOSS server. */
-    val apiKey: String,
+    /** The API key used to authenticate with the ScanOSS server. */
+    @OrtPluginOption(defaultValue = "")
+    val apiKey: Secret,
 
     /**
      * A regular expression to match the scanner name when looking up scan results in the storage.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -19,12 +19,14 @@
 
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
+import com.scanoss.rest.ScanApi
+
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.Secret
 
 data class ScanOssConfig(
     /** The URL of the ScanOSS server. */
-    @OrtPluginOption(defaultValue = "https://api.osskb.org/")
+    @OrtPluginOption(defaultValue = ScanApi.DEFAULT_BASE_URL)
     val apiUrl: String,
 
     /** The API key used to authenticate with the ScanOSS server. */

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -42,6 +42,7 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.plugins.api.Secret
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
@@ -61,7 +62,7 @@ class ScanOssScannerDirectoryTest : StringSpec({
 
     beforeSpec {
         server.start()
-        scanner = spyk(ScanOssFactory.create(apiUrl = "http://localhost:${server.port()}", apiKey = ""))
+        scanner = spyk(ScanOssFactory.create(apiUrl = "http://localhost:${server.port()}", apiKey = Secret("")))
     }
 
     afterSpec {

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerFileTest.kt
@@ -36,6 +36,7 @@ import java.util.UUID
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.plugins.api.Secret
 import org.ossreviewtoolkit.scanner.ScanContext
 
 private val TEST_FILE_TO_SCAN = File("src/test/assets/filesToScan/ScannerFactory.kt")
@@ -54,7 +55,7 @@ class ScanOssScannerFileTest : StringSpec({
 
     beforeSpec {
         server.start()
-        scanner = spyk(ScanOssFactory.create(apiUrl = "http://localhost:${server.port()}", apiKey = ""))
+        scanner = spyk(ScanOssFactory.create(apiUrl = "http://localhost:${server.port()}", apiKey = Secret("")))
     }
 
     afterSpec {


### PR DESCRIPTION
Before 40fa386 the API key effectively was optional as a missing key was turned into an empty string via

    val apiKey = secrets[API_KEY_PROPERTY].orEmpty()

Restore that behavior by using the empty string as a default value.