### PR TITLE
fix(analyzer): Handle incomplete JDK records from foojay

### DIFF
--- a/utils/ort/src/main/kotlin/JavaBootstrapper.kt
+++ b/utils/ort/src/main/kotlin/JavaBootstrapper.kt
@@ -105,7 +105,7 @@ object JavaBootstrapper {
             Match.ANY
         )
 
-        val pkg = pkgs.sortedBy { it.id }.find { it.distributionName == distributionName }
+        val pkg = pkgs.sortedBy { it.id }.find { it.distribution?.name == distributionName }
             ?: return Result.failure(
                 IllegalArgumentException(
                     "No JDK package for distribution '$distributionName' in version '$version' found for bootstrapping."


### PR DESCRIPTION
Fix `NullPointerException` in the Java Analyzer's JDK bootstrapping mechanism when the foojay discovery client returns incomplete JDK candidate data. Improve robustness by skipping or safely handling incomplete records during JDK selection.

Log output in ORT Server:

````
level=ERROR logger=o.o.analyzer.PackageManager 
message="Gradle Inspector failed to resolve dependencies for path 'android/build.gradle': 
NullPointerException: Cannot invoke \"io.foojay.api.discoclient.pkg.Distribution.getName()\" because \"this.distribution\" is null"
````
