### PR TITLE
build(gradle): Ensure a deterministic classpath order for the pathing JAR

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -173,7 +173,7 @@ val pathingJar by tasks.registering(Jar::class) {
     manifest {
         // Work around the command line length limit on Windows when passing the classpath to Java, see
         // https://github.com/gradle/gradle/issues/1989.
-        attributes["Class-Path"] = configurations.runtimeClasspath.get().joinToString(" ") { it.name }
+        attributes["Class-Path"] = configurations.runtimeClasspath.get().sorted().joinToString(" ") { it.name }
     }
 }
 


### PR DESCRIPTION
This should make debugging classpath ordering related issues easier.