### PR TITLE
fix(fossid): Use the URL with credentials when cloning the repo

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -668,7 +668,7 @@ class FossId internal constructor(
 
         val urlWithoutCredentials = url.replaceCredentialsInUri()
         val comment = createOrtScanComment(urlWithoutCredentials, revision, reference)
-        val response = handler.createScan(projectCode, scanCode, comment)
+        val response = handler.createScan(url, projectCode, scanCode, comment)
 
         val data = response.data?.value
 

--- a/plugins/scanners/fossid/src/main/kotlin/events/CloneRepositoryHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/CloneRepositoryHandler.kt
@@ -67,6 +67,7 @@ class CloneRepositoryHandler(val config: FossIdConfig, val service: FossIdServic
     override fun transformURL(url: String): String = urlProvider.getUrl(url)
 
     override suspend fun createScan(
+        repositoryUrl: String,
         projectCode: String,
         scanCode: String,
         comment: OrtScanComment
@@ -77,7 +78,7 @@ class CloneRepositoryHandler(val config: FossIdConfig, val service: FossIdServic
                 config.apiKey.value,
                 projectCode,
                 scanCode,
-                comment.ort.repositoryURL,
+                repositoryUrl,
                 comment.ort.revision,
                 comment.asJsonString()
             )

--- a/plugins/scanners/fossid/src/main/kotlin/events/EventHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/EventHandler.kt
@@ -101,10 +101,12 @@ interface EventHandler {
     fun transformURL(url: String): String = url
 
     /**
-     * Create a scan in FossID with the given [projectCode], [scanCode], and url, revision and reference contained in
-     * the [comment]. Return the response from FossID or null if the scan could not be created.
+     * Create a scan in FossID with the given [repositoryUrl], [projectCode], [scanCode], and revision and reference
+     * contained in the [comment]. Return the response from FossID or null if the scan could not be created. Note that
+     * the [repositoryUrl] may contain the credentials for cloning the repository.
      */
     suspend fun createScan(
+        repositoryUrl: String,
         projectCode: String,
         scanCode: String,
         comment: OrtScanComment

--- a/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
@@ -59,6 +59,7 @@ class UploadArchiveHandler(
     val provenance: NestedProvenance
 ) : EventHandler {
     override suspend fun createScan(
+        repositoryUrl: String,
         projectCode: String,
         scanCode: String,
         comment: OrtScanComment


### PR DESCRIPTION
This is a fixup for af95c97626d9a0365e75a9da52668c4b53ba17e1, which removed the credentials from the repository URL before adding it to the scan comment. Since the `CloneRepositoryHandler` used to take the URL from the comment, it does not have the credentials to clone the repository anymore.

To fix this, extend the `EventHandler` interface, so that the original URL with credentials can be explicitly passed and used for the cloning.
