### PR TITLE
fix(oss-index)!: Rework OSS Index authentication

### DIFF
--- a/clients/oss-index/src/main/kotlin/OssIndexService.kt
+++ b/clients/oss-index/src/main/kotlin/OssIndexService.kt
@@ -138,12 +138,6 @@ interface OssIndexService {
     )
 
     /**
-     * Request vulnerability reports for [components] (does not require authentication; rate limits apply).
-     */
-    @POST("api/v3/component-report")
-    suspend fun getComponentReport(@Body components: ComponentReportRequest): List<ComponentReport>
-
-    /**
      * Request vulnerability reports for [components] (requires basic authentication; rate limits are relaxed).
      */
     @POST("api/v3/authorized/component-report")

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
@@ -72,15 +72,10 @@ class OssIndex(
     private val service by lazy {
         OssIndexService.create(
             config.serverUrl,
-            config.username?.value,
-            config.password?.value,
+            config.username,
+            config.token.value,
             OkHttpClientHelper.buildClient()
         )
-    }
-
-    private val getComponentReport by lazy {
-        val hasCredentials = config.username != null && config.password != null
-        if (hasCredentials) service::getAuthorizedComponentReport else service::getComponentReport
     }
 
     override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
@@ -96,7 +91,7 @@ class OssIndex(
             logger.debug { "Getting report for ${chunk.size} components (chunk ${index + 1} of ${chunks.size})." }
 
             runCatching {
-                val results = getComponentReport(ComponentReportRequest(chunk)).associateBy {
+                val results = service.getAuthorizedComponentReport(ComponentReportRequest(chunk)).associateBy {
                     it.coordinates
                 }
 

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndexConfiguration.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndexConfiguration.kt
@@ -34,14 +34,12 @@ data class OssIndexConfiguration(
     val serverUrl: String,
 
     /**
-     * The username to use for authentication. If not both [username] and [password] are provided, authentication is
-     * disabled.
+     * The username to use for authentication towards the API.
      */
-    val username: Secret?,
+    val username: String,
 
     /**
-     * The password to use for authentication. If not both [username] and [password] are provided, authentication is
-     * disabled.
+     * The token to use for authentication towards the API.
      */
-    val password: Secret?
+    val token: Secret
 )

--- a/plugins/advisors/oss-index/src/test/kotlin/OssIndexTest.kt
+++ b/plugins/advisors/oss-index/src/test/kotlin/OssIndexTest.kt
@@ -44,6 +44,7 @@ import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
+import org.ossreviewtoolkit.plugins.api.Secret
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.test.identifierToPackage
 
@@ -68,7 +69,9 @@ class OssIndexTest : WordSpec({
     "OssIndex" should {
         "return vulnerability information" {
             server.stubComponentsRequest("response_components.json")
-            val ossIndex = OssIndex(config = OssIndexConfiguration("http://localhost:${server.port()}", null, null))
+            val ossIndex = OssIndex(
+                config = OssIndexConfiguration("http://localhost:${server.port()}", "username", Secret("token"))
+            )
 
             val result = ossIndex.retrievePackageFindings(PACKAGES).mapKeys { it.key.id }
 
@@ -113,7 +116,9 @@ class OssIndexTest : WordSpec({
                         aResponse().withStatus(500)
                     )
             )
-            val ossIndex = OssIndex(config = OssIndexConfiguration("http://localhost:${server.port()}", null, null))
+            val ossIndex = OssIndex(
+                config = OssIndexConfiguration("http://localhost:${server.port()}", "username", Secret("token"))
+            )
 
             val result = ossIndex.retrievePackageFindings(PACKAGES).mapKeys { it.key.id.toCoordinates() }
 
@@ -128,7 +133,9 @@ class OssIndexTest : WordSpec({
         }
 
         "provide correct details" {
-            val ossIndex = OssIndex(config = OssIndexConfiguration("http://localhost:${server.port()}", null, null))
+            val ossIndex = OssIndex(
+                config = OssIndexConfiguration("http://localhost:${server.port()}", "username", Secret("token"))
+            )
 
             ossIndex.details shouldBe AdvisorDetails(ADVISOR_NAME, enumSetOf(AdvisorCapability.VULNERABILITIES))
         }
@@ -139,7 +146,7 @@ private const val ADVISOR_NAME = "OSSIndex"
 
 private val PKG_HAMCREST = identifierToPackage("Maven:org.hamcrest:hamcrest-core:1.3")
 private val PKG_JUNIT = identifierToPackage("Maven:junit:junit:4.12")
-private const val COMPONENTS_REQUEST_URL = "/api/v3/component-report"
+private const val COMPONENTS_REQUEST_URL = "/api/v3/authorized/component-report"
 private val PACKAGES = setOf(PKG_HAMCREST, PKG_JUNIT)
 
 private val COMPONENTS_REQUEST_JSON =


### PR DESCRIPTION
As of September 22nd, 2025, authentication will be mandatory, see [1]. Reflect that by making respective properties non-nullable. While at it, also make the `username` a non-`Secret` and use a more fitting `token` property.

BREAKING CHANGE: Users need to move their configured `username` property from the `secrets` to the `options` section, and rename the `password` property in the `secrets` section to `token`.

[1]: https://ossindex.sonatype.org/doc/auth-required