### PR TITLE
feat(fossid): Ignore unknown JSON properties

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
@@ -19,9 +19,6 @@
 
 package org.ossreviewtoolkit.clients.fossid
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 class EntityResponseBody<T>(
     val operation: String? = null,
     val status: Int? = null,

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.BeanProperty
 import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.MapperFeature
@@ -80,6 +81,7 @@ interface FossIdRestService {
             // FossID has a bug in get_results/scan.
             // Sometimes the match_type is "ignored", sometimes it is "Ignored".
             enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             addModule(
                 kotlinModule().addDeserializer(PolymorphicList::class.java, PolymorphicListDeserializer())
                     .addDeserializer(PolymorphicInt::class.java, PolymorphicIntDeserializer())

--- a/clients/fossid-webapp/src/main/kotlin/model/Project.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/Project.kt
@@ -19,10 +19,8 @@
 
 package org.ossreviewtoolkit.clients.fossid.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Project(
     val id: Int,
 

--- a/clients/fossid-webapp/src/main/kotlin/model/Scan.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/Scan.kt
@@ -19,10 +19,8 @@
 
 package org.ossreviewtoolkit.clients.fossid.model
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Scan(
     val id: Int,
     val created: String?,

--- a/clients/fossid-webapp/src/main/kotlin/model/identification/identifiedFiles/License.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/identification/identifiedFiles/License.kt
@@ -19,12 +19,9 @@
 
 package org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-
 import org.ossreviewtoolkit.clients.fossid.model.identification.common.LicenseMatchType
 import org.ossreviewtoolkit.clients.fossid.model.result.LicenseCategory
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class License(
     val fileLicenseMatchType: LicenseMatchType,
 

--- a/clients/fossid-webapp/src/main/kotlin/model/rules/IgnoreRule.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/rules/IgnoreRule.kt
@@ -19,12 +19,9 @@
 
 package org.ossreviewtoolkit.clients.fossid.model.rules
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-
 /**
  * An "ignore rule" allows specifying FossID which files need to be excluded from scan.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class IgnoreRule(
     /**
      * The id of the rule.

--- a/clients/fossid-webapp/src/main/kotlin/model/status/ScanDescription2021dot2.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/status/ScanDescription2021dot2.kt
@@ -19,13 +19,11 @@
 
 package org.ossreviewtoolkit.clients.fossid.model.status
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
  * A description of scan status. This class is for FossID version 2021.2 and later.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class ScanDescription2021dot2(
     val id: Long?,
     val scanId: String,

--- a/clients/fossid-webapp/src/test/kotlin/FossId2025dot1Test.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossId2025dot1Test.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.fossid
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import io.kotest.core.spec.style.StringSpec
+
+import org.ossreviewtoolkit.clients.fossid.model.result.Snippet
+
+class FossId2025dot1Test : StringSpec({
+    "Snippet model can be deserialized" {
+        val responseJson = """
+            {
+                "id": "30",
+                "created": "2025-10-14 14:31:10",
+                "scan_id": "49",
+                "scan_file_id": "112254",
+                "file_id": "63380",
+                "match_type": "partial",
+                "reason": "",
+                "author": "someAuthor",
+                "artifact": "adbc",
+                "version": "0.2.4-rc0",
+                "purl": "pkg:github/aaa/bbb@0.2.4-rc0",
+                "artifact_license": "Apache-2.0",
+                "artifact_license_category": "PERMISSIVE",
+                "release_date": "2024-03-29 00:00:00",
+                "mirror": "asdf123aaaaa",
+                "file": "3rd_party/example/CONTRIBUTING.md",
+                "file_license": "Apache-2.0",
+                "url": "https://github.com/oss-review-toolkit/example/archive/v0.2.4-rc0.tar.gz",
+                "hits": "10 (100%)",
+                "size": "13249",
+                "updated": "2025-10-14 14:31:10",
+                "cpe": null,
+                "score": "1",
+                "match_file_id": "cae2442400f7293382f118cb00000000",
+                "classification": null,
+                "highlighting": "",
+                "projectscan_type": ""
+            }
+        """.trimIndent()
+
+        FossIdRestService.JSON_MAPPER.readValue<Snippet>(responseJson)
+    }
+})


### PR DESCRIPTION
FossID 2025.1 added the `projectscan_type` field to the
`Snippet` model. Add it to the ORT model as well to support this FossId
version, while allowing `null` and empty values for backwards
compatibility.