### PR TITLE
fix(bazel): Always run Bazel after the Conan package manager

### DIFF
--- a/plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-expected-output-conan-package-manager-disabled.yml
+++ b/plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-expected-output-conan-package-manager-disabled.yml
@@ -1,0 +1,78 @@
+---
+projects:
+- id: "Bazel::plugins/package-managers/bazel/src/funTest/assets/projects/synthetic/bazel-conan-dependencies/MODULE.bazel:"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "main"
+    dependencies:
+    - id: "Bazel::glog:0.5.0"
+      linkage: "STATIC"
+      dependencies:
+      - id: "Bazel::gflags:2.2.2"
+        linkage: "STATIC"
+packages:
+- id: "Bazel::gflags:2.2.2"
+  purl: "pkg:bazel/gflags@2.2.2"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: "https://gflags.github.io/gflags/"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz"
+    hash:
+      value: "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf"
+      algorithm: "SHA-256"
+  vcs:
+    type: "Git"
+    url: "https://github.com/gflags/gflags"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/gflags/gflags.git"
+    revision: ""
+    path: ""
+- id: "Bazel::glog:0.5.0"
+  purl: "pkg:bazel/glog@0.5.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: "https://github.com/google/glog"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://github.com/google/glog/archive/refs/tags/v0.5.0.tar.gz"
+    hash:
+      value: "eede71f28371bf39aa69b45de23b329d37214016e2055269b3b5e7cfd40b59f5"
+      algorithm: "SHA-256"
+  vcs:
+    type: "Git"
+    url: "https://github.com/google/glog"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/google/glog.git"
+    revision: ""
+    path: ""

--- a/plugins/package-managers/bazel/src/funTest/kotlin/BazelFunTest.kt
+++ b/plugins/package-managers/bazel/src/funTest/kotlin/BazelFunTest.kt
@@ -22,8 +22,10 @@ package org.ossreviewtoolkit.plugins.packagemanagers.bazel
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 
+import org.ossreviewtoolkit.analyzer.analyze
 import org.ossreviewtoolkit.analyzer.create
 import org.ossreviewtoolkit.analyzer.resolveSingleProject
+import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.utils.test.getAssetFile
@@ -133,5 +135,28 @@ class BazelFunTest : StringSpec({
             )
         ).resolveSingleProject(definitionFile)
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
+    "Bazel dependencies are detected even if the Conan package manager is disabled" {
+        val definitionFile = getAssetFile("projects/synthetic/bazel-conan-dependencies/MODULE.bazel")
+        val projectDir = getAssetFile("projects/synthetic/bazel-conan-dependencies/")
+        val expectedResultFile = getAssetFile(
+            "projects/synthetic/bazel-expected-output-conan-package-manager-disabled.yml"
+        )
+
+        val result = analyze(
+            projectDir = projectDir,
+            allowDynamicVersions = true,
+            packageManagers = listOf(BazelFactory()),
+            packageManagerConfiguration = mapOf(
+                "Bazel" to PackageManagerConfiguration(
+                    options = mapOf(
+                        "bazelDependenciesOnly" to "true"
+                    )
+                )
+            )
+        )
+
+        result.analyzer?.result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 })


### PR DESCRIPTION
Since the package managers are run in parallel, conflicts could arise when accessing data in CONAN_HOME. Therefore, always run Bazel after Conan.

This is a fixup for 56a6d180b731518c745ffe27ed8663be2cee5d20.

See also the discussion at [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/10357

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
