### PR TITLE
feat(utils): Improve authentication of default HTTP client

### DIFF
--- a/utils/ort/src/test/kotlin/OkHttpClientHelperTest.kt
+++ b/utils/ort/src/test/kotlin/OkHttpClientHelperTest.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.utils.ort
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -34,13 +36,21 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 
 import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.PasswordAuthentication
+import java.net.URI
 import java.time.Duration
 
+import kotlin.reflect.KFunction
+
+import okhttp3.Authenticator as OkAuthenticator
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
+import okhttp3.Route
 
 import okio.BufferedSource
 
@@ -135,4 +145,92 @@ class OkHttpClientHelperTest : WordSpec({
             }
         }
     }
+
+    "JavaNetAuthenticatorWrapper" should {
+        "delegate to the default authenticator if the response code is not 401" {
+            val authenticator = mockk<OkAuthenticator>()
+            val route = mockk<Route>()
+            val response = createResponse(HttpURLConnection.HTTP_FORBIDDEN)
+            val modifiedRequest = mockk<Request>()
+            every { authenticator.authenticate(route, response) } returns modifiedRequest
+
+            val lenientAuthenticator = JavaNetAuthenticatorWrapper(authenticator)
+
+            lenientAuthenticator.authenticate(route, response) shouldBe modifiedRequest
+        }
+
+        "query the Java authenticator" {
+            val response = createResponse()
+            preparePasswordAuthentication(success = true)
+
+            val lenientAuthenticator = JavaNetAuthenticatorWrapper(mockk())
+
+            lenientAuthenticator.authenticate(mockk(), response) shouldNotBeNull {
+                header("Authorization") shouldBe "Basic c2NvdHQ6dGlnZXI="
+                url shouldBe AUTH_URL.toHttpUrl()
+            }
+        }
+
+        "return null if the Java authenticator does not return a password authentication" {
+            val response = createResponse()
+            preparePasswordAuthentication(success = false)
+
+            val lenientAuthenticator = JavaNetAuthenticatorWrapper(mockk())
+
+            lenientAuthenticator.authenticate(mockk(), response) should beNull()
+        }
+
+        "return null if the request already has an Authorization header" {
+            val requestWithAuth = Request.Builder()
+                .url(AUTH_URL)
+                .header("Authorization", "Basic wrong-credentials")
+                .build()
+            val response = createResponse(originalRequest = requestWithAuth)
+            preparePasswordAuthentication(success = true)
+
+            val lenientAuthenticator = JavaNetAuthenticatorWrapper(mockk())
+
+            lenientAuthenticator.authenticate(mockk(), response) should beNull()
+        }
+    }
 })
+
+private const val USERNAME = "scott"
+private const val PASSWORD = "tiger"
+private const val AUTH_URL = "https://example.org/auth"
+
+/**
+ * Create a [Response] object with the given response [code]. The request of this response is set to [originalRequest]
+ * if it is provided; otherwise, a default request to [AUTH_URL] is created.
+ */
+private fun createResponse(
+    code: Int = HttpURLConnection.HTTP_UNAUTHORIZED,
+    originalRequest: Request? = null
+): Response {
+    val request = originalRequest ?: Request.Builder()
+        .url(AUTH_URL)
+        .build()
+    return Response.Builder()
+        .request(request)
+        .code(code)
+        .protocol(Protocol.HTTP_2)
+        .message("Unauthorized")
+        .build()
+}
+
+/**
+ * Mock the [requestPasswordAuthentication] function to return a [PasswordAuthentication] object for the test URI
+ * based on the given [success] flag.
+ */
+private fun preparePasswordAuthentication(success: Boolean) {
+    val result = if (success) {
+        PasswordAuthentication(USERNAME, PASSWORD.toCharArray())
+    } else {
+        null
+    }
+
+    val resolveFunc: (URI) -> PasswordAuthentication? = ::requestPasswordAuthentication
+    mockkStatic(resolveFunc as KFunction<*>)
+
+    every { requestPasswordAuthentication(URI.create(AUTH_URL)) } returns result
+}


### PR DESCRIPTION
The standard `JAVA_NET_AUTHENTICATOR` provided by OkHttp that was used so far was only querying the global Java Authenticator when the response contained a challenge with scheme `Basic`. There are, however, servers that do not send this challenge, but for which authentication with the credentials from the Java Authenticator would work. The GitHub package registry is an example of such a server.

To support those servers, add a new `Authenticator` implementation that always queries credentials from the Java `Authenticator`.
