### PR TITLE
chore(CODEOWNERS): Use usernames instead of groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,17 @@
 # last matching pattern is used, see
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax
 
-* @oss-review-toolkit/kotlin-devs
-*.md @oss-review-toolkit/core-devs
-/**/*Sw360* @oss-review-toolkit/kotlin-devs @bs-ondem @oheger-bosch
-/advisor/ @oss-review-toolkit/kotlin-devs @MarcelBochtler @oheger-bosch
-/clients/fossid-webapp/ @oss-review-toolkit/kotlin-devs @nnobelis
+# Members of @oss-review-toolkit/kotlin-devs.
+* @fviernau @MarcelBochtler @mnonnenmacher @nnobelis @oheger-bosch @sschuberth
+
+# Members of @oss-review-toolkit/core-devs.
+*.md @fviernau @MarcelBochtler @mnonnenmacher @sschuberth @tsteenbe
+
+# Owners of the web app reporter.
 /plugins/reporters/web-app-template/ @tsteenbe
-/spdx-utils/src/main/ @oss-review-toolkit/core-devs
-/LICENSE @oss-review-toolkit/core-devs
+
+# Members of @oss-review-toolkit/core-devs.
+/spdx-utils/src/main/ @fviernau @MarcelBochtler @mnonnenmacher @sschuberth @tsteenbe
+
+# Members of @oss-review-toolkit/core-devs.
+/LICENSE @fviernau @MarcelBochtler @mnonnenmacher @sschuberth @tsteenbe


### PR DESCRIPTION
Use usernames instead of groups in the CODEOWNERS file to make the code owners more transparent to external contributors.

This also solves the issue that when a team members picks up a review, it is indivudally assigned as a reviewer of the PR, and all other team members are removed from the reviewers list.

While at it, remove some entries which have become redundant because new members were added to the kotlin-devs team in the meantime.