### PR TITLE
deps(scanner): Remove unused dependencies

### DIFF
--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -34,19 +34,15 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     implementation(libs.bundles.exposed)
-    implementation(libs.hikari)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.kotlinx.coroutines)
     implementation(libs.postgres)
-    implementation(libs.retrofit.converter.jackson)
     implementation(libs.sw360Client) {
         constraints {
             implementation("commons-io:commons-io:2.19.0")
                 .because("commons-io 2.11.0 is vulnerable by CVE-2024-47554")
         }
     }
-
-    funTestApi(testFixtures(projects.scanner))
 
     funTestImplementation(platform(projects.plugins.scanners))
     funTestImplementation(platform(projects.plugins.versionControlSystems))


### PR DESCRIPTION
As reported by `./gradlew -p scanner projectHealth` and double-checked.