### PR TITLE
build(gradle): Always show all warnings to identify issues early

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ org.gradle.configuration-cache.parallel = true
 org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true
+org.gradle.warning.mode = all
 
 kotlin.code.style = official
 


### PR DESCRIPTION
See [1].

[1]: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_warnings