### PR TITLE
build(gradle): Prepare for publishing to the new Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
         with:
           dependency-graph: generate-and-submit
-      - name: Publish to OSSRH
+      - name: Publish to Maven Central
         env:
           GITHUB_DEPENDENCY_GRAPH_REF: refs/heads/main
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     // Apply third-party plugins.
     id("com.vanniktech.maven.publish")
@@ -28,7 +30,7 @@ fun getGroupId(parent: Project?): String =
 group = "org${getGroupId(parent)}"
 
 mavenPublishing {
-    publishToMavenCentral()
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
     pom {
         name = project.name


### PR DESCRIPTION
OSSRH is reaching end of life on June 30, 2025. To prepare for that, the self-migration [1] has been performed, and thus the publishing host needs to be changed from the default https://oss.sonatype.org [2] to the Central Portal.

[1]: https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration
[2]: https://github.com/vanniktech/gradle-maven-publish-plugin/blob/705be5b9f40d91624af277df293ca1c754c86ca4/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt#L39