### PR TITLE
fix(fossid): Increase HTTP timeout for deletion of uploaded content

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -206,6 +206,7 @@ interface FossIdRestService {
     suspend fun extractArchives(@Body body: PostRequestBody): EntityResponseBody<Boolean>
 
     @POST("api.php")
+    @Headers("$READ_TIMEOUT_HEADER:${60 * 1000}")
     suspend fun removeUploadedContent(
         @Body body: PostRequestBody
     ): PolymorphicDataResponseBody<RemoveUploadContentResponse>

--- a/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
@@ -130,6 +130,7 @@ class UploadArchiveHandler(
 
     override suspend fun afterCheckScan(scanCode: String) {
         if (config.deleteUploadedArchiveAfterScan) {
+            logger.info { "Deleting uploaded archive for scan '$scanCode'." }
             service.removeUploadedContent(config.user.value, config.apiKey.value, scanCode)
                 .checkResponse("remove previously uploaded content 2", false)
         }


### PR DESCRIPTION
If configured, the FossID plugin will delete uploaded content after scan completion. Under some circumstances, FossID will **not** send a response to the respective HTTP request within 10 seconds, which results in a timeout in the FossID plugin.
Increase this timeout similar to other remote calls to FossID to reduce the risk to run into this timeout.

