### PR TITLE
Tycho target dependencies

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/tycho/P2RepositoryContentLoader.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/P2RepositoryContentLoader.kt
@@ -135,14 +135,14 @@ internal class P2RepositoryContentLoader : AutoCloseable {
          */
         private fun parseArtifactsFile(file: File): Map<String, Hash> {
             val handler = ElementHandler(ParseArtifactsState())
-                .handleElement("artifact") { state, attributes ->
+                .handleElement("artifact") { state, attributes, _ ->
                     state.withCurrentArtifactId(
                         bundleIdentifier(
                             attributes.getValue("id"),
                             attributes.getValue("version")
                         ).takeIf { attributes.getValue("classifier") == "osgi.bundle" }
                     )
-                }.handleElement("property") { state, attributes ->
+                }.handleElement("property") { state, attributes, _ ->
                     state.withProperty(attributes.getValue("name"), attributes.getValue("value"))
                 }
 
@@ -161,7 +161,7 @@ internal class P2RepositoryContentLoader : AutoCloseable {
             logger.info { "Parsing composite artifacts information for repository '$baseUrl'." }
 
             val handler = ElementHandler(ParseCompositeArtifactsState(URI.create("$baseUrl/compositeArtifacts.xml")))
-                .handleElement("child") { state, attributes ->
+                .handleElement("child") { state, attributes, _ ->
                     state.withChildRepository(attributes.getValue("location"))
                 }
 
@@ -289,26 +289,30 @@ internal data class P2RepositoryContent(
  * repository.
  */
 private data class ParseArtifactsState(
-    /** The ID of the artifact whose properties are currently processed. */
-    val currentArtifactId: String? = null,
+    /** The properties of the current artifact. */
+    val currentProperties: MutableMap<String, String> = mutableMapOf(),
 
     /** A [Map] with the aggregated properties of all encountered artifacts. */
-    val properties: MutableMap<String, MutableMap<String, String>> = mutableMapOf()
+    val properties: MutableMap<String, Map<String, String>> = mutableMapOf()
 ) {
     /**
      * Return an updated [ParseArtifactsState] instance that has the given [artifactId] set as current artifact.
      */
-    fun withCurrentArtifactId(artifactId: String?) = copy(currentArtifactId = artifactId)
+    fun withCurrentArtifactId(artifactId: String?): ParseArtifactsState {
+        artifactId?.also { id ->
+            properties[id] = HashMap(currentProperties)
+        }
+
+        currentProperties.clear()
+        return this
+    }
 
     /**
      * Return an updated [ParseArtifactsState] instance that stores the property defined by the given [key] and [value]
      * for the current artifact.
      */
     fun withProperty(key: String, value: String): ParseArtifactsState {
-        if (currentArtifactId == null) return this
-
-        val artifactProperties = properties.getOrPut(currentArtifactId) { mutableMapOf() }
-        artifactProperties[key] = value
+        currentProperties[key] = value
 
         return this
     }

--- a/plugins/package-managers/maven/src/main/kotlin/tycho/TargetHandler.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/TargetHandler.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.maven.tycho
+
+import java.io.File
+
+/**
+ * A helper class to manage information stored in Tycho target files.
+ *
+ * The target platform plays an important role in Tycho builds as it contains essential information for resolving
+ * dependencies. The Tycho package manager implementation delegates to Tycho itself for the dependency resolution.
+ * However, some information from target files is nevertheless needed to obtain correct metadata for dependencies.
+ * This class is responsible for detecting target files in the analysis root directory and extracting the relevant
+ * data.
+ *
+ * See https://wiki.eclipse.org/Tycho/Target_Platform/.
+ */
+internal class TargetHandler(
+    /** A set with the URLs of the P2 repositories defined in the target files. */
+    val repositoryUrls: Set<String>
+) {
+    companion object {
+        /**
+         * Create an instance of [TargetHandler] that loads its data from target files found below the given
+         * [projectRoot] folder.
+         */
+        fun create(projectRoot: File): TargetHandler {
+            return TargetHandler(collectP2RepositoriesFromTargetFiles(projectRoot))
+        }
+
+        /**
+         * Collect all P2 repositories defined in a Tycho target file found under the given [projectRoot].
+         */
+        private fun collectP2RepositoriesFromTargetFiles(projectRoot: File): Set<String> {
+            // TODO: There may be a better way to locate target files by inspecting the projects found in the build.
+            val targetFiles = projectRoot.walkTopDown().filter {
+                it.name.endsWith(".target") && it.isFile
+            }.toList()
+
+            return targetFiles.flatMapTo(mutableSetOf(), ::parseTargetFile)
+        }
+
+        /**
+         * Parse the given [targetFile] and extract the repository URLs referenced in it.
+         */
+        private fun parseTargetFile(targetFile: File): Set<String> {
+            val handler = ElementHandler(ParseTargetFileState())
+                .handleElement("repository") { state, attributes ->
+                    state.repositoryUrls += attributes.getValue("location")
+                    state
+                }
+
+            return parseXml(targetFile, handler).repositoryUrls
+        }
+    }
+}
+
+/**
+ * A data class to store the state during parsing of a target file.
+ */
+private data class ParseTargetFileState(
+    /** The [Set] with the URLs of repositories that have been found so far. */
+    val repositoryUrls: MutableSet<String> = mutableSetOf()
+)

--- a/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
@@ -115,7 +115,8 @@ class Tycho(override val descriptor: PluginDescriptor = TychoFactory.Companion.d
         val collector = TychoProjectsCollector()
         val (exitCode, buildLog) = runBuild(collector, definitionFile.parentFile)
 
-        val resolver = P2ArtifactResolver.create(definitionFile.parentFile, collector.mavenProjects.values)
+        val targetHandler = TargetHandler.create(definitionFile.parentFile)
+        val resolver = P2ArtifactResolver.create(targetHandler, collector.mavenProjects.values)
 
         val resolvedProjects = createMavenSupport(collector).use { mavenSupport ->
             graphBuilder = createGraphBuilder(mavenSupport, collector.mavenProjects, resolver, repositoryHelper)

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TargetHandlerTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TargetHandlerTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.maven.tycho
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import java.io.File
+
+class TargetHandlerTest : WordSpec({
+    "repositoryUrls" should {
+        "be empty if no target files are found" {
+            val projectRoot = tempdir()
+            val targetHandler = TargetHandler.create(projectRoot)
+
+            targetHandler.repositoryUrls should beEmpty()
+        }
+
+        "collect P2 repositories from target files" {
+            val root = tempdir()
+            val targetFile1 = File("src/test/assets/tycho.target")
+            val targetFile2 = File("src/test/assets/tycho.other.target")
+            val module1 = root.resolve("module1").also { it.mkdirs() }
+            val module2 = root.resolve("module2").also { it.mkdirs() }
+            val subModule = module2.resolve("subModule.target").also { it.mkdirs() }
+            targetFile1.copyTo(module1.resolve("tycho.target"))
+            targetFile2.copyTo(subModule.resolve("tycho.other.target"))
+
+            val targetHandler = TargetHandler.create(root)
+
+            targetHandler.repositoryUrls shouldContainExactlyInAnyOrder listOf(
+                "https://p2.example.com/repo/download.eclipse.org/modeling/tmf/xtext/updates/releases/2.37.0/",
+                "https://p2.example.org/repo/download.eclipse.org/modeling/emft/mwe/updates/releases/2.20.0/",
+                "https://p2.example.com/repository/download.eclipse.org/releases/2024-12",
+                "https://p2.other.example.com/repo/other/test/"
+            )
+        }
+    }
+})

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TargetHandlerTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TargetHandlerTest.kt
@@ -19,13 +19,19 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.maven.tycho
 
+import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 import java.io.File
+
+import org.eclipse.aether.artifact.DefaultArtifact
 
 class TargetHandlerTest : WordSpec({
     "repositoryUrls" should {
@@ -37,16 +43,7 @@ class TargetHandlerTest : WordSpec({
         }
 
         "collect P2 repositories from target files" {
-            val root = tempdir()
-            val targetFile1 = File("src/test/assets/tycho.target")
-            val targetFile2 = File("src/test/assets/tycho.other.target")
-            val module1 = root.resolve("module1").also { it.mkdirs() }
-            val module2 = root.resolve("module2").also { it.mkdirs() }
-            val subModule = module2.resolve("subModule.target").also { it.mkdirs() }
-            targetFile1.copyTo(module1.resolve("tycho.target"))
-            targetFile2.copyTo(subModule.resolve("tycho.other.target"))
-
-            val targetHandler = TargetHandler.create(root)
+            val targetHandler = createTargetHandlerWithTargetFiles()
 
             targetHandler.repositoryUrls shouldContainExactlyInAnyOrder listOf(
                 "https://p2.example.com/repo/download.eclipse.org/modeling/tmf/xtext/updates/releases/2.37.0/",
@@ -56,4 +53,41 @@ class TargetHandlerTest : WordSpec({
             )
         }
     }
+
+    "mapToMavenDependency()" should {
+        "return null if an artifact cannot be mapped to a Maven dependency" {
+            val tychoArtifact = DefaultArtifact("groupId", "artifactId", "ext", "version")
+            val targetHandler = TargetHandler.create(tempdir())
+
+            targetHandler.mapToMavenDependency(tychoArtifact) should beNull()
+        }
+
+        "return the correct Maven dependency if an artifact can be mapped" {
+            val tychoArtifact = DefaultArtifact("p2.eclipse.plugin", "ch.qos.logback.logback-classic", "jar", "1.5.6")
+            val targetHandler = createTargetHandlerWithTargetFiles()
+
+            targetHandler.mapToMavenDependency(tychoArtifact).shouldNotBeNull {
+                groupId shouldBe "ch.qos.logback"
+                artifactId shouldBe "logback-classic"
+                version shouldBe "1.5.6"
+            }
+        }
+    }
 })
+
+/**
+ * Create a new [TargetHandler] instance that is initialized from a folder structure which contains some test
+ * target files.
+ */
+private fun TestConfiguration.createTargetHandlerWithTargetFiles(): TargetHandler {
+    val root = tempdir()
+    val targetFile1 = File("src/test/assets/tycho.target")
+    val targetFile2 = File("src/test/assets/tycho.other.target")
+    val module1 = root.resolve("module1").also { it.mkdirs() }
+    val module2 = root.resolve("module2").also { it.mkdirs() }
+    val subModule = module2.resolve("subModule.target").also { it.mkdirs() }
+    targetFile1.copyTo(module1.resolve("tycho.target"))
+    targetFile2.copyTo(subModule.resolve("tycho.other.target"))
+
+    return TargetHandler.create(root)
+}

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
@@ -234,6 +234,10 @@ class TychoTest : WordSpec({
             val subProject = createMavenProject("sub")
             val projectsList = listOf(rootProject, subProject)
 
+            mockkObject(TargetHandler)
+            val targetHandler = mockk<TargetHandler>()
+            every { TargetHandler.create(definitionFile.parentFile) } returns targetHandler
+
             val tycho = spyk(Tycho())
             injectCliMock(tycho, projectsList.toJson(), projectsList)
 
@@ -247,7 +251,7 @@ class TychoTest : WordSpec({
 
             val slotProjects = slot<Collection<MavenProject>>()
             verify {
-                P2ArtifactResolver.create(definitionFile.parentFile, capture(slotProjects))
+                P2ArtifactResolver.create(targetHandler, capture(slotProjects))
             }
 
             slotProjects.captured shouldContainExactlyInAnyOrder projectsList


### PR DESCRIPTION
This PR adds a special handling to the Tycho implementation for Maven artifacts declared in a Tycho target platform file. Currently, such dependencies are not processed correctly because Tycho references them using alternative identifiers. To fix this, more information is parsed from target file, and some mapping logic is applied.

Refer to the single commits for further details.