### PR TITLE
feat(intellij): Add a configuration to run CLI help

### DIFF
--- a/.run/ORT Help.run.xml
+++ b/.run/ORT Help.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ORT Help" type="JetRunConfigurationType">
+    <option name="MAIN_CLASS_NAME" value="org.ossreviewtoolkit.cli.OrtMainKt" />
+    <module name="oss-review-toolkit.cli.main" />
+    <option name="PROGRAM_PARAMETERS" value="--help" />
+    <shortenClasspath name="ARGS_FILE" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This can also serve as a template to copy other run configuration from to quickly get started with running ORT from IntelliJ IDEA.