### PR TITLE
fix(reporter): Fix a performance issue with generating SPDX reports

### DIFF
--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -88,14 +88,17 @@ data class ResolvedLicenseInfo(
             resolvedLicense.locations.map { it.location.path }
         }
 
+        val applicablePathsCache = mutableMapOf<String, Map<String, Set<String>>>()
         val detectedLicenses = filterTo(mutableSetOf()) { resolvedLicense ->
             resolvedLicense.locations.any {
                 val rootPath = (it.provenance as? RepositoryProvenance)?.vcsInfo?.path.orEmpty()
 
-                val applicableLicensePaths = matcher.getApplicableLicenseFilesForDirectories(
-                    licensePaths,
-                    listOf(rootPath)
-                )
+                val applicableLicensePaths = applicablePathsCache.getOrPut(rootPath) {
+                    matcher.getApplicableLicenseFilesForDirectories(
+                        licensePaths,
+                        listOf(rootPath)
+                    )
+                }
 
                 val applicableLicenseFiles = applicableLicensePaths[rootPath].orEmpty()
 


### PR DESCRIPTION
In 67beb24, a change was introduced to compute the main license of a package. This significantly increased the generation times for the SPDX reports for some projects containing packages with many license findings. The problem was in the aggregating of detected licenses where many relative paths to files with license findings were constructed.

To address this issue, use a cache for already constructed paths. This makes the report generation fast again.

Resolves #10317.
