### PR TITLE
Yarn2: Improve getting the remote package details

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/NodePackageManagerSupport.kt
+++ b/plugins/package-managers/node/src/main/kotlin/NodePackageManagerSupport.kt
@@ -233,3 +233,12 @@ internal fun splitNamespaceAndName(rawName: String): Pair<String, String> {
     val namespace = rawName.removeSuffix(name).removeSuffix("/")
     return Pair(namespace, name)
 }
+
+internal val PackageJson.moduleId: String get() =
+    buildString {
+        append(name.orEmpty())
+        if (!version.isNullOrBlank()) {
+            append("@")
+            append(version)
+        }
+    }

--- a/plugins/package-managers/node/src/main/kotlin/yarn/YarnDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn/YarnDependencyHandler.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.plugins.packagemanagers.node.NodePackageManagerType
 import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageJson
+import org.ossreviewtoolkit.plugins.packagemanagers.node.moduleId
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackage
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackageJson
 import org.ossreviewtoolkit.utils.ort.runBlocking
@@ -97,12 +98,3 @@ internal class YarnDependencyHandler(private val yarn: Yarn) : DependencyHandler
         }
     }
 }
-
-private val PackageJson.moduleId: String get() =
-    buildString {
-        append(name.orEmpty())
-        if (!version.isNullOrBlank()) {
-            append("@")
-            append(version)
-        }
-    }


### PR DESCRIPTION
This cleans-up the code around `getRemotePackageDetails()` and changes the way how things get parallelized.
It's also an alignment with other node managers.

**Before**

![Screenshot from 2025-04-28 09-52-06](https://github.com/user-attachments/assets/6e50f509-9741-41cc-870a-02bfa743c7ae)

**After**

![Screenshot from 2025-04-28 09-51-32](https://github.com/user-attachments/assets/4ef03498-5f9c-4a6a-b9a5-86c4e38565f5)

Part of: https://github.com/oss-review-toolkit/ort/issues/9261.