### PR TITLE
feat(commands): Make the `plugins` output more easily comparable

### DIFF
--- a/plugins/commands/plugins/src/main/kotlin/PluginsCommand.kt
+++ b/plugins/commands/plugins/src/main/kotlin/PluginsCommand.kt
@@ -62,22 +62,17 @@ class PluginsCommand(descriptor: PluginDescriptor = PluginsCommandFactory.descri
         echo()
 
         plugins.forEach { plugin ->
-            echo(
-                HorizontalRule(
-                    buildString {
-                        append(plugin.displayName)
-                        if (plugin.id != plugin.displayName) append(" (id: ${plugin.id})")
-                    },
-                    "-"
-                )
-            )
+            echo(HorizontalRule(plugin.displayName))
             echo()
-            echo(plugin.description)
+
+            echo("ID: ${plugin.id}")
+            echo()
+
+            echo("Description: ${plugin.description}")
             echo()
 
             if (plugin.options.isNotEmpty()) {
-                echo("Configuration options:")
-
+                echo("Options:")
                 echo(
                     UnorderedList(
                         listEntries = plugin.options.map { option ->
@@ -92,7 +87,9 @@ class PluginsCommand(descriptor: PluginDescriptor = PluginsCommandFactory.descri
                         bulletText = "*"
                     )
                 )
-
+                echo()
+            } else {
+                echo("Options: None")
                 echo()
             }
         }


### PR DESCRIPTION
This allows to easily diff the textual output to compare changes in plugin IDs.