### PR TITLE
chore(buildSrc): Remove an unused index

### DIFF
--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -103,13 +103,13 @@ abstract class GeneratePluginDocsTask : DefaultTask() {
                 appendLine("${descriptor["id"]}:")
 
                 fun appendOptions(options: List<Map<*, *>>) {
-                    options.forEachIndexed { index, option ->
-                        val defaultValue = option["default"]
-                        val type = option["type"]
+                    options.forEach {
+                        val defaultValue = it["default"]
+                        val type = it["type"]
                         val isStringValue =
                             (type == "SECRET" || type == "STRING" || type == "STRING_LIST") && defaultValue != null
 
-                        append("    ${option["name"]}: ")
+                        append("    ${it["name"]}: ")
                         if (isStringValue) append("\"")
                         append(defaultValue)
                         if (isStringValue) append("\"")


### PR DESCRIPTION
While at it, stick to the default `it` for the option. This is a fixup for b71980e that silences a compiler warning.