### PR TITLE
build(gradle): Ensure that the `run` task is always executed

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -211,6 +211,9 @@ signing {
 }
 
 tasks.named<JavaExec>("run") {
+    // Work around https://github.com/graalvm/native-build-tools/issues/743.
+    doNotTrackState("The 'run' task is never supposed to be UP-TO-DATE.")
+
     System.getenv("TERM")?.also {
         val mode = it.substringAfter('-', "16color")
         environment("FORCE_COLOR" to mode)


### PR DESCRIPTION
The GraalVM native build tools add an output to the `run` task which causes it to be up-to-dateable. Still ensure that Gradle (and IntelliJ) always execute the task.