### PR TITLE
refactor: Generalize `searchUpwardsForSubdirectory()` for files

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/Maven.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/Maven.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.createIssuesForA
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.identifier
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.isTychoProject
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.toOrtProject
-import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
+import org.ossreviewtoolkit.utils.common.searchUpwardFor
 
 /**
  * The [Maven](https://maven.apache.org/) package manager for Java.
@@ -118,7 +118,7 @@ class Maven(override val descriptor: PluginDescriptor = MavenFactory.descriptor,
         // If running in SBT mode expect that POM files were generated in a "target" subdirectory and that the correct
         // project directory is the parent directory of this.
         val projectDir = if (sbtMode) {
-            workingDir.searchUpwardsForSubdirectory("target") ?: workingDir
+            workingDir.searchUpwardFor(dirPath = "target") ?: workingDir
         } else {
             workingDir
         }

--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -82,7 +82,7 @@ import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.utils.common.DiskCache
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.gibibytes
-import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
+import org.ossreviewtoolkit.utils.common.searchUpwardFor
 import org.ossreviewtoolkit.utils.ort.OrtAuthenticator
 import org.ossreviewtoolkit.utils.ort.OrtProxySelector
 import org.ossreviewtoolkit.utils.ort.downloadText
@@ -518,7 +518,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) : Closeable {
             // TODO: Once SBT is implemented independently of Maven we can completely remove the "localProjects"
             //       parameter to this function as no other caller is actually using it.
             if (sbtMode) {
-                it.searchUpwardsForSubdirectory("target") ?: it
+                it.searchUpwardFor(dirPath = "target") ?: it
             } else {
                 it
             }

--- a/plugins/package-managers/sbt/src/main/kotlin/Sbt.kt
+++ b/plugins/package-managers/sbt/src/main/kotlin/Sbt.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.getCommonParentFile
-import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
+import org.ossreviewtoolkit.utils.common.searchUpwardFor
 import org.ossreviewtoolkit.utils.common.suppressInput
 import org.ossreviewtoolkit.utils.ort.JavaBootstrapper
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -287,7 +287,7 @@ private val DEFAULT_SBT_OPTIONS = listOfNotNull(
 }
 
 private fun moveGeneratedPom(pomFile: File): Result<File> {
-    val targetDirParent = pomFile.parentFile.searchUpwardsForSubdirectory("target")
+    val targetDirParent = pomFile.parentFile.searchUpwardFor(dirPath = "target")
         ?: return Result.failure(IllegalArgumentException("No target subdirectory found for '$pomFile'."))
     val targetFilename = pomFile.relativeTo(targetDirParent).invariantSeparatorsPath.replace('/', '-')
     val targetFile = targetDirParent.resolve(targetFilename)

--- a/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/GitRepo.kt
@@ -47,7 +47,7 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.isSymbolicLink
 import org.ossreviewtoolkit.utils.common.realFile
-import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
+import org.ossreviewtoolkit.utils.common.searchUpwardFor
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -109,7 +109,7 @@ class GitRepo(
     }
 
     override fun getWorkingTree(vcsDirectory: File): WorkingTree {
-        val repoRoot = vcsDirectory.searchUpwardsForSubdirectory(".repo")
+        val repoRoot = vcsDirectory.searchUpwardFor(dirPath = ".repo")
 
         return if (repoRoot == null) {
             object : GitWorkingTree(vcsDirectory, type) {

--- a/utils/common/src/main/kotlin/FileUtils.kt
+++ b/utils/common/src/main/kotlin/FileUtils.kt
@@ -150,19 +150,18 @@ fun File.safeMkdirs(): File {
 }
 
 /**
- * Search [this] directory upwards towards the root until a contained subdirectory called [searchDirName] is found and
- * return the parent of [searchDirName], or return null if no such directory is found.
+ * Search [this] directory upward towards the root until either a directory at [dirPath] or a file at [filePath] is
+ * found. Return the parent of a finding, or return null if nothing was found.
  */
-fun File.searchUpwardsForSubdirectory(searchDirName: String): File? {
-    if (!isDirectory) return null
+fun File.searchUpwardFor(dirPath: String? = null, filePath: String? = null): File? {
+    if (!isDirectory || (dirPath == null && filePath == null)) return null
 
-    var currentDir: File? = absoluteFile
+    return generateSequence(absoluteFile) { it.parentFile }.find {
+        val hasDir = dirPath != null && it.resolve(dirPath).isDirectory
+        val hasFile = filePath != null && it.resolve(filePath).isFile
 
-    while (currentDir != null && !currentDir.resolve(searchDirName).isDirectory) {
-        currentDir = currentDir.parentFile
+        hasDir || hasFile
     }
-
-    return currentDir
 }
 
 /**

--- a/utils/common/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/common/src/test/kotlin/ExtensionsTest.kt
@@ -34,6 +34,7 @@ import io.kotest.matchers.file.exist
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.maps.haveKey
+import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -213,13 +214,27 @@ class ExtensionsTest : WordSpec({
         }
     }
 
-    "File.searchUpwardsForSubdirectory()" should {
+    "File.searchUpwardFor()" should {
         "find the root Git directory" {
-            val gitRoot = File(".").searchUpwardsForSubdirectory(".git")
+            val dir = File(".").searchUpwardFor(dirPath = ".git")
 
-            gitRoot shouldNotBeNull {
+            dir shouldNotBeNull {
                 this shouldBe File("../..").absoluteFile.normalize()
             }
+        }
+
+        "find the root LICENSE file" {
+            val dir = File(".").searchUpwardFor(filePath = "LICENSE")
+
+            dir shouldNotBeNull {
+                this shouldBe File("../..").absoluteFile.normalize()
+            }
+        }
+
+        "find nothing for a file receiver" {
+            val file = tempfile()
+
+            file.searchUpwardFor(filePath = file.name) should beNull()
         }
     }
 


### PR DESCRIPTION
Use the function in more places by generalizing it for files with the `generateSequence()`-approach used in `PodDependencyHandler`.