### PR TITLE
fix(freemarker): Remove uncategorized licenses from category filter

### DIFF
--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -224,13 +224,12 @@ class FreemarkerTemplateProcessor(
         }
 
         /**
-         * Return only those [licenses] that are classified under the given [category], or that are not categorized at
-         * all.
+         * Return only those [licenses] that are classified under the given [category].
          */
         @Suppress("UNUSED") // This function is used in the templates.
         fun filterForCategory(licenses: Collection<ResolvedLicense>, category: String): List<ResolvedLicense> =
             licenses.filter { resolvedLicense ->
-                input.licenseClassifications[resolvedLicense.license]?.contains(category) != false
+                input.licenseClassifications[resolvedLicense.license]?.contains(category) ?: false
             }
 
         /**


### PR DESCRIPTION
Before, `filterForCategory()` returned all licenses that were uncategorized. While this behavior is documented, the behavior is not expected for a function with this name, and it seems like this was an unintentional change in [1].

[1]: ab43f69bd785c700542d74688c454f5066541582
