### PR TITLE
test(osv): Update expected results

### DIFF
--- a/clients/osv/src/funTest/kotlin/OsvServiceWrapperFunTest.kt
+++ b/clients/osv/src/funTest/kotlin/OsvServiceWrapperFunTest.kt
@@ -59,7 +59,6 @@ class OsvServiceWrapperFunTest : WordSpec({
                     "CVE-2021-45931",
                     "CVE-2022-33068",
                     "CVE-2023-25193",
-                    "CVE-2024-56732",
                     "OSV-2020-484"
                 )
 


### PR DESCRIPTION
OSV stopped returning CVE-2024-56732 for commit 6879efc in harfbuzz. This seems reasonable, because 6879efc is much older than 30485ee which supposedly introduced the vulnerability, see [1].

[1]: https://osv.dev/vulnerability/CVE-2024-56732

