### PR TITLE
fix(npm): Ignore module infos for not installed modules

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/project-with-lockfile/package-lock.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/project-with-lockfile/package-lock.json
@@ -17,8 +17,22 @@
         "cson": "~4.1.0"
       },
       "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "3.0.13",
         "promise": "~7.3.1"
       }
+    },
+    "node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.0.13.tgz",
+      "integrity": "sha512-uiKPB0Fv6WEEOZjruu9a6wnW/8jrjzlZbxXscMB8kuCJ1k6kHpcBnuvaAWcqhbI7rqX5GKziwWEdD+wi2gNLfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@types/node": {
       "version": "22.9.0",

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/project-with-lockfile/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/project-with-lockfile/package.json
@@ -18,6 +18,7 @@
     "cson": "~4.1.0"
   },
   "optionalDependencies": {
-    "promise": "~7.3.1"
+    "promise": "~7.3.1",
+    "@lmdb/lmdb-darwin-arm64": "3.0.13"
   }
 }

--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -138,7 +138,7 @@ class Npm(override val descriptor: PluginDescriptor = NpmFactory.descriptor, pri
         }
 
         val project = parseProject(definitionFile, analysisRoot)
-        val projectModuleInfo = listModules(workingDir, issues).undoDeduplication()
+        val projectModuleInfo = listModules(workingDir, issues).undoDeduplication().filterInstalled()
         val scopes = Scope.entries.filterNotTo(mutableSetOf()) { scope -> scope.isExcluded(excludes) }
 
         // Warm-up the cache to speed-up processing.
@@ -222,6 +222,8 @@ private fun ModuleInfo.undoDeduplication(): ModuleInfo {
 
     return undoDeduplicationRec()
 }
+
+private fun ModuleInfo.filterInstalled(): ModuleInfo = copy(dependencies = dependencies.filter { it.value.isInstalled })
 
 private fun ModuleInfo.getNonDeduplicatedModuleInfosForId(): Map<String, ModuleInfo> {
     val queue = LinkedList<ModuleInfo>().apply { add(this@getNonDeduplicatedModuleInfosForId) }


### PR DESCRIPTION
If `npm install` and `npm list` runs without errors, the installation of the modules should be fine. So, it is ok to ignore module infos for not installed modules, for example platform specific optional dependencies which do not match the host's platform.

Fixes: #10815.

