### PR TITLE
feat(helper-cli): Extend `PackageList` by a `declaredLicense` set

### DIFF
--- a/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -57,8 +57,11 @@ analyzer:
     packages:
     - id: "NPM::example-dependency-one:1.0.0"
       purl: "pkg:npm/example-dependency-one@1.0.0"
-      declared_licenses: []
-      declared_licenses_processed: {}
+      declared_licenses:
+      - "Apache-2.0 OR LGPL-2.0-only"
+      - "MIT"
+      declared_licenses_processed:
+        spdx_expression: "(Apache-2.0 OR LGPL-2.0-only) AND MIT"
       description: ""
       homepage_url: ""
       binary_artifact:

--- a/helper-cli/src/funTest/assets/package-list.yml
+++ b/helper-cli/src/funTest/assets/package-list.yml
@@ -14,6 +14,9 @@ dependencies:
       path: "vcs-path/dependency-one"
     sourceArtifact:
       url: "https://example.org/example-dependency-one.zip"
+    declaredLicenses:
+      - "MIT"
+      - "Apache-2.0 OR LGPL-2.0-only"
     isExcluded: true
     isDynamicallyLinked: true
   - id: "NPM::example-dependency-two:2.0.0"

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -150,6 +150,7 @@ private data class Dependency(
     val purl: String? = null,
     val vcs: Vcs? = null,
     val sourceArtifact: SourceArtifact? = null,
+    val declaredLicenses: Set<String> = emptySet(),
     val isExcluded: Boolean = false,
     val isDynamicallyLinked: Boolean = false,
     val labels: Map<String, String> = emptyMap()
@@ -198,7 +199,7 @@ private fun Dependency.toPackage(): Package {
         purl = purl ?: id.toPurl(),
         sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash ?: Hash.NONE) }.orEmpty(),
         vcs = vcsInfo,
-        declaredLicenses = emptySet(),
+        declaredLicenses = declaredLicenses,
         description = "",
         homepageUrl = "",
         binaryArtifact = RemoteArtifact.EMPTY,


### PR DESCRIPTION
When a project does not use a package manager (supported by ORT), the helper-cli provides on alternative way to create an analyzer result from a package list file. Allow to also inject the `declaredLicense` to enable corresponding use cases.
