### PR TITLE
build(gradle): Remove the reproducible-builds plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,5 +38,4 @@ dependencies {
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.ksp)
     implementation(libs.plugin.mavenPublish)
-    implementation(libs.plugin.reproducibleBuilds)
 }

--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -17,11 +17,6 @@
  * License-Filename: LICENSE
  */
 
-plugins {
-    // Apply third-party plugins.
-    id("org.gradlex.reproducible-builds")
-}
-
 repositories {
     mavenCentral()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ jakartaMigrationPlugin = "0.25.0"
 kotlinPlugin = "2.2.0"
 ksp = "2.2.0-2.0.2"
 mavenPublishPlugin = "0.34.0"
-reproducibleBuildsPlugin = "1.0"
 
 aeSecurity = "0.141.2"
 asciidoctorj = "3.0.0"
@@ -90,7 +89,6 @@ plugin-graalVmNativeImage = { module = "org.graalvm.buildtools:native-gradle-plu
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
-plugin-reproducibleBuilds = { module = "org.gradlex:reproducible-builds", version.ref = "reproducibleBuildsPlugin" }
 
 aeSecurity = { module = "org.metaeffekt.core:ae-security", version.ref = "aeSecurity" }
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }


### PR DESCRIPTION
With Gradle 9, building JARs is reproducible by default [1].

[1]: https://docs.gradle.org/9.0.0/release-notes.html#archive-tasks-produce-reproducible-archives-by-default