### PR TITLE
fix(PackageManager): Create a stable processing order of definition f…

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -288,7 +288,8 @@ abstract class PackageManager(val projectType: String) : Plugin {
 
         val result = mutableMapOf<File, List<ProjectAnalyzerResult>>()
 
-        definitionFiles.forEach { definitionFile ->
+        // Create a stable order to process the definition files, starting with the ones with the most path segments.
+        definitionFiles.sortedWith(compareBy({ -it.toPath().nameCount }, { it.path })).forEach { definitionFile ->
             val relativePath = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath.ifEmpty { "." }
 
             logger.info { "Using ${descriptor.displayName} to resolve dependencies for path '$relativePath'..." }


### PR DESCRIPTION
…iles

In case there are several definition files per Package Manager in the repository, distributed over several subdirectories, the order in which these definition files are processed is not stable. This may lead to unstable scan results.
This fix creates a stable processing order, starting with the definition files that have the most path segments.

Workaround for #9699.

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
