### PR TITLE
test(bazel): Run funTests after the Conan package manager ones

### DIFF
--- a/plugins/package-managers/bazel/build.gradle.kts
+++ b/plugins/package-managers/bazel/build.gradle.kts
@@ -52,3 +52,11 @@ dependencies {
     funTestImplementation(testFixtures(projects.analyzer))
     funTestImplementation(projects.plugins.packageManagers.conanPackageManager)
 }
+
+tasks.named<Test>("funTest") {
+    val conanPackageManagerProject = project.project(projects.plugins.packageManagers.conanPackageManager.path)
+    val conanPackageManagerFunTestTask = conanPackageManagerProject.tasks.named<Test>("funTest")
+
+    // Prevent conflicts with the Conan configuration database by running after the Conan package manager tests.
+    mustRunAfter(conanPackageManagerFunTestTask)
+}


### PR DESCRIPTION
Do not run the `funTest` tasks from the `bazel` project in parallel with the Conan package manager ones, as it seems to create conflict related to the Conan configuration database.
