### PR TITLE
feat(cyclonedx)!: Use generic properties for ORT-specific data

### DIFF
--- a/plugins/reporters/cyclonedx/README.md
+++ b/plugins/reporters/cyclonedx/README.md
@@ -1,0 +1,10 @@
+# CycloneDX Reporter
+
+## Property Taxonomy
+
+This table defines the [taxonomy](https://cyclonedx.github.io/cyclonedx-property-taxonomy/) of ORT-specific property names:
+
+| Property Name | Parent Entity | Description |
+|---------------|---------------|-------------|
+| `ort:dependencyType` | `component` | The type of dependency in relation to the parent component. Valid values: "direct", "transitive". |
+| `ort:origin` | `license` | The origin of the license. Valid values: "declared license", "detected license", "concluded license". |

--- a/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result-with-findings.json
+++ b/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result-with-findings.json
@@ -51,12 +51,24 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "concluded license"
+              }
+            ]
           }
         },
         {
           "license": {
-            "name": "MIT WITH Libtool-exception"
+            "name": "MIT WITH Libtool-exception",
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "concluded license"
+              }
+            ]
           }
         },
         {
@@ -65,7 +77,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "declared license"
+              }
+            ]
           }
         },
         {
@@ -74,7 +92,28 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "text": {
+              "contentType": "plain/text",
+              "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -85,6 +124,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -109,7 +154,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "declared license"
+              }
+            ]
           }
         },
         {
@@ -118,7 +169,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -129,6 +186,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -153,7 +216,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -164,6 +233,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -188,7 +263,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         },
         {
@@ -197,7 +278,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -208,6 +295,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -226,7 +319,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -237,6 +336,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     }

--- a/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result.json
+++ b/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result.json
@@ -49,12 +49,24 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "concluded license"
+              }
+            ]
           }
         },
         {
           "license": {
-            "name": "MIT WITH Libtool-exception"
+            "name": "MIT WITH Libtool-exception",
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "concluded license"
+              }
+            ]
           }
         },
         {
@@ -63,7 +75,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "declared license"
+              }
+            ]
           }
         },
         {
@@ -72,7 +90,28 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "text": {
+              "contentType": "plain/text",
+              "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -83,6 +122,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -107,7 +152,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "declared license"
+              }
+            ]
           }
         },
         {
@@ -116,7 +167,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -127,6 +184,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -151,7 +214,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -162,6 +231,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -186,7 +261,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         },
         {
@@ -195,7 +276,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -206,6 +293,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     },
@@ -224,7 +317,13 @@
             "text": {
               "contentType": "plain/text",
               "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-            }
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
           }
         }
       ],
@@ -235,6 +334,12 @@
         {
           "type": "website",
           "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:dependencyType",
+          "value": "direct"
         }
       ]
     }

--- a/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result.xml
+++ b/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result.xml
@@ -48,10 +48,16 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">concluded license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">concluded license</property>
+          </properties>
         </license>
         <license>
-          <name>MIT WITH Libtool-exception</name><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">concluded license</ort:origin>
+          <name>MIT WITH Libtool-exception</name>
+          <properties>
+            <property name="ort:origin">concluded license</property>
+          </properties>
         </license>
         <license>
           <id>BSD-3-Clause</id>
@@ -79,7 +85,10 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">declared license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">declared license</property>
+          </properties>
         </license>
         <license>
           <id>BSD-2-Clause</id>
@@ -103,7 +112,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
         <license>
           <id>MIT</id>
@@ -125,7 +137,10 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
       </licenses>
       <copyright>Copyright 1, Copyright 2</copyright>
@@ -135,7 +150,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <reference type="website">
           <url>https://github.com/oss-review-toolkit/ort</url>
         </reference>
-      </externalReferences><ort:dependencyType xmlns:ort="http://www.w3.org/1999/xhtml">direct</ort:dependencyType>
+      </externalReferences>
+      <properties>
+        <property name="ort:dependencyType">direct</property>
+      </properties>
     </component>
     <component type="library" bom-ref="NPM:@ort:declared-license:1.0">
       <group>@ort</group>
@@ -166,7 +184,10 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">declared license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">declared license</property>
+          </properties>
         </license>
         <license>
           <id>BSD-3-Clause</id>
@@ -194,7 +215,10 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
       </licenses>
       <copyright>Copyright 1</copyright>
@@ -204,7 +228,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <reference type="website">
           <url>https://github.com/oss-review-toolkit/ort</url>
         </reference>
-      </externalReferences><ort:dependencyType xmlns:ort="http://www.w3.org/1999/xhtml">direct</ort:dependencyType>
+      </externalReferences>
+      <properties>
+        <property name="ort:dependencyType">direct</property>
+      </properties>
     </component>
     <component type="library" bom-ref="NPM:@ort:license-file:1.0">
       <group>@ort</group>
@@ -235,7 +262,10 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
       </licenses>
       <copyright>Copyright 1, Copyright 2</copyright>
@@ -245,7 +275,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <reference type="website">
           <url>https://github.com/oss-review-toolkit/ort</url>
         </reference>
-      </externalReferences><ort:dependencyType xmlns:ort="http://www.w3.org/1999/xhtml">direct</ort:dependencyType>
+      </externalReferences>
+      <properties>
+        <property name="ort:dependencyType">direct</property>
+      </properties>
     </component>
     <component type="library" bom-ref="NPM:@ort:license-file-and-additional-licenses:1.0">
       <group>@ort</group>
@@ -282,7 +315,10 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
         <license>
           <id>MIT</id>
@@ -304,7 +340,10 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
       </licenses>
       <copyright>Copyright 1, Copyright 2, Copyright 3</copyright>
@@ -314,7 +353,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <reference type="website">
           <url>https://github.com/oss-review-toolkit/ort</url>
         </reference>
-      </externalReferences><ort:dependencyType xmlns:ort="http://www.w3.org/1999/xhtml">direct</ort:dependencyType>
+      </externalReferences>
+      <properties>
+        <property name="ort:dependencyType">direct</property>
+      </properties>
     </component>
     <component type="library" bom-ref="NPM:@ort:no-license-file:1.0">
       <group>@ort</group>
@@ -342,7 +384,10 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</text><ort:origin xmlns:ort="http://www.w3.org/1999/xhtml">detected license</ort:origin>
+</text>
+          <properties>
+            <property name="ort:origin">detected license</property>
+          </properties>
         </license>
       </licenses>
       <copyright>Copyright 1</copyright>
@@ -352,7 +397,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <reference type="website">
           <url>https://github.com/oss-review-toolkit/ort</url>
         </reference>
-      </externalReferences><ort:dependencyType xmlns:ort="http://www.w3.org/1999/xhtml">direct</ort:dependencyType>
+      </externalReferences>
+      <properties>
+        <property name="ort:dependencyType">direct</property>
+      </properties>
     </component>
   </components>
   <externalReferences>

--- a/plugins/reporters/cyclonedx/src/main/kotlin/Utils.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/Utils.kt
@@ -25,9 +25,9 @@ import kotlin.collections.filter
 
 import org.cyclonedx.Format
 import org.cyclonedx.model.AttachmentText
-import org.cyclonedx.model.ExtensibleType
 import org.cyclonedx.model.Hash
 import org.cyclonedx.model.License
+import org.cyclonedx.model.Property
 
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
@@ -48,7 +48,8 @@ internal fun Collection<String>.mapNamesToLicenses(origin: String, input: Report
         License().apply {
             id = spdxId
             name = licenseName.takeIf { spdxId == null }
-            extensibleTypes = listOf(ExtensibleType(ORT_NAME, "origin", origin))
+
+            addProperty(Property("$ORT_NAME:origin", origin))
 
             if (licenseText != null) {
                 setLicenseText(


### PR DESCRIPTION
Use the preferred generic properties to record ORT-specific data, also see [1]. This also works around the issue that extensible types are still not supported by JSON output. Document the taxonomy accordingly.

[1]: https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/126