### PR TITLE
feat(scanner): Improve S3 storage support

### DIFF
--- a/model/src/main/kotlin/config/FileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/FileStorageConfiguration.kt
@@ -60,7 +60,7 @@ data class FileStorageConfiguration(
         if (storage is S3FileStorageConfiguration) {
             return S3FileStorage(
                 storage.accessKeyId, storage.awsRegion, storage.bucketName, storage.compression,
-                storage.customEndpoint, storage.secretAccessKey
+                storage.customEndpoint, storage.pathStyleAccess, storage.secretAccessKey
             )
         }
 

--- a/model/src/main/kotlin/config/S3FileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/S3FileStorageConfiguration.kt
@@ -32,7 +32,7 @@ data class S3FileStorageConfiguration(
     /** The name of the S3 bucket used to store files in. */
     val bucketName: String,
 
-    /** Whether to use compression for storing files or not. Defaults to true. */
+    /** Whether to use compression for storing files or not. Defaults to false. */
     val compression: Boolean = false,
 
     /** Custom endpoint to perform AWS API Requests */

--- a/model/src/main/kotlin/config/S3FileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/S3FileStorageConfiguration.kt
@@ -38,6 +38,9 @@ data class S3FileStorageConfiguration(
     /** Custom endpoint to perform AWS API Requests */
     val customEndpoint: String? = null,
 
+    /** Whether to enable path style access or not. Required for many non-AWS S3 providers. Defaults to false. */
+    val pathStyleAccess: Boolean = false,
+
     /** The AWS secret for the access key. */
     val secretAccessKey: String? = null
 )

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -309,6 +309,7 @@ ort:
             bucketName: "ort-scan-results"
             compression: false
             customEndpoint: "http://localhost:4567"
+            pathStyleAccess: false # Required for some non-AWS S3 providers that do not support DNS style access.
             secretAccessKey: "secret"
 
       clearlyDefined:

--- a/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
@@ -68,25 +68,26 @@ class S3FileStorage(
     private val secretAccessKey: String? = null
 ) : FileStorage {
     private val s3Client: S3Client by lazy {
-        val provider = if (accessKeyId != null && secretAccessKey != null) {
-            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey))
-        } else {
-            null
-        }
-
-        if (awsRegion != null && provider != null) {
-            S3Client.builder()
-                .region(Region.of(awsRegion))
-                .credentialsProvider(provider)
-                .endpointOverride(if (customEndpoint != null) URI(customEndpoint) else null)
-                .build()
-        } else {
+        S3Client.builder().apply {
             if (awsRegion != null) {
-                S3Client.builder().region(Region.of(awsRegion)).build()
-            } else {
-                S3Client.create()
+                region(Region.of(awsRegion))
             }
-        }
+
+            if (accessKeyId != null && secretAccessKey != null) {
+                credentialsProvider(
+                    StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                            accessKeyId,
+                            secretAccessKey
+                        )
+                    )
+                )
+            }
+
+            if (customEndpoint != null) {
+                endpointOverride(URI(customEndpoint))
+            }
+        }.build()
     }
 
     override fun exists(path: String): Boolean {

--- a/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
@@ -29,6 +29,8 @@ import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
 import org.apache.logging.log4j.kotlin.logger
 
+import org.ossreviewtoolkit.utils.common.collectMessages
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.sync.RequestBody
@@ -95,7 +97,7 @@ class S3FileStorage(
 
         return runCatching { s3Client.headObject(request) }.onFailure { exception ->
             if (exception !is NoSuchKeyException) {
-                logger.warn { "Unable to retrieve status for S3 key $path. Error: ${exception.message}" }
+                logger.warn { "Unable to read '$path' from S3 bucket '$bucketName': ${exception.collectMessages()}" }
             }
         }.isSuccess
     }
@@ -134,7 +136,9 @@ class S3FileStorage(
         runCatching {
             s3Client.putObject(request, body)
         }.onFailure { exception ->
-            if (exception is S3Exception) logger.warn { "Can not write '$path' to S3 bucket '$bucketName'." }
+            if (exception is S3Exception) {
+                logger.warn { "Can not write '$path' to S3 bucket '$bucketName': ${exception.collectMessages()}" }
+            }
         }
     }
 

--- a/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
@@ -64,6 +64,9 @@ class S3FileStorage(
     /** Custom endpoint to perform AWS API Requests */
     private val customEndpoint: String? = null,
 
+    /** Whether to enable path style access or not. Required for many non-AWS S3 providers. Defaults to false. */
+    private val pathStyleAccess: Boolean = false,
+
     /** The AWS secret for the access key. */
     private val secretAccessKey: String? = null
 ) : FileStorage {
@@ -86,6 +89,9 @@ class S3FileStorage(
 
             if (customEndpoint != null) {
                 endpointOverride(URI(customEndpoint))
+                serviceConfiguration {
+                    it.pathStyleAccessEnabled(pathStyleAccess)
+                }
             }
         }.build()
     }

--- a/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/S3FileStorage.kt
@@ -58,7 +58,7 @@ class S3FileStorage(
     /** The name of the S3 bucket used to store files in. */
     private val bucketName: String,
 
-    /** Whether to use compression for storing files or not. Defaults to true. */
+    /** Whether to use compression for storing files or not. Defaults to false. */
     private val compression: Boolean = false,
 
     /** Custom endpoint to perform AWS API Requests */


### PR DESCRIPTION
I tried getting the S3 backend to work with our own Ceph S3 cluster, but it didn't work. It's due to pathStyleAccess being disabled per default in the AWS SDK. I also cleaned up the client builder conditions a bit.