### PR TITLE
ci(github): Add a workflow to build a native Analyzer-only executable

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,37 @@
+name: Native Build
+
+on:
+  workflow_dispatch:
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+permissions: read-all
+
+jobs:
+  analyzer-only:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@01ed653ac833fe80569f1ef9f25585ba2811baab # v1
+        with:
+          distribution: graalvm
+          java-version: 21
+          native-image-job-reports: true
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4
+      - name: Build Executable
+        run: ./gradlew -P cliAnalyzerOnly=true --no-configuration-cache :cli:nativeCompile
+      - name: Compress Executable
+        uses: crazy-max/ghaction-upx@de21b8cbed76979407eeb6e41aa5e270afc3225c # v3
+        with:
+          files: cli/build/native/nativeCompile/ort
+      - name: Upload Executable
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        with:
+          name: ORT Analyzer-only
+          path: cli/build/native/nativeCompile/ort
+          compression-level: 0
+          retention-days: 7


### PR DESCRIPTION
While the generated executable does not work fully as expected yet (e.g. due to missing reflection configuration), this offers a convenient way to build the executable without a local GraalVM development setup.