### PR TITLE
refactor(dos): Remove `fetchConcluded` option

### DIFF
--- a/clients/dos/src/main/kotlin/DosClient.kt
+++ b/clients/dos/src/main/kotlin/DosClient.kt
@@ -122,20 +122,18 @@ class DosClient(private val service: DosService) {
 
     /**
      * Get scan results for a list of [packages]. In case multiple packages are provided, it is assumed that they all
-     * refer to the same provenance (like a monorepo). If [fetchConcluded] is true, return concluded licenses instead of
-     * detected licenses. Return either existing results, a "pending" message if the package is currently being scanned,
-     * a "no-results" message if a scan yielded no results, or null on error. If only some of the packages exist in DOS
-     * database (identified by purl), new bookmarks for the remaining packages are made (hence the need to provide the
-     * declared licenses for these packages in this request).
+     * refer to the same provenance (like a monorepo). Return either existing results, a "pending" message if the
+     * package is currently being scanned, a "no-results" message if a scan yielded no results, or null on error. If
+     * only some of the packages exist in DOS database (identified by purl), new bookmarks for the remaining packages
+     * are made (hence the need to provide the declared licenses for these packages in this request).
      */
-    suspend fun getScanResults(packages: List<PackageInfo>, fetchConcluded: Boolean): ScanResultsResponseBody? {
+    suspend fun getScanResults(packages: List<PackageInfo>): ScanResultsResponseBody? {
         if (packages.isEmpty()) {
             logger.error { "The list of PURLs to get scan results for must not be empty." }
             return null
         }
 
-        val options = ScanResultsRequestBody.ReqOptions(fetchConcluded)
-        val requestBody = ScanResultsRequestBody(packages, options)
+        val requestBody = ScanResultsRequestBody(packages)
         val response = service.getScanResults(requestBody)
         val responseBody = response.body()
 
@@ -146,10 +144,6 @@ class DosClient(private val service: DosService) {
                 "pending" -> logger.info { "Scan pending for $purls." }
                 "ready" -> {
                     logger.info { "Scan results ready for $purls." }
-
-                    if (fetchConcluded) {
-                        logger.info { "Returning concluded licenses instead of detected licenses." }
-                    }
                 }
             }
 

--- a/clients/dos/src/main/kotlin/DosModel.kt
+++ b/clients/dos/src/main/kotlin/DosModel.kt
@@ -65,17 +65,8 @@ data class ScanResultsRequestBody(
      * refer to the same provenance (like a monorepo). If only some of the packages exist in the DOS database, new purl
      * bookmarks will be added for the missing packages (hence the need for the declared license here).
      */
-    val packages: List<PackageInfo>,
-
-    /** Options fort requesting scan results. */
-    val options: ReqOptions? = null
-) {
-    @Serializable
-    data class ReqOptions(
-        /** An option to fetch the concluded licenses along with the scan results. Defaults to "false". */
-        val fetchConcluded: Boolean? = false
-    )
-}
+    val packages: List<PackageInfo>
+)
 
 @Serializable
 data class ScanResultsResponseBody(

--- a/plugins/scanners/dos/src/main/kotlin/DosScanner.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DosScanner.kt
@@ -115,7 +115,7 @@ class DosScanner(
 
             // Ask for scan results from DOS API
             val existingScanResults = runCatching {
-                client.getScanResults(packages, config.fetchConcluded)
+                client.getScanResults(packages)
             }.onFailure {
                 issues += createAndLogIssue(it.collectMessages())
             }.onSuccess {
@@ -232,7 +232,7 @@ class DosScanner(
             when (jobState.state.status) {
                 "completed" -> {
                     logger.info { "Scan completed for job with ID '$jobId'." }
-                    return client.getScanResults(listOf(pkg), config.fetchConcluded)
+                    return client.getScanResults(listOf(pkg))
                 }
 
                 "failed" -> {

--- a/plugins/scanners/dos/src/main/kotlin/DosScannerConfig.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DosScannerConfig.kt
@@ -39,10 +39,6 @@ data class DosScannerConfig(
     @OrtPluginOption(defaultValue = "5")
     val pollInterval: Long,
 
-    /** Use license conclusions as detected licenses when they exist? **/
-    @OrtPluginOption(defaultValue = "false")
-    val fetchConcluded: Boolean,
-
     /** The URL where the DOS / package curation front-end is running. **/
     @OrtPluginOption(defaultValue = "http://localhost:3000")
     val frontendUrl: String,

--- a/plugins/scanners/dos/src/test/kotlin/DosScannerTest.kt
+++ b/plugins/scanners/dos/src/test/kotlin/DosScannerTest.kt
@@ -69,7 +69,6 @@ class DosScannerTest : StringSpec({
             token = Secret(""),
             timeout = 60L,
             pollInterval = 5L,
-            fetchConcluded = false,
             frontendUrl = "http://localhost:3000"
         )
     }
@@ -87,7 +86,7 @@ class DosScannerTest : StringSpec({
                 )
         )
 
-        scanner.client.getScanResults(emptyList(), false) shouldBe null
+        scanner.client.getScanResults(emptyList()) shouldBe null
     }
 
     "getScanResults() should return 'no-results' when no results in db" {
@@ -106,8 +105,7 @@ class DosScannerTest : StringSpec({
                     purl = "purl",
                     declaredLicenseExpressionSPDX = null
                 )
-            ),
-            false
+            )
         )?.state?.status
 
         status shouldBe "no-results"
@@ -129,8 +127,7 @@ class DosScannerTest : StringSpec({
                     purl = "purl",
                     declaredLicenseExpressionSPDX = null
                 )
-            ),
-            false
+            )
         )
 
         response?.state?.status shouldBe "pending"
@@ -153,8 +150,7 @@ class DosScannerTest : StringSpec({
                     purl = "purl",
                     declaredLicenseExpressionSPDX = null
                 )
-            ),
-            false
+            )
         )
 
         val actualJson = JSON.encodeToString(response?.results)


### PR DESCRIPTION
The `fetchConcluded` option will be removed from the endpoint on DOS API, so remove the option from the DOS scanner configuration, and the `options` parameter from the `ScanResultsRequestBody` class.

This option was an experimental feature in the early development, and was mainly used to see the effects of the license conclusions before the DOS API also supported being used as a package configurations provider. There will be changes coming to the access to license conclusions on DOS API as users will be allowed to create their own license conclusions, and these will be linked to the organization the user belongs in, and the license conclusions will then be returned based on which organization they are queried for, so the scan results endpoint will be changed to only return the actual scanner findings (so in practice will behave as if `fetchConcluded` was set to `false`) to reduce maintenance efforts.