### PR TITLE
feat(utils): Add `sourceCodeOrigin` to the package configuration

### DIFF
--- a/model/src/test/kotlin/config/PackageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/PackageConfigurationTest.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.model.config
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
@@ -215,10 +214,16 @@ class PackageConfigurationTest : WordSpec({
             ) shouldBe false
         }
 
-        "fail if the package configuration has only an identifier" {
-            shouldThrow<IllegalArgumentException> {
-                PackageConfiguration(id = Identifier.EMPTY.copy(name = "some-name"))
-            }
+        "return true if the package configuration contains only the identifier and the latter matches" {
+            val config = PackageConfiguration(id = Identifier.EMPTY.copy(name = "some-name"))
+
+            config.matches(
+                config.id,
+                RepositoryProvenance(
+                    vcsInfo = VcsInfo.EMPTY,
+                    resolvedRevision = "12345678"
+                )
+            ) shouldBe true
         }
     }
 })


### PR DESCRIPTION
The source code origin defines whether the package configuration applies to any source artifact or VCS location.

See [1].

[1]: https://github.com/oss-review-toolkit/ort/issues/9918#issuecomment-2696963351

Preliminary work for https://github.com/oss-review-toolkit/ort/pull/10375.