### PR TITLE
fix(scanners): Determine paths invariantly for Windows

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
@@ -136,7 +136,7 @@ class UploadArchiveHandler(
         path.walkBottomUp()
             .filter { it != path }
             .forEach { file ->
-                val relativePath = file.toRelativeString(path)
+                val relativePath = file.relativeTo(path).invariantSeparatorsPath
                 if (shouldDeleteFile(relativePath, includes, excludes)) {
                     file.delete()
                 }


### PR DESCRIPTION
This makes `UploadArchiveHandlerTest` pass on Windows again.