### PR TITLE
chore(scanner): Partly avoid the need for custom serial formats

### DIFF
--- a/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/Askalono.kt
@@ -45,8 +45,6 @@ import org.ossreviewtoolkit.utils.common.Os
 
 private const val CONFIDENCE_NOTICE = "Confidence threshold not high enough for any known license"
 
-private val JSON = Json { ignoreUnknownKeys = true }
-
 object AskalonoCommand : CommandLineTool {
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)
@@ -107,7 +105,7 @@ class Askalono(
     }
 
     override fun createSummary(result: String, startTime: Instant, endTime: Instant): ScanSummary {
-        val results = result.byteInputStream().use { JSON.decodeToSequence<AskalonoResult>(it) }
+        val results = result.byteInputStream().use { Json.decodeToSequence<AskalonoResult>(it) }
 
         val licenseFindings = mutableSetOf<LicenseFinding>()
 

--- a/plugins/scanners/askalono/src/main/kotlin/AskalonoResultModel.kt
+++ b/plugins/scanners/askalono/src/main/kotlin/AskalonoResultModel.kt
@@ -20,7 +20,9 @@
 package org.ossreviewtoolkit.plugins.scanners.askalono
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 
+// See https://github.com/jpeddicord/askalono/blob/0.5.0/cli/src/formats.rs#L12-L23.
 @Serializable
 data class AskalonoResult(
     val path: String,
@@ -28,13 +30,17 @@ data class AskalonoResult(
     val error: String? = null
 )
 
+// See https://github.com/jpeddicord/askalono/blob/0.5.0/cli/src/formats.rs#L25-L30.
 @Serializable
+@JsonIgnoreUnknownKeys
 data class PathResult(
     val score: Float,
     val license: LicenseResult
 )
 
+// See https://github.com/jpeddicord/askalono/blob/0.5.0/cli/src/formats.rs#L32-L37.
 @Serializable
+@JsonIgnoreUnknownKeys
 data class LicenseResult(
     val name: String,
     val aliases: Set<String>

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLc.kt
@@ -44,8 +44,6 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
-private val JSON = Json { ignoreUnknownKeys = true }
-
 object BoyterLcCommand : CommandLineTool {
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)
@@ -115,7 +113,7 @@ class BoyterLc(
     }
 
     override fun createSummary(result: String, startTime: Instant, endTime: Instant): ScanSummary {
-        val results = JSON.decodeFromString<List<BoyterLcResult>>(result)
+        val results = Json.decodeFromString<List<BoyterLcResult>>(result)
 
         val licenseFindings = results.flatMapTo(mutableSetOf()) {
             val filePath = File(it.directory, it.filename)

--- a/plugins/scanners/boyterlc/src/main/kotlin/BoyterLcResultModel.kt
+++ b/plugins/scanners/boyterlc/src/main/kotlin/BoyterLcResultModel.kt
@@ -21,14 +21,18 @@ package org.ossreviewtoolkit.plugins.scanners.boyterlc
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 
+// See https://github.com/boyter/lc/blob/7a7c5750857efde2f1d50b1c3b62c07943587421/parsers/structs.go#L20-L31.
 @Serializable
+@JsonIgnoreUnknownKeys
 class BoyterLcResult(
     @SerialName("Directory") val directory: String,
     @SerialName("Filename") val filename: String,
     @SerialName("LicenseGuesses") val licenseGuesses: List<LicenseGuess>
 )
 
+// See https://github.com/boyter/lc/blob/v1.3.1/parsers/structs.go#L15-L18.
 @Serializable
 data class LicenseGuess(
     @SerialName("LicenseId") val licenseId: String,


### PR DESCRIPTION
If the only customization is to ignore unknown keys, prefer to use the class annotation instead, which nicely documents the class to be potentially incomplete as not all properties are needed.