### PR TITLE
build(gradle): Do not explicitly enable KSP 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,6 @@ org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true
 
 kotlin.code.style = official
-ksp.useKSP2 = true
 
 # The version of the JDK to use for building ORT.
 # Keep this aligned with `toolchainVersion` in `gradle/gradle-daemon-jvm.properties`.


### PR DESCRIPTION
This is the default now as of KSP 2.1.20-2.0.0 [1], which was taken into use in https://github.com/oss-review-toolkit/ort/commit/00f5279c020a955cca7f0e990768447a257f5995.

[1]: https://github.com/google/ksp/releases/tag/2.1.20-2.0.0