### PR TITLE
Use the URL for authentication if available

### DIFF
--- a/utils/ort/src/main/kotlin/Utils.kt
+++ b/utils/ort/src/main/kotlin/Utils.kt
@@ -23,6 +23,7 @@ import java.io.File
 import java.net.Authenticator
 import java.net.PasswordAuthentication
 import java.net.URI
+import java.net.URL
 
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -120,10 +121,10 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
 }
 
 /**
- * Request a [PasswordAuthentication] object for the given [host], [port], and [scheme]. Install the [OrtAuthenticator]
- * and the [OrtProxySelector] beforehand to ensure they are active.
+ * Request a [PasswordAuthentication] object for the given [host], [port], [scheme], and optional [url]. Install the
+ * [OrtAuthenticator] and the [OrtProxySelector] beforehand to ensure they are active.
  */
-fun requestPasswordAuthentication(host: String, port: Int, scheme: String): PasswordAuthentication? {
+fun requestPasswordAuthentication(host: String, port: Int, scheme: String, url: URL? = null): PasswordAuthentication? {
     OrtAuthenticator.install()
     OrtProxySelector.install()
 
@@ -133,7 +134,9 @@ fun requestPasswordAuthentication(host: String, port: Int, scheme: String): Pass
         /* port = */ port,
         /* protocol = */ scheme,
         /* prompt = */ null,
-        /* scheme = */ null
+        /* scheme = */ null,
+        /* url = */ url,
+        /* reqType = */ Authenticator.RequestorType.SERVER
     )
 }
 
@@ -142,7 +145,7 @@ fun requestPasswordAuthentication(host: String, port: Int, scheme: String): Pass
  * [OrtProxySelector] beforehand to ensure they are active.
  */
 fun requestPasswordAuthentication(uri: URI): PasswordAuthentication? =
-    requestPasswordAuthentication(uri.host, uri.port, uri.scheme)
+    requestPasswordAuthentication(uri.host, uri.port, uri.scheme, uri.toURL())
 
 /**
  * Normalize a string representing a [VCS URL][vcsUrl] to a common string form.

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -47,6 +47,10 @@ import org.apache.logging.log4j.kotlin.CoroutineThreadContext
 import org.apache.logging.log4j.kotlin.withLoggingContext
 
 class UtilsTest : WordSpec({
+    afterEach {
+        unmockkAll()
+    }
+
     "filterVersionNames" should {
         "return an empty list for a blank version" {
             val names = listOf("dummy")
@@ -437,21 +441,17 @@ class UtilsTest : WordSpec({
             mockkObject(OrtProxySelector)
             mockkStatic(Authenticator::class)
 
-            try {
-                val passwordAuth = mockk<PasswordAuthentication>()
+            val passwordAuth = mockk<PasswordAuthentication>()
 
-                every {
-                    Authenticator.requestPasswordAuthentication(host, null, port, scheme, null, null)
-                } returns passwordAuth
+            every {
+                Authenticator.requestPasswordAuthentication(host, null, port, scheme, null, null)
+            } returns passwordAuth
 
-                requestPasswordAuthentication(host, port, scheme) shouldBe passwordAuth
+            requestPasswordAuthentication(host, port, scheme) shouldBe passwordAuth
 
-                verify {
-                    OrtAuthenticator.install()
-                    OrtProxySelector.install()
-                }
-            } finally {
-                unmockkAll()
+            verify {
+                OrtAuthenticator.install()
+                OrtProxySelector.install()
             }
         }
 

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -444,10 +444,49 @@ class UtilsTest : WordSpec({
             val passwordAuth = mockk<PasswordAuthentication>()
 
             every {
-                Authenticator.requestPasswordAuthentication(host, null, port, scheme, null, null)
+                Authenticator.requestPasswordAuthentication(
+                    host,
+                    null,
+                    port,
+                    scheme,
+                    null,
+                    null,
+                    null,
+                    Authenticator.RequestorType.SERVER
+                )
             } returns passwordAuth
 
             requestPasswordAuthentication(host, port, scheme) shouldBe passwordAuth
+
+            verify {
+                OrtAuthenticator.install()
+                OrtProxySelector.install()
+            }
+        }
+
+        "return a correct authentication object for a URL" {
+            val url = URI.create("https://www.example.org:442/auth/test")
+
+            mockkObject(OrtAuthenticator)
+            mockkObject(OrtProxySelector)
+            mockkStatic(Authenticator::class)
+
+            val passwordAuth = mockk<PasswordAuthentication>()
+
+            every {
+                Authenticator.requestPasswordAuthentication(
+                    "www.example.org",
+                    null,
+                    442,
+                    "https",
+                    null,
+                    null,
+                    url.toURL(),
+                    Authenticator.RequestorType.SERVER
+                )
+            } returns passwordAuth
+
+            requestPasswordAuthentication(url) shouldBe passwordAuth
 
             verify {
                 OrtAuthenticator.install()


### PR DESCRIPTION
This PR improves the authentication mechanism in ORT to pass a URL to the Authenticator if it is available. So far, only the host is used which has the consequence that only a single set of credentials can be used per host.