### PR TITLE
fix(scanner): Ensure file archiver archives any text files

### DIFF
--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -26,7 +26,6 @@ import kotlin.time.measureTimedValue
 
 import org.apache.logging.log4j.kotlin.logger
 import org.apache.tika.Tika
-import org.apache.tika.mime.MimeTypes
 
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.utils.common.FileMatcher
@@ -89,7 +88,7 @@ class FileArchiver(
                     return@packZip false
                 }
 
-                if (tika.detect(file) != MimeTypes.PLAIN_TEXT) {
+                if (!tika.detect(file).startsWith("text/")) {
                     logger.info { "Not adding file '$relativePath' to archive because it is not a text file." }
                     return@packZip false
                 }

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -187,5 +187,16 @@ class FileArchiverTest : StringSpec() {
             result shouldBe true
             targetDir should containFile("License")
         }
+
+        "include files with mime type text/x-web-markdown" {
+            createFile("License.md") { writeText("# Heading level 1") }
+
+            val archiver = FileArchiver.createDefault()
+            archiver.archive(workingDir, PROVENANCE)
+            val result = archiver.unarchive(targetDir, PROVENANCE)
+
+            result shouldBe true
+            targetDir should containFile("License.md")
+        }
     }
 }


### PR DESCRIPTION
The detection mechanism may detects any plain text file as `text/x-web-markdown` in case it has `.md` as filename extension. Fix the filtering to make any `text/*` type pass.

Note: Looking at `FileArchiverTest`, the code seems to assume that the
      detection is independent of the filename extension, which does
      not hold. It seems to make sense to incorporate this finding into
      the test code.

Fixes: #10850.

