### PR TITLE
fix(docker): Install `wheel` after a potential `pip` upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,8 +167,8 @@ RUN scancode-license-data --path /opt/scancode-license-data \
 
 RUN pip install --no-cache-dir -U \
     pip=="$PIP_VERSION" \
-    wheel \
     && pip install --no-cache-dir -U \
+    wheel \
     Mercurial \
     conan=="$CONAN_VERSION" \
     pipenv=="$PYTHON_PIPENV_VERSION" \


### PR DESCRIPTION
If `pip` was upgraded, `wheel` needs to be installed for that new version. This fixes the `conan` installation to complain about

    error: invalid command 'bdist_wheel'