### PR TITLE
build(gradle): Only warn about new Detekt rules if they were recompiled

### DIFF
--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -20,6 +20,8 @@
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     // Apply precompiled plugins.
     id("ort-library-conventions")
@@ -46,7 +48,7 @@ interface StyledTextOutputProvider {
     val out: StyledTextOutputFactory
 }
 
-tasks.named<Jar>("jar") {
+tasks.named<KotlinCompile>("compileKotlin") {
     // Resolve objects at configuration time to be compatible with the configuration cache.
     val objects = objects
 


### PR DESCRIPTION
Do not issue the warning if the JAR was rebuilt, which might occur when the global project version has changed, but no code of Detekt rules.