### PR TITLE
fix(downloader): Determining the VCS type should not require availability

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -53,9 +53,7 @@ abstract class VersionControlSystem : Plugin {
          * Return the applicable VCS for the given [vcsType], or null if none is applicable.
          */
         fun forType(vcsType: VcsType, configs: Map<String, PluginConfig> = emptyMap()) =
-            getAllVcsByPriority(configs).find { vcs ->
-                vcs.type == vcsType && vcs.isAvailable()
-            }
+            getAllVcsByPriority(configs).find { vcs -> vcs.type == vcsType }
 
         /**
          * A map to cache the [VersionControlSystem], if any, for previously queried URLs and their respective plugin
@@ -78,9 +76,7 @@ abstract class VersionControlSystem : Plugin {
                 when (val type = VcsHost.parseUrl(vcsUrl).type) {
                     VcsType.UNKNOWN -> {
                         // ...then eventually try to determine the type also dynamically.
-                        getAllVcsByPriority(configs).find { vcs ->
-                            vcs.isApplicableUrl(vcsUrl) && vcs.isAvailable()
-                        }
+                        getAllVcsByPriority(configs).find { vcs -> vcs.isApplicableUrl(vcsUrl) }
                     }
 
                     else -> forType(type, configs)


### PR DESCRIPTION
Determining the `VersionControlSystem` from `VcsType` or URL should work statically without any underlying external tool to be available at this point. If at all, the whole `VersionControlSystem` plugin should not load if a required external tool is not available.