### PR TITLE
fix(scanner): Correct setting scanner tool versions

### DIFF
--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -277,8 +277,8 @@ data class ScannerRun(
     /**
      * Merge this [ScannerRun] with the given [other] [ScannerRun].
      *
-     * Both [ScannerRun]s must have the same [environment] and [config], otherwise an [IllegalArgumentException] is
-     * thrown.
+     * Both [ScannerRun]s must have the same [config] and non-conflicting [environment], otherwise an
+     * [IllegalArgumentException] is thrown.
      *
      * files and scanResults are merged by their [KnownProvenance]s, while issues and scanners are merged by their
      * names.
@@ -303,11 +303,7 @@ data class ScannerRun(
         return ScannerRun(
             startTime = minOf(startTime, other.startTime),
             endTime = maxOf(endTime, other.endTime),
-            environment = environment.also {
-                require(it == other.environment) {
-                    "Cannot merge ScannerRuns with different environments: $it != ${other.environment}."
-                }
-            },
+            environment = environment + other.environment,
             config = config.also {
                 require(it == other.config) {
                     "Cannot merge ScannerRuns with different configurations: $it != ${other.config}."

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -170,7 +170,7 @@ class ScannerRunTest : WordSpec({
             }.message shouldBe "Cannot merge ScannerRuns with different configurations: $config1 != $config2."
         }
 
-        "not merge runs with different environments" {
+        "not merge runs with conflicting environments" {
             val env1 = Environment("1.0.0", "x86_64")
             val env2 = Environment("2.0.0", "x86_64")
 
@@ -184,7 +184,8 @@ class ScannerRunTest : WordSpec({
 
             shouldThrow<IllegalArgumentException> {
                 run1 + run2
-            }.message shouldBe "Cannot merge ScannerRuns with different environments: $env1 != $env2."
+            }.message shouldBe
+                "Cannot merge Environments with different ORT versions: '${env1.ortVersion}' != '${env2.ortVersion}'."
         }
 
         "combine start and end time" {

--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -172,7 +172,7 @@ class Pub(override val descriptor: PluginDescriptor = PubFactory.descriptor, pri
 
     private val flutterHome by lazy {
         Os.getPathFromEnvironment(flutterCommand)?.realFile?.parentFile?.parentFile
-            ?: Os.env["FLUTTER_HOME"]?.let { File(it) } ?: flutterInstallDir / "flutter"
+            ?: Os.env["FLUTTER_HOME"]?.let { File(it) } ?: (flutterInstallDir / "flutter")
     }
 
     private val flutterAbsolutePath = flutterHome / "bin"

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -66,7 +66,6 @@ import org.ossreviewtoolkit.scanner.utils.FileListResolver
 import org.ossreviewtoolkit.scanner.utils.alignRevisions
 import org.ossreviewtoolkit.scanner.utils.filterScanResultsByVcsPaths
 import org.ossreviewtoolkit.scanner.utils.getVcsPathsForProvenances
-import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.Environment
@@ -132,17 +131,7 @@ class Scanner(
             )
         )
 
-        val toolVersions = mutableMapOf<String, String>()
-
-        scannerWrappers.values.flatten().forEach { scanner ->
-            if (scanner is CommandLineTool) {
-                toolVersions[scanner.descriptor.id] = scanner.getVersion()
-            }
-        }
-
-        val scannerRun = (projectResults + packageResults).copy(
-            environment = Environment(toolVersions = toolVersions)
-        )
+        val scannerRun = projectResults + packageResults
 
         val paddedScannerRun = scannerRun.takeUnless { scannerConfig.includeFilesWithoutFindings }
             ?: scannerRun.padNoneLicenseFindings()
@@ -176,6 +165,10 @@ class Scanner(
         createMissingArchives(controller)
 
         val endTime = Instant.now()
+
+        val toolVersions = scannerWrappers.associate { scanner ->
+            scanner.descriptor.id to scanner.version
+        }
 
         val provenances = packages.mapTo(mutableSetOf()) { pkg ->
             val packageProvenance = controller.getPackageProvenance(pkg.id)
@@ -214,7 +207,7 @@ class Scanner(
         return ScannerRun(
             startTime = startTime,
             endTime = endTime,
-            environment = Environment(),
+            environment = Environment(toolVersions = toolVersions),
             config = scannerConfig,
             provenances = provenances,
             scanResults = scanResults,

--- a/utils/ort/src/main/kotlin/Environment.kt
+++ b/utils/ort/src/main/kotlin/Environment.kt
@@ -112,6 +112,64 @@ data class Environment(
             "GOPATH"
         )
     }
+
+    /**
+     * Merge this [Environment] with the given [other] [Environment].
+     *
+     * Both [Environment]s must have the same properties except for [variables] and [toolVersions], otherwise an
+     * [IllegalArgumentException] is thrown.
+     */
+    operator fun plus(other: Environment) =
+        Environment(
+            ortVersion = ortVersion.also {
+                require(it == other.ortVersion) {
+                    "Cannot merge Environments with different ORT versions: '$ortVersion' != '${other.ortVersion}'."
+                }
+            },
+            buildJdk = buildJdk.also {
+                require(it == other.buildJdk) {
+                    "Cannot merge Environments with different build JDKs: '$buildJdk' != '${other.buildJdk}'."
+                }
+            },
+            javaVersion = javaVersion.also {
+                require(it == other.javaVersion) {
+                    "Cannot merge Environments with different Java versions: '$javaVersion' != '${other.javaVersion}'."
+                }
+            },
+            os = os.also {
+                require(it == other.os) {
+                    "Cannot merge Environments with different operating systems: '$os' != '${other.os}'."
+                }
+            },
+            processors = processors.also {
+                require(it == other.processors) {
+                    "Cannot merge Environments with different processor counts: '$processors' != '${other.processors}'."
+                }
+            },
+            maxMemory = maxMemory.also {
+                require(it == other.maxMemory) {
+                    "Cannot merge Environments with different memory amounts: '$maxMemory' != '${other.maxMemory}'."
+                }
+            },
+            variables = run {
+                val keyIntersection by lazy { variables.keys.intersect(other.variables.keys) }
+
+                require(variables == other.variables || keyIntersection.isEmpty()) {
+                    "Cannot merge Environments with conflicting variable keys: $keyIntersection"
+                }
+
+                variables + other.variables
+            },
+            toolVersions = run {
+                val keyIntersection by lazy { toolVersions.keys.intersect(other.toolVersions.keys) }
+
+                require(toolVersions == other.toolVersions || keyIntersection.isEmpty()) {
+                    "Cannot merge Environments with conflicting tool versions keys: $keyIntersection"
+                }
+
+                toolVersions + other.toolVersions
+            }
+        )
 }
 
 /**

--- a/utils/ort/src/main/kotlin/Environment.kt
+++ b/utils/ort/src/main/kotlin/Environment.kt
@@ -123,7 +123,7 @@ val ortDataDirectory by lazy {
         it.isEmpty()
     }?.let {
         File(it)
-    } ?: Os.userHomeDirectory / ".ort"
+    } ?: (Os.userHomeDirectory / ".ort")
 }
 
 /**
@@ -134,7 +134,7 @@ val ortConfigDirectory by lazy {
         it.isEmpty()
     }?.let {
         File(it)
-    } ?: ortDataDirectory / "config"
+    } ?: (ortDataDirectory / "config")
 }
 
 /**
@@ -145,5 +145,5 @@ val ortToolsDirectory by lazy {
         it.isEmpty()
     }?.let {
         File(it)
-    } ?: ortDataDirectory / "tools"
+    } ?: (ortDataDirectory / "tools")
 }


### PR DESCRIPTION
By now no `ScannerWrapper` implements `CommandLineTool` anymore, so get the versions directly from the `ScannerDetails`.

While at it, already set `toolVersions` in the internal `scan()` function, which avoids a copy of the `ScannerRun`s later on.