### PR TITLE
feat(conan): Add version-specific authentication for remotes

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -271,12 +271,7 @@ class Conan(
                 if (auth != null) {
                     // Configure Conan's authentication based on ORT's authentication for the remote.
                     runCatching {
-                        command.run(
-                            "user",
-                            "-r", remoteName,
-                            "-p", String(auth.password).masked(),
-                            auth.userName.masked()
-                        ).requireSuccess()
+                        handler.authenticate(remoteName, auth.userName.masked(), String(auth.password).masked())
                     }.onFailure {
                         logger.error { "Failed to configure user authentication for remote '$remoteName'." }
                     }

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.DUMMY_COMPILER_SETTINGS
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEPENDENCIES
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEV_DEPENDENCIES
+import org.ossreviewtoolkit.utils.common.MaskedString
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -117,6 +118,10 @@ internal class ConanV1Handler(private val conan: Conan) : ConanVersionHandler {
 
     override fun runInspectCommand(workingDir: File, pkgName: String, jsonFile: File) {
         conan.command.run(workingDir, "inspect", pkgName, "--json", jsonFile.absolutePath).requireSuccess()
+    }
+
+    override fun authenticate(remote: String, username: MaskedString, password: MaskedString) {
+        conan.command.run("user", "-r", remote, "-p", password, username).requireSuccess()
     }
 
     /**

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.DUMMY_
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEPENDENCIES
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEV_DEPENDENCIES
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_TEST_DEPENDENCIES
+import org.ossreviewtoolkit.utils.common.MaskedString
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.alsoIfNull
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
@@ -164,6 +165,10 @@ internal class ConanV2Handler(private val conan: Conan) : ConanVersionHandler {
             "--out-file",
             jsonFile.absolutePath
         ).requireSuccess()
+    }
+
+    override fun authenticate(remote: String, username: MaskedString, password: MaskedString) {
+        conan.command.run("remote", "login", "-p", password, remote, username).requireSuccess()
     }
 
     /**

--- a/plugins/package-managers/conan/src/main/kotlin/ConanVersionHandler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanVersionHandler.kt
@@ -24,6 +24,7 @@ import java.io.File
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.utils.common.MaskedString
 
 /**
  * A version handler interface for Conan. Its implementations provide the package manager logic for a specific Conan
@@ -61,6 +62,11 @@ internal interface ConanVersionHandler {
      * Run the command "conan inspect" for the given [pkgName] and write the output to [jsonFile].
      */
     fun runInspectCommand(workingDir: File, pkgName: String, jsonFile: File)
+
+    /**
+     * Authenticate against the given [remote] with the provided [username] and [password].
+     */
+    fun authenticate(remote: String, username: MaskedString, password: MaskedString)
 }
 
 /**


### PR DESCRIPTION
Introduce a new `authenticate` function in the `ConanVersionHandler` to allow each handler to implement version-specific authentication for remotes. The `conan user` command has been removed from Conan 2.x [1], which caused issues analyzing Conan 2.x projects.

[1] https://docs.conan.io/1/migrating_to_2.0/commands.html#removed-conan-user

