### PR TITLE
Generalize a work-around to always run `JavaExec` tasks 

### DIFF
--- a/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-application-conventions.gradle.kts
@@ -212,10 +212,16 @@ signing {
     }
 }
 
-tasks.named<JavaExec>("run") {
-    // Work around https://github.com/graalvm/native-build-tools/issues/743.
-    doNotTrackState("The 'run' task is never supposed to be UP-TO-DATE.")
+tasks.withType<JavaExec>().configureEach {
+    val normalizedName = name.trimEnd { !it.isLetter() }.lowercase()
 
+    // Work around https://youtrack.jetbrains.com/issue/KTIJ-34755.
+    if (normalizedName.endsWith("main") || normalizedName.endsWith("run")) {
+        doNotTrackState("Interactive Java execution tasks are never supposed to be UP-TO-DATE.")
+    }
+}
+
+tasks.named<JavaExec>("run") {
     System.getenv("TERM")?.also {
         val mode = it.substringAfter('-', "16color")
         environment("FORCE_COLOR" to mode)

--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -190,9 +190,7 @@ tasks.withType<KotlinCompile>().configureEach {
         allWarningsAsErrors = true
         freeCompilerArgs = listOf(
             "-Xannotation-default-target=param-property",
-            "-Xconsistent-data-class-copy-visibility",
-            // Work-around for https://youtrack.jetbrains.com/issue/KT-78352.
-            "-Xwarning-level=IDENTITY_SENSITIVE_OPERATIONS_WITH_VALUE_TYPE:disabled"
+            "-Xconsistent-data-class-copy-visibility"
         )
         jvmTarget = maxKotlinJvmTarget
         optIn = optInRequirements

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -742,7 +742,7 @@ class Scanner(
             provenancesWithMissingArchives.forEach { (pkg, nestedProvenance) ->
                 var dir: File? = null
 
-                // runCatching has a bug with smart-cast, see https://youtrack.jetbrains.com/issue/KT-62938.
+                // runCatching has a bug with smart-cast, see https://youtrack.jetbrains.com/issue/KT-27748.
                 try {
                     dir = provenanceDownloader.downloadRecursively(nestedProvenance)
                     archiver.archive(dir, nestedProvenance.root)


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 