### PR TITLE
refactor(model): Change `FileArchiver` to first apply the matcher

### DIFF
--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -80,20 +80,21 @@ class FileArchiver(
             directory.packZip(zipFile, overwrite = true) { file ->
                 val relativePath = file.relativeTo(directory).invariantSeparatorsPath
 
+                if (!matcher.matches(relativePath)) {
+                    logger.debug {
+                        "Not adding '$relativePath' to archive because it does not match the configured patterns."
+                    }
+
+                    return@packZip false
+                }
+
                 if (tika.detect(file) != MimeTypes.PLAIN_TEXT) {
                     logger.warn { "Not adding file '$relativePath' to archive because it is not a text file." }
                     return@packZip false
                 }
 
-                matcher.matches(relativePath).also { result ->
-                    logger.debug {
-                        if (result) {
-                            "Adding '$relativePath' to archive."
-                        } else {
-                            "Not adding '$relativePath' to archive."
-                        }
-                    }
-                }
+                logger.debug { "Adding '$relativePath' to archive." }
+                true
             }
         }
 


### PR DESCRIPTION
Apply the file pattern matcher before checking if the file is a text file. This makes more sense, because there is no reason to check the type of files that are not configured to be archived anyway.