### PR TITLE
feat(utils): Support a fallback `Authenticator`

### DIFF
--- a/utils/ort/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/OrtAuthenticator.kt
@@ -70,7 +70,14 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
 
     // First look if the credentials are already present in the URL, then search for (potentially machine-specific)
     // credentials in a netrc-style file, and finally look for generic credentials passed as environment variables.
-    private val delegateAuthenticators = listOf(UserInfoAuthenticator(), NetRcAuthenticator(), EnvVarAuthenticator())
+    // If none of these can provide credentials, fall back to the original authenticator, if any. This allows tools
+    // that use ORT programmatically to provide a custom authenticator.
+    private val delegateAuthenticators = listOfNotNull(
+        UserInfoAuthenticator(),
+        NetRcAuthenticator(),
+        EnvVarAuthenticator(),
+        original
+    )
 
     private val serverAuthentication: ConcurrentHashMap<String, PasswordAuthentication> = ConcurrentHashMap()
 


### PR DESCRIPTION
In `OrtAuthenticator`, use an already installed `Authenticator` as a fallback if the requested credentials cannot be found otherwise. This allows extending the authentication mechanism, which may be needed by environments that integrate ORT, for instance ORT Server.
