### PR TITLE
test(spdx): Re-align a test case name

### DIFF
--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -60,7 +60,7 @@ class SpdxDocumentReporterFunTest : WordSpec({
             errors should beEmpty()
         }
 
-        "create the expected document" {
+        "create the expected document for a synthetic ORT result" {
             val expectedResult = readResource("/spdx-document-reporter-expected-output.spdx.json")
 
             val jsonSpdxDocument = generateReport(ORT_RESULT, FileFormat.JSON)


### PR DESCRIPTION
Use the same name again as for the analog test case for YAML output. The inconsistent naming has been introduced by 254ae3b.

