### PR TITLE
fix(gradle): Rework conversion of repositories to ORT model

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
@@ -64,19 +64,17 @@ internal fun Configuration.isRelevant(): Boolean {
 /**
  * Return a map that associates names of artifact repositories to their model representations.
  */
-internal fun RepositoryHandler.associateNamesWithUrlsTo(repositories: MutableMap<String, OrtRepository?>) =
-    associateTo(repositories) { it.name to it.toOrtRepository() }
+internal fun RepositoryHandler.associateNamesWithUrlsTo(repositories: MutableMap<String, UrlArtifactRepository>) =
+    filterIsInstance<UrlArtifactRepository>().associateByTo(repositories) { (it as ArtifactRepository).name }
 
 /**
- * Convert this [ArtifactRepository] to an [OrtRepository] if it possesses the relevant properties. Return *null* for
- * an unsupported repository type.
+ * Convert this [UrlArtifactRepository] to an [OrtRepository] by extracting the relevant properties.
  */
-private fun ArtifactRepository.toOrtRepository(): OrtRepository? =
-    (this as? UrlArtifactRepository)?.let { urlRepository ->
-        val credentials = (urlRepository as? AuthenticationSupported)?.credentials
-        OrtRepositoryImpl(
-            url = urlRepository.url.toString(),
-            username = credentials?.username,
-            password = credentials?.password
-        )
-    }
+internal fun UrlArtifactRepository.toOrtRepository(): OrtRepository {
+    val credentials = (this as? AuthenticationSupported)?.credentials
+    return OrtRepositoryImpl(
+        url = url.toString(),
+        username = credentials?.username,
+        password = credentials?.password
+    )
+}

--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -21,7 +21,6 @@ package org.ossreviewtoolkit.plugins.packagemanagers.gradleplugin
 
 import OrtDependency
 import OrtDependencyTreeModel
-import OrtRepository
 
 import org.apache.maven.model.building.FileModelSource
 import org.apache.maven.model.building.ModelBuildingResult
@@ -32,6 +31,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.artifacts.repositories.UrlArtifactRepository
 import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
@@ -49,7 +49,7 @@ import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.util.GradleVersion
 
 internal class OrtModelBuilder : ToolingModelBuilder {
-    private val repositories = mutableMapOf<String, OrtRepository?>()
+    private val repositories = mutableMapOf<String, UrlArtifactRepository>()
 
     private val platformCategories = setOf("platform", "enforced-platform")
 
@@ -99,7 +99,7 @@ internal class OrtModelBuilder : ToolingModelBuilder {
             name = project.name,
             version = project.version.toString().takeUnless { it == "unspecified" }.orEmpty(),
             configurations = ortConfigurations,
-            repositories = repositories.values.filterNotNull(),
+            repositories = repositories.values.map { it.toOrtRepository() },
             errors = errors,
             warnings = warnings
         )
@@ -190,7 +190,7 @@ internal class OrtModelBuilder : ToolingModelBuilder {
                                 repositories[repositoryId]?.let { repository ->
                                     // Note: Only Maven-style layout is supported for now.
                                     buildString {
-                                        append(repository.url.removeSuffix("/"))
+                                        append(repository.url.toString().removeSuffix("/"))
                                         append('/')
                                         append(id.group.replace('.', '/'))
                                         append('/')


### PR DESCRIPTION
In 6c5ab2e6b00da5b9836050978d063547d592707b, logic has been added to the Gradle plugin to obtain the credentials for repositories referenced by the build. According to [1], querying credentials in this way assigns an empty set of credentials to a repository if no authentication information is present. However, such an empty set causes later problems when resolving dependencies.

To fix this, do the resolving of dependencies first, and only afterward process the repositories and obtain their credentials.

[1]: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts /repositories/AuthenticationSupported.html#getCredentials()

