### PR TITLE
test(spdx-reporter): Test the validity of the YAML against the schema

### DIFF
--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper.fromJson
 import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper.fromYaml
 import org.ossreviewtoolkit.utils.spdxdocument.model.SPDX_VERSION_2_2
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxDocument
+import org.ossreviewtoolkit.utils.test.InputFormat
 import org.ossreviewtoolkit.utils.test.matchJsonSchema
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.readOrtResult
@@ -77,6 +78,14 @@ class SpdxDocumentReporterFunTest : WordSpec({
     }
 
     "Reporting SPDX-2.2 to YAML" should {
+        "create a valid document" {
+            val schemaJson = readResource("/spdx-v2.2.2-schema.json")
+
+            val yamlSpdxDocument = generateReport(ORT_RESULT, FileFormat.JSON, SPDX_VERSION_2_2)
+
+            yamlSpdxDocument should matchJsonSchema(schemaJson, InputFormat.YAML)
+        }
+
         "create the expected document for a synthetic scan result" {
             val expectedResult = readResource("/synthetic-scan-result-expected-output.spdx.yml")
 

--- a/utils/test/src/main/kotlin/Matchers.kt
+++ b/utils/test/src/main/kotlin/Matchers.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.utils.test
 import com.github.difflib.DiffUtils
 import com.github.difflib.UnifiedDiffUtils
 
-import com.networknt.schema.InputFormat
+import com.networknt.schema.InputFormat as NetworkNtInputFormat
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 
@@ -124,10 +124,19 @@ fun matchExpectedResult(
     }
 }
 
-fun matchJsonSchema(schemaJson: String): Matcher<String> =
+/**
+ * This enum wraps the upstream one to avoid the need for callers of `matchJsonSchema()` to depend on the
+ * 'json-schema-validator' library directly.
+ */
+enum class InputFormat(internal val networkNtInputformat: NetworkNtInputFormat) {
+    JSON(NetworkNtInputFormat.JSON),
+    YAML(NetworkNtInputFormat.YAML)
+}
+
+fun matchJsonSchema(schemaJson: String, inputFormat: InputFormat = InputFormat.JSON): Matcher<String> =
     Matcher { actual ->
         val schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7).getSchema(schemaJson)
-        val violations = schema.validate(actual, InputFormat.JSON)
+        val violations = schema.validate(actual, inputFormat.networkNtInputformat)
 
         MatcherResult(
             violations.isEmpty(),


### PR DESCRIPTION
Validating both, JSON and YAML, against the schema is valuable in particular with regard to the recently introduced patching the `SPDX-2.3` output to `SPDX-2.2` which potentially could be inhanced with JSON or YAML format specific code.

