### PR TITLE
fix(package-configuration-providers): Fix support for version ranges

### DIFF
--- a/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
@@ -43,16 +43,20 @@ open class SimplePackageConfigurationProvider(
     override val descriptor: PluginDescriptor = pluginDescriptor,
     configurations: Collection<PackageConfiguration>
 ) : PackageConfigurationProvider {
+    /**
+     * A map that stores all package configurations by their [Identifier] for fast lookup. The version of the
+     * [Identifier]s must be ignored because it could be a version range.
+     */
     private val configurationsById: Map<Identifier, List<PackageConfiguration>>
 
     init {
         configurations.checkAtMostOneConfigurationPerIdAndProvenance()
 
-        configurationsById = configurations.groupBy { it.id }
+        configurationsById = configurations.groupBy { it.id.copy(version = "") }
     }
 
     override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
-        configurationsById[packageId]?.filter { it.matches(packageId, provenance) }.orEmpty()
+        configurationsById[packageId.copy(version = "")]?.filter { it.matches(packageId, provenance) }.orEmpty()
 }
 
 private fun Collection<PackageConfiguration>.checkAtMostOneConfigurationPerIdAndProvenance() {

--- a/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
+++ b/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
@@ -21,8 +21,14 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
 
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
@@ -55,6 +61,43 @@ class SimplePackageConfigurationProviderTest : WordSpec({
             shouldThrow<IllegalArgumentException> {
                 SimplePackageConfigurationProvider(configurations = configurations)
             }
+        }
+    }
+
+    "getPackageConfigurations" should {
+        val id = Identifier("Maven:org.ossreviewtoolkit:model:1.0.0")
+        val provenance = ArtifactProvenance(
+            sourceArtifact = RemoteArtifact(url = "https://example.org/artifact.zip", hash = Hash.NONE)
+        )
+
+        "return package configurations exactly matching the identifier" {
+            val packageConfig1 = PackageConfiguration(id = id, sourceCodeOrigin = SourceCodeOrigin.ARTIFACT)
+            val packageConfig2 = PackageConfiguration(id = id, sourceArtifactUrl = provenance.sourceArtifact.url)
+            val packageConfig3 =
+                PackageConfiguration(id = id.copy(version = "2.0.0"), sourceCodeOrigin = SourceCodeOrigin.ARTIFACT)
+
+            val provider = SimplePackageConfigurationProvider(
+                configurations = listOf(packageConfig1, packageConfig2, packageConfig3)
+            )
+
+            provider.getPackageConfigurations(id, provenance) should
+                containExactlyInAnyOrder(packageConfig1, packageConfig2)
+        }
+
+        "return package configurations with matching version ranges" {
+            val packageConfig1 =
+                PackageConfiguration(id = id.copy(version = "[1.0,2.0)"), sourceCodeOrigin = SourceCodeOrigin.ARTIFACT)
+            val packageConfig2 =
+                PackageConfiguration(id = id.copy(version = "[0.1,)"), sourceCodeOrigin = SourceCodeOrigin.ARTIFACT)
+            val packageConfig3 =
+                PackageConfiguration(id = id.copy(version = "]1.0.0,)"), sourceCodeOrigin = SourceCodeOrigin.ARTIFACT)
+
+            val provider = SimplePackageConfigurationProvider(
+                configurations = listOf(packageConfig1, packageConfig2, packageConfig3)
+            )
+
+            provider.getPackageConfigurations(id, provenance) should
+                containExactlyInAnyOrder(packageConfig1, packageConfig2)
         }
     }
 })


### PR DESCRIPTION
Fix the `SimplePackageConfigurationProvider` to support version ranges in the same way as 385044b fixed the lookup for resolved package configurations in the `OrtResult`.

This fixes the support for all bundled package configuration providers that either extend `SimplePackageConfigurationProvider` or use it internally. The only exception is the `DosPackageConfigurationProvider`.

Fixes #10673.