### PR TITLE
fix(spdx): Convert hash value to lowercase when creating SpdxChecksum

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -72,7 +72,7 @@ private fun Hash.toSpdxChecksum(): SpdxChecksum? =
         ?.let {
             SpdxChecksum(
                 algorithm = it,
-                checksumValue = value
+                checksumValue = value.lowercase()
             )
         }
 


### PR DESCRIPTION
Wraps `SpdxChecksum` creation in `runCatching` to handle validation failures, preventing failure of SPDX report generation when checksum validation fails.

This PR should fix #10659. More context is provided there.