### PR TITLE
build(gradle): Do not publish "funTest" feature variants

### DIFF
--- a/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
@@ -24,6 +24,13 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
+runCatching {
+    components["java"] as AdhocComponentWithVariants
+}.onSuccess {
+    it.withVariantsFromConfiguration(configurations["funTestApiElements"]) { skip() }
+    it.withVariantsFromConfiguration(configurations["funTestRuntimeElements"]) { skip() }
+}
+
 fun getGroupId(parent: Project?): String =
     parent?.let { "${getGroupId(it.parent)}.${it.name.replace("-", "")}" }.orEmpty()
 


### PR DESCRIPTION
These are only needed locally. This speeds up publishing and works around a bogus "Dependency version information is missing" error on Sonatype Central Portal when publishing releases.

Note that the lookup in `components` throws instead of returning `null` if "java" is not present.

Also see [1] which explains to do the same for test fixtures, which in fact are just feature variants.

[1]: https://docs.gradle.org/current/userguide/java_testing.html#ex-disable-publishing-of-test-fixtures-variants