### PR TITLE
feat(fossid-webapp)!: Add a function to list all projects

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -93,6 +93,16 @@ suspend fun FossIdRestService.getProject(user: String, apiKey: String, projectCo
     )
 
 /**
+ * Get all projects available in this instance.
+ *
+ * The HTTP request is sent with [user] and [apiKey] as credentials.
+ */
+suspend fun FossIdRestService.listProjects(user: String, apiKey: String) =
+    listProjects(
+        PostRequestBody("list_projects", PROJECT_GROUP, user, apiKey, emptyMap())
+    )
+
+/**
  * Get the scan for the given [scanCode].
  *
  * The HTTP request is sent with [user] and [apiKey] as credentials.

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -265,6 +265,9 @@ interface FossIdRestService {
     suspend fun getProject(@Body body: PostRequestBody): PolymorphicDataResponseBody<Project>
 
     @POST("api.php")
+    suspend fun listProjects(@Body body: PostRequestBody): PolymorphicResponseBody<Project>
+
+    @POST("api.php")
     suspend fun getScan(@Body body: PostRequestBody): PolymorphicDataResponseBody<Scan>
 
     @POST("api.php")

--- a/clients/fossid-webapp/src/main/kotlin/model/Project.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/Project.kt
@@ -45,6 +45,6 @@ data class Project(
     val isArchived: Boolean?,
 
     val jiraProjectKey: String?,
-    val creationDate: String,
+    val creationDate: String?,
     val dateLimitDate: String?
 )

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.shouldContainValue
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -348,6 +349,15 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.getProject("", "", "semver4j_2_20201203_090342") shouldNotBeNull {
             error shouldBe "Classes.FossID.user_not_found_or_api_key_is_not_correct"
             message shouldBe "User is not found or API key is incorrect"
+        }
+    }
+
+    "Projects can be listed" {
+        service.listProjects("", "") shouldNotBeNull {
+            data shouldNotBeNull {
+                this shouldHaveSize 2
+                first().projectName shouldBe "TestProject1"
+            }
         }
     }
 })

--- a/clients/fossid-webapp/src/test/resources/return-type/mappings/apiphp-list_projects_not_empty.json
+++ b/clients/fossid-webapp/src/test/resources/return-type/mappings/apiphp-list_projects_not_empty.json
@@ -1,0 +1,26 @@
+{
+  "id" : "d235bf75-7318-44bd-8801-27359f923e32",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"action\":\"list_projects\",\"group\":\"projects\",\"data\":{\"username\":\"\",\"key\":\"\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"operation\":\"projects_list_projects\",\"status\":\"1\",\"data\": [ {      \"id\": \"404\",      \"creator\": \"23\",      \"project_code\": \"project_1\",      \"project_name\": \"TestProject1\",      \"limit_date\": null,      \"product_code\": \"\",      \"product_name\": \"TestProduct1\",      \"description\": \"A test project\",      \"comment\": \"\",      \"is_archived\": \"0\",      \"jira_project_key\": \"\",      \"created\": \"2023-01-24 15:52:35\",      \"updated\": \"2024-03-24 17:36:58\",      \"scans\": null,      \"policy_rules\": null,      \"warnings\": null    },    {      \"id\": \"426\",      \"creator\": \"226\",      \"project_code\": \"test_semver4j\",      \"project_name\": \"test_semver4j\",      \"limit_date\": null,      \"product_code\": \"\",      \"product_name\": \"\",      \"description\": \"\",      \"comment\": \"Created by ORT\",      \"is_archived\": \"0\",      \"jira_project_key\": \"\",      \"created\": \"2022-03-09 15:51:31\",      \"updated\": null,      \"scans\": \"2\",      \"policy_rules\": null,      \"warnings\": null    }]}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 03 Dec 2020 08:03:42 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "d235bf75-7318-44bd-8801-27359f923e32",
+  "persistent" : true,
+  "insertionIndex" : 1
+}


### PR DESCRIPTION
The function wraps the `list_projects` action of the FossID API which returns a list of all projects the user has access to. This information is relevant for some use cases, e.g. gathering statistics or cleaning up old scans.

In the response of this function, the `creationDate` property for projects is not filled out. Therefore, make it nullable; it is currently not used elsewhere in ORT. (Because of this modification of the model, this is a breaking change.)