### PR TITLE
feat(freemarker): Add `val PackageModel.labels` for convenient access

### DIFF
--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -161,6 +161,12 @@ class FreemarkerTemplateProcessor(
         val excluded: Boolean by lazy { input.ortResult.isExcluded(id) }
 
         /**
+         * The labels for the package.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        val labels: Map<String, String> by lazy { input.ortResult.getPackage(id)?.metadata?.labels.orEmpty() }
+
+        /**
          * The resolved license information for the package.
          */
         val license: ResolvedLicenseInfo by lazy {


### PR DESCRIPTION
Package labels can be used for injecting custom data into any plain text report. So, make it more convenient for the '.ftl' to access the labels.
