### PR TITLE
test(bazel): Rename to "BazelDetectionFunTest" as it is in `funTest`

### DIFF
--- a/plugins/package-managers/bazel/src/funTest/kotlin/BazelDetectionFunTest.kt
+++ b/plugins/package-managers/bazel/src/funTest/kotlin/BazelDetectionFunTest.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
 import org.ossreviewtoolkit.utils.test.patchActualResult
 
-class BazelDetectionTest : StringSpec({
+class BazelDetectionFunTest : StringSpec({
     "MODULE.bazel files present in a local registry should not be considered as definition files" {
         val definitionFile = getAssetFile("projects/synthetic/bazel-local-registry2/MODULE.bazel")
         val expectedResultFile = getAssetFile("projects/synthetic/bazel-expected-output-local-registry2.yml")


### PR DESCRIPTION
This test depends on the `buildozer` tool.