### PR TITLE
fix(model): Fix issues with computing the shortest paths

### DIFF
--- a/model/src/main/kotlin/DependencyNavigator.kt
+++ b/model/src/main/kotlin/DependencyNavigator.kt
@@ -192,19 +192,19 @@ private fun getShortestPathsForScope(nodes: Sequence<DependencyNode>): Map<Ident
     val queue = nodes.mapTo(LinkedList()) { QueueItem(it.getStableReference(), null) }
 
     while (queue.isNotEmpty()) {
-        val item = queue.poll()
-        if (item.node in predecessorForVisitedNode) continue
+        val (node, predecessorNode) = queue.poll()
+        if (node in predecessorForVisitedNode) continue
 
-        predecessorForVisitedNode[item.node] = item.predecessorNode
+        predecessorForVisitedNode[node] = predecessorNode
         // Once any node with a particular identifier is visited, the endpoint of the shortest path to that
         // identifier is known to be that visited node.
-        firstVisitedNodeForId.putIfAbsent(item.node.id, item.node)
+        firstVisitedNodeForId.putIfAbsent(node.id, node)
 
-        item.node.visitDependencies { dependencyNodes ->
+        node.visitDependencies { dependencyNodes ->
             dependencyNodes.forEach { dependencyNode ->
                 val ref = dependencyNode.getStableReference()
                 if (ref !in predecessorForVisitedNode) {
-                    queue.offer(QueueItem(ref, item.node))
+                    queue.offer(QueueItem(ref, node))
                 }
             }
         }


### PR DESCRIPTION
Using the Breath First Search is the standard approach to computing shortest paths, and is simple. The previous code deviated from that common algorithm. It lacked the abort criterion for already visited nodes, which may lead to unnecessary traversal. This lack of abortion removes the `O(V+E)` guarantee, let alone what happens in case of a cycle. In real word, large memory consumption and looping forever has been observed. Apart from that, the previous code did not clearly distinguish what a node for the algorithm is, a `DependencyNode` or an `Identifier`?!

Re-write the algorithm so that the first part (until the queue is empty) is a plain simple Breath First Search. A node is a `DependencyNode` which is simple to grasp, and the `O(V+E)` execution time, and O(V) memory consumption should ensure sufficient efficiency.

The second part the reconstructs the found shortest paths for each `DependencyNode` and determines the minimal path for each `Identifier`. This part has similar asymptotic execution time and memory consumption as the first part. Thus, overall memory and execution time issues should be addressed.

