### PR TITLE
Improvements to SPDX report validation

### DIFF
--- a/plugins/package-managers/spdx/src/main/kotlin/utils/SpdxDocumentCache.kt
+++ b/plugins/package-managers/spdx/src/main/kotlin/utils/SpdxDocumentCache.kt
@@ -48,6 +48,11 @@ internal class SpdxDocumentCache {
         documentCache.getOrPut(file) {
             logger.info { "Loading SpdxDocument from '$file'." }
 
-            runCatching { SpdxModelMapper.read(file) }
+            runCatching {
+                SpdxModelMapper.read<SpdxDocument>(file).apply {
+                    packages.forEach { it.validate() }
+                    files.forEach { it.validate() }
+                }
+            }
         }
 }

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -97,7 +97,7 @@ class SpdxDocumentReporterFunTest : WordSpec({
             )
         }
 
-        "omit file information if corresponding option is disabled" {
+        "omit file information if the corresponding option is disabled" {
             val jsonSpdxDocument = generateReport(
                 ortResult,
                 FileFormat.JSON,

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -396,7 +396,7 @@ private val ortResult = OrtResult(
                 summary = ScanSummary.EMPTY.copy(
                     licenseFindings = setOf(
                         LicenseFinding(
-                            license = "GPL-3.0-only",
+                            license = "GPL-2.0-only WITH NOASSERTION",
                             location = TextLocation("LICENSE", 1)
                         )
                     ),

--- a/plugins/reporters/spdx/src/funTest/resources/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/resources/spdx-document-reporter-expected-output.spdx.json
@@ -135,7 +135,7 @@
     "filesAnalyzed" : false,
     "homepage" : "NONE",
     "licenseConcluded" : "NOASSERTION",
-    "licenseDeclared" : "GPL-3.0-only",
+    "licenseDeclared" : "GPL-2.0-only WITH NOASSERTION",
     "name" : "seventh-package",
     "versionInfo" : "0.0.1"
   }, {
@@ -156,8 +156,8 @@
     "hasFiles" : [ "SPDXRef-File-2", "SPDXRef-File-3" ],
     "homepage" : "NONE",
     "licenseConcluded" : "NOASSERTION",
-    "licenseDeclared" : "GPL-3.0-only",
-    "licenseInfoFromFiles" : [ "GPL-3.0-only" ],
+    "licenseDeclared" : "GPL-2.0-only WITH NOASSERTION",
+    "licenseInfoFromFiles" : [ "GPL-2.0-only WITH NOASSERTION" ],
     "name" : "seventh-package",
     "packageVerificationCode" : {
       "packageVerificationCodeValue" : "e14acc46fad3a38a1ef2830067619812b51cb4bc"
@@ -215,7 +215,7 @@
     "copyrightText" : "NONE",
     "fileName" : "LICENSE",
     "licenseConcluded" : "NOASSERTION",
-    "licenseInfoInFiles" : [ "GPL-3.0-only" ]
+    "licenseInfoInFiles" : [ "GPL-2.0-only WITH NOASSERTION" ]
   }, {
     "SPDXID" : "SPDXRef-File-3",
     "checksums" : [ {

--- a/plugins/reporters/spdx/src/funTest/resources/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/resources/spdx-document-reporter-expected-output.spdx.yml
@@ -150,7 +150,7 @@ packages:
   filesAnalyzed: false
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"
-  licenseDeclared: "GPL-3.0-only"
+  licenseDeclared: "GPL-2.0-only WITH NOASSERTION"
   name: "seventh-package"
   versionInfo: "0.0.1"
 - SPDXID: "SPDXRef-Package-Maven-seventh-package-group-seventh-package-0.0.1-source-artifact"
@@ -170,9 +170,9 @@ packages:
   - "SPDXRef-File-3"
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"
-  licenseDeclared: "GPL-3.0-only"
+  licenseDeclared: "GPL-2.0-only WITH NOASSERTION"
   licenseInfoFromFiles:
-  - "GPL-3.0-only"
+  - "GPL-2.0-only WITH NOASSERTION"
   name: "seventh-package"
   packageVerificationCode:
     packageVerificationCodeValue: "e14acc46fad3a38a1ef2830067619812b51cb4bc"
@@ -226,7 +226,7 @@ files:
   fileName: "LICENSE"
   licenseConcluded: "NOASSERTION"
   licenseInfoInFiles:
-  - "GPL-3.0-only"
+  - "GPL-2.0-only WITH NOASSERTION"
 - SPDXID: "SPDXRef-File-3"
   checksums:
   - algorithm: "SHA1"

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -288,11 +288,8 @@ internal fun OrtResult.getSpdxFiles(
             ),
             filename = fileFindings.path,
             licenseConcluded = SpdxConstants.NOASSERTION,
-            licenseInfoInFiles = fileFindings.licenses.takeIf { it.isNotEmpty() }?.map { it.toString() }
-                ?: listOf(SpdxConstants.NONE),
-            copyrightText = fileFindings.copyrights.sorted().joinToString("\n").takeUnless {
-                it.isBlank()
-            } ?: SpdxConstants.NONE
+            licenseInfoInFiles = fileFindings.licenses.map { it.toString() }.ifEmpty { listOf(SpdxConstants.NONE) },
+            copyrightText = fileFindings.copyrights.sorted().joinToString("\n").ifBlank { SpdxConstants.NONE }
         )
     }
 

--- a/utils/spdx-document/src/main/kotlin/model/SpdxAnnotation.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxAnnotation.kt
@@ -67,10 +67,15 @@ data class SpdxAnnotation(
     }
 
     init {
-        val validPrefixes = listOf(SpdxConstants.PERSON, SpdxConstants.ORGANIZATION, SpdxConstants.TOOL)
-
-        require(validPrefixes.any { annotator.startsWith(it) }) {
-            "The annotator has to start with any of $validPrefixes."
-        }
+        validate()
     }
+
+    fun validate(): SpdxAnnotation =
+        apply {
+            val validPrefixes = listOf(SpdxConstants.PERSON, SpdxConstants.ORGANIZATION, SpdxConstants.TOOL)
+
+            require(validPrefixes.any { annotator.startsWith(it) }) {
+                "The annotator has to start with any of $validPrefixes."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxChecksum.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxChecksum.kt
@@ -51,15 +51,20 @@ data class SpdxChecksum(
     }
 
     init {
-        require(checksumValue.isNotBlank()) { "The checksum value must not be blank." }
-
-        require(checksumValue.matches(HEX_SYMBOLS_REGEX)) {
-            "The checksum value must only contain lower case hexadecimal symbols."
-        }
-
-        require(algorithm.checksumHexDigits == -1 || checksumValue.length == algorithm.checksumHexDigits) {
-            "Expected a checksum value with ${algorithm.checksumHexDigits} hexadecimal symbols, but found " +
-                "${checksumValue.length}."
-        }
+        validate()
     }
+
+    fun validate(): SpdxChecksum =
+        apply {
+            require(checksumValue.isNotBlank()) { "The checksum value must not be blank." }
+
+            require(checksumValue.matches(HEX_SYMBOLS_REGEX)) {
+                "The checksum value must only contain lower case hexadecimal symbols."
+            }
+
+            require(algorithm.checksumHexDigits == -1 || checksumValue.length == algorithm.checksumHexDigits) {
+                "Expected a checksum value with ${algorithm.checksumHexDigits} hexadecimal symbols, but found " +
+                    "${checksumValue.length}."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxCreationInfo.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxCreationInfo.kt
@@ -56,10 +56,15 @@ data class SpdxCreationInfo(
 
 ) {
     init {
-        require(creators.isNotEmpty()) { "Creators must contain at least one entry, but was empty." }
-
-        require(licenseListVersion.isEmpty() || licenseListVersion.split('.').size == 2) {
-            "The license list version must contain exactly the major and minor parts."
-        }
+        validate()
     }
+
+    fun validate(): SpdxCreationInfo =
+        apply {
+            require(creators.isNotEmpty()) { "Creators must contain at least one entry, but was empty." }
+
+            require(licenseListVersion.isEmpty() || licenseListVersion.split('.').size == 2) {
+                "The license list version must contain exactly the major and minor parts."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxDocument.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxDocument.kt
@@ -133,43 +133,48 @@ data class SpdxDocument(
     val relationships: List<SpdxRelationship> = emptyList()
 ) {
     init {
-        require(spdxId.isNotBlank()) { "The SPDX-ID must not be blank." }
-
-        require(spdxVersion.isNotBlank()) { "The SPDX version must not be blank." }
-
-        require(name.isNotBlank()) { "The document name for SPDX-ID '$spdxId' must not be blank." }
-
-        require(dataLicense.isNotBlank()) { "The data license must not be blank." }
-
-        require(packages.isNotEmpty()) { "At least one package must be listed in packages" }
-
-        val duplicateExternalDocumentRefs = externalDocumentRefs.getDuplicates { it.externalDocumentId }
-        require(duplicateExternalDocumentRefs.isEmpty()) {
-            "The document must not contain duplicate external document references but has " +
-                "${duplicateExternalDocumentRefs.keys}."
-        }
-
-        require(documentNamespace.isNotBlank()) { "The document namespace must not be blank." }
-
-        val duplicatePackages = packages.getDuplicates { it.spdxId }
-        require(duplicatePackages.isEmpty()) {
-            "The document must not contain duplicate packages but has ${duplicatePackages.keys}."
-        }
-
-        val duplicateFiles = files.getDuplicates { it.spdxId }
-        require(duplicateFiles.isEmpty()) {
-            "The document must not contain duplicate files but has ${duplicateFiles.keys}."
-        }
-
-        val duplicateSnippets = snippets.getDuplicates { it.spdxId }
-        require(duplicateSnippets.isEmpty()) {
-            "The document must not contain duplicate snippets but has ${duplicateSnippets.keys}."
-        }
-
-        val hasDescribesRelationship = relationships.any { it.relationshipType == SpdxRelationship.Type.DESCRIBES }
-        require(hasDescribesRelationship || documentDescribes.isNotEmpty()) {
-            "The document must either have at least one relationship of type 'DESCRIBES' or contain the " +
-                "'documentDescribes' field."
-        }
+        validate()
     }
+
+    fun validate(): SpdxDocument =
+        apply {
+            require(spdxId.isNotBlank()) { "The SPDX-ID must not be blank." }
+
+            require(spdxVersion.isNotBlank()) { "The SPDX version must not be blank." }
+
+            require(name.isNotBlank()) { "The document name for SPDX-ID '$spdxId' must not be blank." }
+
+            require(dataLicense.isNotBlank()) { "The data license must not be blank." }
+
+            require(packages.isNotEmpty()) { "At least one package must be listed in packages" }
+
+            val duplicateExternalDocumentRefs = externalDocumentRefs.getDuplicates { it.externalDocumentId }
+            require(duplicateExternalDocumentRefs.isEmpty()) {
+                "The document must not contain duplicate external document references but has " +
+                    "${duplicateExternalDocumentRefs.keys}."
+            }
+
+            require(documentNamespace.isNotBlank()) { "The document namespace must not be blank." }
+
+            val duplicatePackages = packages.getDuplicates { it.spdxId }
+            require(duplicatePackages.isEmpty()) {
+                "The document must not contain duplicate packages but has ${duplicatePackages.keys}."
+            }
+
+            val duplicateFiles = files.getDuplicates { it.spdxId }
+            require(duplicateFiles.isEmpty()) {
+                "The document must not contain duplicate files but has ${duplicateFiles.keys}."
+            }
+
+            val duplicateSnippets = snippets.getDuplicates { it.spdxId }
+            require(duplicateSnippets.isEmpty()) {
+                "The document must not contain duplicate snippets but has ${duplicateSnippets.keys}."
+            }
+
+            val hasDescribesRelationship = relationships.any { it.relationshipType == SpdxRelationship.Type.DESCRIBES }
+            require(hasDescribesRelationship || documentDescribes.isNotEmpty()) {
+                "The document must either have at least one relationship of type 'DESCRIBES' or contain the " +
+                    "'documentDescribes' field."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxExternalDocumentReference.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxExternalDocumentReference.kt
@@ -42,16 +42,21 @@ data class SpdxExternalDocumentReference(
     val checksum: SpdxChecksum
 ) {
     init {
-        require(externalDocumentId.isNotBlank()) { "The external document ID must not be blank." }
-
-        require(externalDocumentId.startsWith(SpdxConstants.DOCUMENT_REF_PREFIX)) {
-            "The external document ID must start with '${SpdxConstants.DOCUMENT_REF_PREFIX}'."
-        }
-
-        require(spdxDocument.isNotEmpty()) { "The SPDX document must not be empty." }
-
-        require(spdxDocument.trim() == spdxDocument) {
-            "The SPDX document must not contain any leading or trailing whitespace."
-        }
+        validate()
     }
+
+    fun validate(): SpdxExternalDocumentReference =
+        apply {
+            require(externalDocumentId.isNotBlank()) { "The external document ID must not be blank." }
+
+            require(externalDocumentId.startsWith(SpdxConstants.DOCUMENT_REF_PREFIX)) {
+                "The external document ID must start with '${SpdxConstants.DOCUMENT_REF_PREFIX}'."
+            }
+
+            require(spdxDocument.isNotEmpty()) { "The SPDX document must not be empty." }
+
+            require(spdxDocument.trim() == spdxDocument) {
+                "The SPDX document must not contain any leading or trailing whitespace."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxExternalReference.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxExternalReference.kt
@@ -94,12 +94,7 @@ data class SpdxExternalReference(
     }
 
     init {
-        require(referenceLocator.isNotBlank()) { "The referenceLocator must not be blank." }
-
-        require(referenceType.category == Category.OTHER || referenceType.category == referenceCategory) {
-            "The category for '${referenceType.name}' must be '${referenceType.category}', but was " +
-                "'$referenceCategory'."
-        }
+        validate()
     }
 
     constructor(referenceType: Type, referenceLocator: String, comment: String = "") : this(
@@ -108,6 +103,16 @@ data class SpdxExternalReference(
         referenceType,
         referenceLocator
     )
+
+    fun validate(): SpdxExternalReference =
+        apply {
+            require(referenceLocator.isNotBlank()) { "The referenceLocator must not be blank." }
+
+            require(referenceType.category == Category.OTHER || referenceType.category == referenceCategory) {
+                "The category for '${referenceType.name}' must be '${referenceType.category}', but was " +
+                    "'$referenceCategory'."
+            }
+        }
 }
 
 private class ReferenceTypeDeserializer : StdDeserializer<SpdxExternalReference.Type>(

--- a/utils/spdx-document/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
@@ -61,7 +61,17 @@ data class SpdxExtractedLicenseInfo(
     val seeAlsos: List<String> = emptyList()
 ) {
     init {
-        require(licenseId.isNotBlank()) { "The license ID must not be blank (the optional name is '$name')." }
-        require(extractedText.isNotBlank()) { "The extracted text must not be blank (the license ID is '$licenseId')." }
+        validate()
     }
+
+    fun validate(): SpdxExtractedLicenseInfo =
+        apply {
+            require(licenseId.isNotBlank()) {
+                "The license ID must not be blank (the optional name is '$name')."
+            }
+
+            require(extractedText.isNotBlank()) {
+                "The extracted text must not be blank (the license ID is '$licenseId')."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxFile.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxFile.kt
@@ -170,32 +170,37 @@ data class SpdxFile(
     }
 
     init {
-        require(spdxId.startsWith(REF_PREFIX)) {
-            "The SPDX ID '$spdxId' has to start with '$REF_PREFIX'."
-        }
+        validate()
+    }
 
-        require(checksums.any { it.algorithm == SpdxChecksum.Algorithm.SHA1 }) {
-            "At least one SHA1 checksum must be provided."
-        }
+    fun validate(): SpdxFile =
+        apply {
+            require(spdxId.startsWith(REF_PREFIX)) {
+                "The SPDX ID '$spdxId' has to start with '$REF_PREFIX'."
+            }
 
-        require(copyrightText.isNotBlank()) { "The copyright text must not be blank." }
+            require(checksums.any { it.algorithm == SpdxChecksum.Algorithm.SHA1 }) {
+                "At least one SHA1 checksum must be provided."
+            }
 
-        require(filename.isNotBlank()) { "The filename for SPDX-ID '$spdxId' must not be blank." }
+            require(copyrightText.isNotBlank()) { "The copyright text must not be blank." }
 
-        require(licenseConcluded.isSpdxExpressionOrNotPresent()) {
-            "The license concluded must be either an SpdxExpression, 'NONE' or 'NOASSERTION', but was " +
-                "$licenseConcluded."
-        }
+            require(filename.isNotBlank()) { "The filename for SPDX-ID '$spdxId' must not be blank." }
 
-        // TODO: The check for [licenseInfoInFiles] can be made more strict, but the SPDX specification is not exact
-        //       enough yet to do this safely.
-        licenseInfoInFiles.filterNot {
-            it.isSpdxExpressionOrNotPresent(ALLOW_LICENSEREF_EXCEPTIONS)
-        }.let { nonSpdxLicenses ->
-            require(nonSpdxLicenses.isEmpty()) {
-                "The entries in 'licenseInfoInFiles' must each be either an SPDX expression, 'NONE' or " +
-                    "'NOASSERTION', but found ${nonSpdxLicenses.joinToString { "'$it'" }}."
+            require(licenseConcluded.isSpdxExpressionOrNotPresent()) {
+                "The license concluded must be either an SpdxExpression, 'NONE' or 'NOASSERTION', but was " +
+                    "$licenseConcluded."
+            }
+
+            // TODO: The check for [licenseInfoInFiles] can be made more strict, but the SPDX specification is not exact
+            //       enough yet to do this safely.
+            licenseInfoInFiles.filterNot {
+                it.isSpdxExpressionOrNotPresent(ALLOW_LICENSEREF_EXCEPTIONS)
+            }.let { nonSpdxLicenses ->
+                require(nonSpdxLicenses.isEmpty()) {
+                    "The entries in 'licenseInfoInFiles' must each be either an SPDX expression, 'NONE' or " +
+                        "'NOASSERTION', but found ${nonSpdxLicenses.joinToString { "'$it'" }}."
+                }
             }
         }
-    }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxFile.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxFile.kt
@@ -169,10 +169,6 @@ data class SpdxFile(
         VIDEO
     }
 
-    init {
-        validate()
-    }
-
     fun validate(): SpdxFile =
         apply {
             require(spdxId.startsWith(REF_PREFIX)) {

--- a/utils/spdx-document/src/main/kotlin/model/SpdxPackage.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxPackage.kt
@@ -190,10 +190,6 @@ data class SpdxPackage(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val versionInfo: String = ""
 ) {
-    init {
-        validate()
-    }
-
     fun validate(): SpdxPackage =
         apply {
             require(spdxId.startsWith(SpdxConstants.REF_PREFIX)) {

--- a/utils/spdx-document/src/main/kotlin/model/SpdxPackage.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxPackage.kt
@@ -191,43 +191,48 @@ data class SpdxPackage(
     val versionInfo: String = ""
 ) {
     init {
-        require(spdxId.startsWith(SpdxConstants.REF_PREFIX)) {
-            "The SPDX ID '$spdxId' has to start with '${SpdxConstants.REF_PREFIX}'."
-        }
-
-        require(spdxId.all { it.isLetterOrDigit() || it == '.' || it == '-' }) {
-            "The SPDX ID '$spdxId' is only allowed to contain letters, numbers, '.', and '-'."
-        }
-
-        require(copyrightText.isNotBlank()) { "The copyright text must not be blank." }
-
-        require(downloadLocation.isNotBlank()) { "The download location must not be blank." }
-
-        require(name.isNotBlank()) { "The package name for SPDX-ID '$spdxId' must not be blank." }
-
-        val validPrefixes = listOf(SpdxConstants.PERSON, SpdxConstants.ORGANIZATION)
-
-        if (originator != null) {
-            require(originator == SpdxConstants.NOASSERTION || validPrefixes.any { originator.startsWith(it) }) {
-                "If specified, the originator has to start with any of $validPrefixes or be set to 'NOASSERTION'."
-            }
-        }
-
-        if (supplier != null) {
-            require(supplier == SpdxConstants.NOASSERTION || validPrefixes.any { supplier.startsWith(it) }) {
-                "If specified, the supplier has to start with any of $validPrefixes or be set to 'NOASSERTION'."
-            }
-        }
-
-        // TODO: The check for [licenseInfoFromFiles] can be made more strict, but the SPDX specification is not exact
-        //       enough yet to do this safely.
-        licenseInfoFromFiles.filterNot {
-            it.isSpdxExpressionOrNotPresent(ALLOW_LICENSEREF_EXCEPTIONS)
-        }.let { nonSpdxLicenses ->
-            require(nonSpdxLicenses.isEmpty()) {
-                "The entries in 'licenseInfoFromFiles' must each be either an SPDX expression, 'NONE' or " +
-                    "'NOASSERTION', but found ${nonSpdxLicenses.joinToString { "'$it'" }}."
-            }
-        }
+        validate()
     }
+
+    fun validate(): SpdxPackage =
+        apply {
+            require(spdxId.startsWith(SpdxConstants.REF_PREFIX)) {
+                "The SPDX ID '$spdxId' has to start with '${SpdxConstants.REF_PREFIX}'."
+            }
+
+            require(spdxId.all { it.isLetterOrDigit() || it == '.' || it == '-' }) {
+                "The SPDX ID '$spdxId' is only allowed to contain letters, numbers, '.', and '-'."
+            }
+
+            require(copyrightText.isNotBlank()) { "The copyright text must not be blank." }
+
+            require(downloadLocation.isNotBlank()) { "The download location must not be blank." }
+
+            require(name.isNotBlank()) { "The package name for SPDX-ID '$spdxId' must not be blank." }
+
+            val validPrefixes = listOf(SpdxConstants.PERSON, SpdxConstants.ORGANIZATION)
+
+            if (originator != null) {
+                require(originator == SpdxConstants.NOASSERTION || validPrefixes.any { originator.startsWith(it) }) {
+                    "If specified, the originator has to start with any of $validPrefixes or be set to 'NOASSERTION'."
+                }
+            }
+
+            if (supplier != null) {
+                require(supplier == SpdxConstants.NOASSERTION || validPrefixes.any { supplier.startsWith(it) }) {
+                    "If specified, the supplier has to start with any of $validPrefixes or be set to 'NOASSERTION'."
+                }
+            }
+
+            // TODO: The check for [licenseInfoFromFiles] can be made more strict, but the SPDX specification is not
+            //       exact enough yet to do this safely.
+            licenseInfoFromFiles.filterNot {
+                it.isSpdxExpressionOrNotPresent(ALLOW_LICENSEREF_EXCEPTIONS)
+            }.let { nonSpdxLicenses ->
+                require(nonSpdxLicenses.isEmpty()) {
+                    "The entries in 'licenseInfoFromFiles' must each be either an SPDX expression, 'NONE' or " +
+                        "'NOASSERTION', but found ${nonSpdxLicenses.joinToString { "'$it'" }}."
+                }
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxPackageVerificationCode.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxPackageVerificationCode.kt
@@ -38,14 +38,19 @@ data class SpdxPackageVerificationCode(
     val packageVerificationCodeValue: String
 ) {
     init {
-        require(packageVerificationCodeValue.matches(SpdxChecksum.HEX_SYMBOLS_REGEX)) {
-            "The package verification code must only contain lower case hexadecimal digits but was " +
-                "'$packageVerificationCodeValue'."
-        }
-
-        require(SpdxChecksum.Algorithm.SHA1.checksumHexDigits == packageVerificationCodeValue.length) {
-            "Expected a checksum value with ${SpdxChecksum.Algorithm.SHA1.checksumHexDigits} hexadecimal digits, but " +
-                "found ${packageVerificationCodeValue.length}."
-        }
+        validate()
     }
+
+    fun validate(): SpdxPackageVerificationCode =
+        apply {
+            require(packageVerificationCodeValue.matches(SpdxChecksum.HEX_SYMBOLS_REGEX)) {
+                "The package verification code must only contain lower case hexadecimal digits but was " +
+                    "'$packageVerificationCodeValue'."
+            }
+
+            require(SpdxChecksum.Algorithm.SHA1.checksumHexDigits == packageVerificationCodeValue.length) {
+                "Expected a checksum value with ${SpdxChecksum.Algorithm.SHA1.checksumHexDigits} hexadecimal digits, " +
+                    "but found ${packageVerificationCodeValue.length}."
+            }
+        }
 }

--- a/utils/spdx-document/src/main/kotlin/model/SpdxRelationship.kt
+++ b/utils/spdx-document/src/main/kotlin/model/SpdxRelationship.kt
@@ -263,12 +263,17 @@ data class SpdxRelationship(
     }
 
     init {
-        require(spdxElementId.isNotBlank()) {
-            "The SPDX element ID must not be blank."
-        }
-
-        require(relatedSpdxElement.isNotBlank()) {
-            "The related SPDX element must not be blank."
-        }
+        validate()
     }
+
+    fun validate(): SpdxRelationship =
+        apply {
+            require(spdxElementId.isNotBlank()) {
+                "The SPDX element ID must not be blank."
+            }
+
+            require(relatedSpdxElement.isNotBlank()) {
+                "The related SPDX element must not be blank."
+            }
+        }
 }


### PR DESCRIPTION
Validation is still called as part of `init`, so there is no change in behavior currently. However, this refactoring prepares for eventually doing validation not at construction time of the class, to allow e.g. for writing SPDX documents with invalid SPDX expressions for later validation by external tools like [1] instead of failing report generation completely.

[1]: https://tools.spdx.org/app/validate/