### PR TITLE
chore(gradle): Access the application's JAR lazily

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -144,7 +144,7 @@ tasks.named<BuildNativeImageTask>("nativeCompile") {
     }
 }
 
-val jar by tasks.getting(Jar::class)
+val appJar = tasks.named<Jar>("jar")
 
 val pathingJar by tasks.registering(Jar::class) {
     archiveClassifier = "pathing"
@@ -157,7 +157,7 @@ val pathingJar by tasks.registering(Jar::class) {
 }
 
 tasks.named<CreateStartScripts>("startScripts") {
-    classpath = jar.outputs.files + pathingJar.get().outputs.files
+    classpath = appJar.get().outputs.files + pathingJar.get().outputs.files
 
     doLast {
         // Append the plugin directory to the Windows classpath.


### PR DESCRIPTION
Ensure to not create the task if it does not exist by preferring the lazy `named` over the eager `getting`. While at it, rename the task variable to better explain what kind of JAR task it is, as there is also the `pathingJar`.