### PR TITLE
fix(fossid): Do not pass a URL with user info to the authenticator

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdUrlProvider.kt
@@ -100,11 +100,12 @@ class FossIdUrlProvider private constructor(
          * known for this host, strip the credentials part from [replaced].
          */
         private fun insertCredentials(replaced: String): String {
-            // In order to have a valid URL, the variables must be replaced by some credentials first.
-            val replacedUrl = replaced.insertCredentials(UNKNOWN_CREDENTIALS)
+            // In order to have a valid URL from which credentials can be stripped, the variables must be replaced by
+            // some credentials first.
+            val replacedUrl = replaced.insertCredentials(UNKNOWN_CREDENTIALS).replaceCredentialsInUri()
 
             return queryAuthenticator(replacedUrl)?.let { replaced.insertCredentials(it) }
-                ?: replacedUrl.replaceCredentialsInUri()
+                ?: replacedUrl
         }
 
         /**

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdUrlProviderTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdUrlProviderTest.kt
@@ -140,6 +140,6 @@ private fun mockAuthenticator(
     mockkStatic("org.ossreviewtoolkit.utils.ort.UtilsKt")
     every { requestPasswordAuthentication(any()) } answers {
         val uri = firstArg<URI>()
-        authentication.takeIf { uri.host == host && uri.port == port && uri.scheme == "https" }
+        authentication.takeIf { uri.host == host && uri.port == port && uri.scheme == "https" && uri.userInfo == null }
     }
 }


### PR DESCRIPTION
When querying the authenticator for the credentials of a repository to be scanned by FossID, do not use a URL with a user info component, which may be present after applying URL mapping. This will trigger ORT's `UserInfoAuthenticator` and yield invalid results.
