### PR TITLE
feat(FossId): Improve failure handling

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
@@ -35,6 +35,10 @@ typealias MapResponseBody<T> = EntityResponseBody<Map<String, T>>
 
 typealias PolymorphicResponseBody<T> = EntityResponseBody<PolymorphicList<T>>
 
+typealias PolymorphicDataResponseBody<T> = EntityResponseBody<PolymorphicData<T>>
+
 class PolymorphicList<T>(data: List<T> = listOf()) : List<T> by data
 
 class PolymorphicInt(val value: Int?)
+
+class PolymorphicData<out T>(val value: T?)

--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -283,7 +283,7 @@ suspend fun FossIdRestService.listMatchedLines(
     scanCode: String,
     path: String,
     snippetId: Int
-): EntityResponseBody<MatchedLines> {
+): PolymorphicDataResponseBody<MatchedLines> {
     val base64Path = Base64.encode(path.toByteArray())
     return listMatchedLines(
         PostRequestBody(

--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -30,6 +30,7 @@ import okio.sink
 
 import org.apache.logging.log4j.kotlin.logger
 
+import org.ossreviewtoolkit.clients.fossid.model.CreateScanResponse
 import org.ossreviewtoolkit.clients.fossid.model.identification.common.LicenseMatchType
 import org.ossreviewtoolkit.clients.fossid.model.report.ReportType
 import org.ossreviewtoolkit.clients.fossid.model.report.SelectionType
@@ -149,7 +150,7 @@ suspend fun FossIdRestService.createScan(
     gitRepoUrl: String,
     gitBranch: String,
     comment: String = ""
-): MapResponseBody<String> =
+): PolymorphicDataResponseBody<CreateScanResponse> =
     createScan(
         PostRequestBody(
             "create",

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -43,6 +43,7 @@ import okhttp3.ResponseBody
 
 import org.apache.logging.log4j.kotlin.logger
 
+import org.ossreviewtoolkit.clients.fossid.model.CreateScanResponse
 import org.ossreviewtoolkit.clients.fossid.model.Project
 import org.ossreviewtoolkit.clients.fossid.model.Scan
 import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
@@ -273,7 +274,7 @@ interface FossIdRestService {
     suspend fun createProject(@Body body: PostRequestBody): MapResponseBody<String>
 
     @POST("api.php")
-    suspend fun createScan(@Body body: PostRequestBody): MapResponseBody<String>
+    suspend fun createScan(@Body body: PostRequestBody): PolymorphicDataResponseBody<CreateScanResponse>
 
     @POST("api.php")
     suspend fun runScan(@Body body: PostRequestBody): EntityResponseBody<Nothing>

--- a/clients/fossid-webapp/src/main/kotlin/model/CreateScanResponse.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/CreateScanResponse.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.fossid.model
+
+/**
+ * This class is present to handle the high polymorphism of the 'createScan' response.
+ */
+data class CreateScanResponse(
+    // Normal response.
+    val scanId: String? = null,
+
+    // Error response when there is a credentials issue (see https://github.com/oss-review-toolkit/ort/issues/8462).
+    val code: String? = null,
+    val message: String? = null,
+    val messageParameters: Map<String, String>? = null
+)

--- a/clients/fossid-webapp/src/test/kotlin/FossId2024dot2Test.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossId2024dot2Test.kt
@@ -77,7 +77,7 @@ class FossId2024dot2Test : StringSpec({
         service.getProject("", "", PROJECT_CODE_2024) shouldNotBeNull {
             checkResponse("get project")
 
-            data.shouldNotBeNull().isArchived shouldBe false
+            data?.value.shouldNotBeNull().isArchived shouldBe false
         }
     }
 })

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -95,7 +95,7 @@ class FossIdClientNewProjectTest : StringSpec({
             SCAN_CODE,
             "https://github.com/gundy/semver4j.git",
             "671aa533f7e33c773bf620b9f466650c3b9ab26e"
-        ).shouldNotBeNull().data.shouldNotBeNull() shouldContain("scan_id" to "4920")
+        ).shouldNotBeNull().data?.value?.scanId shouldBe "4920"
     }
 
     "Download from Git can be triggered" {

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -107,7 +107,7 @@ class FossIdClientNewProjectTest : StringSpec({
     "Download status can be queried" {
         service.checkDownloadStatus("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("check download status")
-            data shouldBe DownloadStatus.FINISHED
+            data?.value shouldBe DownloadStatus.FINISHED
         }
     }
 

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.maps.shouldContainValue
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -253,6 +254,28 @@ class FossIdClientReturnTypeTest : StringSpec({
     "When the scan to delete does not exist, no exception is thrown" {
         service.deleteScan("", "", SCAN_CODE_1) shouldNotBeNull {
             error shouldBe "Classes.TableRepository.row_not_found"
+        }
+    }
+
+    "When create scan returns an error, no exception is thrown" {
+        service.createScan(
+            "",
+            "",
+            PROJECT_CODE_1,
+            SCAN_CODE_1,
+            "git_repo_url",
+            "develop"
+        ) shouldNotBeNull {
+            message shouldBe "These issues were found while parsing the request:"
+            data?.value?.message shouldBe "Field git_repo_url: there was an issue executing command: timeout 200 git " +
+                "ls-remote 'ssh git repo' 2>&1. Exit status: 128. Output: Repository not found The requested " +
+                "repository does not exist, or you do not have permission to access it. fatal: Could not read from " +
+                "remote repository.  Please make sure you have the correct access rights and the repository exists."
+            data?.value?.messageParameters?.shouldContainValue(
+                "Repository not found The requested repository does not exist, or you do not have permission " +
+                    "to access it. fatal: Could not read from remote repository.  Please make sure you have the " +
+                    "correct access rights and the repository exists."
+            )
         }
     }
 

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -74,7 +74,7 @@ class FossIdClientReturnTypeTest : StringSpec({
     "Single scan can be queried" {
         service.getScan("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("get scan")
-            data.shouldBeTypeOf<Scan>()
+            data?.value.shouldBeTypeOf<Scan>()
         }
     }
 
@@ -88,7 +88,7 @@ class FossIdClientReturnTypeTest : StringSpec({
     "Scans for project can be listed when there is exactly one" {
         service.listScansForProject("", "", PROJECT_CODE_3) shouldNotBeNull {
             checkResponse("list scans")
-            data shouldNotBeNull {
+            data.shouldNotBeNull {
                 size shouldBe 1
                 first().shouldBeTypeOf<Scan>()
             }
@@ -167,7 +167,7 @@ class FossIdClientReturnTypeTest : StringSpec({
             119
         ) shouldNotBeNull {
             checkResponse("list matched lines")
-            data shouldNotBeNull {
+            data?.value shouldNotBeNull {
                 localFile shouldNot beEmpty()
                 mirrorFile shouldNot beEmpty()
             }
@@ -318,6 +318,13 @@ class FossIdClientReturnTypeTest : StringSpec({
             "TestORT"
         ) shouldNotBeNull {
             checkResponse("add file comment")
+        }
+    }
+
+    "An error response can be parsed" {
+        service.getProject("", "", "semver4j_2_20201203_090342") shouldNotBeNull {
+            error shouldBe "Classes.FossID.user_not_found_or_api_key_is_not_correct"
+            message shouldBe "User is not found or API key is incorrect"
         }
     }
 })

--- a/clients/fossid-webapp/src/test/resources/return-type/mappings/apiphp-create_scan.json
+++ b/clients/fossid-webapp/src/test/resources/return-type/mappings/apiphp-create_scan.json
@@ -1,0 +1,26 @@
+{
+  "id" : "ae6669fb-7ca6-496a-9268-7e4eebb64007",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"action\":\"create\",\"group\":\"scans\",\"data\":{\"username\":\"\",\"key\":\"\",\"scan_code\":\"semver4j_20201203_090342\",\"project_code\":\"semver4j\",\"git_repo_url\":\"git_repo_url\",\"git_branch\":\"develop\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"operation\":\"scans_create\",  \"status\":\"0\",  \"data\":[{\"code\": \"RequestData.Base.issue_with_executing_command\",    \"message\":\"Field git_repo_url: there was an issue executing command: timeout 200 git ls-remote 'ssh git repo' 2>&1. Exit status: 128. Output: Repository not found The requested repository does not exist, or you do not have permission to access it. fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists.\",    \"message_parameters\":{\"fieldname\":\"git_repo_url\",      \"cmd\":\"timeout 200 git ls-remote 'ssh git repo' 2>&1\",      \"exitStatus\":128,      \"out\":\"Repository not found The requested repository does not exist, or you do not have permission to access it. fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists.\"}  }],  \"error\":\"RequestData.Base.issues_while_parsing_request\",  \"message\":\"These issues were found while parsing the request:\",  \"message_parameters\":[]}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 03 Dec 2020 08:03:42 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "ae6669fb-7ca6-496a-9268-7e4eebb64007",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/clients/fossid-webapp/src/test/resources/return-type/mappings/apiphp-get_project_error.json
+++ b/clients/fossid-webapp/src/test/resources/return-type/mappings/apiphp-get_project_error.json
@@ -1,0 +1,26 @@
+{
+  "id" : "2ee103eb-e768-446c-8e50-316969023512",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{  \"action\" : \"get_information\",  \"group\" : \"projects\",  \"data\" : {    \"username\":\"\",    \"key\":\"\",    \"project_code\": \"semver4j_2_20201203_090342\"  }}  ",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{  \"operation\": \"projects_get_information\",  \"status\": \"0\",  \"data\": [], \"error\": \"Classes.FossID.user_not_found_or_api_key_is_not_correct\", \"message\": \"User is not found or API key is incorrect\", \"message_parameters\": []}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Wed, 16 Apr 2025 07:03:22 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "2ee103eb-e768-446c-8e50-316969023512",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -679,7 +679,16 @@ class FossId internal constructor(
             .createScan(config.user.value, config.apiKey.value, projectCode, scanCode, url, revision, reference)
             .checkResponse("create scan")
 
-        val scanId = response.data?.get("scan_id")
+        val data = response.data?.value
+
+        if (data?.message != null) {
+            logger.warn {
+                "Create scan returned an error content as payload (see issue #8462)." +
+                    " Additional information: ${data.message}"
+            }
+        }
+
+        val scanId = data?.scanId
 
         requireNotNull(scanId) { "Scan could not be created. The response was: ${response.message}." }
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -237,9 +237,9 @@ class FossId internal constructor(
     private suspend fun getProject(projectCode: String): Project? =
         service.getProject(config.user.value, config.apiKey.value, projectCode).run {
             when {
-                error == null && data != null -> {
+                error == null && data?.value != null -> {
                     logger.info { "Project '$projectCode' exists." }
-                    data
+                    data?.value
                 }
 
                 error == "Project does not exist" && status == 0 -> {
@@ -747,7 +747,7 @@ class FossId internal constructor(
             val response = service.checkDownloadStatus(config.user.value, config.apiKey.value, scanCode)
                 .checkResponse("check download status")
 
-            when (response.data) {
+            when (response.data?.value) {
                 DownloadStatus.FINISHED -> return@wait true
 
                 DownloadStatus.FAILED -> error("Could not download scan: ${response.message}.")
@@ -888,7 +888,7 @@ class FossId internal constructor(
                                     snippet.id
                                 ).checkResponse("list snippets matched lines")
 
-                                val lines = checkNotNull(matchedLinesResponse.data) {
+                                val lines = checkNotNull(matchedLinesResponse.data?.value) {
                                     "Matched lines could not be listed. Response was " +
                                         "${matchedLinesResponse.message}."
                                 }

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
@@ -36,6 +36,7 @@ import io.mockk.unmockkObject
 import org.ossreviewtoolkit.clients.fossid.EntityResponseBody
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.FossIdServiceWithVersion
+import org.ossreviewtoolkit.clients.fossid.PolymorphicData
 import org.ossreviewtoolkit.clients.fossid.PolymorphicList
 import org.ossreviewtoolkit.clients.fossid.PolymorphicResponseBody
 import org.ossreviewtoolkit.clients.fossid.addComponentIdentification
@@ -971,7 +972,7 @@ fun FossIdServiceWithVersion.mockFiles(
     if (matchedLines.isNotEmpty()) {
         coEvery { listMatchedLines(USER, API_KEY, scanCode, any(), any()) } answers {
             val lines = matchedLines[arg(5)]
-            EntityResponseBody(status = 1, data = lines)
+            EntityResponseBody(status = 1, data = PolymorphicData(lines))
         }
     }
 

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.runInterruptible
 import org.ossreviewtoolkit.clients.fossid.EntityResponseBody
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.MapResponseBody
+import org.ossreviewtoolkit.clients.fossid.PolymorphicData
 import org.ossreviewtoolkit.clients.fossid.checkDownloadStatus
 import org.ossreviewtoolkit.clients.fossid.createIgnoreRule
 import org.ossreviewtoolkit.clients.fossid.createProject
@@ -193,7 +194,7 @@ class FossIdTest : WordSpec({
             coEvery { service.downloadFromGit(USER, API_KEY, scanCode) } returns
                 EntityResponseBody(status = 1)
             coEvery { service.checkDownloadStatus(USER, API_KEY, scanCode) } returns
-                EntityResponseBody(status = 1, data = DownloadStatus.FAILED)
+                EntityResponseBody(status = 1, data = PolymorphicData(DownloadStatus.FAILED))
 
             val fossId = createFossId(config)
             fossId.scan(createPackage(createIdentifier(index = 1), vcsInfo))

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.ossreviewtoolkit.clients.fossid.EntityResponseBody
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.FossIdServiceWithVersion
-import org.ossreviewtoolkit.clients.fossid.MapResponseBody
 import org.ossreviewtoolkit.clients.fossid.PolymorphicData
+import org.ossreviewtoolkit.clients.fossid.PolymorphicDataResponseBody
 import org.ossreviewtoolkit.clients.fossid.PolymorphicInt
 import org.ossreviewtoolkit.clients.fossid.PolymorphicList
 import org.ossreviewtoolkit.clients.fossid.PolymorphicResponseBody
@@ -48,6 +48,7 @@ import org.ossreviewtoolkit.clients.fossid.listMatchedLines
 import org.ossreviewtoolkit.clients.fossid.listPendingFiles
 import org.ossreviewtoolkit.clients.fossid.listScansForProject
 import org.ossreviewtoolkit.clients.fossid.listSnippets
+import org.ossreviewtoolkit.clients.fossid.model.CreateScanResponse
 import org.ossreviewtoolkit.clients.fossid.model.Scan
 import org.ossreviewtoolkit.clients.fossid.model.identification.common.LicenseMatchType
 import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
@@ -548,7 +549,10 @@ internal fun FossIdServiceWithVersion.expectCreateScan(
 ): FossIdServiceWithVersion {
     coEvery {
         createScan(USER, API_KEY, projectCode, scanCode, vcsInfo.url, vcsInfo.revision, comment)
-    } returns MapResponseBody(status = 1, data = mapOf("scan_id" to SCAN_ID.toString()))
+    } returns PolymorphicDataResponseBody(
+        status = 1,
+        data = PolymorphicData(CreateScanResponse(SCAN_ID.toString()))
+    )
     return this
 }
 

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.clients.fossid.EntityResponseBody
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.FossIdServiceWithVersion
 import org.ossreviewtoolkit.clients.fossid.MapResponseBody
+import org.ossreviewtoolkit.clients.fossid.PolymorphicData
 import org.ossreviewtoolkit.clients.fossid.PolymorphicInt
 import org.ossreviewtoolkit.clients.fossid.PolymorphicList
 import org.ossreviewtoolkit.clients.fossid.PolymorphicResponseBody
@@ -466,7 +467,7 @@ internal fun FossIdServiceWithVersion.expectProjectRequest(
     error: String? = null
 ): FossIdServiceWithVersion {
     coEvery { getProject(USER, API_KEY, projectCode) } returns
-        EntityResponseBody(status = status, error = error, data = mockk())
+        EntityResponseBody(status = status, error = error, data = PolymorphicData(mockk()))
     return this
 }
 
@@ -531,7 +532,7 @@ internal fun FossIdServiceWithVersion.expectDownload(scanCode: String): FossIdSe
     coEvery { downloadFromGit(USER, API_KEY, scanCode) } returns
         EntityResponseBody(status = 1)
     coEvery { checkDownloadStatus(USER, API_KEY, scanCode) } returns
-        EntityResponseBody(status = 1, data = DownloadStatus.FINISHED)
+        EntityResponseBody(status = 1, data = PolymorphicData(DownloadStatus.FINISHED))
     return this
 }
 
@@ -597,7 +598,7 @@ internal fun FossIdServiceWithVersion.mockFiles(
         PolymorphicResponseBody(status = 1, data = PolymorphicList(snippets))
     if (matchedLinesFlag) {
         coEvery { listMatchedLines(USER, API_KEY, scanCode, any(), any()) } returns
-            EntityResponseBody(status = 1, data = matchedLines)
+            EntityResponseBody(status = 1, data = PolymorphicData(matchedLines))
     }
 
     return this


### PR DESCRIPTION
For some requests, failure responses returned by FossID could not be deserialized. This made diagnosing failures really hard, since the deserialization exception swallowed the original response. To improve this situation, add logic to handle failure responses at least in some cases.

This PR has still some limitations. Especially, requests for which the result value is ignored (type `EntityResponseBody<Nothing>`) do not work with this approach. Creating this as draft as a proposal, so that there is a chance that anybody comes up with a better solution - or it is decided that this can be merged as is, since it provides some improvements.