### PR TITLE
build(gradle): Remove the `versions` plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
 import org.eclipse.jgit.ignore.FastIgnoreRule
 
 import org.jetbrains.gradle.ext.Gradle
@@ -29,7 +27,6 @@ plugins {
     // Apply third-party plugins.
     alias(libs.plugins.gitSemver)
     alias(libs.plugins.ideaExt)
-    alias(libs.plugins.versions)
 }
 
 semver {
@@ -70,21 +67,6 @@ extensions.findByName("develocity")?.withGroovyBuilder {
     getProperty("buildScan")?.withGroovyBuilder {
         setProperty("termsOfUseUrl", "https://gradle.com/terms-of-service")
         setProperty("termsOfUseAgree", "yes")
-    }
-}
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
-    gradleReleaseChannel = "current"
-    outputFormatter = "json"
-
-    val nonFinalQualifiers = listOf(
-        "alpha", "b", "beta", "cr", "dev", "ea", "eap", "m", "milestone", "pr", "preview", "rc", "\\d{14}"
-    ).joinToString("|", "(", ")")
-
-    val nonFinalQualifiersRegex = Regex(".*[.-]$nonFinalQualifiers[.\\d-+]*", RegexOption.IGNORE_CASE)
-
-    rejectVersionIf {
-        candidate.version.matches(nonFinalQualifiersRegex)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ kotlinPlugin = "2.1.20"
 ksp = "2.1.20-2.0.0"
 mavenPublishPlugin = "0.31.0"
 reproducibleBuildsPlugin = "1.0"
-versionsPlugin = "0.52.0"
 
 aeSecurity = "0.136.0"
 asciidoctorj = "3.0.0"
@@ -80,7 +79,6 @@ gitSemver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "gitSe
 ideaExt = { id = "org.jetbrains.gradle.plugin.idea-ext", version.ref = "ideaExtPlugin" }
 jakartaMigration = { id = "com.netflix.nebula.jakartaee-migration", version.ref = "jakartaMigrationPlugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
-versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]
 # These are Maven coordinates for Gradle plugins, which are required for use in precompiled plugin scripts.


### PR DESCRIPTION
The task to update dependencies has been fully taken over by Renovate. Local users may want to give [1] a try instead.

[1]: https://github.com/bishiboosh/caupain