### PR TITLE
fix(fossid-webapp): Fix request Logging

### DIFF
--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -32,6 +32,7 @@
     <logger name="org.apache.http.wire" level="ERROR" />
     <logger name="org.eclipse.jgit.internal.storage.file.FileSnapshot" level="ERROR" />
     <logger name="org.ossreviewtoolkit.analyzer.managers.Yarn2" level="INFO" />
+    <logger name="org.ossreviewtoolkit.clients.fossid.LoggingInterceptor" level="INFO" />
     <logger name="org.ossreviewtoolkit.clients.fossid.FossIdRestService" level="INFO" />
     <logger name="org.ossreviewtoolkit.plugins.reporters.fossid.FossIdReporter" level="INFO" />
     <logger name="org.ossreviewtoolkit.plugins.reporters.fossid.FossIdSnippetReporter" level="INFO" />

--- a/clients/fossid-webapp/src/main/kotlin/LoggingInterceptor.kt
+++ b/clients/fossid-webapp/src/main/kotlin/LoggingInterceptor.kt
@@ -59,14 +59,15 @@ object LoggingInterceptor : Interceptor {
                 val contentType = requestBody.contentType()
                 val charset = contentType?.charset(StandardCharsets.UTF_8) ?: StandardCharsets.UTF_8
 
-                if (request.header("Content-Type") != "application/octet-stream") {
-                    val requestContent = buffer.readString(charset)
-                    append(requestContent.sanitizeForLogging())
-                    append("--> END ${request.method} (${requestBody.contentLength()}-byte body)")
-                } else {
+                val requestContentType = listOfNotNull(request.header("Content-Type"), contentType?.toString())
+                if ("application/octet-stream" in requestContentType) {
                     append(
                         "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)"
                     )
+                } else {
+                    val requestContent = buffer.readString(charset)
+                    append(requestContent.sanitizeForLogging())
+                    append("--> END ${request.method} (${requestBody.contentLength()}-byte body)")
                 }
             }
         }


### PR DESCRIPTION
Under some specific circumstances (when upload mode is enabled but the archive is not big enough to trigger the upload in chunks), OkHttp removes the content type header. Since this header is used to determine if a request body should be logged or not, this could crash the scanner when the request logging is enabled and the LoggingInterceptor tries to log binary content. This commit fixes this behavior by adding an extra check on the actual request body.


Note: I didn't find out why OkHttp removes this header. I found [this link](https://stackoverflow.com/questions/65712843/okhttp-does-not-allow-for-setting-of-content-type) but it does not apply here.
Anyway the extra protection brought by this PR does not hurt.
