### PR TITLE
fix(schema): Fix JSON schema for package-configuration

### DIFF
--- a/integrations/schemas/package-configuration-schema.json
+++ b/integrations/schemas/package-configuration-schema.json
@@ -40,6 +40,12 @@
     },
     "source_artifact_url": {
       "type": "string"
+    },
+    "source_code_origin": {
+      "enum": [
+        "VCS",
+        "ARTIFACT"
+      ]
     }
   },
   "definitions": {
@@ -143,16 +149,27 @@
   "required": [
     "id"
   ],
-  "oneOf": [
-    {
-      "required": [
-        "vcs"
-      ]
-    },
-    {
-      "required": [
-        "source_artifact_url"
-      ]
-    }
-  ]
+  "not": {
+    "description": "A package configuration must contain at most one of 'vcs', 'source_artifact_url', or 'source_code_origin'.",
+    "anyOf": [
+      {
+        "allOf": [
+          { "required": ["vcs"] },
+          { "required": ["source_artifact_url"] }
+        ]
+      },
+      {
+        "allOf": [
+          { "required": ["vcs"] },
+          { "required": ["source_code_origin"] }
+        ]
+      },
+      {
+        "allOf": [
+          { "required": ["source_artifact_url"] },
+          { "required": ["source_code_origin"] }
+        ]
+      }
+    ]
+  }
 }

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -27,6 +27,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 
 import java.io.File
 
@@ -137,6 +138,130 @@ class JsonSchemaTest : StringSpec({
             .validate(repositoryConfiguration, InputFormat.YAML)
 
         errors should beEmpty()
+    }
+
+    "Package configuration with no matchers validates successfully" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithNoMatchers = """
+            id: "Pip::example-package:0.0.1"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithNoMatchers, InputFormat.YAML)
+
+        errors should beEmpty()
+    }
+
+    "Package configuration with only vcs validates successfully" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithVcs = """
+            id: "Pip::example-package:0.0.1"
+            vcs:
+              type: "Git"
+              url: "https://github.com/example/repo.git"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithVcs, InputFormat.YAML)
+
+        errors should beEmpty()
+    }
+
+    "Package configuration with only source_artifact_url validates successfully" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithSourceArtifact = """
+            id: "Pip::example-package:0.0.1"
+            source_artifact_url: "https://example.com/package.tar.gz"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithSourceArtifact, InputFormat.YAML)
+
+        errors should beEmpty()
+    }
+
+    "Package configuration with only source_code_origin validates successfully" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithSourceCodeOrigin = """
+            id: "Pip::example-package:0.0.1"
+            source_code_origin: "VCS"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithSourceCodeOrigin, InputFormat.YAML)
+
+        errors should beEmpty()
+    }
+
+    "Package configuration with vcs and source_artifact_url fails validation" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithVcsAndSourceArtifact = """
+            id: "Pip::example-package:0.0.1"
+            vcs:
+              type: "Git"
+              url: "https://github.com/example/repo.git"
+            source_artifact_url: "https://example.com/package.tar.gz"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithVcsAndSourceArtifact, InputFormat.YAML)
+
+        errors shouldNot beEmpty()
+    }
+
+    "Package configuration with vcs and source_code_origin fails validation" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithVcsAndSourceCodeOrigin = """
+            id: "Pip::example-package:0.0.1"
+            vcs:
+              type: "Git"
+              url: "https://github.com/example/repo.git"
+            source_code_origin: "VCS"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithVcsAndSourceCodeOrigin, InputFormat.YAML)
+
+        errors shouldNot beEmpty()
+    }
+
+    "Package configuration with source_artifact_url and source_code_origin fails validation" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithSourceArtifactAndSourceCodeOrigin = """
+            id: "Pip::example-package:0.0.1"
+            source_artifact_url: "https://example.com/package.tar.gz"
+            source_code_origin: "ARTIFACT"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithSourceArtifactAndSourceCodeOrigin, InputFormat.YAML)
+
+        errors shouldNot beEmpty()
+    }
+
+    "Package configuration with all three matchers fails validation" {
+        val packageConfigurationSchema = File("../integrations/schemas/package-configuration-schema.json").toURI()
+        val schema = schemaV7.getSchema(packageConfigurationSchema)
+
+        val configWithAllMatchers = """
+            id: "Pip::example-package:0.0.1"
+            vcs:
+              type: "Git"
+              url: "https://github.com/example/repo.git"
+            source_artifact_url: "https://example.com/package.tar.gz"
+            source_code_origin: "VCS"
+        """.trimIndent()
+
+        val errors = schema.validate(configWithAllMatchers, InputFormat.YAML)
+
+        errors shouldNot beEmpty()
     }
 })
 


### PR DESCRIPTION
[1] introduced version ranges for package-configurations by adding the `sourceCodeOrigin` field.
Add this missing field and specify the requirements and restrictions for the three mutually exclusive fields in the schema.

[1]: https://github.com/oss-review-toolkit/ort/pull/10375

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
