### PR TITLE
Revert "ci(release): Disable the dependency grap generation"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
         with:
-          dependency-graph: disabled
+          dependency-graph: generate-and-submit
       - name: Publish to Maven Central
         env:
           GITHUB_DEPENDENCY_GRAPH_REF: refs/heads/main


### PR DESCRIPTION
This reverts commit f6771fa as it did not help to make the release process work again.