### PR TITLE
Exclude binary license files to prevent reporter hang

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ slf4j = "2.0.17"
 springCore = "6.2.7"
 svnkit = "1.10.12"
 sw360Client = "17.0.1-m2"
+tika = "3.1.0"
 wagonHttp = "3.5.3"
 wiremock = "3.13.0"
 xmlutil = "0.91.1"
@@ -186,6 +187,7 @@ slf4j = { module = "org.slf4j:slf4j-api ", version.ref = "slf4j" }
 springCore = { module = "org.springframework:spring-core", version.ref = "springCore" }
 svnkit = { module = "com.tmatesoft.svnkit:svnkit", version.ref = "svnkit" }
 sw360Client = { module = "org.eclipse.sw360:client", version.ref = "sw360Client" }
+tika = { module = "org.apache.tika:tika-core", version.ref = "tika" }
 wagon-http = { module = "org.apache.maven.wagon:wagon-http", version.ref = "wagonHttp" }
 wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 xz = { module = "org.tukaani:xz", version.ref = "xz" }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.postgres)
     implementation(libs.semver4j)
+    implementation(libs.tika)
 
     testFixturesImplementation(projects.utils.testUtils)
 


### PR DESCRIPTION
Binary license files are now detected and excluded during license info resolution. In previous cases, such files caused the reporter to enter an endless loop during report generation, as the archiver attempted to include the binary content in the report.

To verify this behavior, a test file named LICENSE-BIN is added to archive.zip. It contains 4 arbitrary bytes created with a hex editor to simulate a non-text license file.

Apache Tika is introduced to detect MIME types and distinguish between text and non-text files. This ensures that only valid, readable license files are processed and included in the final report.