### PR TITLE
chore: Remove verbose logging from `python-inspector`

### DIFF
--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
@@ -95,8 +95,6 @@ internal object PythonInspector : CommandLineTool {
                     add(setupFile.absolutePath)
                 }
             }
-
-            add("--verbose")
         }
 
         return try {


### PR DESCRIPTION
Unfortunately, the `python-inspector` prints credentials when using `--verbose` e.g. [1]:

```
repos:
 PypiSimpleRepository(
   index_url='https://example.com',
   credentials={'login': 'user', 'password': 'secret'}
 )
```

As a stop-gap measure, remove the `--verbose` option to avoid printing these credentials.

[1]: https://github.com/aboutcode-org/python-inspector/blob/4a91a4d4d5c3006927fe16476a853c2e1890a6d2/src/python_inspector/api.py#L280

