### PR TITLE
feat: Add funct to filter for classified licenses

### DIFF
--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -235,6 +235,15 @@ class FreemarkerTemplateProcessor(
             }
 
         /**
+         * Return only those [licenses] that are classified.
+         */
+        @Suppress("unused") // This function is used in the templates.
+        fun filterForClassified(licenses: Collection<ResolvedLicense>): List<ResolvedLicense> =
+            licenses.filter { resolvedLicense ->
+                input.licenseClassifications[resolvedLicense.license]?.isNotEmpty() == true
+            }
+
+        /**
          * Merge the [ResolvedLicense]s of multiple [models] and filter them using [licenseView] and
          * [PackageModel.licenseChoices]. [Omits][omitExcluded] excluded packages, licenses, and copyrights by default.
          * [Undefined][omitNotPresent] licenses can be filtered out optionally. [LicenseChoices][skipLicenseChoices] are


### PR DESCRIPTION
Hi!

We thought it would be handy to have a helper function for the freemaker templates, to filter only classified licenses. Would be cool to integrate it with ORT if you are interested!

Thanks!