### PR TITLE
docs: Never put a comman after "e.g."

### DIFF
--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -127,8 +127,8 @@ data class Package(
     val isMetadataOnly: Boolean = false,
 
     /**
-     * Indicates whether the source code of the package has been modified compared to the original source code,
-     * e.g., in case of a fork of an upstream Open Source project.
+     * Indicates whether the source code of the package has been modified compared to the original source code, e.g. in
+     * case of a fork of an upstream Open Source project.
      */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     val isModified: Boolean = false,

--- a/model/src/main/kotlin/config/VulnerabilityResolutionReason.kt
+++ b/model/src/main/kotlin/config/VulnerabilityResolutionReason.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
  */
 enum class VulnerabilityResolutionReason {
     /**
-     * No remediation is available for this vulnerability, e.g., because it requires a change to be made
+     * No remediation is available for this vulnerability, e.g. because it requires a change to be made
      * by a third party that is not responsive.
      */
     CANT_FIX_VULNERABILITY,
@@ -38,13 +38,13 @@ enum class VulnerabilityResolutionReason {
     INEFFECTIVE_VULNERABILITY,
 
     /**
-     * The vulnerability is irrelevant due to a tooling or database mismatch, e.g., the package version used
+     * The vulnerability is irrelevant due to a tooling or database mismatch, e.g. the package version used
      * does not match the version for which the vulnerability provider has reported a vulnerability.
      */
     INVALID_MATCH_VULNERABILITY,
 
     /**
-     * The vulnerability is valid but has been mitigated, e.g., measures have been taken to ensure
+     * The vulnerability is valid but has been mitigated, e.g. measures have been taken to ensure
      * this vulnerability can not be exploited.
      */
     MITIGATED_VULNERABILITY,
@@ -56,7 +56,7 @@ enum class VulnerabilityResolutionReason {
     NOT_A_VULNERABILITY,
 
     /**
-     * This vulnerability will never be fixed, e.g., because the package which is affected is orphaned,
+     * This vulnerability will never be fixed, e.g. because the package which is affected is orphaned,
      * declared end-of-life, or otherwise deprecated.
      */
     WILL_NOT_FIX_VULNERABILITY,

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -54,7 +54,7 @@ class DefaultDirLicenseFactProvider(descriptor: PluginDescriptor = DefaultDirLic
     id = "Dir",
     displayName = "Directory License Fact Provider",
     description = "A license fact provider that reads license information from a local directory. The files must be " +
-        "named after the SPDX-conform license IDs, e.g., 'Apache-2.0' or 'LicenseRef-custom-license'.",
+        "named after the SPDX-conform license IDs, e.g. 'Apache-2.0' or 'LicenseRef-custom-license'.",
     factory = LicenseFactProviderFactory::class
 )
 open class DirLicenseFactProvider(

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -92,7 +92,7 @@ data class ConanConfig(
 
     /**
      * If true, the Conan package manager will call a command called "conan2" instead of "conan". This is required to
-     * be able to support both Conan major versions in a given environment e.g., the ORT Docker image or a local
+     * be able to support both Conan major versions in a given environment, e.g. the ORT Docker image or a local
      * development environment.
      */
     @OrtPluginOption(defaultValue = "false")

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2.kt
@@ -55,7 +55,7 @@ private const val YARN_NPM_INFO_CHUNK_SIZE = 1000
 data class Yarn2Config(
     /**
      * If true, the `yarn npm info` commands called by this package manager will not verify the server certificate of
-     * the HTTPS connection to the NPM registry. This allows replacing the latter by a local one, e.g., for intercepting
+     * the HTTPS connection to the NPM registry. This allows replacing the latter by a local one, e.g. for intercepting
      * the requests or replaying them.
      */
     @OrtPluginOption(defaultValue = "false")

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -59,7 +59,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
 
 /**
  * A class to process [Apache Freemarker][1] templates, intended to be called by a [Reporter] that uses the generated
- * files in a postprocessing step, e.g., generating a PDF.
+ * files in a postprocessing step, e.g. generating a PDF.
  *
  * [1]: https://freemarker.apache.org
  */

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -108,7 +108,7 @@ data class FossIdConfig(
     /**
      * A comma-separated list of URL mappings that allow transforming the VCS URLs of repositories before they are
      * passed to the FossID service. This may be necessary if FossID uses a different mechanism to clone a repository,
-     * e.g., via SSH instead of HTTP. Their values define the mapping to be applied consisting of two parts separated by
+     * e.g. via SSH instead of HTTP. Their values define the mapping to be applied consisting of two parts separated by
      * the string " -> ":
      * * A regular expression to match the repository URL.
      * * The replacement to be used for this repository URL. It can access the capture groups defined by the regular

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdNamingProvider.kt
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.kotlin.logger
  * This class provides names for scans when the FossID scanner creates them, based on the provided [namingScanPattern].
  * If the pattern is null, a default pattern is used.
  *
- * The pattern can include built-in variables which are prefixed in the pattern with `#`, e.g., `#projectName_#branch`.
+ * The pattern can include built-in variables which are prefixed in the pattern with `#`, e.g. `#projectName_#branch`.
  *
  * The following built-in variables are available:
  * * **projectName**: The project name, if configured in the scanner options.


### PR DESCRIPTION
If at all, the common should come before.