### PR TITLE
Set SCANOSS readFromStorage property to false and remove it from config

### DIFF
--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -69,7 +69,7 @@ class ScanOss(
 
     override val matcher: ScannerMatcher? = null
 
-    override val readFromStorage = config.readFromStorage
+    override val readFromStorage = false
 
     override val writeToStorage = config.writeToStorage
 

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -49,12 +49,6 @@ data class ScanOssConfig(
     val maxVersion: String?,
 
     /**
-     * Whether to read scan results from the storage.
-     */
-    @OrtPluginOption(defaultValue = "true")
-    val readFromStorage: Boolean,
-
-    /**
      * Whether to write scan results to the storage.
      */
     @OrtPluginOption(defaultValue = "true")

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -34,21 +34,6 @@ data class ScanOssConfig(
     val apiKey: Secret,
 
     /**
-     * A regular expression to match the scanner name when looking up scan results in the storage.
-     */
-    val regScannerName: String?,
-
-    /**
-     * The minimum version of stored scan results to use.
-     */
-    val minVersion: String?,
-
-    /**
-     * The maximum version of stored scan results to use.
-     */
-    val maxVersion: String?,
-
-    /**
      * Whether to write scan results to the storage.
      */
     @OrtPluginOption(defaultValue = "true")

--- a/plugins/scanners/scanoss/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/TestUtils.kt
@@ -42,19 +42,11 @@ internal fun createScanOss(config: ScanOssConfig): ScanOss = ScanOss(config = co
 internal fun createScanOssConfig(
     apiUrl: String = ScanApi.DEFAULT_BASE_URL,
     apiKey: Secret = Secret(""),
-    regScannerName: String? = null,
-    minVersion: String? = null,
-    maxVersion: String? = null,
-    readFromStorage: Boolean = true,
     writeToStorage: Boolean = true
 ): ScanOssConfig =
     ScanOssConfig(
         apiUrl = apiUrl,
         apiKey = apiKey,
-        regScannerName = regScannerName,
-        minVersion = minVersion,
-        maxVersion = maxVersion,
-        readFromStorage = readFromStorage,
         writeToStorage = writeToStorage
     )
 


### PR DESCRIPTION
This PR changes the SCANOSS scanner's `readFromStorage` property to be explicitly set to `false`, following the same approach implemented for other snippet scanners like FossId.

The consensus for snippet scanners is that their results should never come from the scan storage. This change complements the previous commit (oss-review-toolkit/ort@e5571b4) that set the matcher property to null.