### PR TITLE
docs(PluginAPI): Fix plugin compiler path in Readme

### DIFF
--- a/plugins/api/README.md
+++ b/plugins/api/README.md
@@ -158,7 +158,7 @@ plugins {
 
 dependencies {
     ksp("org.ossreviewtoolkit:advisor:[version]")
-    ksp("org.ossreviewtoolkit:compiler:[version]")
+    ksp("org.ossreviewtoolkit.plugins:compiler:[version]")
 }
 ```
 


### PR DESCRIPTION
This was noticed during the upgrade of the MockVCS plugin [1] to the new plugin API, thanks to https://github.com/oss-review-toolkit/ort-package-manager-plugin/pull/142.

[1] https://github.com/pepper-jk/ort-mock-vcs-plugin

Signed-off-by: Jens Keim <jens.keim@forvia.com>