### PR TITLE
fix(conan): Properly check for Conan version

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -73,8 +73,9 @@ internal class ConanCommand(private val useConan2: Boolean = false) : CommandLin
 
     override fun transformVersion(output: String) =
         // Conan could report version strings like:
-        // Conan version 1.18.0
-        output.removePrefix("Conan version ")
+        // \033[0;32mConan version 1.18.0\033[0;m
+        // Conan version 2.18.0
+        output.substringAfter("Conan version ")
 
     override fun getVersionRequirement(): RangesList = RangesListFactory.create(">=1.44.0 <3.0")
 


### PR DESCRIPTION
Conan version 1 prints a color coded string (green) when using `--version` parameter. Version 2 does not.
In some TTYs this leads to the version string not being transformed correctly. To also cover the potential colder coding commands `substringAfter` is used instead of `removePrefix`.
