### PR TITLE
ci(github): Do not fail fast for the (unit) test matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     needs: build
     steps:


### PR DESCRIPTION
This allows to more easily identify Windows-specific failures, when seeing that tests on Linux succeed.