### PR TITLE
ci: Stop generating Jacoco reports

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,17 +67,12 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
     - name: Run unit tests
-      run: ./gradlew --scan test jacocoTestReport
+      run: ./gradlew --scan test
     - name: Create Test Summary
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: "**/test-results/**/TEST-*.xml"
       if: always()
-    - name: Upload code coverage data
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: test-${{ matrix.os }}
   funTest-non-docker:
     needs: build
     runs-on: ubuntu-24.04
@@ -116,17 +111,12 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
     - name: Run functional tests that do not require external tools
-      run: ./gradlew --scan -Ptests.exclude=org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport
+      run: ./gradlew --scan -Ptests.exclude=org.ossreviewtoolkit.plugins.packagemanagers.* funTest
     - name: Create Test Summary
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: "**/test-results/**/TEST-*.xml"
       if: always()
-    - name: Upload code coverage data
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: funTest-non-docker
   funTest-docker:
     runs-on: ubuntu-24.04
     steps:
@@ -161,14 +151,9 @@ jobs:
           -e HOME=/home/runner \
           -e GRADLE_OPTS="$GRADLE_OPTS" \
           ${{ env.TEST_IMAGE_TAG }} \
-          -c "./gradlew --scan -Ptests.include=org.ossreviewtoolkit.plugins.packagemanagers.* funTest jacocoFunTestReport"
+          -c "./gradlew --scan -Ptests.include=org.ossreviewtoolkit.plugins.packagemanagers.* funTest"
     - name: Create Test Summary
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: "**/test-results/**/TEST-*.xml"
       if: always()
-    - name: Upload code coverage data
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: funTest-docker

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![Slack][1]][2]
 
-[![Static Analysis][3]][4] [![Build and Test][5]][6] [![Code coverage][7]][8]
+[![Static Analysis][3]][4] [![Build and Test][5]][6]
 
-[![REUSE status][9]][10] [![OpenSSF Best Practices][11]][12] [![OpenSSF Scorecard][13]][14]
+[![REUSE status][7]][8] [![OpenSSF Best Practices][9]][10] [![OpenSSF Scorecard][11]][12]
 
 [1]: https://img.shields.io/badge/Join_us_on_Slack!-ort--talk-blue.svg?longCache=true&logo=slack
 [2]: http://slack.oss-review-toolkit.org
@@ -14,14 +14,12 @@
 [4]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml
 [5]: https://github.com/oss-review-toolkit/ort/actions/workflows/build-and-test.yml/badge.svg
 [6]: https://github.com/oss-review-toolkit/ort/actions/workflows/build-and-test.yml
-[7]: https://codecov.io/gh/oss-review-toolkit/ort/branch/main/graph/badge.svg?token=QD2tCSUTVN
-[8]: https://app.codecov.io/gh/oss-review-toolkit/ort
-[9]: https://api.reuse.software/badge/github.com/oss-review-toolkit/ort
-[10]: https://api.reuse.software/info/github.com/oss-review-toolkit/ort
-[11]: https://www.bestpractices.dev/projects/4618/badge
-[12]: https://www.bestpractices.dev/projects/4618
-[13]: https://api.scorecard.dev/projects/github.com/oss-review-toolkit/ort/badge
-[14]: https://scorecard.dev/viewer/?uri=github.com/oss-review-toolkit/ort
+[7]: https://api.reuse.software/badge/github.com/oss-review-toolkit/ort
+[8]: https://api.reuse.software/info/github.com/oss-review-toolkit/ort
+[9]: https://www.bestpractices.dev/projects/4618/badge
+[10]: https://www.bestpractices.dev/projects/4618
+[11]: https://api.scorecard.dev/projects/github.com/oss-review-toolkit/ort/badge
+[12]: https://scorecard.dev/viewer/?uri=github.com/oss-review-toolkit/ort
 
 # Introduction
 


### PR DESCRIPTION
Stop generating Jacoco reports as they recently often cause hangs in CI.

Relates to #10305.