### PR TITLE
feat(npm): Speed-up getting the remote package details

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
@@ -68,9 +68,9 @@ internal class NpmDependencyHandler(
         }
 }
 
-private val ModuleInfo.isInstalled: Boolean get() = path != null
+internal val ModuleInfo.isInstalled: Boolean get() = path != null
 
-private val ModuleInfo.isProject: Boolean get() = resolved == null
+internal val ModuleInfo.isProject: Boolean get() = resolved == null
 
 private val ModuleInfo.packageJsonFile: File get() =
     File(


### PR DESCRIPTION
Obtaining the package details via `npm info` is a performance bottleneck of ORT's NPM package manager. Request the package details for all packages upfront, in parellel to reduce execution time. Experiments on a development machine show that execution of `NpmFunTest` now takes `1 min 13 sec` instead of `3 min 47 sec`.

Fixes: #9950.

**before**

![Screenshot from 2025-03-19 13-32-26](https://github.com/user-attachments/assets/b629792a-167a-4d44-beb3-31521fe4798d)

**after**

![Screenshot from 2025-03-19 13-18-31](https://github.com/user-attachments/assets/5e2b4e8b-e8a5-47bf-ac97-6d057f5ffcfc)



