### PR TITLE
ci(release): Disable the dependency grap generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
         with:
-          dependency-graph: generate-and-submit
+          dependency-graph: disabled
       - name: Publish to Maven Central
         env:
           GITHUB_DEPENDENCY_GRAPH_REF: refs/heads/main


### PR DESCRIPTION
Disable the generation and submission of the GitHub dependency graph because it might be the reason that the release workflow is currently failing with an error [1].

[1]: https://github.com/oss-review-toolkit/ort/actions/runs/16724857711/job/47342431882