### PR TITLE
test: Use infix matchers for collections to avoid explicit list creation

### DIFF
--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -20,8 +20,9 @@
 package org.ossreviewtoolkit.analyzer
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.VcsInfo
@@ -64,7 +65,7 @@ class PackageManagerTest : WordSpec({
         }
 
         "handle multiple authors per string" {
-            parseAuthorString("Paul Miller (http://paulmillr.com), Elan Shanker").shouldContainExactlyInAnyOrder(
+            parseAuthorString("Paul Miller (http://paulmillr.com), Elan Shanker") should containExactlyInAnyOrder(
                 AuthorInfo("Paul Miller", null, "http://paulmillr.com"),
                 AuthorInfo("Elan Shanker", null, null)
             )

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -28,8 +28,8 @@ import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -157,7 +157,7 @@ class ExamplesFunTest : StringSpec({
 
         val result = evaluator.run(script)
 
-        result.violations.map { it.rule } shouldContainExactlyInAnyOrder listOf(
+        result.violations.map { it.rule } should containExactlyInAnyOrder(
             "COPYLEFT_LIMITED_IN_SOURCE",
             "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML",
             "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",

--- a/evaluator/src/test/kotlin/EvaluatorTest.kt
+++ b/evaluator/src/test/kotlin/EvaluatorTest.kt
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.evaluator
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -185,7 +185,7 @@ class EvaluatorTest : WordSpec({
 
             val result = Evaluator(incompatibleOrtResult).run(script)
 
-            result.violations.map { it.message } shouldContainExactlyInAnyOrder listOf(
+            result.violations.map { it.message } should containExactlyInAnyOrder(
                 "The outbound license AGPL-3.0-or-later of project 'Maven:group:project-foo:1' is incompatible " +
                     "with the inbound license AGPL-3.0-only of its dependency " +
                     "'Maven:group:package-foo-transitive:1'. Software under a copyleft license such as the " +

--- a/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.collections.containAll
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -193,7 +192,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                     "akka" in node.id.namespace
                 }
 
-                akkaDependencies.shouldContainExactlyInAnyOrder(
+                akkaDependencies should containExactlyInAnyOrder(
                     Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
                     Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
                 )

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -22,10 +22,10 @@ package org.ossreviewtoolkit.model
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.should
@@ -368,7 +368,7 @@ class OrtResultTest : WordSpec({
 
             val ruleViolations = ortResult.getRuleViolations(omitResolved = false, minSeverity = Severity.entries.min())
 
-            ruleViolations.map { it.rule }.shouldContainExactly("rule id")
+            ruleViolations.map { it.rule } should containExactly("rule id")
         }
 
         "drop violations which are resolved or below minSeverity if omitResolved is true and minSeverity is WARNING" {
@@ -419,7 +419,7 @@ class OrtResultTest : WordSpec({
 
             val ruleViolations = ortResult.getRuleViolations(omitResolved = true, minSeverity = Severity.WARNING)
 
-            ruleViolations.map { it.rule }.shouldContainExactly("Rule violation without resolution")
+            ruleViolations.map { it.rule } should containExactly("Rule violation without resolution")
         }
     }
 })

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -20,8 +20,9 @@
 package org.ossreviewtoolkit.model
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.model.FileList.Entry
 import org.ossreviewtoolkit.model.utils.alignRevisions
@@ -90,7 +91,7 @@ class ScannerRunTest : WordSpec({
             )
 
             run.getFileList(id) shouldNotBeNull {
-                files shouldContainExactlyInAnyOrder listOf(
+                files should containExactlyInAnyOrder(
                     Entry("vcs/path/file1.txt", "1111111111111111111111111111111111111111"),
                     Entry("vcs/path/sub/repository/some/dir/file4.txt", "4444444444444444444444444444444444444444")
                 )

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -28,11 +28,8 @@ import io.kotest.engine.spec.tempfile
 import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.maps.containExactly as containExactlyEntries
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -63,9 +60,9 @@ class OrtConfigurationTest : WordSpec({
             ortConfig.forceOverwrite shouldBe true
 
             with(ortConfig.licenseFilePatterns) {
-                licenseFilenames shouldContainExactly listOf("license*")
-                patentFilenames shouldContainExactly listOf("patents")
-                otherLicenseFilenames shouldContainExactly listOf("readme*")
+                licenseFilenames should containExactly("license*")
+                patentFilenames should containExactly("patents")
+                otherLicenseFilenames should containExactly("readme*")
             }
 
             ortConfig.packageCurationProviders should containExactly(
@@ -109,8 +106,8 @@ class OrtConfigurationTest : WordSpec({
                 allowDynamicVersions shouldBe true
                 skipExcluded shouldBe true
 
-                enabledPackageManagers shouldContainExactlyInAnyOrder listOf("Gradle")
-                disabledPackageManagers shouldContainExactlyInAnyOrder listOf("Maven", "NPM")
+                enabledPackageManagers should containExactlyInAnyOrder("Gradle")
+                disabledPackageManagers should containExactlyInAnyOrder("Maven", "NPM")
 
                 packageManagers shouldNotBeNull {
                     get("Gradle") shouldNotBeNull {
@@ -119,7 +116,7 @@ class OrtConfigurationTest : WordSpec({
 
                     get("Yarn2") shouldNotBeNull {
                         options shouldNotBeNull {
-                            this shouldContainExactly mapOf("disableRegistryCertificateVerification" to "false")
+                            this should containExactlyEntries("disableRegistryCertificateVerification" to "false")
                         }
                     }
 
@@ -132,42 +129,42 @@ class OrtConfigurationTest : WordSpec({
             with(ortConfig.advisor) {
                 config shouldNotBeNull {
                     get("GitHubDefects") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "endpointUrl" to "https://api.github.com/graphql",
                             "labelFilter" to "!duplicate, !enhancement, !invalid, !question, !documentation, *",
                             "maxNumberOfIssuesPerRepository" to "50",
                             "parallelRequests" to "5"
                         )
 
-                        secrets shouldContainExactly mapOf(
+                        secrets should containExactlyEntries(
                             "token" to "githubAccessToken"
                         )
                     }
 
                     get("OssIndex") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "serverUrl" to "https://ossindex.sonatype.org/"
                         )
 
-                        secrets shouldContainExactly mapOf(
+                        secrets should containExactlyEntries(
                             "username" to "username",
                             "password" to "password"
                         )
                     }
 
                     get("OSV") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "serverUrl" to "https://api.osv.dev"
                         )
                     }
 
                     get("VulnerableCode") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "serverUrl" to "http://localhost:8000",
                             "readTimeout" to "40"
                         )
 
-                        secrets shouldContainExactly mapOf(
+                        secrets should containExactlyEntries(
                             "apiKey" to "0123456789012345678901234567890123456789"
                         )
                     }
@@ -210,7 +207,7 @@ class OrtConfigurationTest : WordSpec({
                     }
                 }
 
-                detectedLicenseMapping shouldContainExactly mapOf(
+                detectedLicenseMapping should containExactlyEntries(
                     "BSD (Three Clause License)" to "BSD-3-clause",
                     "LicenseRef-scancode-generic-cla" to "NOASSERTION"
                 )
@@ -242,7 +239,7 @@ class OrtConfigurationTest : WordSpec({
 
                 config shouldNotBeNull {
                     get("ScanCode") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "commandLine" to "--copyright,--license,--info,--strip-root,--timeout,300",
                             "commandLineNonConfig" to "--processes,4",
                             "preferFileLicense" to "false",
@@ -255,7 +252,7 @@ class OrtConfigurationTest : WordSpec({
                         val urlMapping = "https://my-repo.example.org(?<repoPath>.*) -> " +
                             "ssh://my-mapped-repo.example.org\${repoPath}"
 
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "serverUrl" to "https://fossid.example.com/instance/",
                             "projectName" to "My Project",
                             "namingScanPattern" to "#projectName_#repositoryName_#currentTimestamp_#deltaTag_#branch",
@@ -270,20 +267,20 @@ class OrtConfigurationTest : WordSpec({
                             "sensitivity" to "10"
                         )
 
-                        secrets shouldContainExactly mapOf(
+                        secrets should containExactlyEntries(
                             "user" to "user",
                             "apiKey" to "XYZ"
                         )
                     }
 
                     get("SCANOSS") shouldNotBeNull {
-                        options shouldContainExactly mapOf("apiUrl" to "https://api.osskb.org/")
-                        secrets shouldContainExactly mapOf("apiKey" to "your API key")
+                        options should containExactlyEntries("apiUrl" to "https://api.osskb.org/")
+                        secrets should containExactlyEntries("apiKey" to "your API key")
                     }
                 }
 
                 storages shouldNotBeNull {
-                    keys shouldContainExactlyInAnyOrder setOf(
+                    keys should containExactlyInAnyOrder(
                         "local", "http", "aws", "clearlyDefined", "postgres", "sw360Configuration"
                     )
 
@@ -342,10 +339,10 @@ class OrtConfigurationTest : WordSpec({
                     sw360Storage.token shouldBe "token"
                 }
 
-                storageReaders shouldContainExactly listOf("local", "postgres", "http", "aws", "clearlyDefined")
-                storageWriters shouldContainExactly listOf("postgres")
+                storageReaders should containExactly("local", "postgres", "http", "aws", "clearlyDefined")
+                storageWriters should containExactly("postgres")
 
-                ignorePatterns shouldContainExactly listOf("**/META-INF/DEPENDENCIES")
+                ignorePatterns should containExactly("**/META-INF/DEPENDENCIES")
 
                 provenanceStorage shouldNotBeNull {
                     fileStorage shouldNotBeNull {
@@ -374,27 +371,27 @@ class OrtConfigurationTest : WordSpec({
 
             with(ortConfig.reporter) {
                 config shouldNotBeNull {
-                    keys shouldContainExactlyInAnyOrder setOf("CycloneDx", "FossId", "CtrlXAutomation")
+                    keys should containExactlyInAnyOrder("CycloneDx", "FossId", "CtrlXAutomation")
 
                     get("CycloneDx") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "schema.version" to "1.6"
                         )
                         secrets should beEmpty()
                     }
 
                     get("FossId") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "serverUrl" to "https://fossid.example.com/instance/"
                         )
-                        secrets shouldContainExactly mapOf(
+                        secrets should containExactlyEntries(
                             "user" to "user",
                             "apiKey" to "XYZ"
                         )
                     }
 
                     get("CtrlXAutomation") shouldNotBeNull {
-                        options shouldContainExactly mapOf(
+                        options should containExactlyEntries(
                             "licenseCategoriesToInclude" to "include-in-disclosure-document"
                         )
                         secrets should beEmpty()

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -28,7 +28,6 @@ import io.kotest.matchers.collections.contain
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -175,7 +174,7 @@ class LicenseInfoResolverTest : WordSpec({
             result.licenses.find { it.license == "Apache-2.0 WITH LLVM-exception".toSpdx() } shouldNotBeNull {
                 originalExpressions.filter {
                     it.source == LicenseSource.DETECTED
-                }.map { it.expression } shouldContainExactlyInAnyOrder listOf(
+                }.map { it.expression } should containExactlyInAnyOrder(
                     "Apache-2.0 WITH LLVM-exception".toSpdx()
                 )
             }
@@ -426,7 +425,7 @@ class LicenseInfoResolverTest : WordSpec({
 
             result.licenses.flatMap { resolvedLicense ->
                 resolvedLicense.originalExpressions.filter { it.source == LicenseSource.DETECTED }
-            } shouldContainExactlyInAnyOrder listOf(
+            } should containExactlyInAnyOrder(
                 ResolvedOriginalExpression("Apache-2.0".toSpdx(), LicenseSource.DETECTED, false),
                 ResolvedOriginalExpression("MIT".toSpdx(), LicenseSource.DETECTED, true)
             )
@@ -482,7 +481,7 @@ class LicenseInfoResolverTest : WordSpec({
             )
             result.licenses.flatMap { resolvedLicense ->
                 resolvedLicense.originalExpressions.map { it.expression }
-            } shouldContainExactlyInAnyOrder listOf("MIT".toSpdx())
+            } should containExactlyInAnyOrder("MIT".toSpdx())
         }
 
         "contain a list of the original license expressions" {

--- a/model/src/test/kotlin/licenses/ResolvedLicenseTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseTest.kt
@@ -20,8 +20,9 @@
 package org.ossreviewtoolkit.model.licenses
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.TextLocation
@@ -53,7 +54,7 @@ class ResolvedLicenseTest : WordSpec({
             resolvedCopyrights shouldHaveSize 1
             with(resolvedCopyrights.first()) {
                 statement shouldBe "Copyright (C) 2022 The ORT Project Authors"
-                findings.map { it.location.path }.shouldContainExactlyInAnyOrder("/path/to/file/A", "/path/to/file/B")
+                findings.map { it.location.path } should containExactlyInAnyOrder("/path/to/file/A", "/path/to/file/B")
             }
         }
 
@@ -83,7 +84,7 @@ class ResolvedLicenseTest : WordSpec({
             resolvedCopyrights shouldHaveSize 1
             with(resolvedCopyrights.first()) {
                 statement shouldBe "Copyright (C) 2022 The ORT Project Authors"
-                findings.map { it.location.path }.shouldContainExactlyInAnyOrder("/path/to/file/A", "/path/to/file/B")
+                findings.map { it.location.path } should containExactlyInAnyOrder("/path/to/file/A", "/path/to/file/B")
             }
         }
     }

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -24,7 +24,6 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
@@ -207,7 +206,7 @@ class DependencyGraphBuilderTest : WordSpec({
                 .build()
             val scopes = graph.createScopes()
 
-            scopeDependencies(scopes, scope) shouldContainExactly listOf(depCyc2)
+            scopeDependencies(scopes, scope) should containExactly(depCyc2)
 
             graph.nodes shouldHaveSize 3
         }

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -24,7 +24,6 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -91,7 +90,7 @@ class DependencyGraphConverterTest : WordSpec({
             val convertedResult = DependencyGraphConverter.convert(analyzerResult, excludes)
 
             val allPackagesTypes = convertedResult.packages.mapTo(mutableSetOf()) { it.id.type }
-            allPackagesTypes shouldContainExactlyInAnyOrder listOf("Maven", "Go")
+            allPackagesTypes should containExactlyInAnyOrder("Maven", "Go")
         }
 
         "convert a result with a partial dependency graph" {

--- a/plugins/package-managers/gradle/src/test/kotlin/GradleDependencyHandlerTest.kt
+++ b/plugins/package-managers/gradle/src/test/kotlin/GradleDependencyHandlerTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
@@ -143,7 +142,7 @@ class GradleDependencyHandlerTest : WordSpec({
                 .packages()
                 .map { it.id }
 
-            packageIds shouldContainExactlyInAnyOrder setOf(dep1.toId(), dep2.toId())
+            packageIds should containExactlyInAnyOrder(dep1.toId(), dep2.toId())
         }
 
         "deal with transitive dependencies correctly" {

--- a/plugins/package-managers/maven/src/test/kotlin/MavenTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/MavenTest.kt
@@ -21,7 +21,8 @@ package org.ossreviewtoolkit.plugins.packagemanagers.maven
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.tycho.addTychoExtension
 
@@ -53,7 +54,7 @@ class MavenTest : WordSpec({
             val maven = Maven()
             val mappedDefinitionFiles = maven.mapDefinitionFiles(tempdir(), definitionFiles)
 
-            mappedDefinitionFiles shouldContainExactlyInAnyOrder listOf(mavenDefinitionFile, mavenSubModule)
+            mappedDefinitionFiles should containExactlyInAnyOrder(mavenDefinitionFile, mavenSubModule)
         }
     }
 })

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/DependencyTreeParserTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/DependencyTreeParserTest.kt
@@ -21,10 +21,11 @@ package org.ossreviewtoolkit.plugins.packagemanagers.maven.tycho
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import io.mockk.every
@@ -112,7 +113,7 @@ class DependencyTreeParserTest : WordSpec({
                     scope shouldBe "compile"
                     classifier shouldBe ""
 
-                    children shouldContainExactlyInAnyOrder listOf(
+                    children should containExactlyInAnyOrder(
                         DependencyTreeMojoNode(
                             "org.apache.commons",
                             "commons-lang3",
@@ -388,7 +389,7 @@ class DependencyTreeParserTest : WordSpec({
             ).toList()
 
             projectDependencies.shouldBeSingleton { node ->
-                node.children.map { it.artifact.artifactId } shouldContainExactlyInAnyOrder listOf(
+                node.children.map { it.artifact.artifactId } should containExactlyInAnyOrder(
                     "commons-configuration2",
                     "org.objectweb.asm"
                 )
@@ -430,7 +431,7 @@ class DependencyTreeParserTest : WordSpec({
             ).toList()
 
             projectDependencies.shouldBeSingleton { node ->
-                node.children.map { it.artifact.artifactId } shouldContainExactlyInAnyOrder listOf(
+                node.children.map { it.artifact.artifactId } should containExactlyInAnyOrder(
                     "commons-configuration2",
                     "org.objectweb.asm.source"
                 )
@@ -481,7 +482,7 @@ class DependencyTreeParserTest : WordSpec({
             }.toList()
 
             projectDependencies.shouldBeSingleton { node ->
-                node.children.map { it.artifact.artifactId } shouldContainExactlyInAnyOrder listOf(
+                node.children.map { it.artifact.artifactId } should containExactlyInAnyOrder(
                     "commons-configuration2",
                     "org.objectweb.asm"
                 )

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/P2ArtifactResolverTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/P2ArtifactResolverTest.kt
@@ -23,7 +23,9 @@ import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import io.mockk.every
@@ -71,7 +73,7 @@ class P2ArtifactResolverTest : WordSpec({
                 listOf(project1, project2, project3, project4)
             )
 
-            repositories shouldContainExactlyInAnyOrder listOf(repositoryUrl1, repositoryUrl2, repositoryUrl3)
+            repositories should containExactlyInAnyOrder(repositoryUrl1, repositoryUrl2, repositoryUrl3)
         }
 
         "collect P2 repositories from target files" {

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/P2RepositoryContentLoaderTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/P2RepositoryContentLoaderTest.kt
@@ -28,8 +28,8 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.result.shouldBeFailure
@@ -152,7 +152,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
                 .shouldBeSuccess { content ->
                     content.baseUrl shouldBe server.repositoryUrl()
                     content.artifacts.keys should beEmpty()
-                    content.childRepositories shouldContainExactlyInAnyOrder listOf(
+                    content.childRepositories should containExactlyInAnyOrder(
                         "https://p2.example.org/test/repository",
                         server.repositoryUrl("/child/repository")
                     )
@@ -172,7 +172,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
                 .shouldBeSuccess { content ->
                     content.baseUrl shouldBe server.repositoryUrl()
                     content.artifacts.keys should beEmpty()
-                    content.childRepositories shouldContainExactlyInAnyOrder listOf(
+                    content.childRepositories should containExactlyInAnyOrder(
                         "https://p2.example.org/test/repository",
                         server.repositoryUrl("/child/repository")
                     )
@@ -228,7 +228,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
 
             issues should beEmpty()
 
-            contents.flatMap { it.artifacts.keys } shouldContainExactlyInAnyOrder listOf(
+            contents.flatMap { it.artifacts.keys } should containExactlyInAnyOrder(
                 P2Identifier("org.apache.commons.io:2.8.0.v20210415-0900"),
                 P2Identifier("org.apache.commons.codec:1.14.0.v20200818-1422"),
                 P2Identifier("org.apache.commons.logging.source:1.2.0.v20180409-1502"),
@@ -266,7 +266,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
                 listOf(server.repositoryUrl())
             )
 
-            contents.flatMap { it.artifacts.keys } shouldContainExactlyInAnyOrder listOf(
+            contents.flatMap { it.artifacts.keys } should containExactlyInAnyOrder(
                 P2Identifier("org.apache.commons.io:2.8.0.v20210415-0900"),
                 P2Identifier("org.apache.commons.codec:1.14.0.v20200818-1422"),
                 P2Identifier("org.apache.commons.logging.source:1.2.0.v20180409-1502"),
@@ -297,7 +297,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
                 listOf(server.repositoryUrl(), server.repositoryUrl(basePath2))
             )
 
-            contents.flatMap { it.artifacts.keys } shouldContainExactlyInAnyOrder listOf(
+            contents.flatMap { it.artifacts.keys } should containExactlyInAnyOrder(
                 P2Identifier("org.apache.commons.logging.source:1.2.0.v20180409-1502"),
                 P2Identifier(
                     bundleId = "org.eclipse.orbit.releng.recipes.feature.aggregation.source:1.0.0.v20211212-1642",
@@ -326,7 +326,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
                 listOf(server.repositoryUrl(), server.repositoryUrl(basePath2))
             )
 
-            contents.flatMap { it.artifacts.keys } shouldContainExactlyInAnyOrder listOf(
+            contents.flatMap { it.artifacts.keys } should containExactlyInAnyOrder(
                 P2Identifier("org.apache.commons.logging.source:1.2.0.v20180409-1502"),
                 P2Identifier(
                     bundleId = "org.eclipse.orbit.releng.recipes.feature.aggregation.source:1.0.0.v20211212-1642",
@@ -377,8 +377,7 @@ class P2RepositoryContentLoaderTest : WordSpec({
 
             issues should beEmpty()
 
-            contents.flatMap { it.artifacts.keys } shouldContainExactlyInAnyOrder listOf(
-
+            contents.flatMap { it.artifacts.keys } should containExactlyInAnyOrder(
                 P2Identifier("org.apache.commons.io:2.8.0.v20210415-0900"),
                 P2Identifier("org.apache.commons.codec:1.14.0.v20200818-1422"),
                 P2Identifier("org.apache.commons.logging.source:1.2.0.v20180409-1502"),

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TargetHandlerTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TargetHandlerTest.kt
@@ -23,7 +23,7 @@ import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -45,7 +45,7 @@ class TargetHandlerTest : WordSpec({
         "collect P2 repositories from target files" {
             val targetHandler = createTargetHandlerWithTargetFiles()
 
-            targetHandler.repositoryUrls shouldContainExactlyInAnyOrder listOf(
+            targetHandler.repositoryUrls should containExactlyInAnyOrder(
                 "https://p2.example.com/repo/download.eclipse.org/modeling/tmf/xtext/updates/releases/2.37.0/",
                 "https://p2.example.org/repo/download.eclipse.org/modeling/emft/mwe/updates/releases/2.20.0/",
                 "https://p2.example.com/repository/download.eclipse.org/releases/2024-12",
@@ -85,7 +85,7 @@ class TargetHandlerTest : WordSpec({
         "collect feature IDs from target files" {
             val targetHandler = createTargetHandlerWithTargetFiles()
 
-            targetHandler.featureIds shouldContainExactlyInAnyOrder listOf(
+            targetHandler.featureIds should containExactlyInAnyOrder(
                 "maven.libraries.with.transitives",
                 "some.feature"
             )

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
@@ -26,6 +26,7 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.engine.spec.tempfile
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
@@ -101,7 +102,7 @@ class TychoTest : WordSpec({
             val tycho = Tycho()
             val mappedDefinitionFiles = tycho.mapDefinitionFiles(tempdir(), definitionFiles)
 
-            mappedDefinitionFiles shouldContainExactlyInAnyOrder listOf(tychoDefinitionFile1, tychoDefinitionFile2)
+            mappedDefinitionFiles should containExactlyInAnyOrder(tychoDefinitionFile1, tychoDefinitionFile2)
         }
     }
 
@@ -226,7 +227,7 @@ class TychoTest : WordSpec({
                 regExBuildProjectError.matchEntire(issue.message)?.groupValues?.get(1)
             }
 
-            projectIssues shouldContainExactlyInAnyOrder listOf(
+            projectIssues should containExactlyInAnyOrder(
                 subProject2.identifier("Tycho").toCoordinates(),
                 subProject3.identifier("Tycho").toCoordinates()
             )
@@ -363,13 +364,13 @@ class TychoTest : WordSpec({
                 sourceArtifact shouldBe RemoteArtifact.EMPTY
                 vcs shouldBe VcsInfo.EMPTY
                 vcsProcessed shouldBe VcsInfo.EMPTY
-                declaredLicenses shouldContainExactlyInAnyOrder listOf(bundleProperties["Bundle-License"])
+                declaredLicenses should containExactlyInAnyOrder(bundleProperties["Bundle-License"])
                 declaredLicensesProcessed shouldBe ProcessedDeclaredLicense(
                     spdxExpression = SpdxExpression.parse("Apache-2.0"),
                     mapped = mapOf("The Apache License" to SpdxExpression.parse("Apache-2.0"))
                 )
                 concludedLicense should beNull()
-                authors shouldContainExactlyInAnyOrder listOf(bundleProperties["Bundle-Vendor"])
+                authors should containExactlyInAnyOrder(bundleProperties["Bundle-Vendor"])
                 homepageUrl shouldBe "https://example.com/package"
             }
         }
@@ -390,7 +391,8 @@ class TychoTest : WordSpec({
                 }
 
                 node.artifact shouldBe mappedArtifact
-                node.repositories shouldContainExactlyInAnyOrder listOf(repo1, repo2)
+                node.repositories should containExactlyInAnyOrder(repo1, repo2)
+
                 pkg
             }
 

--- a/plugins/package-managers/node/src/test/kotlin/NpmDetectionTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/NpmDetectionTest.kt
@@ -22,7 +22,8 @@ package org.ossreviewtoolkit.plugins.packagemanagers.node
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
-import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -85,7 +86,7 @@ class NpmDetectionTest : WordSpec({
                 resolve(PNPM.lockfileName).writeText("#")
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(NPM, PNPM)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(NPM, PNPM)
         }
 
         "return only NPM if distinguished by lockfile" {
@@ -94,7 +95,7 @@ class NpmDetectionTest : WordSpec({
                 resolve(NPM.lockfileName).writeText("{}")
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(NPM)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(NPM)
         }
 
         "return only NPM if distinguished by other file" {
@@ -103,7 +104,7 @@ class NpmDetectionTest : WordSpec({
                 NPM.markerFileName?.also { resolve(it).writeText("{}") }
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(NPM)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(NPM)
         }
 
         "return only PNPM if distinguished by lockfile" {
@@ -112,7 +113,7 @@ class NpmDetectionTest : WordSpec({
                 resolve(PNPM.lockfileName).writeText("#")
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(PNPM)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(PNPM)
         }
 
         "return only PNPM if distinguished by workspace file" {
@@ -121,7 +122,7 @@ class NpmDetectionTest : WordSpec({
                 resolve(PNPM.workspaceFileName).writeText("#")
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(PNPM)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(PNPM)
         }
 
         "return only YARN if distinguished by lockfile" {
@@ -130,7 +131,7 @@ class NpmDetectionTest : WordSpec({
                 resolve(YARN.lockfileName).writeText(YARN_LOCK_FILE_HEADER)
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(YARN)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(YARN)
         }
 
         "return only YARN2 if distinguished by lockfile" {
@@ -139,7 +140,7 @@ class NpmDetectionTest : WordSpec({
                 resolve(YARN2.lockfileName).writeText(YARN2_LOCK_FILE_HEADER)
             }
 
-            NodePackageManagerType.forDirectory(projectDir).shouldContainExactlyInAnyOrder(YARN2)
+            NodePackageManagerType.forDirectory(projectDir) should containExactlyInAnyOrder(YARN2)
         }
     }
 
@@ -156,8 +157,8 @@ class NpmDetectionTest : WordSpec({
             val projectDir = getAssetFile("projects/synthetic/npm/workspaces")
 
             NPM.getWorkspaces(projectDir) shouldNotBeNull {
-                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) }
-                    .shouldContainExactly("/packages/**", "/apps/**")
+                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) } should
+                    containExactly("/packages/**", "/apps/**")
             }
         }
 
@@ -167,7 +168,7 @@ class NpmDetectionTest : WordSpec({
 
             val filteredFiles = NodePackageManagerDetection(definitionFiles).filterApplicable(NPM)
 
-            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath }.shouldContainExactlyInAnyOrder(
+            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath } should containExactlyInAnyOrder(
                 "npm/no-lockfile/package.json",
                 "npm/node-modules/package.json",
                 "npm/project-with-lockfile/package.json",
@@ -193,8 +194,8 @@ class NpmDetectionTest : WordSpec({
             val projectDir = getAssetFile("projects/synthetic/pnpm/workspaces")
 
             PNPM.getWorkspaces(projectDir) shouldNotBeNull {
-                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) }
-                    .shouldContainExactly("/src/app/", "/src/packages/**")
+                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) } should
+                    containExactly("/src/app/", "/src/packages/**")
             }
         }
 
@@ -204,7 +205,7 @@ class NpmDetectionTest : WordSpec({
 
             val filteredFiles = NodePackageManagerDetection(definitionFiles).filterApplicable(PNPM)
 
-            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath }.shouldContainExactlyInAnyOrder(
+            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath } should containExactlyInAnyOrder(
                 "pnpm/babel/package.json",
                 "pnpm/project-with-lockfile/package.json",
                 "pnpm/workspaces/package.json",
@@ -228,7 +229,8 @@ class NpmDetectionTest : WordSpec({
             val projectDir = getAssetFile("projects/synthetic/yarn/workspaces")
 
             YARN.getWorkspaces(projectDir) shouldNotBeNull {
-                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) }.shouldContainExactly("/packages/**")
+                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) } should
+                    containExactly("/packages/**")
             }
         }
 
@@ -238,7 +240,7 @@ class NpmDetectionTest : WordSpec({
 
             val filteredFiles = NodePackageManagerDetection(definitionFiles).filterApplicable(YARN)
 
-            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath }.shouldContainExactlyInAnyOrder(
+            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath } should containExactlyInAnyOrder(
                 "yarn/babel/package.json",
                 "yarn/project-with-lockfile/package.json",
                 "yarn/workspaces/package.json"
@@ -259,7 +261,8 @@ class NpmDetectionTest : WordSpec({
             val projectDir = getAssetFile("projects/synthetic/yarn2/workspaces")
 
             YARN2.getWorkspaces(projectDir) shouldNotBeNull {
-                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) }.shouldContainExactly("/packages/**")
+                mapNotNull { it.withoutPrefix(projectDir.invariantSeparatorsPath) } should
+                    containExactly("/packages/**")
             }
         }
 
@@ -269,7 +272,7 @@ class NpmDetectionTest : WordSpec({
 
             val filteredFiles = NodePackageManagerDetection(definitionFiles).filterApplicable(YARN2)
 
-            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath }.shouldContainExactlyInAnyOrder(
+            filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath } should containExactlyInAnyOrder(
                 "yarn2/project-with-lockfile/package.json",
                 "yarn2/workspaces/package.json"
             )

--- a/plugins/package-managers/spdx/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
+++ b/plugins/package-managers/spdx/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.plugins.packagemanagers.spdx
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.haveSize
@@ -263,11 +262,11 @@ class SpdxDocumentFileFunTest : WordSpec({
             val projectIds = projectResults.map { it.project.id }
             val packageIds = projectResults.flatMap { projResult -> projResult.packages.map { it.id } }
 
-            projectIds shouldContainExactlyInAnyOrder listOf(
+            projectIds should containExactlyInAnyOrder(
                 Identifier("SpdxDocumentFile::xyz:0.1.0"),
                 Identifier("SpdxDocumentFile::subproject-xyz:0.1.0")
             )
-            packageIds shouldContainExactlyInAnyOrder listOf(
+            packageIds should containExactlyInAnyOrder(
                 Identifier("SpdxDocumentFile::curl:7.70.0"),
                 Identifier("SpdxDocumentFile::my-lib:8.88.8"),
                 Identifier("SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g")

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
@@ -22,8 +22,8 @@ package org.ossreviewtoolkit.plugins.reporters.asciidoc
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.longs.beInRange
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
@@ -72,7 +72,7 @@ class PdfTemplateReporterFunTest : StringSpec({
         )
 
         val reportFiles = reportFileResults.map { it.shouldBeSuccess() }
-        reportFiles.shouldContainExactlyInAnyOrder(
+        reportFiles should containExactlyInAnyOrder(
             outputDir.resolve("AsciiDoc_defect_report.pdf"),
             outputDir.resolve("AsciiDoc_disclosure_document.pdf"),
             outputDir.resolve("AsciiDoc_vulnerability_report.pdf")

--- a/plugins/reporters/freemarker/src/test/kotlin/FreeMarkerTemplateProcessorTest.kt
+++ b/plugins/reporters/freemarker/src/test/kotlin/FreeMarkerTemplateProcessorTest.kt
@@ -23,7 +23,6 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -266,7 +265,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
             result should haveSize(2)
             with(result[0]) {
                 license.toString() shouldBe "MIT"
-                originalExpressions.map { it.expression.toString() } shouldContainExactlyInAnyOrder listOf(
+                originalExpressions.map { it.expression.toString() } should containExactlyInAnyOrder(
                     "MIT",
                     "GPL-2.0-only OR MIT"
                 )
@@ -367,7 +366,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
             result should haveSize(1)
             with(result.first()) {
                 license.toString() shouldBe "MIT"
-                originalExpressions.map { it.expression.toString() } shouldContainExactlyInAnyOrder listOf(
+                originalExpressions.map { it.expression.toString() } should containExactlyInAnyOrder(
                     "GPL-2.0-only OR MIT OR Apache-2.0"
                 )
             }

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeResultParserTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeResultParserTest.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.plugins.scanners.scancode
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
@@ -59,7 +58,7 @@ class ScanCodeResultParserTest : FreeSpec({
 
                 val summary = parseResult(resultFile).toScanSummary(preferFileLicense = true)
 
-                summary.licenseFindings.map { it.license.toString() }.shouldContainExactlyInAnyOrder(
+                summary.licenseFindings.map { it.license.toString() } should containExactlyInAnyOrder(
                     "LicenseRef-scancode-generic-cla AND MIT",
                     "MIT",
                     "MIT",

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -22,11 +22,10 @@ package org.ossreviewtoolkit.plugins.scanners.scanoss
 import com.scanoss.utils.JsonUtils
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 
 import java.io.File
@@ -109,8 +108,8 @@ class ScanOssResultParserTest : WordSpec({
                 score = 100.0f
             )
 
-            summary.snippetFindings shouldHaveSize (1)
-            summary.snippetFindings.shouldContainExactly(
+            summary.snippetFindings should haveSize(1)
+            summary.snippetFindings should containExactly(
                 SnippetFinding(
                     TextLocation("src/main/java/com/vdurmont/semver4j/Requirement.java", 1, 710),
                     setOf(

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 
 import io.mockk.every
@@ -105,7 +105,7 @@ class ScanOssScannerDirectoryTest : StringSpec({
                 )
             )
 
-            snippetFindings.shouldContainExactly(
+            snippetFindings should containExactly(
                 SnippetFinding(
                     TextLocation("utils/src/main/kotlin/ArchiveUtils.kt", 1, 240),
                     setOf(

--- a/scanner/src/test/kotlin/ScannerMatcherTest.kt
+++ b/scanner/src/test/kotlin/ScannerMatcherTest.kt
@@ -20,7 +20,8 @@
 package org.ossreviewtoolkit.scanner
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.maps.containExactly
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.ScannerDetails
@@ -141,7 +142,7 @@ class ScannerMatcherTest : WordSpec({
                 "other" to "value"
             )
 
-            ScannerMatcherConfig.create(options).second shouldContainExactly mapOf("other" to "value")
+            ScannerMatcherConfig.create(options).second should containExactly("other" to "value")
         }
     }
 })

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.scanner
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -208,7 +208,7 @@ class ScannerTest : WordSpec({
 
             scanner.scan(setOf(pkgWithVcs1, pkgWithVcs2, pkgWithVcs3), createContext())
 
-            storedScanResults shouldContainExactly listOf(packageScannerResult)
+            storedScanResults should containExactly(packageScannerResult)
         }
     }
 

--- a/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
+++ b/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
@@ -20,9 +20,10 @@
 package org.ossreviewtoolkit.scanner.provenance
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.CopyrightFinding
@@ -44,7 +45,7 @@ class NestedProvenanceScanResultTest : WordSpec({
             val filteredResult = nestedProvenanceScanResult.filterByVcsPath("submodules/a")
             val repositories = filteredResult.nestedProvenance.getRepositoryUrls()
 
-            repositories shouldContainExactlyInAnyOrder listOf(
+            repositories should containExactlyInAnyOrder(
                 provenanceRoot.vcsInfo.url,
                 provenanceSubmoduleA.vcsInfo.url
             )
@@ -54,7 +55,7 @@ class NestedProvenanceScanResultTest : WordSpec({
             val filteredResult = nestedProvenanceScanResult.filterByVcsPath("submodules/a/dir")
             val repositories = filteredResult.nestedProvenance.getRepositoryUrls()
 
-            repositories shouldContainExactlyInAnyOrder listOf(
+            repositories should containExactlyInAnyOrder(
                 provenanceRoot.vcsInfo.url,
                 provenanceSubmoduleA.vcsInfo.url
             )
@@ -76,7 +77,7 @@ class NestedProvenanceScanResultTest : WordSpec({
                 with(filteredResult.scanResults.getValue(filteredResult.nestedProvenance.root).single()) {
                     summary.licenseFindings shouldNotContain LicenseFinding("Apache-2.0", TextLocation("file", 1))
 
-                    summary.licenseFindings shouldContainExactly listOf(
+                    summary.licenseFindings should containExactly(
                         LicenseFinding("Apache-2.0", TextLocation("submodules/file", 1))
                     )
                 }

--- a/utils/common/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/common/src/test/kotlin/ExtensionsTest.kt
@@ -27,7 +27,7 @@ import io.kotest.engine.spec.tempfile
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly as containExactlyCollection
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.file.aDirectory
 import io.kotest.matchers.file.aFile
 import io.kotest.matchers.file.exist
@@ -63,7 +63,7 @@ class ExtensionsTest : WordSpec({
         "return all duplicates" {
             val strings = listOf("foo", "bar", "baz", "foo", "bar", "bar")
 
-            strings.getDuplicates().shouldContainExactlyInAnyOrder("foo", "bar")
+            strings.getDuplicates() should containExactlyInAnyOrder("foo", "bar")
         }
 
         "return duplicates according to a selector" {

--- a/utils/ort/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/ort/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -27,7 +27,6 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.maps.containExactly as containExactlyEntries
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -133,7 +132,7 @@ class DeclaredLicenseProcessorTest : StringSpec() {
             val processedLicenses = DeclaredLicenseProcessor.process(declaredLicenses, declaredLicenseMapping)
 
             processedLicenses.spdxExpression shouldBe "Apache-2.0 AND MIT".toSpdx()
-            processedLicenses.mapped shouldContainExactly mapOf("https://domain/path/license.html" to "MIT".toSpdx())
+            processedLicenses.mapped should containExactlyEntries("https://domain/path/license.html" to "MIT".toSpdx())
             processedLicenses.unmapped should beEmpty()
         }
 
@@ -144,7 +143,7 @@ class DeclaredLicenseProcessorTest : StringSpec() {
             val processedLicenses = DeclaredLicenseProcessor.process(declaredLicenses, declaredLicenseMapping)
 
             processedLicenses.spdxExpression shouldBe "Apache-2.0 AND MIT".toSpdx()
-            processedLicenses.mapped shouldContainExactly mapOf(
+            processedLicenses.mapped should containExactlyEntries(
                 "Copyright (c) the authors." to SpdxConstants.NONE.toSpdx()
             )
             processedLicenses.unmapped should beEmpty()

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.utils.ort
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -256,7 +256,7 @@ class UtilsTest : WordSpec({
                 "v3.9.0.99"
             )
 
-            filterVersionNames("3.9.0.99", names).shouldContainExactly("3.9.0.99-a3d9827", "sdk-3.9.0.99", "v3.9.0.99")
+            filterVersionNames("3.9.0.99", names) should containExactly("3.9.0.99-a3d9827", "sdk-3.9.0.99", "v3.9.0.99")
         }
 
         "find names that match the version without an ignorable suffix" {
@@ -266,7 +266,7 @@ class UtilsTest : WordSpec({
                 "6.2.10"
             )
 
-            filterVersionNames("6.2.9.Final", names).shouldContainExactly("6.2.9")
+            filterVersionNames("6.2.9.Final", names) should containExactly("6.2.9")
         }
     }
 


### PR DESCRIPTION
Make some related changes for sets / maps along the way.