### PR TITLE
deps(gradle): Add org.bouncycastle library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ asciidoctorj = "3.0.0"
 asciidoctorjPdf = "2.3.19"
 blackduckCommon = "67.0.19"
 blackduckCommonApi = "2023.10.0.7"
+bouncyCastle = "1.81"
 clikt = "5.0.3"
 commonsCompress = "1.28.0"
 cyclonedx = "10.2.1"
@@ -94,6 +95,7 @@ asciidoctorj-pdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = 
 awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
 blackduck-common = { module = "com.blackduck.integration:blackduck-common", version.ref = "blackduckCommon" }
 blackduck-common-api = { module = "com.blackduck.integration:blackduck-common-api", version.ref = "blackduckCommonApi" }
+bouncyCastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 cyclonedx = { module = "org.cyclonedx:cyclonedx-core-java", version.ref = "cyclonedx" }

--- a/plugins/package-managers/maven/build.gradle.kts
+++ b/plugins/package-managers/maven/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.downloader)
     implementation(projects.utils.commonUtils)
 
+    implementation(libs.bouncyCastle)
     implementation(libs.maven.embedder)
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.kotlinx.serialization.json)


### PR DESCRIPTION
Added dependency `net.i2p.crypto:eddsa` to resolve `DownloadException` as reported in https://github.com/oss-review-toolkit/ort/issues/10748.

The root error `NoSuchAlgorithmException: EdDSA provider not supported` is caused by a missing dependency as outlined [here](https://stackoverflow.com/questions/65566138/apache-mina-sshd-ssh-client-always-prints-eddsa-provider-not-supported/65566139#65566139) by @sschuberth.