### PR TITLE
Add functionality to deal with a "main license"

### DIFF
--- a/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
-import org.ossreviewtoolkit.utils.spdx.andOrNull
+import org.ossreviewtoolkit.utils.spdx.toExpression
 
 internal class GetPackageLicensesCommand : OrtHelperCommand(
     help = "Shows the root license and the detected license for a package denoted by the given package identifier."
@@ -113,7 +113,7 @@ internal class GetPackageLicensesCommand : OrtHelperCommand(
 }
 
 private fun Collection<LicenseFinding>.toSpdxExpression(): String =
-    map { it.license }.andOrNull()?.sorted()?.toString() ?: SpdxConstants.NONE
+    map { it.license }.toExpression()?.sorted()?.toString() ?: SpdxConstants.NONE
 
 private data class Result(
     val detectedLicense: String,

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.utils.common.zip
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression.Strictness.ALLOW_LICENSEREF_EXCEPTIONS
-import org.ossreviewtoolkit.utils.spdx.andOrNull
+import org.ossreviewtoolkit.utils.spdx.toExpression
 
 /**
  * This class contains curation data for a package. It is used to amend the automatically detected metadata for a
@@ -184,7 +184,7 @@ data class PackageCurationData(
             purl = purl ?: other.purl,
             cpe = cpe ?: other.cpe,
             authors = authors.orEmpty() + other.authors.orEmpty(),
-            concludedLicense = setOfNotNull(concludedLicense, other.concludedLicense).andOrNull(),
+            concludedLicense = setOfNotNull(concludedLicense, other.concludedLicense).toExpression(),
             description = description ?: other.description,
             homepageUrl = homepageUrl ?: other.homepageUrl,
             binaryArtifact = binaryArtifact ?: other.binaryArtifact,

--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -77,21 +77,19 @@ class DefaultLicenseInfoProvider(val ortResult: OrtResult) : LicenseInfoProvider
         )
 
     private fun createDetectedLicenseInfo(id: Identifier): DetectedLicenseInfo {
-        val findings = mutableListOf<Findings>()
-
-        ortResult.getScanResultsForId(id).map {
+        val findings = ortResult.getScanResultsForId(id).map {
             // If a VCS path curation has been applied after the scanning stage, it is possible to apply that
             // curation without re-scanning in case the new VCS path is a subdirectory of the scanned VCS path.
             // So, filter by VCS path to enable the user to see the effect on the detected license with a shorter
             // turn around time / without re-scanning.
             it.filterByVcsPath(ortResult.getPackage(id)?.metadata?.vcsProcessed?.path.orEmpty())
-        }.forEach { (provenance, _, summary, _) ->
-            val config = getConfiguration(id, provenance)
+        }.map {
+            val config = getConfiguration(id, it.provenance)
 
-            findings += Findings(
-                provenance = provenance,
-                licenses = summary.licenseFindings,
-                copyrights = summary.copyrightFindings,
+            Findings(
+                provenance = it.provenance,
+                licenses = it.summary.licenseFindings,
+                copyrights = it.summary.copyrightFindings,
                 licenseFindingCurations = config.licenseFindingCurations,
                 pathExcludes = config.pathExcludes,
                 relativeFindingsPath = config.relativeFindingsPath

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.utils.ort.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
-import org.ossreviewtoolkit.utils.spdx.andOrNull
 import org.ossreviewtoolkit.utils.spdx.toExpression
 
 /**
@@ -75,7 +74,7 @@ data class ResolvedLicenseInfo(
     fun toCompoundExpression(): SpdxExpression? =
         licenses.flatMapTo(mutableSetOf()) { resolvedLicense ->
             resolvedLicense.originalExpressions.map { it.expression }
-        }.andOrNull()
+        }.toExpression()
 
     /**
      * Return the main license of a package (or project) as an [SpdxExpression], or null if there is no main license.

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxOperator
 import org.ossreviewtoolkit.utils.spdx.SpdxSimpleExpression
+import org.ossreviewtoolkit.utils.spdx.toExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 /**
@@ -322,11 +323,7 @@ fun associateLicensesWithExceptions(license: SpdxExpression): SpdxExpression {
 
                 handledExceptions += validLicenseExceptionCombinations.map { it.exception }
 
-                when (validLicenseExceptionCombinations.size) {
-                    0 -> childLicense
-                    1 -> validLicenseExceptionCombinations.first()
-                    else -> SpdxCompoundExpression(SpdxOperator.AND, validLicenseExceptionCombinations)
-                }
+                validLicenseExceptionCombinations.toExpression() ?: childLicense
             }
 
             else -> childLicense
@@ -341,11 +338,5 @@ fun associateLicensesWithExceptions(license: SpdxExpression): SpdxExpression {
     }
 
     // Recreate the compound AND-expression from the associated licenses.
-    check(associatedLicenses.isNotEmpty())
-
-    return if (associatedLicenses.size == 1) {
-        associatedLicenses.first()
-    } else {
-        SpdxCompoundExpression(SpdxOperator.AND, associatedLicenses)
-    }
+    return checkNotNull(associatedLicenses.toExpression())
 }

--- a/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
+++ b/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
@@ -47,7 +47,7 @@ import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
-import org.ossreviewtoolkit.utils.spdx.andOrNull
+import org.ossreviewtoolkit.utils.spdx.toExpression
 
 private const val ISSUE_PRIORITY = 900
 
@@ -356,7 +356,7 @@ class OpossumReporter(
                     val license = licenseFindings
                         .filter { it.location.path == pathFromFinding }
                         .map { it.license }
-                        .andOrNull()
+                        .toExpression()
 
                     val pathSignal = OpossumSignal.create(
                         source,

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -150,7 +150,7 @@ internal fun Package.toSpdxPackage(
         SpdxPackageVerificationCode(packageVerificationCodeValue = it)
     }
 
-    val resolvedLicenseExpressions = licenseInfoResolver.resolveLicenseInfo(id).filterExcluded()
+    val resolvedLicenseInfo = licenseInfoResolver.resolveLicenseInfo(id).filterExcluded()
         .applyChoices(ortResult.getPackageLicenseChoices(id))
         .applyChoices(ortResult.getRepositoryLicenseChoices())
 
@@ -180,7 +180,7 @@ internal fun Package.toSpdxPackage(
             SpdxPackageType.PROJECT -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
             else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
         },
-        licenseDeclared = resolvedLicenseExpressions.mainLicense()
+        licenseDeclared = resolvedLicenseInfo.mainLicense()
             ?.simplify()
             ?.sorted()
             ?.nullOrBlankToSpdxNoassertionOrNone()
@@ -188,7 +188,7 @@ internal fun Package.toSpdxPackage(
         licenseInfoFromFiles = if (packageVerificationCode == null) {
             emptyList()
         } else {
-            resolvedLicenseExpressions.filter(LicenseView.ONLY_DETECTED)
+            resolvedLicenseInfo.filter(LicenseView.ONLY_DETECTED)
                 .mapTo(mutableSetOf()) { it.license.nullOrBlankToSpdxNoassertionOrNone() }
                 .sorted()
         },

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
-import org.ossreviewtoolkit.utils.spdx.andOrNull
+import org.ossreviewtoolkit.utils.spdx.toExpression
 
 /**
  * Generate a summary from the given SCANOSS [result], using [startTime], [endTime] as metadata. This variant can be
@@ -157,7 +157,7 @@ private fun getSnippets(details: ScanFileDetails): Set<Snippet> {
     return buildSet {
         purls.forEach { purl ->
             locations.forEach { snippetLocation ->
-                val license = licenses.andOrNull()?.sorted() ?: SpdxLicenseIdExpression(SpdxConstants.NOASSERTION)
+                val license = licenses.toExpression()?.sorted() ?: SpdxLicenseIdExpression(SpdxConstants.NOASSERTION)
 
                 add(Snippet(score, snippetLocation, provenance, purl, license))
             }

--- a/utils/spdx/src/main/kotlin/Extensions.kt
+++ b/utils/spdx/src/main/kotlin/Extensions.kt
@@ -39,6 +39,19 @@ fun SpdxExpression?.nullOrBlankToSpdxNoassertionOrNone(): String =
     }
 
 /**
+ * Combine this collection of [SpdxExpression]s into one using the [operator], or return null if the collection is
+ * empty.
+ */
+fun Collection<SpdxExpression>.toExpression(operator: SpdxOperator = SpdxOperator.AND): SpdxExpression? =
+    distinct().run {
+        when (size) {
+            0 -> null
+            1 -> first()
+            else -> SpdxCompoundExpression(operator, this)
+        }
+    }
+
+/**
  * Create an [SpdxLicenseIdExpression] from this [SpdxLicense].
  */
 fun SpdxLicense.toExpression(): SpdxLicenseIdExpression {

--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -292,7 +292,7 @@ class SpdxCompoundExpression(
             return children.sortedBy { it.toString() }
         }
 
-        return getSortedChildrenWithSameOperator(this).concat(operator)
+        return checkNotNull(getSortedChildrenWithSameOperator(this).toExpression(operator))
     }
 
     override fun validate(strictness: Strictness) {
@@ -632,42 +632,3 @@ data class SpdxLicenseReferenceExpression(
 
     override fun getLicenseUrl(): String? = null
 }
-
-/**
- * Shortcut for [concat]([SpdxOperator.AND]).
- */
-fun Collection<SpdxExpression>.and(): SpdxExpression = concat(SpdxOperator.AND)
-
-/**
- * Shortcut for [concatOrNull]([SpdxOperator.AND]).
- */
-fun Collection<SpdxExpression>.andOrNull(): SpdxExpression? = concatOrNull(SpdxOperator.AND)
-
-/**
- * Shortcut for [concat]([SpdxOperator.OR]).
- */
-fun Collection<SpdxExpression>.or(): SpdxExpression = concat(SpdxOperator.OR)
-
-/**
- * Shortcut for [concatOrNull]([SpdxOperator.OR]).
- */
-fun Collection<SpdxExpression>.orOrNull(): SpdxExpression? = concatOrNull(SpdxOperator.OR)
-
-/**
- * Return an n-ary compound expression if this collection contains multiple expression, or the single expression in
- * case this collection contains just a single element. Throws if the collection is empty.
- */
-fun Collection<SpdxExpression>.concat(operator: SpdxOperator): SpdxExpression {
-    require(isNotEmpty()) {
-        "Cannot create a concatenated SPDX expression from an empty collection."
-    }
-
-    val distinctExpressions = distinct()
-    return distinctExpressions.singleOrNull() ?: SpdxCompoundExpression(operator, distinctExpressions)
-}
-
-/**
- * Return null if this collection is empty or else the result of [concat].
- */
-fun Collection<SpdxExpression>.concatOrNull(operator: SpdxOperator): SpdxExpression? =
-    takeIf { it.isNotEmpty() }?.concat(operator)

--- a/utils/spdx/src/main/kotlin/parser/SpdxExpressionParser.kt
+++ b/utils/spdx/src/main/kotlin/parser/SpdxExpressionParser.kt
@@ -20,12 +20,12 @@
 package org.ossreviewtoolkit.utils.spdx.parser
 
 import org.ossreviewtoolkit.utils.common.nextOrNull
-import org.ossreviewtoolkit.utils.spdx.SpdxCompoundExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseReferenceExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxOperator
+import org.ossreviewtoolkit.utils.spdx.toExpression
 
 /**
  * A parser for SPDX expressions. It consumes a sequence of [Token]s and produces an [SpdxExpression].
@@ -102,10 +102,7 @@ class SpdxExpressionParser(
             children.add(parseAndExpression())
         }
 
-        return when {
-            children.size > 1 -> SpdxCompoundExpression(SpdxOperator.OR, children)
-            else -> children.first()
-        }
+        return checkNotNull(children.toExpression(SpdxOperator.OR))
     }
 
     /**
@@ -119,10 +116,7 @@ class SpdxExpressionParser(
             children.add(parsePrimary())
         }
 
-        return when {
-            children.size > 1 -> SpdxCompoundExpression(SpdxOperator.AND, children)
-            else -> children.first()
-        }
+        return checkNotNull(children.toExpression(SpdxOperator.AND))
     }
 
     /**

--- a/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
@@ -355,7 +355,6 @@ class SpdxExpressionChoiceTest : WordSpec({
             val expression = listOf(
                 "Apache-1.1",
                 "Apache-2.0",
-                "Apache-2.0",
                 "Artistic-1.0-Perl",
                 "Artistic-2.0",
                 "BSD-2-Clause",

--- a/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
@@ -338,16 +338,6 @@ class SpdxExpressionChoiceTest : WordSpec({
             )
         }
 
-        "be explicit about the choices even if they could be simplified" {
-            val choices = "(a OR b) AND (a OR b)".toSpdx().validChoices()
-
-            choices.map { it.toString() } should containExactlyInAnyOrder(
-                "a",
-                "b AND a",
-                "b"
-            )
-        }
-
         "return in reasonable time for a complex AND expression".config(
             blockingTest = true,
             timeout = 150.milliseconds

--- a/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionChoiceTest.kt
@@ -352,14 +352,52 @@ class SpdxExpressionChoiceTest : WordSpec({
             blockingTest = true,
             timeout = 150.milliseconds
         ) {
-            val expression = "Apache-1.1 AND OFL-1.1 AND Apache-2.0 AND Apache-2.0 AND Artistic-1.0-Perl AND " +
-                "Artistic-2.0 AND BSD-2-Clause AND BSD-2-Clause-Darwin AND BSD-2-Clause-Views AND BSD-3-Clause AND " +
-                "BSL-1.0 AND CC-BY-2.5 AND CC-BY-4.0 AND CDDL-1.0 AND CDDL-1.1 AND CPL-1.0 AND EPL-1.0 AND " +
-                "EPL-2.0 AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-only WITH Classpath-exception-2.0 AND " +
-                "GPL-2.0-or-later AND GPL-2.0-or-later WITH Classpath-exception-2.0 AND ICU AND ISC AND JSON AND " +
-                "LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND " +
-                "LPPL-1.3c AND MIT AND MPL-1.0 AND MPL-1.1 AND MPL-2.0 AND NTP AND Noweb AND Python-2.0 AND Ruby AND " +
-                "Unicode-DFS-2016 AND W3C AND W3C-19980720 AND W3C-20150513"
+            val expression = listOf(
+                "Apache-1.1",
+                "Apache-2.0",
+                "Apache-2.0",
+                "Artistic-1.0-Perl",
+                "Artistic-2.0",
+                "BSD-2-Clause",
+                "BSD-2-Clause-Darwin",
+                "BSD-2-Clause-Views",
+                "BSD-3-Clause",
+                "BSL-1.0",
+                "CC-BY-2.5",
+                "CC-BY-4.0",
+                "CDDL-1.0",
+                "CDDL-1.1",
+                "CPL-1.0",
+                "EPL-1.0",
+                "EPL-2.0",
+                "GPL-1.0-or-later",
+                "GPL-2.0-only WITH Classpath-exception-2.0",
+                "GPL-2.0-only",
+                "GPL-2.0-or-later WITH Classpath-exception-2.0",
+                "GPL-2.0-or-later",
+                "ICU",
+                "ISC",
+                "JSON",
+                "LGPL-2.0-only",
+                "LGPL-2.0-or-later",
+                "LGPL-2.1-only",
+                "LGPL-2.1-or-later",
+                "LGPL-3.0-only",
+                "LPPL-1.3c",
+                "MIT",
+                "MPL-1.0",
+                "MPL-1.1",
+                "MPL-2.0",
+                "NTP",
+                "Noweb",
+                "OFL-1.1",
+                "Python-2.0",
+                "Ruby",
+                "Unicode-DFS-2016",
+                "W3C",
+                "W3C-19980720",
+                "W3C-20150513"
+            ).joinToString(separator = " AND ")
 
             val choices = expression.toSpdx().validChoices()
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

@fviernau, I realized only after my second commit that you already introduced `concat()`-based functions like `andOrNull()` which serve a similar purpose as the function I'm introducing. The last commit removes your functions in favor of mine, as I felt it to be a bit more generic, and it avoids potential confusions when reading "andOrNull", where "Or" could be misinterpreted as an SPDX operator. Please have a look.