### PR TITLE
Black duck maven repo has a new name. 

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -58,7 +58,7 @@ repositories {
 
     exclusiveContent {
         forRepository {
-            maven("https://sig-repo.synopsys.com/bds-bdio-release")
+            maven("https://repo.blackduck.com/bds-bdio-release")
         }
 
         filter {


### PR DESCRIPTION
This update refers to the new repo location and resolves a build error on HEAD

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
