### PR TITLE
chore(common-utils): Rework `OsTest` for robustness

### DIFF
--- a/utils/common/src/test/kotlin/OsTest.kt
+++ b/utils/common/src/test/kotlin/OsTest.kt
@@ -20,38 +20,47 @@
 package org.ossreviewtoolkit.utils.common
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.file.aFile
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
-
-import java.io.File
 
 import org.ossreviewtoolkit.utils.common.Os.getPathFromEnvironment
 
 class OsTest : WordSpec({
-    "getPathFromEnvironment" should {
-        "find system executables on Windows".config(enabled = Os.isWindows) {
-            val winverPath = File(Os.env["SYSTEMROOT"], "system32/winver.exe")
+    "getPathFromEnvironment()" should {
+        "return the path to system executables on Windows".config(enabled = Os.isWindows) {
+            getPathFromEnvironment("winver") shouldNotBeNull {
+                this shouldBe aFile()
+                name shouldBe "winver.exe"
+            }
 
-            getPathFromEnvironment("winver") shouldNot beNull()
-            getPathFromEnvironment("winver") shouldBe winverPath
+            getPathFromEnvironment("winver.exe") shouldNotBeNull {
+                this shouldBe aFile()
+                name shouldBe "winver.exe"
+            }
+        }
 
-            getPathFromEnvironment("winver.exe") shouldNot beNull()
-            getPathFromEnvironment("winver.exe") shouldBe winverPath
-
+        "return null for special names on Windows".config(enabled = Os.isWindows) {
             getPathFromEnvironment("") should beNull()
             getPathFromEnvironment("*") should beNull()
             getPathFromEnvironment("nul") should beNull()
         }
 
-        "find system executables on non-Windows".config(enabled = !Os.isWindows) {
-            getPathFromEnvironment("sh") shouldNotBeNull {
-                toString() shouldBeIn listOf("/bin/sh", "/usr/bin/sh")
+        "return the path to system executables on non-Windows".config(enabled = !Os.isWindows) {
+            getPathFromEnvironment("chown") shouldNotBeNull {
+                this shouldBe aFile()
+                name shouldBe "chown"
             }
 
+            getPathFromEnvironment("env") shouldNotBeNull {
+                this shouldBe aFile()
+                name shouldBe "env"
+            }
+        }
+
+        "return null for special names on non-Windows".config(enabled = !Os.isWindows) {
             getPathFromEnvironment("") should beNull()
             getPathFromEnvironment("/") should beNull()
         }


### PR DESCRIPTION
Verify that returned paths actually point to existing files. For non-Windows, use more basic executables to find even on very minimalistic systems. Finally, split out test cases for special names.