### PR TITLE
refactor(scancode): Inline the `SCANNER_NAME` property

### DIFF
--- a/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/ScanCode.kt
@@ -79,8 +79,6 @@ class ScanCode(
     private val config: ScanCodeConfig
 ) : LocalPathScannerWrapper() {
     companion object {
-        const val SCANNER_NAME = "ScanCode"
-
         private const val LICENSE_REFERENCES_OPTION_VERSION = "32.0.0"
         private const val OUTPUT_FORMAT_OPTION = "--json"
     }

--- a/plugins/scanners/scancode/src/main/kotlin/model/FileEntry.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/model/FileEntry.kt
@@ -24,7 +24,6 @@ import kotlin.collections.orEmpty
 
 import kotlinx.serialization.Serializable
 
-import org.ossreviewtoolkit.plugins.scanners.scancode.ScanCode
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
@@ -59,8 +58,7 @@ sealed interface FileEntry {
         override val scanErrors: List<String>
     ) : FileEntry {
         companion object {
-            private val LICENSE_REF_PREFIX_SCAN_CODE = SpdxConstants.LICENSE_REF_PREFIX +
-                "${ScanCode.SCANNER_NAME.lowercase()}-"
+            private val LICENSE_REF_PREFIX_SCAN_CODE = "${SpdxConstants.LICENSE_REF_PREFIX}scancode-"
 
             private fun getSpdxId(spdxLicenseKey: String?, key: String): String {
                 val spdxId = spdxLicenseKey?.toSpdxId(allowPlusSuffix = true)


### PR DESCRIPTION
This is only used once, and in lowercase form.