### PR TITLE
Fix issue with scan results from failed scans being reused even if scan problem is resolved

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -226,6 +226,14 @@ issues:
   scan_result: 1
   how_to_fix: "Some how to fix text."
 - _id: 16
+  timestamp: "2025-06-13T09:11:24.891480005Z"
+  type: "SCANNER"
+  source: "FakeScanner"
+  message: "Example error for issue that isn't in the scan summaries."
+  severity: "ERROR"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 17
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -235,7 +243,7 @@ issues:
   - 1
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 17
+- _id: 18
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -243,7 +251,7 @@ issues:
   severity: "ERROR"
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 18
+- _id: 19
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -251,7 +259,7 @@ issues:
   severity: "WARNING"
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 19
+- _id: 20
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -259,7 +267,7 @@ issues:
   severity: "HINT"
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 20
+- _id: 21
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -268,7 +276,7 @@ issues:
   pkg: 2
   path: 0
   how_to_fix: "Some how to fix text."
-- _id: 21
+- _id: 22
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -609,6 +617,8 @@ packages:
   scan_results:
   - 5
   is_excluded: false
+  issues:
+  - 16
 - _id: 3
   id: "Ant:junit:junit:4.12"
   is_project: false
@@ -1003,7 +1013,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 2
       issues:
-      - 20
+      - 21
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -1028,7 +1038,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 3
       issues:
-      - 21
+      - 22
       children:
       - key: 10
         linkage: "DYNAMIC"
@@ -1109,10 +1119,10 @@ statistics:
     rule_violation_resolutions: 1
     vulnerability_resolutions: 0
   open_issues:
-    errors: 5
+    errors: 6
     warnings: 4
     hints: 3
-    severe: 9
+    severe: 10
   open_rule_violations:
     errors: 1
     warnings: 1

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
@@ -262,6 +262,15 @@
     "how_to_fix" : "Some how to fix text."
   }, {
     "_id" : 16,
+    "timestamp" : "2025-06-13T09:11:24.891480005Z",
+    "type" : "SCANNER",
+    "source" : "FakeScanner",
+    "message" : "Example error for issue that isn't in the scan summaries.",
+    "severity" : "ERROR",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 17,
     "timestamp" : "1970-01-01T00:00:00Z",
     "type" : "ADVISOR",
     "source" : "VulnerableCode",
@@ -271,7 +280,7 @@
     "pkg" : 2,
     "how_to_fix" : "Some how to fix text."
   }, {
-    "_id" : 17,
+    "_id" : 18,
     "timestamp" : "1970-01-01T00:00:00Z",
     "type" : "ADVISOR",
     "source" : "VulnerableCode",
@@ -280,7 +289,7 @@
     "pkg" : 2,
     "how_to_fix" : "Some how to fix text."
   }, {
-    "_id" : 18,
+    "_id" : 19,
     "timestamp" : "1970-01-01T00:00:00Z",
     "type" : "ADVISOR",
     "source" : "VulnerableCode",
@@ -289,7 +298,7 @@
     "pkg" : 2,
     "how_to_fix" : "Some how to fix text."
   }, {
-    "_id" : 19,
+    "_id" : 20,
     "timestamp" : "1970-01-01T00:00:00Z",
     "type" : "ADVISOR",
     "source" : "VulnerableCode",
@@ -298,7 +307,7 @@
     "pkg" : 2,
     "how_to_fix" : "Some how to fix text."
   }, {
-    "_id" : 20,
+    "_id" : 21,
     "timestamp" : "2024-04-25T07:44:20.725613974Z",
     "type" : "ANALYZER",
     "source" : "Gradle",
@@ -308,7 +317,7 @@
     "path" : 0,
     "how_to_fix" : "Some how to fix text."
   }, {
-    "_id" : 21,
+    "_id" : 22,
     "timestamp" : "2024-04-25T07:44:20.725613974Z",
     "type" : "ANALYZER",
     "source" : "Gradle",
@@ -671,7 +680,8 @@
     "levels" : [ 0, 1 ],
     "scopes" : [ 0, 1 ],
     "scan_results" : [ 5 ],
-    "is_excluded" : false
+    "is_excluded" : false,
+    "issues" : [ 16 ]
   }, {
     "_id" : 3,
     "id" : "Ant:junit:junit:4.12",
@@ -1076,7 +1086,7 @@
         "key" : 3,
         "linkage" : "DYNAMIC",
         "pkg" : 2,
-        "issues" : [ 20 ],
+        "issues" : [ 21 ],
         "children" : [ {
           "key" : 4,
           "linkage" : "DYNAMIC",
@@ -1105,7 +1115,7 @@
         "key" : 9,
         "linkage" : "DYNAMIC",
         "pkg" : 3,
-        "issues" : [ 21 ],
+        "issues" : [ 22 ],
         "children" : [ {
           "key" : 10,
           "linkage" : "DYNAMIC",
@@ -1198,10 +1208,10 @@
       "vulnerability_resolutions" : 0
     },
     "open_issues" : {
-      "errors" : 5,
+      "errors" : 6,
       "warnings" : 4,
       "hints" : 3,
-      "severe" : 9
+      "severe" : 10
     },
     "open_rule_violations" : {
       "errors" : 1,

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
@@ -226,6 +226,14 @@ issues:
   scan_result: 1
   how_to_fix: "Some how to fix text."
 - _id: 16
+  timestamp: "2025-06-13T09:11:24.891480005Z"
+  type: "SCANNER"
+  source: "FakeScanner"
+  message: "Example error for issue that isn't in the scan summaries."
+  severity: "ERROR"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 17
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -235,7 +243,7 @@ issues:
   - 1
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 17
+- _id: 18
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -243,7 +251,7 @@ issues:
   severity: "ERROR"
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 18
+- _id: 19
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -251,7 +259,7 @@ issues:
   severity: "WARNING"
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 19
+- _id: 20
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
@@ -259,7 +267,7 @@ issues:
   severity: "HINT"
   pkg: 2
   how_to_fix: "Some how to fix text."
-- _id: 20
+- _id: 21
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -268,7 +276,7 @@ issues:
   pkg: 2
   path: 0
   how_to_fix: "Some how to fix text."
-- _id: 21
+- _id: 22
   timestamp: "2024-04-25T07:44:20.725613974Z"
   type: "ANALYZER"
   source: "Gradle"
@@ -609,6 +617,8 @@ packages:
   scan_results:
   - 5
   is_excluded: false
+  issues:
+  - 16
 - _id: 3
   id: "Ant:junit:junit:4.12"
   is_project: false
@@ -1003,7 +1013,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 2
       issues:
-      - 20
+      - 21
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -1028,7 +1038,7 @@ dependency_trees:
       linkage: "DYNAMIC"
       pkg: 3
       issues:
-      - 21
+      - 22
       children:
       - key: 10
         linkage: "DYNAMIC"
@@ -1109,10 +1119,10 @@ statistics:
     rule_violation_resolutions: 1
     vulnerability_resolutions: 0
   open_issues:
-    errors: 5
+    errors: 6
     warnings: 4
     hints: 3
-    severe: 9
+    severe: 10
   open_rule_violations:
     errors: 1
     warnings: 1

--- a/plugins/reporters/evaluated-model/src/funTest/resources/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/reporter-test-input.yml
@@ -674,6 +674,12 @@ scanner:
     summary:
       start_time: "1970-01-01T00:00:00Z"
       end_time: "1970-01-01T00:00:00Z"
+  issues:
+    Maven:org.apache.commons:commons-text:1.1:
+      - timestamp: "2025-06-13T09:11:24.891480005Z"
+        source: "FakeScanner"
+        message: "Example error for issue that isn't in the scan summaries."
+        severity: "ERROR"
   scanners:
     Ant:junit:junit:4.12:
     - "Dummy"

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -280,6 +280,9 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
         issues += addAnalyzerIssues(project.id, evaluatedPackage)
 
+        // Add scanner issues that are not part of the scan summaries.
+        issues += addScannerIssues(project.id, evaluatedPackage)
+
         scanResults += convertScanResultsForPackage(evaluatedPackage, findings)
 
         findings.filter { it.type == EvaluatedFindingType.LICENSE }.mapNotNullTo(detectedLicenses) { it.license }
@@ -343,6 +346,9 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
         issues += addAnalyzerIssues(pkg.id, evaluatedPackage)
 
+        // Add scanner issues that are not part of the scan summaries.
+        issues += addScannerIssues(pkg.id, evaluatedPackage)
+
         scanResults += convertScanResultsForPackage(evaluatedPackage, findings)
 
         findings.filter { it.type == EvaluatedFindingType.LICENSE }.mapNotNullTo(detectedLicenses) { it.license }
@@ -359,6 +365,18 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
         input.ortResult.analyzer?.result?.issues?.get(id)?.let { analyzerIssues ->
             result += addIssues(analyzerIssues, EvaluatedIssueType.ANALYZER, pkg, null, null)
+        }
+
+        return result
+    }
+
+    /**
+     * Add issues from scanner that are not part of the scan summaries.
+     */
+    private fun addScannerIssues(id: Identifier, pkg: EvaluatedPackage): List<EvaluatedIssue> {
+        val result = mutableListOf<EvaluatedIssue>()
+        input.ortResult.scanner?.issues?.get(id)?.let { scannerIssues ->
+            result += addIssues(scannerIssues, type = EvaluatedIssueType.SCANNER, pkg, null, null)
         }
 
         return result
@@ -591,7 +609,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addIssues(
-        issues: List<Issue>,
+        issues: Collection<Issue>,
         type: EvaluatedIssueType,
         pkg: EvaluatedPackage,
         scanResult: EvaluatedScanResult?,

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -65,10 +65,10 @@ internal class ScanController(
     private val nestedProvenanceResolutionIssues = mutableMapOf<Identifier, Issue>()
 
     /**
-     * A map of [Identifier]s associated with a list of [Issue]s that occurred during a scan besides the issues
+     * A map of [Identifier]s associated with a set of [Issue]s that occurred during a scan besides the issues
      * created by the scanners themselves as part of the [ScanSummary].
      */
-    private val issues = mutableMapOf<Identifier, MutableList<Issue>>()
+    private val issues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
     /**
      * A map of [KnownProvenance]s to their resolved [NestedProvenance]s.
@@ -124,7 +124,7 @@ internal class ScanController(
     fun getAllFileLists(): Map<KnownProvenance, FileList> = fileLists
 
     fun addIssue(id: Identifier, issue: Issue) {
-        issues.getOrPut(id) { mutableListOf() } += issue
+        issues.getOrPut(id) { mutableSetOf() } += issue
     }
 
     /**
@@ -196,6 +196,11 @@ internal class ScanController(
      * Return the nested provenance resolution issues associated with the given [provenance].
      */
     fun getNestedProvenanceResolutionIssue(id: Identifier): Issue? = nestedProvenanceResolutionIssues[id]
+
+    /**
+     * Get issues that are not part of the scan summaries.
+     */
+    fun getIssues(): Map<Identifier, Set<Issue>> = issues
 
     /**
      * Get the [NestedProvenance] for the provided [id], or null if no nested provenance for the [id] is available.


### PR DESCRIPTION
Add a new `issues` property to the `ScannerRun` class and collect issues from completely failing scans for path scanners in the issues map instead of creating and storing empty scan results.

Please see the individual commits for details.