### PR TITLE
fix(model): Keep the root project under all circumstances

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -461,7 +461,12 @@ data class OrtResult(
                 dependencyNavigator.projectDependencies(it, matcher = MATCH_SUB_PROJECTS)
             }
 
+            subProjectIds.forEach { logger.info { "wklenk --- sub-project it=$it" } }
+
             projects.removeAll { it.id in subProjectIds }
+
+            // This line would do the thing
+            // projects.removeAll { it.id in subProjectIds && it.id.namespace.isNotEmpty() }
         }
 
         return projects


### PR DESCRIPTION
If a repository has monorepo-like structures, possibly with sub-projects declaring dependencies to the root-project, it may happen that the root-project is removed when generating the SPDX report, as it is a dependency of a sub-project and one does not want to include it.

