### PR TITLE
refactor(Repository): Add `RepositoryProvenance` attribute

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -146,7 +147,12 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
             // Only include nested VCS if they are part of the analyzed directory.
             workingTree.getRootPath().resolve(path).startsWith(info.absoluteProjectPath)
         }.orEmpty()
-        val repository = Repository(vcs = vcs, nestedRepositories = nestedVcs, config = info.repositoryConfiguration)
+        val provenance = RepositoryProvenance(vcs, vcs.revision)
+        val repository = Repository(
+            provenance = provenance,
+            nestedRepositories = nestedVcs,
+            config = info.repositoryConfiguration
+        )
 
         val endTime = Instant.now()
 

--- a/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -120,7 +121,7 @@ internal class CreateAnalyzerResultFromPackageListCommand : OrtHelperCommand(
                 environment = Environment()
             ),
             repository = Repository(
-                vcs = projectVcs.normalize(),
+                provenance = RepositoryProvenance(projectVcs.normalize(), projectVcs.revision),
                 config = RepositoryConfiguration(
                     excludes = Excludes(
                         scopes = listOf(

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -207,6 +207,7 @@ private fun createOrtResult(
         url = "https://github.com/oss-review-toolkit/example.git",
         revision = "0000000000000000000000000000000000000000"
     )
+    val provenance = RepositoryProvenance(vcsInfo, vcsInfo.revision)
     val licenseFindings = detectedLicensesForFilePath.flatMapTo(mutableSetOf()) { (filePath, licenses) ->
         licenses.map { license ->
             LicenseFinding(license, TextLocation(filePath, startLine = 1, endLine = 2))
@@ -214,7 +215,7 @@ private fun createOrtResult(
     }
 
     return OrtResult.EMPTY.copy(
-        repository = Repository(vcsInfo),
+        repository = Repository(provenance),
         analyzer = AnalyzerRun.EMPTY.copy(
             result = AnalyzerResult.EMPTY.copy(
                 projects = setOf(

--- a/evaluator/src/testFixtures/kotlin/TestData.kt
+++ b/evaluator/src/testFixtures/kotlin/TestData.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
@@ -179,7 +180,10 @@ val allProjects = setOf(
 
 val ortResult = OrtResult(
     repository = Repository(
-        vcs = VcsInfo.EMPTY,
+        provenance = RepositoryProvenance(
+            vcsInfo = VcsInfo.EMPTY,
+            resolvedRevision = ""
+        ),
         config = RepositoryConfiguration(
             excludes = Excludes(
                 paths = listOf(

--- a/model/src/main/kotlin/Repository.kt
+++ b/model/src/main/kotlin/Repository.kt
@@ -29,9 +29,14 @@ import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
  */
 data class Repository(
     /**
+     * Provenance wrapper for original VCS information, if present.
+     */
+    val provenance: RepositoryProvenance,
+
+    /**
      * Original VCS-related information from the working tree containing the analyzer root.
      */
-    val vcs: VcsInfo,
+    val vcs: VcsInfo = provenance.vcsInfo,
 
     /**
      * Processed VCS-related information from the working tree containing the analyzer root that has e.g. common
@@ -57,6 +62,7 @@ data class Repository(
          */
         @JvmField
         val EMPTY = Repository(
+            provenance = RepositoryProvenance(VcsInfo.EMPTY, VcsInfo.EMPTY.revision),
             vcs = VcsInfo.EMPTY,
             vcsProcessed = VcsInfo.EMPTY,
             nestedRepositories = emptyMap(),

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -82,6 +82,7 @@ class OrtResultTest : WordSpec({
     "getDefinitionFilePathRelativeToAnalyzerRoot()" should {
         "use the correct vcs" {
             val vcs = VcsInfo(type = VcsType.GIT, url = "https://example.com/git", revision = "")
+            val provenance = RepositoryProvenance(vcs, vcs.revision)
             val nestedVcs1 = VcsInfo(type = VcsType.GIT, url = "https://example.com/git1", revision = "")
             val nestedVcs2 = VcsInfo(type = VcsType.GIT, url = "https://example.com/git2", revision = "")
             val project1 = Project.EMPTY.copy(
@@ -104,7 +105,7 @@ class OrtResultTest : WordSpec({
             )
             val ortResult = OrtResult(
                 Repository(
-                    vcs = vcs,
+                    provenance = provenance,
                     nestedRepositories = mapOf(
                         "path/1" to nestedVcs1,
                         "path/2" to nestedVcs2
@@ -122,6 +123,7 @@ class OrtResultTest : WordSpec({
 
         "fail if no vcs matches" {
             val vcs = VcsInfo(type = VcsType.GIT, url = "https://example.com/git", revision = "")
+            val provenance = RepositoryProvenance(vcs, vcs.revision)
             val nestedVcs1 = VcsInfo(type = VcsType.GIT, url = "https://example.com/git1", revision = "")
             val nestedVcs2 = VcsInfo(type = VcsType.GIT, url = "https://example.com/git2", revision = "")
             val project = Project.EMPTY.copy(
@@ -132,7 +134,7 @@ class OrtResultTest : WordSpec({
             )
             val ortResult = OrtResult(
                 Repository(
-                    vcs = vcs,
+                    provenance = provenance,
                     nestedRepositories = mapOf(
                         "path/1" to nestedVcs1
                     )

--- a/model/src/testFixtures/kotlin/TestData.kt
+++ b/model/src/testFixtures/kotlin/TestData.kt
@@ -136,7 +136,10 @@ val scanResults = listOf(
 
 val ortResult = OrtResult(
     repository = Repository(
-        vcs = VcsInfo.EMPTY,
+        provenance = RepositoryProvenance(
+            vcsInfo = VcsInfo.EMPTY,
+            resolvedRevision = ""
+        ),
         config = RepositoryConfiguration(
             excludes = Excludes(
                 paths = listOf(

--- a/plugins/reporters/ctrlx/src/funTest/kotlin/CtrlXAutomationReporterFunTest.kt
+++ b/plugins/reporters/ctrlx/src/funTest/kotlin/CtrlXAutomationReporterFunTest.kt
@@ -42,6 +42,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.RootDependencyIndex
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
@@ -142,6 +143,8 @@ private fun createReporterInput(): ReporterInput {
         path = "sub/path"
     )
 
+    val analyzedProvenance = RepositoryProvenance(analyzedVcs, analyzedVcs.revision)
+
     val package1 = Package.EMPTY.copy(
         id = Identifier("Maven:ns:package1:1.0"),
         declaredLicenses = setOf("LicenseRef-scancode-broadcom-commercial"),
@@ -164,8 +167,7 @@ private fun createReporterInput(): ReporterInput {
     return ReporterInput(
         OrtResult(
             repository = Repository(
-                vcs = analyzedVcs,
-                vcsProcessed = analyzedVcs
+                provenance = analyzedProvenance
             ),
             analyzer = AnalyzerRun.EMPTY.copy(
                 result = AnalyzerResult(

--- a/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
+++ b/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
@@ -42,6 +42,7 @@ import org.ossreviewtoolkit.clients.fossid.model.report.SelectionType
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
@@ -238,6 +239,7 @@ private fun createReporterInput(vararg scanCodes: String): ReporterInput {
         url = "https://github.com/path/first-project.git",
         path = "sub/path"
     )
+    val analyzedProvenance = RepositoryProvenance(analyzedVcs, analyzedVcs.revision)
 
     val results = scanCodes.associateByTo(
         destination = sortedMapOf(),
@@ -266,8 +268,7 @@ private fun createReporterInput(vararg scanCodes: String): ReporterInput {
                         )
                     )
                 ),
-                vcs = analyzedVcs,
-                vcsProcessed = analyzedVcs
+                provenance = analyzedProvenance
             ),
             scanner = scannerRunOf(*results.toList().toTypedArray())
         )

--- a/plugins/reporters/freemarker/src/test/kotlin/FreeMarkerTemplateProcessorTest.kt
+++ b/plugins/reporters/freemarker/src/test/kotlin/FreeMarkerTemplateProcessorTest.kt
@@ -94,6 +94,10 @@ private val PROJECT_VCS_INFO = VcsInfo(
     url = "ssh://git@host/manifests/repo?manifest=path/to/manifest.xml",
     revision = "deadbeaf44444444333333332222222211111111"
 )
+private val PROJECT_PROVENANCE = RepositoryProvenance(
+    PROJECT_VCS_INFO,
+    PROJECT_VCS_INFO.revision
+)
 private val NESTED_VCS_INFO = VcsInfo(
     type = VcsType.GIT,
     url = "ssh://git@host/project/repo",
@@ -107,7 +111,7 @@ private val idNestedProject = Identifier("SpdxDocumentFile:@ort:project-in-neste
 
 private val ORT_RESULT = OrtResult(
     repository = Repository(
-        vcs = PROJECT_VCS_INFO,
+        provenance = PROJECT_PROVENANCE,
         config = RepositoryConfiguration(),
         nestedRepositories = mapOf("nested-vcs-dir" to NESTED_VCS_INFO)
     ),

--- a/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
+++ b/plugins/reporters/opossum/src/test/kotlin/OpossumReporterTest.kt
@@ -241,11 +241,14 @@ private fun createOrtResult(): OrtResult {
         url = "https://github.com/path/first-project.git",
         path = "sub/path"
     )
+    val analyzedProvenance = RepositoryProvenance(
+        analyzedVcs,
+        analyzedVcs.revision
+    )
 
     return OrtResult(
         repository = Repository(
-            vcs = analyzedVcs,
-            vcsProcessed = analyzedVcs
+            provenance = analyzedProvenance
         ),
         analyzer = AnalyzerRun.EMPTY.copy(
             config = AnalyzerConfiguration(allowDynamicVersions = true),

--- a/plugins/reporters/spdx/src/testFixtures/kotlin/TestData.kt
+++ b/plugins/reporters/spdx/src/testFixtures/kotlin/TestData.kt
@@ -53,6 +53,8 @@ private val ANALYZED_VCS = VcsInfo(
     url = "https://github.com/path/proj1-repo.git"
 )
 
+private val ANALYZED_PROVENANCE = RepositoryProvenance(ANALYZED_VCS, ANALYZED_VCS.revision)
+
 val ORT_RESULT = OrtResult(
     repository = Repository(
         config = RepositoryConfiguration(
@@ -66,7 +68,7 @@ val ORT_RESULT = OrtResult(
                 )
             )
         ),
-        vcs = ANALYZED_VCS,
+        provenance = ANALYZED_PROVENANCE,
         vcsProcessed = ANALYZED_VCS
     ),
     analyzer = AnalyzerRun.EMPTY.copy(

--- a/reporter/src/testFixtures/kotlin/TestData.kt
+++ b/reporter/src/testFixtures/kotlin/TestData.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
@@ -66,10 +67,13 @@ import org.ossreviewtoolkit.utils.test.scannerRunOf
 // TODO: Create a way to reduce the code required to prepare an OrtResult for testing.
 val ORT_RESULT = OrtResult(
     repository = Repository(
-        vcs = VcsInfo(
-            type = VcsType.GIT,
-            url = "https://github.com/oss-review-toolkit/ort.git",
-            revision = "main"
+        provenance = RepositoryProvenance(
+            vcsInfo = VcsInfo(
+                type = VcsType.GIT,
+                url = "https://github.com/oss-review-toolkit/ort.git",
+                revision = "main"
+            ),
+            resolvedRevision = "main"
         ),
         config = RepositoryConfiguration(
             excludes = Excludes(


### PR DESCRIPTION
The `Repository` data structure seems the easiest place to allow `Provenance`s as `Analyzer` and `Scanner` input.
This avoids refactoring the attributes of higher level data structures, such as `OrtResult`.
At the moment the implementation limits it to `RepositoryProvence` though, in order to keep its previous behavior. To that end, it also continues to expose the raw `VcsInfo` of the `provenance` as its `vcs` attribute.

Signed-off-by: Jens Keim <jens.keim@forvia.com>