### PR TITLE
build(gradle): Use the new Black Duck repository URL

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -58,7 +58,7 @@ repositories {
 
     exclusiveContent {
         forRepository {
-            maven("https://sig-repo.synopsys.com/bds-bdio-release")
+            maven("https://repo.blackduck.com/bds-bdio-release")
         }
 
         filter {


### PR DESCRIPTION
See the note at [1] which says

    SIG-Repo is now https://repo.blackduck.com/

    All users should update their configurations to use the new
    repo.blackduck.com domain.

Also see the FAQ at [2].

[1]: https://sig-repo.synopsys.com/
[2]: https://community.blackduck.com/s/article/Black-Duck-Domain-Change-FAQ