### PR TITLE
feat(gradle): Publish a version catalog for ORT

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ include(":utils:scripting")
 include(":utils:spdx")
 include(":utils:spdx-document")
 include(":utils:test")
+include(":version-catalog")
 
 project(":clients:bazel-module-registry").name = "bazel-module-registry-client"
 project(":clients:clearly-defined").name = "clearly-defined-client"

--- a/version-catalog/build.gradle.kts
+++ b/version-catalog/build.gradle.kts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply core plugins.
+    `version-catalog`
+
+    // Apply precompiled plugins.
+    id("ort-base-conventions")
+    id("ort-publication-conventions")
+}
+
+gradle.projectsEvaluated {
+    catalog {
+        versionCatalog {
+            val hyphenRegex = Regex("([a-z])-([a-z])")
+
+            rootProject.subprojects.filter { subproject ->
+                subproject.pluginManager.hasPlugin("ort-publication-conventions")
+            }.forEach { subproject ->
+                val alias = subproject.projectDir.toRelativeString(rootDir)
+                    .replace(hyphenRegex) {
+                        "${it.groupValues[1]}${it.groupValues[2].uppercase()}"
+                    }
+                    .replace(File.separatorChar, '-')
+
+                with(subproject) {
+                    library("ort-$alias", "$group:$name:$version")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows programmatic users of ORT libraries to consume them by only declaring the version once, and not for all libraries. Also no custom library declarations are needed anymore on the consumer side.

For details see [1].

[1]: https://docs.gradle.org/current/userguide/version_catalogs.html#sec:version-catalog-plugin