### PR TITLE
feat(fossid): Extend logging for FossID project access issues

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -247,7 +247,11 @@ class FossId internal constructor(
                     null
                 }
 
-                else -> throw IOException("Could not get project. Additional information : $error")
+                else -> {
+                    val errorMessage = "Could not get project '$projectCode' for user '${config.user.value}: $error'"
+                    logger.error(errorMessage)
+                    throw IOException(errorMessage)
+                }
             }
         }
 


### PR DESCRIPTION
This commit adds handling for situation, where project exists in FossID, but ORT user have no access granted.

