### PR TITLE
feat(swiftpm): Provide URL to artifact on Swift PM registry

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,3 +17,4 @@ Copyright (C) 2022-2024 EPAM Systems, Inc.
 Copyright (C) 2023-2024 Double Open Oy
 Copyright (C) 2024 Robert Bosch GmbH
 Copyright (C) 2024 Cariad SE
+Copyright (C) 2025 Quartett mobile GmbH

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-lockfile-v3-with-SPM-registry-configuration.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-lockfile-v3-with-SPM-registry-configuration.yml
@@ -1,0 +1,48 @@
+---
+project:
+  id: "SwiftPM::src/funTest/assets/projects/synthetic/lockfile-v3-with-SPM-registry-configuration/Package.resolved:<REPLACE_REVISION>"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "Swift::alamofire.alamofire:5.4.4"
+packages:
+- id: "Swift::alamofire.alamofire:5.4.4"
+  purl: "pkg:swift/alamofire.alamofire@5.4.4"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://some.other.artifactory.url/artifactory/api/swift/swift/alamofire/alamofire/alamofire-5.4.4.zip"
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-registry-configuration.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-registry-configuration.yml
@@ -1,0 +1,5 @@
+---
+version: 1
+registries:
+  some-scope:
+    url: "https://some.artifactory.url/artifactory/api/swift/swift"

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/lockfile-v3-with-SPM-registry-configuration/.swiftpm/configuration/registries.json
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/lockfile-v3-with-SPM-registry-configuration/.swiftpm/configuration/registries.json
@@ -1,0 +1,10 @@
+{
+  "authentication" : {},
+  "registries" : {
+    "alamofire" : {
+      "supportsAvailability" : false,
+      "url" : "https://some.other.artifactory.url/artifactory/api/swift/swift"
+    }
+  },
+  "version" : 1
+}

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/lockfile-v3-with-SPM-registry-configuration/Package.resolved
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/lockfile-v3-with-SPM-registry-configuration/Package.resolved
@@ -1,0 +1,13 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire.alamofire",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "5.4.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/registry-configuration/registries.json
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/registry-configuration/registries.json
@@ -1,0 +1,10 @@
+{
+  "authentication" : {},
+  "registries" : {
+    "some-scope" : {
+      "supportsAvailability" : false,
+      "url" : "https://some.artifactory.url/artifactory/api/swift/swift"
+    }
+  },
+  "version" : 1
+}

--- a/plugins/package-managers/swiftpm/src/funTest/kotlin/SwiftPmFunTest.kt
+++ b/plugins/package-managers/swiftpm/src/funTest/kotlin/SwiftPmFunTest.kt
@@ -73,12 +73,26 @@ class SwiftPmFunTest : WordSpec({
         }
     }
 
-    "Analyzing a lockfile with a dependency loaded over SPM registry instead of source control" should {
+    @Suppress("MaxLineLength")
+    "Analyzing a lockfile with a dependency loaded over SPM registry instead of source control with no registry config present" should {
         "return the correct result" {
             val definitionFile =
                 getAssetFile("projects/synthetic/only-lockfile-v3-with-SPM-registry-dependency/Package.resolved")
             val expectedResultFile =
                 getAssetFile("projects/synthetic/expected-output-only-lockfile-v3-with-SPM-registry-dependency.yml")
+
+            val result = SwiftPmFactory.create().resolveSingleProject(definitionFile)
+
+            result.withInvariantIssues().toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+        }
+    }
+
+    "Analyzing a lockfile with a dependency loaded over SPM registry with registry configuration" should {
+        "return the correct result" {
+            val definitionFile =
+                getAssetFile("projects/synthetic/lockfile-v3-with-SPM-registry-configuration/Package.resolved")
+            val expectedResultFile =
+                getAssetFile("projects/synthetic/expected-lockfile-v3-with-SPM-registry-configuration.yml")
 
             val result = SwiftPmFactory.create().resolveSingleProject(definitionFile)
 
@@ -120,6 +134,17 @@ class SwiftPmFunTest : WordSpec({
                 .resolveSingleProject(definitionFile, allowDynamicVersions = true, resolveScopes = true)
 
             result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+        }
+    }
+
+    "readSwiftPackageRegistryConfiguration()" should {
+        "parse a valid 'registries.json' file correctly" {
+            val registriesFile = getAssetFile("projects/synthetic/registry-configuration/registries.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/expected-output-registry-configuration.yml")
+
+            val result = readSwiftPackageRegistryConfiguration(registriesFile)
+
+            result.toYaml() should matchExpectedResult(expectedResultFile, registriesFile)
         }
     }
 })

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -17,14 +17,19 @@
  * License-Filename: LICENSE
  */
 
+@file:Suppress("TooManyFunctions")
+
 package org.ossreviewtoolkit.plugins.packagemanagers.swiftpm
 
 import java.io.File
+
+import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
@@ -93,9 +98,22 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
             }
         }
 
+        val localSwiftPackageRegistryConfiguration =
+            readLocalSwiftPackageRegistryConfiguration(definitionFile.parentFile)
+                ?: readLocalSwiftPackageRegistryConfiguration(analysisRoot)
+
         return when (definitionFile.name) {
-            PACKAGE_SWIFT_NAME -> resolveDefinitionFileDependencies(analysisRoot, definitionFile)
-            else -> resolveLockfileDependencies(analysisRoot, definitionFile)
+            PACKAGE_SWIFT_NAME -> resolveDefinitionFileDependencies(
+                analysisRoot = analysisRoot,
+                packageSwiftFile = definitionFile,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
+
+            else -> resolveLockfileDependencies(
+                analysisRoot = analysisRoot,
+                packageResolvedFile = definitionFile,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
         }
     }
 
@@ -105,25 +123,31 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
      */
     private fun resolveLockfileDependencies(
         analysisRoot: File,
-        packageResolvedFile: File
+        packageResolvedFile: File,
+        localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
     ): List<ProjectAnalyzerResult> {
         val issues = mutableListOf<Issue>()
         val packages = mutableSetOf<Package>()
         val scopeDependencies = mutableSetOf<Scope>()
 
-        parseLockfile(packageResolvedFile).onSuccess { pins ->
-            pins.mapTo(packages) { it.toPackage() }
-            scopeDependencies += Scope(
-                name = DEPENDENCIES_SCOPE_NAME,
-                dependencies = packages.mapTo(mutableSetOf()) { it.toReference(linkage = PackageLinkage.DYNAMIC) }
-            )
-        }.onFailure {
-            issues += createAndLogIssue(it.message.orEmpty())
-        }
+        parseLockfile(packageResolvedFile)
+            .onSuccess { pins ->
+                pins.mapTo(packages) { it.toPackage(localSwiftPackageRegistryConfiguration) }
+                scopeDependencies += Scope(
+                    name = DEPENDENCIES_SCOPE_NAME,
+                    dependencies = packages.mapTo(mutableSetOf()) { it.toReference(linkage = PackageLinkage.DYNAMIC) }
+                )
+            }.onFailure {
+                issues += createAndLogIssue(it.message.orEmpty())
+            }
 
         return listOf(
             ProjectAnalyzerResult(
-                project = projectFromDefinitionFile(analysisRoot, packageResolvedFile, scopeDependencies),
+                project = projectFromDefinitionFile(
+                    analysisRoot = analysisRoot,
+                    definitionFile = packageResolvedFile,
+                    scopeDependencies = scopeDependencies
+                ),
                 packages = packages,
                 issues = issues
             )
@@ -137,7 +161,8 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
      */
     private fun resolveDefinitionFileDependencies(
         analysisRoot: File,
-        packageSwiftFile: File
+        packageSwiftFile: File,
+        localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
     ): List<ProjectAnalyzerResult> {
         val swiftPackage = getSwiftPackage(packageSwiftFile)
 
@@ -157,10 +182,21 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
             }
         }
 
-        swiftPackage.getTransitiveDependencies().mapTo(packages) { it.toPackage(pinsByIdentity) }
+        swiftPackage.getTransitiveDependencies().mapTo(packages) {
+            it.toPackage(
+                pinsByIdentity = pinsByIdentity,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
+        }
+
         scopeDependencies += Scope(
             name = DEPENDENCIES_SCOPE_NAME,
-            dependencies = swiftPackage.dependencies.mapTo(mutableSetOf()) { it.toPackageReference(pinsByIdentity) }
+            dependencies = swiftPackage.dependencies.mapTo(mutableSetOf()) {
+                it.toPackageReference(
+                    pinsByIdentity = pinsByIdentity,
+                    localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+                )
+            }
         )
 
         return listOf(
@@ -222,13 +258,37 @@ private fun SwiftPackage.toId(pinsByIdentity: Map<String, PinV2>): Identifier =
 private fun SwiftPackage.toVcsInfo(pinsByIdentity: Map<String, PinV2>): VcsInfo =
     pinsByIdentity[identity]?.toVcsInfo() ?: VcsHost.parseUrl(url)
 
-private fun SwiftPackage.toPackage(pinsByIdentity: Map<String, PinV2>): Package =
-    createPackage(toId(pinsByIdentity), toVcsInfo(pinsByIdentity))
+private fun SwiftPackage.sourceArtifact(
+    pinsByIdentity: Map<String, PinV2>,
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): RemoteArtifact =
+    pinsByIdentity[identity]?.sourceArtifact(localSwiftPackageRegistryConfiguration) ?: RemoteArtifact.EMPTY
 
-private fun SwiftPackage.toPackageReference(pinsByIdentity: Map<String, PinV2>): PackageReference =
+private fun SwiftPackage.toPackage(
+    pinsByIdentity: Map<String, PinV2>,
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): Package =
+    createPackage(
+        id = toId(pinsByIdentity),
+        vcsInfo = toVcsInfo(pinsByIdentity),
+        sourceArtifact = sourceArtifact(
+            pinsByIdentity = pinsByIdentity,
+            localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+        )
+    )
+
+private fun SwiftPackage.toPackageReference(
+    pinsByIdentity: Map<String, PinV2>,
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): PackageReference =
     PackageReference(
         id = toId(pinsByIdentity),
-        dependencies = dependencies.mapTo(mutableSetOf()) { it.toPackageReference(pinsByIdentity) }
+        dependencies = dependencies.mapTo(mutableSetOf()) {
+            it.toPackageReference(
+                pinsByIdentity = pinsByIdentity,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
+        }
     )
 
 private fun SwiftPackage.getTransitiveDependencies(): Set<SwiftPackage> {
@@ -274,15 +334,53 @@ private fun PinV2.toVcsInfo(): VcsInfo {
     )
 }
 
-private fun PinV2.toPackage(): Package = createPackage(toId(), toVcsInfo())
+private fun PinV2.sourceArtifact(
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): RemoteArtifact =
+    if (kind == PinV2.Kind.REGISTRY) {
+        val userLevelSwiftPackageRegistryConfiguration = readUserLevelSwiftPackageRegistryConfiguration()
 
-private fun createPackage(id: Identifier, vcsInfo: VcsInfo) =
+        // Identifier for registry entries have the following format: <SCOPE>.<NAME>.
+        val (scope, name) = identity.split('.', limit = 2)
+
+        val registry = localSwiftPackageRegistryConfiguration?.let { it.registries[scope] }
+            ?: userLevelSwiftPackageRegistryConfiguration?.let { it.registries[scope] }
+
+        if (registry != null) {
+            // The "registry.url" only contains the base URL of the registry.
+            // We need to append the identity and replace all dots with slashes to get the correct path.
+            var url = registry.url
+            if (!registry.url.endsWith("/")) {
+                url += "/"
+            }
+
+            url += identity.replace(".", "/")
+            url += "/"
+            url += "$name-${state?.version}.zip"
+
+            RemoteArtifact(url = url, hash = Hash.NONE)
+        } else {
+            logger.warn { "Unable to determine Swift PM registry for: '$identity'" }
+            RemoteArtifact.EMPTY
+        }
+    } else {
+        RemoteArtifact.EMPTY
+    }
+
+private fun PinV2.toPackage(localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?) =
+    createPackage(
+        id = toId(),
+        vcsInfo = toVcsInfo(),
+        sourceArtifact = sourceArtifact(localSwiftPackageRegistryConfiguration)
+    )
+
+private fun createPackage(id: Identifier, vcsInfo: VcsInfo, sourceArtifact: RemoteArtifact) =
     Package(
         vcs = vcsInfo,
         description = "",
         id = id,
         binaryArtifact = RemoteArtifact.EMPTY,
-        sourceArtifact = RemoteArtifact.EMPTY,
+        sourceArtifact = sourceArtifact,
         declaredLicenses = emptySet(), // SPM files do not declare any licenses.
         homepageUrl = ""
     )


### PR DESCRIPTION
Read the project local and global swift registry configurations to provide the source artifact URL for dependencies fetched over a Swift PM Registry

This PR provides a follow-up of https://github.com/oss-review-toolkit/ort/pull/10124. This PR will now provide the `sourceArtifactUrl` for dependencies fetched over a Swift PM registry, which is required if the ORT scanner is turned on in a project.

We've tested the fix internally with several projects using Swift PM over registry and it worked great.
