### PR TITLE
Fix typo: removed duplicate word 'list' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export JAVA_OPTS="$JAVA_OPTS -Xmx8g"
 ```
 
 If ORT requires external tools to analyze a project, these tools are listed by the `ort requirements` command.
-If a package manager is not list listed there, support for it is integrated directly into ORT and does not require any external tools to be installed.
+If a package manager is not listed there, support for it is integrated directly into ORT and does not require any external tools to be installed.
 
 ## From binaries
 

--- a/examples/resolutions.ort.yml
+++ b/examples/resolutions.ort.yml
@@ -4,6 +4,9 @@ resolutions:
   - message: "Could not download 'Maven:com.example:library:.*"
     reason: "CANT_FIX_ISSUE"
     comment: "An example for an issue resolution."
+  - message: "NOTICE_DEFAULT"
+    reason: "BUILD_TOOL_ISSUE"
+    comment: "Empty notice file is expected when no licenses are detected."
   rule_violations:
   - message: "Example rule violation*."
     reason: "DYNAMIC_LINKAGE_EXCEPTION"


### PR DESCRIPTION
I found a small typo in the README where the word "list" was duplicated.
This is a minor fix. My first contribution – happy to help!
