### PR TITLE
build: Replace printVersion gradle task with an ORT specific version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
       - name: Get ORT version
         run: |
-          ORT_VERSION=$(./gradlew -q properties --property version | sed -nr "s/version: (.+)/\1/p")
+          ORT_VERSION=$(./gradlew -q printVersion)
           echo "ORT_VERSION=${ORT_VERSION}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+import git.semver.plugin.gradle.PrintTask
+
 import org.eclipse.jgit.ignore.FastIgnoreRule
 
 import org.jetbrains.gradle.ext.Gradle
@@ -85,6 +87,15 @@ tasks.register("allDependencies") {
         b.mustRunAfter(a)
     }
 }
+
+open class OrtPrintTask : PrintTask({ "" }, "Prints the current project version") {
+    private val projectVersion = project.version.toString()
+
+    @TaskAction
+    fun printVersion() = println(projectVersion)
+}
+
+tasks.replace("printVersion", OrtPrintTask::class.java)
 
 val checkCopyrightsInNoticeFile by tasks.registering {
     val gitFilesProvider = providers.of(GitFilesValueSource::class) { parameters { workingDir = rootDir } }


### PR DESCRIPTION
Simplify retrieving the current ORT version by creating a separate task. This is helpful for automated tasks where the exact version is required.
