### PR TITLE
fix(conan): Properly check for Conan version

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -130,7 +130,7 @@ class Conan(
     override val globsForDefinitionFiles = listOf("conanfile*.txt", "conanfile*.py")
 
     private val handler by lazy {
-        if (command.getVersion().startsWith("1.")) {
+        if (command.getVersion().startsWith("Conan version 1.")) {
             ConanV1Handler(this)
         } else {
             ConanV2Handler(this)


### PR DESCRIPTION
Conan v1 and v2 return 'Conan version X.XX' when called with '--version' parameter. To properly determine which variant of the Conan handler to be used, the full prefix has to be checked, otherwise ConanV2Handler will always be used.

For reference the outputs of Conan v1 and v2 from Docker image version 61.0.0:

ort@e3e6081438c0:~$ conan --version
Conan version 1.66.0

ort@e3e6081438c0:~$ conan2 --version
Conan version 2.14.0