### PR TITLE
refactor(license-fact-provider): Ensure that license texts are not blank

### DIFF
--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -30,7 +30,7 @@ class CompositeLicenseFactProvider(
      *  providers: the first provider in the list that has a fact for a given license ID will be used.
      */
     private val providers: List<LicenseFactProvider>
-) : LicenseFactProvider {
+) : LicenseFactProvider() {
     override val descriptor = PluginDescriptor(
         id = "Composite",
         displayName = "Composite License Fact Provider",

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseText.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseText.kt
@@ -19,18 +19,10 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
-import org.ossreviewtoolkit.plugins.api.Plugin
-
-/** A provider for license facts. */
-abstract class LicenseFactProvider : Plugin {
-    /** Return the [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
-    abstract fun getLicenseText(licenseId: String): LicenseText?
-
-    /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
-    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
-    @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
-
-    /** Return `true´ if this provider has a license text for the given [licenseId]. */
-    abstract fun hasLicenseText(licenseId: String): Boolean
+/** A value class to represent a valid license text. It guarantees that the text is not blank. */
+@JvmInline
+value class LicenseText(val text: String) {
+    init {
+        require(text.isNotBlank()) { "The license text must not be blank." }
+    }
 }

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -58,7 +58,7 @@ class DefaultDirLicenseFactProvider(descriptor: PluginDescriptor = DefaultDirLic
 )
 open class DirLicenseFactProvider(
     override val descriptor: PluginDescriptor = DirLicenseFactProviderFactory.descriptor,
-    private val config: DirLicenseFactProviderConfig
+    config: DirLicenseFactProviderConfig
 ) : LicenseFactProvider {
     private val licenseTextDir = File(config.licenseTextDir).also {
         if (!it.isDirectory) {

--- a/plugins/license-fact-providers/dir/src/test/kotlin/DirLicenseFactProviderTest.kt
+++ b/plugins/license-fact-providers/dir/src/test/kotlin/DirLicenseFactProviderTest.kt
@@ -33,13 +33,22 @@ class DirLicenseFactProviderTest : WordSpec({
 
             val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
 
-            provider.getLicenseText("LicenseRef-custom-license") shouldBe "custom license text"
+            provider.getLicenseText("LicenseRef-custom-license")?.text shouldBe "custom license text"
         }
 
         "return null if no license text is found" {
             val provider = DirLicenseFactProviderFactory.create(licenseTextDir = tempdir().absolutePath)
 
             provider.getLicenseText("LicenseRef-non-existing-license") should beNull()
+        }
+
+        "return null if the license text file is blank" {
+            val licenseDir = tempdir()
+            licenseDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
+
+            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
+
+            provider.getLicenseText("LicenseRef-blank-license") should beNull()
         }
     }
 
@@ -57,6 +66,15 @@ class DirLicenseFactProviderTest : WordSpec({
             val provider = DirLicenseFactProviderFactory.create(licenseTextDir = tempdir().absolutePath)
 
             provider.hasLicenseText("LicenseRef-non-existing-license") shouldBe false
+        }
+
+        "return false if the license text file is blank" {
+            val licenseDir = tempdir()
+            licenseDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
+
+            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
+
+            provider.hasLicenseText("LicenseRef-blank-license") shouldBe false
         }
     }
 })

--- a/plugins/license-fact-providers/scancode/src/funTest/kotlin/ScanCodeLicenseFactProviderFunTest.kt
+++ b/plugins/license-fact-providers/scancode/src/funTest/kotlin/ScanCodeLicenseFactProviderFunTest.kt
@@ -37,7 +37,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
 
             val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
 
-            provider.getLicenseText("test") shouldBe "custom license text"
+            provider.getLicenseText("test")?.text shouldBe "custom license text"
         }
 
         "remove YAML front matter from the license text" {
@@ -54,14 +54,14 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
 
             val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
 
-            provider.getLicenseText("test") shouldBe "custom license text"
+            provider.getLicenseText("test")?.text shouldBe "custom license text"
         }
 
         "read license texts from the detected ScanCode license directory" {
             val provider = ScanCodeLicenseFactProviderFactory.create()
 
             provider.getLicenseText("MIT") shouldNotBeNull {
-                this should startWith("Permission is hereby granted, free of charge, to any person obtaining")
+                text should startWith("Permission is hereby granted, free of charge, to any person obtaining")
             }
         }
 
@@ -69,6 +69,22 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
             val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = tempdir().absolutePath)
 
             provider.getLicenseText("UnknownLicense") should beNull()
+        }
+
+        "return null if the license file contains only YAML front matter" {
+            val licenseDir = tempdir()
+            (licenseDir / "test.LICENSE").writeText(
+                """
+                |---
+                |key: value
+                |---
+                |
+                """.trimMargin()
+            )
+
+            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
+
+            provider.getLicenseText("test") should beNull()
         }
     }
 
@@ -83,6 +99,22 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
             val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = tempdir().absolutePath)
 
             provider.hasLicenseText("UnknownLicense") shouldBe false
+        }
+
+        "return false if the license file contains only YAML front matter" {
+            val licenseDir = tempdir()
+            (licenseDir / "test.LICENSE").writeText(
+                """
+                |---
+                |key: value
+                |---
+                |
+                """.trimMargin()
+            )
+
+            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
+
+            provider.hasLicenseText("test") shouldBe false
         }
     }
 })

--- a/plugins/license-fact-providers/scancode/src/test/kotlin/ScanCodeLicenseFactProviderTest.kt
+++ b/plugins/license-fact-providers/scancode/src/test/kotlin/ScanCodeLicenseFactProviderTest.kt
@@ -23,8 +23,8 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 class ScanCodeLicenseFactProviderTest : WordSpec({
-    "removeYamlFrontMatter" should {
-        "remove a YAML front matter" {
+    "skipYamlFrontMatter()" should {
+        "skip a YAML front matter" {
             val text = """
                 ---
                 key: alasir
@@ -62,10 +62,6 @@ class ScanCodeLicenseFactProviderTest : WordSpec({
             """.trimIndent()
         }
 
-        "remove trailing whitespace" {
-            "last sentence\n".removeYamlFrontMatter() shouldBe "last sentence"
-        }
-
         "remove leading empty lines" {
             "\nfirst sentence".removeYamlFrontMatter() shouldBe "first sentence"
         }
@@ -75,3 +71,5 @@ class ScanCodeLicenseFactProviderTest : WordSpec({
         }
     }
 })
+
+private fun String.removeYamlFrontMatter() = lineSequence().skipYamlFrontMatter().joinToString("\n")

--- a/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
@@ -25,6 +25,7 @@ import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProviderFactory
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseText
 
 @OrtPlugin(
     id = "SPDX",
@@ -34,8 +35,12 @@ import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 )
 class SpdxLicenseFactProvider(
     override val descriptor: PluginDescriptor = SpdxLicenseFactProviderFactory.descriptor
-) : LicenseFactProvider {
-    override fun getLicenseText(licenseId: String) = getLicenseTextResource(licenseId)?.readText()
+) : LicenseFactProvider() {
+    override fun getLicenseText(licenseId: String) =
+        getLicenseTextResource(licenseId)?.readText()?.let {
+            // It can be safely assumed that the license text is not blank as all SPDX license texts are non-blank.
+            LicenseText(it)
+        }
 
     override fun hasLicenseText(licenseId: String) = getLicenseTextResource(licenseId) != null
 

--- a/plugins/license-fact-providers/spdx/src/test/kotlin/SpdxLicenseFactProviderTest.kt
+++ b/plugins/license-fact-providers/spdx/src/test/kotlin/SpdxLicenseFactProviderTest.kt
@@ -37,20 +37,20 @@ class SpdxLicenseFactProviderTest : WordSpec({
 
     "getLicenseText()" should {
         "return the license text for Apache-2.0" {
-            val text = provider.getLicenseText(SpdxLicense.APACHE_2_0.id)
-            text should contain("Apache License")
-            text should haveLength(11357)
+            val license = provider.getLicenseText(SpdxLicense.APACHE_2_0.id)
+            license?.text should contain("Apache License")
+            license?.text should haveLength(11357)
         }
 
         "return the license text for all SPDX licenses" {
             enumValues<SpdxLicense>().forAll {
-                provider.getLicenseText(it.id) shouldNot beEmpty()
+                provider.getLicenseText(it.id)?.text shouldNot beEmpty()
             }
         }
 
         "return the license text for all SPDX exceptions" {
             enumValues<SpdxLicenseException>().forAll {
-                provider.getLicenseText(it.id) shouldNot beEmpty()
+                provider.getLicenseText(it.id)?.text shouldNot beEmpty()
             }
         }
 

--- a/plugins/reporters/aosd/src/main/kotlin/Aosd20Reporter.kt
+++ b/plugins/reporters/aosd/src/main/kotlin/Aosd20Reporter.kt
@@ -106,7 +106,7 @@ private fun Package.toLicenses(input: ReporterInput): List<AOSD20.License> {
 
         return effectiveLicense?.decompose()?.map { licenseExpression ->
             val name = licenseExpression.toString()
-            val text = input.licenseFactProvider.getLicenseText(name)
+            val text = input.licenseFactProvider.getLicenseText(name)?.text
 
             AOSD20.License(
                 name = name,

--- a/plugins/reporters/aosd/src/main/kotlin/Aosd21Reporter.kt
+++ b/plugins/reporters/aosd/src/main/kotlin/Aosd21Reporter.kt
@@ -94,7 +94,7 @@ private fun Map<Identifier, IndexedValue<CuratedPackage>>.toComponents(
             ?.takeUnless { it.offersChoice() }
 
         val licenseTexts = licenseExpression?.licenses().orEmpty().mapNotNullTo(mutableSetOf()) { license ->
-            input.licenseFactProvider.getLicenseText(license)
+            input.licenseFactProvider.getLicenseText(license)?.text
         }.joinToString("\n--\n") { it.trimEnd() }
 
         with(pkg.metadata) {

--- a/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationReporter.kt
+++ b/plugins/reporters/ctrlx/src/main/kotlin/CtrlXAutomationReporter.kt
@@ -94,7 +94,7 @@ class CtrlXAutomationReporter(
             var licenses = effectiveLicense?.decompose()?.map {
                 val name = it.toString()
                 val spdxId = SpdxLicense.forId(name)?.id
-                val text = input.licenseFactProvider.getLicenseText(name)
+                val text = input.licenseFactProvider.getLicenseText(name)?.text
                 License(name = name, spdx = spdxId, text = text.orEmpty())
             }
 

--- a/plugins/reporters/cyclonedx/src/main/kotlin/Utils.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/Utils.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicense
 internal fun Collection<String>.mapNamesToLicenses(origin: String, input: ReporterInput): List<License> =
     map { licenseName ->
         val spdxId = SpdxLicense.forId(licenseName)?.id
-        val licenseText = input.licenseFactProvider.getLicenseText(licenseName)
+        val licenseText = input.licenseFactProvider.getLicenseText(licenseName)?.text
 
         // Prefer to set the id in case of an SPDX "core" license and only use the name as a fallback, also
         // see https://github.com/CycloneDX/cyclonedx-core-java/issues/8.

--- a/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
+++ b/plugins/reporters/opossum/src/main/kotlin/OpossumReporter.kt
@@ -130,7 +130,7 @@ class OpossumReporter(
             addBaseUrl("/", input.ortResult.repository.vcs)
 
             SpdxLicense.entries.forEach {
-                val licenseText = input.licenseFactProvider.getLicenseText(it.id)
+                val licenseText = input.licenseFactProvider.getLicenseText(it.id)?.text
                 frequentLicenses += OpossumFrequentLicense(it.id, it.fullName, licenseText)
             }
 

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -242,7 +242,7 @@ internal fun SpdxDocument.addExtractedLicenseInfo(licenseFactProvider: LicenseFa
     val nonSpdxLicenses = allLicenses.filter { SpdxConstants.isPresent(it) && SpdxLicense.forId(it) == null }
 
     val extractedLicenseInfo = nonSpdxLicenses.sorted().mapNotNull { license ->
-        licenseFactProvider.getLicenseText(license)?.takeIf { it.isNotBlank() }?.let { text ->
+        licenseFactProvider.getLicenseText(license)?.text?.let { text ->
             SpdxExtractedLicenseInfo(
                 licenseId = license,
                 extractedText = text


### PR DESCRIPTION
Ensure in all license fact providers that returned license texts are not blank. Also use a value class `LicenseText` to model this in the API of `getLicenseText()`, this ensures that all consumers can rely on the text not being blank, and that if a provider implements that wrong, it will fail immediately instead of leading to follow-up errors.