### PR TITLE
ci(github): Switch "windows-2022" to "windows-2025"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2022]
+        os: [ubuntu-24.04, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Repository
@@ -53,7 +53,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2022]
+        os: [ubuntu-24.04, windows-2025]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     needs: build


### PR DESCRIPTION
Upgrade for more modern tools, see [1]. For information, GitHub will make "latest" point to "windows-2025" end of September 2025.

[1]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md