### PR TITLE
ci(github): Allow configuration caching when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
-        run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
+        run: ./gradlew publishAndReleaseToMavenCentral
       - name: Build ORT Distributions
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
This is supposed to be supported as of [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/10596