### PR TITLE
docs(website): Fix wrong `SourceCodeOrigin` value for source artifacts

### DIFF
--- a/website/docs/configuration/package-configurations.md
+++ b/website/docs/configuration/package-configurations.md
@@ -40,7 +40,7 @@ source_code_origin: VCS
 # Apply to versions all versions greater or equal to 4.0 
 # and lower or equal to 4.2.1 where a source artifact was scanned.
 id: "NPM::ansi-styles:[4.0,4.2.1]"
-source_code_origin: SOURCE_ARTIFACT
+source_code_origin: ARTIFACT
 
 # Apply only to version 4.2.1, regardless whether
 # code repository or source artifact was scanned.


### PR DESCRIPTION
The enum constant is `SourceCodeOrigin.ARTIFACT`, not `SourceCodeOrigin.SOURCE_ARTIFACT`.