### PR TITLE
fix(spdx-reporter): Do not try to add empty license texts

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -242,7 +242,7 @@ internal fun SpdxDocument.addExtractedLicenseInfo(licenseFactProvider: LicenseFa
     val nonSpdxLicenses = allLicenses.filter { SpdxConstants.isPresent(it) && SpdxLicense.forId(it) == null }
 
     val extractedLicenseInfo = nonSpdxLicenses.sorted().mapNotNull { license ->
-        licenseFactProvider.getLicenseText(license)?.let { text ->
+        licenseFactProvider.getLicenseText(license)?.takeIf { it.isNotBlank() }?.let { text ->
             SpdxExtractedLicenseInfo(
                 licenseId = license,
                 extractedText = text


### PR DESCRIPTION
The `SpdxExtractedLicenseInfo` class requires that the license text is not empty. However, in some situations it can be that a license text from a `LicenseFactProvider` is empty, for example, if a ScanCode license text contains only YAML front matter, or if a custom license text file is empty. To not fail the SPDX reporter in this situation, simply check if a license text is empty before creating the `SpdxExtractedLicenseInfo`.