### PR TITLE
feat(helper-cli): Extend PackageList by a concluded license

### DIFF
--- a/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/helper-cli/src/funTest/assets/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -88,6 +88,7 @@ analyzer:
       purl: "pkg:github/example-org/example-dependency-two@v2.0.0"
       declared_licenses: []
       declared_licenses_processed: {}
+      concluded_license: "MIT-Festival"
       description: ""
       homepage_url: ""
       binary_artifact:

--- a/helper-cli/src/funTest/assets/package-list.yml
+++ b/helper-cli/src/funTest/assets/package-list.yml
@@ -28,6 +28,7 @@ dependencies:
       path: "vcs-path/dependency-two"
     sourceArtifact:
       url: "https://example.org/example-dependency-two.zip"
+    concludedLicense: "MIT-Festival"
     isExcluded: false
     isDynamicallyLinked: false
     labels:

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -58,6 +58,7 @@ import org.ossreviewtoolkit.utils.config.setPackageCurations
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 internal class CreateAnalyzerResultFromPackageListCommand : OrtHelperCommand(
     help = "A command which turns a package list file into an analyzer result."
@@ -151,6 +152,7 @@ private data class Dependency(
     val vcs: Vcs? = null,
     val sourceArtifact: SourceArtifact? = null,
     val declaredLicenses: Set<String> = emptySet(),
+    val concludedLicense: SpdxExpression? = null,
     val isExcluded: Boolean = false,
     val isDynamicallyLinked: Boolean = false,
     val labels: Map<String, String> = emptyMap()
@@ -200,6 +202,7 @@ private fun Dependency.toPackage(): Package {
         sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash ?: Hash.NONE) }.orEmpty(),
         vcs = vcsInfo,
         declaredLicenses = declaredLicenses,
+        concludedLicense = concludedLicense,
         description = "",
         homepageUrl = "",
         binaryArtifact = RemoteArtifact.EMPTY,


### PR DESCRIPTION
When a project does not use a package manager (supported by ORT), the helper-cli provides one alternative way to create an analyzer result from a package list file. Allow to also inject the concluded license to support the corresponding use cases without the need for using separate curations.

