### PR TITLE
fix(Maven): Add the Maven Wagon HTTP provider

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ slf4j = "2.0.17"
 springCore = "6.2.5"
 svnkit = "1.10.12"
 sw360Client = "17.0.1-m2"
+wagonHttp = "3.5.3"
 wiremock = "3.12.1"
 xmlutil = "0.90.3"
 xz = "1.10"
@@ -185,6 +186,7 @@ slf4j = { module = "org.slf4j:slf4j-api ", version.ref = "slf4j" }
 springCore = { module = "org.springframework:spring-core", version.ref = "springCore" }
 svnkit = { module = "com.tmatesoft.svnkit:svnkit", version.ref = "svnkit" }
 sw360Client = { module = "org.eclipse.sw360:client", version.ref = "sw360Client" }
+wagon-http = { module = "org.apache.maven.wagon:wagon-http", version.ref = "wagonHttp" }
 wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 xz = { module = "org.tukaani:xz", version.ref = "xz" }
 

--- a/plugins/package-managers/maven/build.gradle.kts
+++ b/plugins/package-managers/maven/build.gradle.kts
@@ -45,6 +45,10 @@ dependencies {
     // container automatically. They are required on the classpath for Maven dependency resolution to work.
     runtimeOnly(libs.bundles.mavenResolver)
 
+    // Under certain circumstances, Tycho uses Wagon to download metadata for SNAPSHOT artifacts. Therefore, at
+    // least the wagon-http dependency should be available on the classpath.
+    runtimeOnly(libs.wagon.http)
+
     // TODO: Remove this once https://issues.apache.org/jira/browse/MNG-6561 is resolved.
     runtimeOnly(libs.maven.compat)
 


### PR DESCRIPTION
When fetching metadata for snapshot artifacts, Tycho seems to use Wagon to download this data from repositories. So, the Wagon HTTP provider needs to be present on the classpath.

The exact circumstances when Tycho uses Wagon are unclear; but analyzing a real-life project failed with an error message that no wagon could be found supporting the protocol "https". Adding this artifact to the classpath fixed the issue.
