### PR TITLE
feat(fossid): Add NON_LICENSE category to LicenseCategory

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/result/LicenseCategory.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/result/LicenseCategory.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.clients.fossid.model.result
 enum class LicenseCategory {
     COMMERCIAL,
     NON_COMMERCIAL,
+    NON_LICENSE,
     PERMISSIVE,
     SOURCE_AVAILABLE,
     STRONG_COPYLEFT,


### PR DESCRIPTION
New versions of FossID sometimes return 'NON_LICENSE' as a License Category. This makes such responses parsable.