### PR TITLE
docs(website): Add generated plugin docs

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4
+      - name: Generate plugin docs
+        run: ./gradlew generatePluginDocs
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           node-version: 18

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4
+      - name: Generate plugin docs
+        run: ./gradlew generatePluginDocs
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           node-version: 18

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,3 +219,11 @@ val checkGitAttributes by tasks.registering {
         if (hasErrors) throw GradleException("There were stale '.gitattribute' entries.")
     }
 }
+
+tasks.register<GeneratePluginDocsTask>("generatePluginDocs") {
+    inputFiles = fileTree("plugins") {
+        include("**/build/generated/ksp/main/resources/META-INF/plugin/*.json")
+    }
+
+    dependsOn(getTasksByName("kspKotlin", /* recursive = */ true))
+}

--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import groovy.json.JsonSlurper
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GeneratePluginDocsTask : DefaultTask() {
+    init {
+        group = "Documentation"
+        description = "Generate documentation for the plugins."
+    }
+
+    @get:InputFiles
+    abstract var inputFiles: ConfigurableFileTree
+
+    @OutputDirectory
+    val outputDirectory = project.layout.projectDirectory.file("website/docs/plugins").asFile
+
+    @Internal
+    val jsonSlurper = JsonSlurper()
+
+    @TaskAction
+    fun generatePluginDocs() {
+        require(inputFiles.files.isNotEmpty()) {
+            "No plugin descriptions found, make sure to provide input files to this task."
+        }
+
+        logger.lifecycle("Generating plugin documentation.")
+        logger.lifecycle("Found a total of ${inputFiles.count()} plugins.")
+
+        generatePluginDocs("advisors")
+        generatePluginDocs("package-configuration-providers")
+        generatePluginDocs("package-curation-providers")
+        generatePluginDocs("package-managers")
+        generatePluginDocs("reporters")
+        generatePluginDocs("scanners")
+    }
+
+    private fun generatePluginDocs(pluginType: String) {
+        val plugins = inputFiles.filter { it.invariantSeparatorsPath.contains("plugins/$pluginType") }
+        val dir = outputDirectory.resolve(pluginType).also { it.mkdirs() }
+
+        logger.lifecycle("Found ${plugins.count()} ${pluginType.replace('-', ' ')}.")
+
+        plugins.forEach { file ->
+            val json = checkNotNull(jsonSlurper.parse(file) as? Map<*, *>)
+            val descriptor = checkNotNull(json["descriptor"] as? Map<*, *>)
+
+            val outputFile = dir.resolve("${descriptor["displayName"]}.md")
+
+            val markdown = buildString {
+                // Set max heading level so that option sections are visible in the TOC.
+                appendLine("---")
+                appendLine("toc_max_heading_level: 4")
+                appendLine("---")
+                appendLine()
+
+                // Write header.
+                appendLine("# ${descriptor["displayName"]}")
+                appendLine()
+                appendLine("![${descriptor["id"]}](https://img.shields.io/badge/Plugin_ID-${descriptor["id"]}-gold)")
+                appendLine()
+                appendLine(descriptor["description"])
+                appendLine()
+
+                val allOptions = ((descriptor["options"]) as List<*>).map { it as Map<*, *> }
+
+                if (allOptions.isEmpty()) return@buildString
+
+                val (options, secrets) = allOptions.partition { it["type"] != "SECRET" }
+
+                appendLine("## Configuration")
+                appendLine()
+
+                // Write example configuration.
+                appendLine("### Example")
+                appendLine()
+                appendLine("```json")
+                appendLine("{")
+                appendLine("  \"${descriptor["id"]}\": {")
+
+                fun appendOptions(options: List<Map<*, *>>) {
+                    options.forEachIndexed { index, option ->
+                        val defaultValue = option["default"]
+                        val type = option["type"]
+                        val isStringValue =
+                            (type == "SECRET" || type == "STRING" || type == "STRING_LIST") && defaultValue != null
+
+                        append("      \"${option["name"]}\": ")
+                        if (isStringValue) append("\"")
+                        append(defaultValue)
+                        if (isStringValue) append("\"")
+                        if (index < options.size - 1) append(",")
+                        appendLine()
+                    }
+                }
+
+                if (options.isNotEmpty()) {
+                    appendLine("    \"options\": {")
+                    appendOptions(options)
+                    append("    }")
+                    if (secrets.isNotEmpty()) append(",")
+                    appendLine()
+                }
+
+                if (secrets.isNotEmpty()) {
+                    appendLine("    \"secrets\": {")
+                    appendOptions(secrets)
+                    appendLine("    }")
+                }
+
+                appendLine("  }")
+                appendLine("}")
+                appendLine("```")
+                appendLine()
+                appendLine("### Options")
+                appendLine()
+
+                // Write option descriptions.
+                allOptions.forEach { option ->
+                    val type = option["type"]
+
+                    appendLine("#### ${option["name"]}")
+                    appendLine()
+                    appendLine("![$type](https://img.shields.io/badge/Type-$type-blue)")
+
+                    if (option["isRequired"] == true) {
+                        appendLine("![Required](https://img.shields.io/badge/Required-orange)")
+                    }
+
+                    option["default"]?.also {
+                        appendLine("![Default](https://img.shields.io/badge/Default-$it-darkgreen)")
+                    }
+
+                    appendLine()
+                    appendLine(option["description"])
+                    appendLine()
+                }
+            }
+
+            logger.lifecycle("Writing docs for ${descriptor["id"]} to ${outputFile.absolutePath}.")
+            outputFile.writeText(markdown)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/LicenseUtils.kt
+++ b/buildSrc/src/main/kotlin/LicenseUtils.kt
@@ -48,6 +48,13 @@ object CopyrightableFiles {
         "website/docs/configuration/_category_.yml",
         "website/docs/getting-started/_category_.yml",
         "website/docs/guides/_category_.yml",
+        "website/docs/plugins/_category_.yml",
+        "website/docs/plugins/advisors/_category_.yml",
+        "website/docs/plugins/package-configuration-providers/_category_.yml",
+        "website/docs/plugins/package-curation-providers/_category_.yml",
+        "website/docs/plugins/package-managers/_category_.yml",
+        "website/docs/plugins/reporters/_category_.yml",
+        "website/docs/plugins/scanners/_category_.yml",
         "website/docs/tools/_category_.yml",
         "website/sidebars.js"
     )

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Development

--- a/website/docs/license.md
+++ b/website/docs/license.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # License

--- a/website/docs/plugins/.gitignore
+++ b/website/docs/plugins/.gitignore
@@ -1,0 +1,2 @@
+# Plugin docs are generated and should not be committed.
+**/*.md

--- a/website/docs/plugins/_category_.yml
+++ b/website/docs/plugins/_category_.yml
@@ -1,0 +1,5 @@
+position: 6
+label: "Plugins"
+link:
+  type: "generated-index"
+  title: "Plugins"

--- a/website/docs/plugins/advisors/_category_.yml
+++ b/website/docs/plugins/advisors/_category_.yml
@@ -1,0 +1,4 @@
+label: "Advisors"
+link:
+  type: "generated-index"
+  title: "Advisors"

--- a/website/docs/plugins/package-configuration-providers/_category_.yml
+++ b/website/docs/plugins/package-configuration-providers/_category_.yml
@@ -1,0 +1,4 @@
+label: "Package Configuration Providers"
+link:
+  type: "generated-index"
+  title: "Package Configuration Providers"

--- a/website/docs/plugins/package-curation-providers/_category_.yml
+++ b/website/docs/plugins/package-curation-providers/_category_.yml
@@ -1,0 +1,4 @@
+label: "Package Curation Providers"
+link:
+  type: "generated-index"
+  title: "Package Curation Providers"

--- a/website/docs/plugins/package-managers/_category_.yml
+++ b/website/docs/plugins/package-managers/_category_.yml
@@ -1,0 +1,4 @@
+label: "Package Managers"
+link:
+  type: "generated-index"
+  title: "Package Managers"

--- a/website/docs/plugins/reporters/_category_.yml
+++ b/website/docs/plugins/reporters/_category_.yml
@@ -1,0 +1,4 @@
+label: "Reporters"
+link:
+  type: "generated-index"
+  title: "Reporters"

--- a/website/docs/plugins/scanners/_category_.yml
+++ b/website/docs/plugins/scanners/_category_.yml
@@ -1,0 +1,4 @@
+label: "Scanners"
+link:
+  type: "generated-index"
+  title: "Scanners"

--- a/website/docs/related-tools.md
+++ b/website/docs/related-tools.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Related Tools
 ---
 


### PR DESCRIPTION
Add a Gradle task to generate plugin docs for the website from the generated JSON descriptions of plugins. The generated docs are not committed and instead generated when deploying the website.

The generated docs look like this:
![grafik](https://github.com/user-attachments/assets/f2da6f7c-6036-4966-a0cc-52a42c1263a1)
