### PR TITLE
fix(swiftpm): Use `identity` as `name` for Swift PM registry dependencies

### DIFF
--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v3-with-SPM-registry-dependency.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-only-lockfile-v3-with-SPM-registry-dependency.yml
@@ -1,0 +1,48 @@
+---
+project:
+  id: "SwiftPM::src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved:<REPLACE_REVISION>"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "Swift::alamofire.alamofire:5.4.4"
+packages:
+- id: "Swift::alamofire.alamofire:5.4.4"
+  purl: "pkg:swift/alamofire.alamofire@5.4.4"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved
@@ -1,0 +1,13 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire.alamofire",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "5.4.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/plugins/package-managers/swiftpm/src/funTest/kotlin/SwiftPmFunTest.kt
+++ b/plugins/package-managers/swiftpm/src/funTest/kotlin/SwiftPmFunTest.kt
@@ -73,6 +73,19 @@ class SwiftPmFunTest : WordSpec({
         }
     }
 
+    "Analyzing a lockfile with a dependency loaded over SPM registry instead of source control" should {
+        "return the correct result" {
+            val definitionFile =
+                getAssetFile("projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved")
+            val expectedResultFile =
+                getAssetFile("projects/synthetic/expected-output-only-lockfile-v3-with-SPM-registry-dependency.yml")
+
+            val result = SwiftPmFactory.create().resolveSingleProject(definitionFile)
+
+            result.withInvariantIssues().toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+        }
+    }
+
     "Analyzing a definition file with a sibling lockfile" should {
         "return the correct result" {
             val definitionFile = getAssetFile("projects/synthetic/project-with-lockfile/Package.swift")

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -244,7 +244,12 @@ private fun PinV2.toId(): Identifier =
     Identifier(
         type = PACKAGE_TYPE,
         namespace = "",
-        name = getCanonicalName(location),
+        // For SPM registry dependencies the `location` field is blank, so use the `identity` field instead.
+        name = if (kind == PinV2.Kind.REGISTRY) {
+            identity
+        } else {
+            getCanonicalName(location)
+        },
         version = state?.run {
             when {
                 !version.isNullOrBlank() -> version


### PR DESCRIPTION
Currently only the `location` field is used to derive the `name` of a Swift PM dependency. For dependencies fetched over a [Package Registry Service (Swift PM registry)](https://forums.swift.org/t/swift-package-registry-service/37219) the `location` field is empty which leads to incomplete and invalid results. For those dependencies the `identity` needs to be used instead.

_Technical notes:_

- Screenshots of a broken and fixed scan with SPM registries involved:

broken:
![broken_spm_registry_deps](https://github.com/user-attachments/assets/596c1fd5-4811-48a8-8a50-2d069b047241)
fixed:
![fixed_spm_registry_deps](https://github.com/user-attachments/assets/79df1b50-340f-41f4-a375-39872d6a9a5a)
_Note:_ Like seen, the scan also stops resolving the broken SPM registries further which results in much shorter scan results.

- Test outcome of the newly added test without the fix:
expected:
```yml
project:
  id: "SwiftPM::src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved:e1d45fb08d20491de87deb7decd464633707ebaf"
  definition_file_path: "plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved"
  declared_licenses: []
  declared_licenses_processed: {}
  vcs:
    type: ""
    url: ""
    revision: ""
    path: ""
  vcs_processed:
    type: "Git"
    url: "https://github.com/oss-review-toolkit/ort.git"
    revision: "e1d45fb08d20491de87deb7decd464633707ebaf"
    path: "plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency"
  homepage_url: ""
  scopes:
  - name: "dependencies"
    dependencies:
    - id: "Swift::alamofire.alamofire:5.4.4"
packages:
- id: "Swift::alamofire.alamofire:5.4.4"
  purl: "pkg:swift/alamofire.alamofire@5.4.4"
  declared_licenses: []
  declared_licenses_processed: {}
  description: ""
  homepage_url: ""
  binary_artifact:
    url: ""
    hash:
      value: ""
      algorithm: ""
  source_artifact:
    url: ""
    hash:
      value: ""
      algorithm: ""
  vcs:
    type: ""
    url: ""
    revision: ""
    path: ""
  vcs_processed:
    type: ""
    url: ""
    revision: ""
    path: ""
```

but was:

```yml
project:
  id: "SwiftPM::src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved:e1d45fb08d20491de87deb7decd464633707ebaf"
  definition_file_path: "plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved"
  declared_licenses: []
  declared_licenses_processed: {}
  vcs:
    type: ""
    url: ""
    revision: ""
    path: ""
  vcs_processed:
    type: "Git"
    url: "https://github.com/oss-review-toolkit/ort.git"
    revision: "e1d45fb08d20491de87deb7decd464633707ebaf"
    path: "plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency"
  homepage_url: ""
  scopes:
  - name: "dependencies"
    dependencies:
    - id: "Swift::null:5.4.4"
packages:
- id: "Swift::null:5.4.4"
  purl: "pkg:swift/null@5.4.4"
  declared_licenses: []
  declared_licenses_processed: {}
  description: ""
  homepage_url: ""
  binary_artifact:
    url: ""
    hash:
      value: ""
      algorithm: ""
  source_artifact:
    url: ""
    hash:
      value: ""
      algorithm: ""
  vcs:
    type: ""
    url: ""
    revision: ""
    path: ""
  vcs_processed:
    type: ""
    url: ""
    revision: ""
    path: ""
```