### PR TITLE
feat(utils): Make `OrtAuthenticator` extensible

### DIFF
--- a/utils/ort/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/OrtAuthenticator.kt
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.kotlin.logger
  * A caching authenticator that chains other authenticators. For proxy authentication, the [OrtProxySelector] is
  * required to also be installed.
  */
-class OrtAuthenticator(private val original: Authenticator? = null) : Authenticator() {
+open class OrtAuthenticator(private val original: Authenticator? = null) : Authenticator() {
     companion object {
         /**
          * Install this authenticator as the global default.
@@ -72,7 +72,7 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
     // credentials in a netrc-style file, and finally look for generic credentials passed as environment variables.
     // If none of these can provide credentials, fall back to the original authenticator, if any. This allows tools
     // that use ORT programmatically to provide a custom authenticator.
-    private val delegateAuthenticators = listOfNotNull(
+    protected open val delegateAuthenticators = listOfNotNull(
         UserInfoAuthenticator(),
         NetRcAuthenticator(),
         EnvVarAuthenticator(),


### PR DESCRIPTION
In b2d09a69, `OrtAuthenticator` has been extended to fall back to the originally installed authenticator if no matching credentials can be found. It turned out that this is not sufficient for all scenarios in which ORT is invoked programmatically. Especially ORT Server needs more control over the authentication mechanism and sometimes needs to override credentials returned by ORT's implementation.

Therefore, make `OrtAuthenticator` an open class and support overriding the list of delegate authenticators. This gives integrating code much more flexibility to set up authentication.
