### PR TITLE
fix(python-inspector): Null check for purl before mapping it

### DIFF
--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
@@ -111,7 +111,7 @@ internal object PythonInspector : CommandLineTool {
             val packagePurls = mutableSetOf<String>()
             binaryResult.projects.forEach { project ->
                 project.packageData.forEach { data ->
-                    data.dependencies.mapTo(packagePurls) { it.purl }
+                    data.dependencies.mapNotNullTo(packagePurls) { it.purl }
                 }
             }
 
@@ -121,7 +121,7 @@ internal object PythonInspector : CommandLineTool {
                         "(${binaryResult.packages.size}), which might indicate a bug in python-inspector."
                 }
 
-                val resultsPurls = binaryResult.packages.mapTo(mutableSetOf()) { it.purl }
+                val resultsPurls = binaryResult.packages.mapNotNullTo(mutableSetOf()) { it.purl }
                 logger.warn { "Packages that are not contained as dependencies: ${packagePurls - resultsPurls}" }
                 logger.warn { "Dependencies that are not contained as packages: ${resultsPurls - packagePurls}" }
             }
@@ -174,7 +174,7 @@ internal object PythonInspector : CommandLineTool {
 
     @Serializable
     internal data class Dependency(
-        val purl: String,
+        val purl: String?,
         val scope: String,
         val isRuntime: Boolean,
         val isOptional: Boolean,
@@ -213,7 +213,7 @@ internal object PythonInspector : CommandLineTool {
         val repositoryHomepageUrl: String?,
         val repositoryDownloadUrl: String?,
         val apiDataUrl: String,
-        val purl: String
+        val purl: String?
     )
 
     @Serializable

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.utils.toPurl
 
 private const val TYPE = "PyPI"
 
@@ -142,7 +143,7 @@ internal fun List<PythonInspector.Package>.toOrtPackages(): Set<Package> =
             // The package has a namespace property which is currently always empty. Deliberately set the namespace to
             // an empty string here to be consistent with the resolved packages which do not have a namespace property.
             id = id,
-            purl = pkg.purl,
+            purl = pkg.purl ?: id.toPurl(),
             authors = pkg.parties.toAuthors(),
             declaredLicenses = declaredLicenses,
             declaredLicensesProcessed = declaredLicensesProcessed,


### PR DESCRIPTION
With the introduction of commit 0b9fa5b, null purl's output given by python-inspector causes a crash on pdt file parsing.

Fixes: #10734