### PR TITLE
feat(fossid): Add option to treat pending identifications as errors

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -277,6 +277,8 @@ ort:
 
           sensitivity: 10
 
+          treatPendingIdentificationsAsError: false
+
         secrets:
           user: user
           apiKey: XYZ

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -259,7 +259,8 @@ class OrtConfigurationTest : WordSpec({
                             "detectCopyrightStatements" to "true",
                             "timeout" to "60",
                             "urlMappings" to urlMapping,
-                            "sensitivity" to "10"
+                            "sensitivity" to "10",
+                            "treatPendingIdentificationsAsError" to "false"
                         )
 
                         secrets should containExactlyEntries(

--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -907,7 +907,7 @@ class FossId internal constructor(
                 source = descriptor.id,
                 message = "This scan has $pendingFilesCount file(s) pending identification in FossID. " +
                     "Please review and resolve them at: $fossIdScanUrl",
-                severity = Severity.HINT
+                severity = if (config.treatPendingIdentificationsAsError) Severity.ERROR else Severity.HINT
             )
         )
 

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -131,7 +131,11 @@ data class FossIdConfig(
 
     /** Whether to write scan results to the storage. */
     @OrtPluginOption(defaultValue = "true")
-    val writeToStorage: Boolean
+    val writeToStorage: Boolean,
+
+    /** Treat pending identifications as errors instead of hints. */
+    @OrtPluginOption(defaultValue = "false")
+    val treatPendingIdentificationsAsError: Boolean
 ) {
     init {
         require(deltaScanLimit > 0) {

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -152,7 +152,8 @@ internal fun createConfig(
         urlMappings = null,
         writeToStorage = false,
         logRequests = false,
-        isArchiveMode = isArchiveMode
+        isArchiveMode = isArchiveMode,
+        treatPendingIdentificationsAsError = false
     )
 
     val namingProvider = createNamingProviderMock()


### PR DESCRIPTION
Add 'treatPendingIdentificationsAsError' configuration option to allow treating pending identifications in FossID as errors instead of hints. 