### PR TITLE
fix(cli): Do not output ORT_* environment variables unless set

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -57,12 +57,9 @@ import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.mebibytes
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.Environment
-import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
-import org.ossreviewtoolkit.utils.ort.ORT_DATA_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ort.ORT_NAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
-import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.ort.printStackTrace
 
 import org.slf4j.LoggerFactory
@@ -207,11 +204,7 @@ class OrtMain : CliktCommand(ORT_NAME) {
             row {
                 val content = mutableListOf("Environment variables:")
 
-                listOf(
-                    ORT_CONFIG_DIR_ENV_NAME to ortConfigDirectory.path,
-                    ORT_DATA_DIR_ENV_NAME to ortDataDirectory.path,
-                    *env.variables.toList().toTypedArray()
-                ).mapTo(content) { (key, value) ->
+                env.variables.mapTo(content) { (key, value) ->
                     val safeValue = value.replaceCredentialsInUri(MaskedString.DEFAULT_MASK)
                     "${Theme.Default.info(key)} = ${Theme.Default.warning(safeValue)}"
                 }

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -168,7 +168,7 @@ data class OrtConfiguration(
                     PropertySource.map(it)
                 },
                 file?.takeIf { it.isFile }?.let {
-                    logger.info { "Using ORT configuration file '$it'." }
+                    logger.info { "Using ORT configuration file '${it.absolutePath}'." }
 
                     PropertySource.file(it)
                 }

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -190,6 +190,8 @@ data class OrtConfiguration(
                     throw ConfigException(message)
                 }
 
+                logger.info { "All property sources were empty, falling back to the default configuration." }
+
                 OrtConfiguration()
             }
 

--- a/utils/ort/src/main/kotlin/Environment.kt
+++ b/utils/ort/src/main/kotlin/Environment.kt
@@ -99,6 +99,10 @@ data class Environment(
         val ORT_USER_AGENT = "$ORT_NAME/$ORT_VERSION"
 
         private val RELEVANT_VARIABLES = listOf(
+            // ORT variables.
+            ORT_DATA_DIR_ENV_NAME,
+            ORT_CONFIG_DIR_ENV_NAME,
+            ORT_TOOLS_DIR_ENV_NAME,
             // Windows variables.
             "USERPROFILE",
             "OS",


### PR DESCRIPTION
The previous code did always output values for `ORT_CONFIG_DIR` and `ORT_DATA_DIR` even if these variables were not set, in which case their internal defaults were shown. This is confusion when dealing with reports from users, as it is unclear whether these variables were actually set.

Change the code to only show values for these variables if they really were set, aligning with the behavior for third-party variables shown.

While at it, also show `ORT_TOOLS_DIR` if set.