### PR TITLE
fix(utils): detect key‑based duplicates in Set inputs

### DIFF
--- a/utils/common/src/main/kotlin/IterableUtils.kt
+++ b/utils/common/src/main/kotlin/IterableUtils.kt
@@ -46,12 +46,12 @@ fun Iterable<Int>.collapseToRanges(): List<Pair<Int, Int>> {
  * Return a map that associates duplicates as identified by [keySelector] with belonging lists of entries.
  */
 fun <T, K> Iterable<T>.getDuplicates(keySelector: (T) -> K): Map<K, List<T>> =
-    if (this is Set) emptyMap() else groupBy(keySelector).filter { it.value.size > 1 }
+    groupBy(keySelector).filter { it.value.size > 1 }
 
 /**
  * Return a set of duplicate entries in this [Iterable].
  */
-fun <T> Iterable<T>.getDuplicates(): Set<T> = getDuplicates { it }.keys
+fun <T> Iterable<T>.getDuplicates(): Set<T> = if (this is Set) emptySet() else getDuplicates { it }.keys
 
 /**
  * Return the next value in the iteration, or null if there is no next value.

--- a/utils/common/src/test/kotlin/IterableUtilsTest.kt
+++ b/utils/common/src/test/kotlin/IterableUtilsTest.kt
@@ -95,6 +95,16 @@ class IterableUtilsTest : WordSpec({
                 "b" to listOf("a" to "b", "b" to "b"),
                 "z" to listOf("a" to "z", "o" to "z")
             )
+
+            val strings = setOf(
+                "aaa",
+                "bbb",
+                "cc"
+            )
+
+            strings.getDuplicates { it.length } shouldBe mapOf(
+                3 to listOf("aaa", "bbb")
+            )
         }
     }
 })


### PR DESCRIPTION
`Iterable<T>.getDuplicates(keySelector)` returned no results when the receiver was a `Set`, even if different elements shared the same key. The early‑exit shortcut has been removed, so logical duplicates are now reported correctly.

Changes
* Drop Set fast‑path in `getDuplicates(keySelector)`; keep it only for the zero‑arg variant where it is safe.
* Align zero‑arg implementation and add regression tests.
