### PR TITLE
Extend analyzer plugin docs with examples for `.ort.yml` syntax

### DIFF
--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -102,53 +102,57 @@ abstract class GeneratePluginDocsTask : DefaultTask() {
                 // Write example configuration.
                 appendLine("### Example")
                 appendLine()
+
+                fun appendOptionsAndSecrets() {
+                    val indent = if (tool != null) {
+                        appendLine("  $tool:")
+                        4
+                    } else {
+                        2
+                    }
+
+                    val i = " ".repeat(indent)
+
+                    appendLine("$i$pluginTypeCamelCase:")
+                    appendLine("$i  ${descriptor["id"]}:")
+
+                    fun appendOptions(options: List<Map<*, *>>) {
+                        options.forEach {
+                            val defaultValue = it["default"]
+                            val type = it["type"]
+                            val isStringValue = type == "SECRET" || type == "STRING" || type == "STRING_LIST"
+
+                            append("$i      ${it["name"]}: ")
+                            if (defaultValue != null) {
+                                if (isStringValue) append("\"")
+                                append(defaultValue)
+                                if (isStringValue) append("\"")
+                            } else {
+                                append("<OPTIONAL_$type>")
+                            }
+                            appendLine()
+                        }
+                    }
+
+                    if (options.isNotEmpty()) {
+                        appendLine("$i    options:")
+                        appendOptions(options)
+                    }
+
+                    if (secrets.isNotEmpty()) {
+                        appendLine("$i    secrets:")
+                        appendOptions(secrets)
+                    }
+                }
+
                 appendLine("Use the following syntax to configure this plugin globally as part of `config.yml`:")
                 appendLine()
                 appendLine("```yaml")
                 appendLine("ort:")
-
-                val indent = if (tool != null) {
-                    appendLine("  $tool:")
-                    4
-                } else {
-                    2
-                }
-
-                val i = " ".repeat(indent)
-
-                appendLine("$i$pluginTypeCamelCase:")
-                appendLine("$i  ${descriptor["id"]}:")
-
-                fun appendOptions(options: List<Map<*, *>>) {
-                    options.forEach {
-                        val defaultValue = it["default"]
-                        val type = it["type"]
-                        val isStringValue = type == "SECRET" || type == "STRING" || type == "STRING_LIST"
-
-                        append("$i      ${it["name"]}: ")
-                        if (defaultValue != null) {
-                            if (isStringValue) append("\"")
-                            append(defaultValue)
-                            if (isStringValue) append("\"")
-                        } else {
-                            append("<OPTIONAL_$type>")
-                        }
-                        appendLine()
-                    }
-                }
-
-                if (options.isNotEmpty()) {
-                    appendLine("$i    options:")
-                    appendOptions(options)
-                }
-
-                if (secrets.isNotEmpty()) {
-                    appendLine("$i    secrets:")
-                    appendOptions(secrets)
-                }
-
+                appendOptionsAndSecrets()
                 appendLine("```")
                 appendLine()
+
                 appendLine("### Options")
                 appendLine()
 

--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -154,6 +154,18 @@ abstract class GeneratePluginDocsTask : DefaultTask() {
                 appendLine("```")
                 appendLine()
 
+                if (tool == "analyzer") {
+                    appendLine("Use the following syntax to configure this plugin in a repository's `.ort.yml`:")
+                    appendLine()
+                    appendLine("```yaml")
+
+                    // See https://github.com/oss-review-toolkit/ort/issues/5715.
+                    appendOptionsAndSecrets(0, pluginTypeParts.joinToString("_"))
+
+                    appendLine("```")
+                    appendLine()
+                }
+
                 appendLine("### Options")
                 appendLine()
 

--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -103,17 +103,18 @@ abstract class GeneratePluginDocsTask : DefaultTask() {
                 appendLine("### Example")
                 appendLine()
 
-                fun appendOptionsAndSecrets() {
+                fun appendOptionsAndSecrets(startIndent: Int, pluginType: String) {
                     val indent = if (tool != null) {
-                        appendLine("  $tool:")
-                        4
+                        append(" ".repeat(startIndent))
+                        appendLine("$tool:")
+                        startIndent + 2
                     } else {
-                        2
+                        startIndent
                     }
 
                     val i = " ".repeat(indent)
 
-                    appendLine("$i$pluginTypeCamelCase:")
+                    appendLine("$i$pluginType:")
                     appendLine("$i  ${descriptor["id"]}:")
 
                     fun appendOptions(options: List<Map<*, *>>) {
@@ -149,7 +150,7 @@ abstract class GeneratePluginDocsTask : DefaultTask() {
                 appendLine()
                 appendLine("```yaml")
                 appendLine("ort:")
-                appendOptionsAndSecrets()
+                appendOptionsAndSecrets(2, pluginTypeCamelCase)
                 appendLine("```")
                 appendLine()
 

--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -26,7 +26,6 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.support.uppercaseFirstChar
 
 abstract class GeneratePluginDocsTask : DefaultTask() {
     init {


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 