### PR TITLE
feat(fossid): Add parameter to disable content deletion after scan

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -279,6 +279,8 @@ ort:
 
           treatPendingIdentificationsAsError: false
 
+          deleteUploadedArchiveAfterScan: true
+
         secrets:
           user: user
           apiKey: XYZ

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -260,7 +260,8 @@ class OrtConfigurationTest : WordSpec({
                             "timeout" to "60",
                             "urlMappings" to urlMapping,
                             "sensitivity" to "10",
-                            "treatPendingIdentificationsAsError" to "false"
+                            "treatPendingIdentificationsAsError" to "false",
+                            "deleteUploadedArchiveAfterScan" to "true"
                         )
 
                         secrets should containExactlyEntries(

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -135,7 +135,14 @@ data class FossIdConfig(
 
     /** Treat pending identifications as errors instead of hints. */
     @OrtPluginOption(defaultValue = "false")
-    val treatPendingIdentificationsAsError: Boolean
+    val treatPendingIdentificationsAsError: Boolean,
+
+    /**
+     * Whether to delete uploaded content after scan completion. When set to false, archives remain on the
+     * FossID server, which can help diagnose archive upload issues.
+     */
+    @OrtPluginOption(defaultValue = "true")
+    val deleteUploadedArchiveAfterScan: Boolean
 ) {
     init {
         require(deltaScanLimit > 0) {

--- a/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
@@ -129,8 +129,10 @@ class UploadArchiveHandler(
     }
 
     override suspend fun afterCheckScan(scanCode: String) {
-        service.removeUploadedContent(config.user.value, config.apiKey.value, scanCode)
-            .checkResponse("remove previously uploaded content 2", false)
+        if (config.deleteUploadedArchiveAfterScan) {
+            service.removeUploadedContent(config.user.value, config.apiKey.value, scanCode)
+                .checkResponse("remove previously uploaded content 2", false)
+        }
     }
 
     internal fun deleteExcludedFiles(path: File, includes: Includes?, excludes: Excludes?) {

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -153,7 +153,8 @@ internal fun createConfig(
         writeToStorage = false,
         logRequests = false,
         isArchiveMode = isArchiveMode,
-        treatPendingIdentificationsAsError = false
+        treatPendingIdentificationsAsError = false,
+        deleteUploadedArchiveAfterScan = true
     )
 
     val namingProvider = createNamingProviderMock()


### PR DESCRIPTION
This allows users to retain content when needed for debugging or analysis purposes while maintaining the default cleanup behavior.