### PR TITLE
build(gradle): Remove the Jakarta migration plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ downloadPlugin = "5.6.0"
 gitSemverPlugin = "0.16.1"
 graalVmNativeImagePlugin = "0.11.0"
 ideaExtPlugin = "1.2"
-jakartaMigrationPlugin = "0.25.0"
 kotlinPlugin = "2.2.0"
 ksp = "2.2.0-2.0.2"
 mavenPublishPlugin = "0.34.0"
@@ -76,7 +75,6 @@ buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig
 download = { id = "de.undercouch.download", version.ref = "downloadPlugin" }
 gitSemver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "gitSemverPlugin" }
 ideaExt = { id = "org.jetbrains.gradle.plugin.idea-ext", version.ref = "ideaExtPlugin" }
-jakartaMigration = { id = "com.netflix.nebula.jakartaee-migration", version.ref = "jakartaMigrationPlugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
 
 [libraries]

--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -20,14 +20,6 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-library-conventions")
-
-    // Apply third-party plugins.
-    alias(libs.plugins.jakartaMigration)
-}
-
-jakartaeeMigration {
-    includeTransform("com.atlassian.jira:jira-rest-java-client-core")
-    configurations.filterNot { it.isCanBeDeclared }.forEach(::transform)
 }
 
 dependencies {


### PR DESCRIPTION
This should not be required anymore as of jira-rest-java-client version 7, see [1]. Also, the current configuration (which is not using the standard `migrate()` function) is causing an error when publishing signed artifacts to Maven Central, see [2].

[1]: https://bitbucket.org/atlassian/jira-rest-java-client/commits/c313359cd8205e5ca724a3a8dad9d03baf494505
[2]: https://github.com/oss-review-toolkit/ort/actions/runs/16724857711/job/47337695570