### PR TITLE
fix(plugins): Do not write "null" as string for `configClass`

### DIFF
--- a/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/JsonSpecGenerator.kt
@@ -63,7 +63,7 @@ class JsonSpecGenerator(private val codeGenerator: CodeGenerator) {
                 }
             }
 
-            put("configClass", pluginSpec.configClass?.typeName.toString())
+            put("configClass", pluginSpec.configClass?.typeName?.toString())
             put("factoryClass", pluginSpec.factory.qualifiedName)
         }
 


### PR DESCRIPTION
In case `configClass` is null, write `null` instead of "null".