### PR TITLE
feat(fossid): Increase read timeout for report generation

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -327,6 +327,7 @@ interface FossIdRestService {
     suspend fun createIgnoreRule(@Body body: PostRequestBody): EntityResponseBody<Nothing>
 
     @POST("api.php")
+    @Headers("$READ_TIMEOUT_HEADER:${5 * 60 * 1000}")
     suspend fun generateReport(@Body body: PostRequestBody): Response<ResponseBody>
 
     @POST("api.php")


### PR DESCRIPTION
Increase the read timeout for the generate report call to prevent timeouts on larger reports or when fossid is overloaded.