### PR TITLE
test(bundler): update expected output for multi_json homepage move

### DIFF
--- a/plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -198,7 +198,7 @@ packages:
   description: "A common interface to multiple JSON libraries, including Oj, Yajl,\
     \ the JSON gem (with C-extensions), the pure-Ruby JSON gem, NSJSONSerialization,\
     \ gson.rb, JrJackson, and OkJson."
-  homepage_url: "https://github.com/intridea/multi_json"
+  homepage_url: "https://github.com/sferik/multi_json"
   binary_artifact:
     url: ""
     hash:


### PR DESCRIPTION
The multi_json gem has been transferred from **intridea** to **sferik** and its README now declares https://github.com/sferik/multi_json as the canonical project URL.

Update the Bundler functional-test expectation (`bundler-expected-output-gemspec.yml`) to reflect the new `homepage_url` value so the test remains green.
