### PR TITLE
feat(pip): Add 'pythonInspectorVerbose' option to enable detailed resolver output

### DIFF
--- a/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
@@ -49,7 +49,8 @@ class PythonInspectorFunTest : StringSpec({
                 definitionFile = definitionFile,
                 pythonVersion = "27",
                 operatingSystem = "linux",
-                analyzeSetupPyInsecurely = true
+                analyzeSetupPyInsecurely = true,
+                verbose = false
             )
         } finally {
             workingDir.resolve(".cache").safeDeleteRecursively()
@@ -70,7 +71,8 @@ class PythonInspectorFunTest : StringSpec({
                 definitionFile = definitionFile,
                 pythonVersion = "311",
                 operatingSystem = "linux",
-                analyzeSetupPyInsecurely = false
+                analyzeSetupPyInsecurely = false,
+                verbose = false
             )
         } finally {
             workingDir.resolve(".cache").safeDeleteRecursively()

--- a/plugins/package-managers/python/src/main/kotlin/Pip.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Pip.kt
@@ -60,7 +60,13 @@ data class PipConfig(
      * The Python version to resolve dependencies for. If not set, the version is detected from the environment and if
      * that fails, the default version is used.
      */
-    val pythonVersion: String?
+    val pythonVersion: String?,
+
+    /**
+     * If "true", enables verbose logging in `python-inspector`.
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val pythonInspectorVerbose: Boolean
 )
 
 /**
@@ -125,7 +131,8 @@ class Pip internal constructor(
                     definitionFile = definitionFile,
                     pythonVersion = pythonVersion.split('.', limit = 3).take(2).joinToString(""),
                     operatingSystem = config.operatingSystem,
-                    analyzeSetupPyInsecurely = config.analyzeSetupPyInsecurely
+                    analyzeSetupPyInsecurely = config.analyzeSetupPyInsecurely,
+                    verbose = config.pythonInspectorVerbose
                 )
             } finally {
                 workingDir.resolve(".cache").safeDeleteRecursively()

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspector.kt
@@ -63,7 +63,8 @@ internal object PythonInspector : CommandLineTool {
         definitionFile: File,
         pythonVersion: String,
         operatingSystem: String,
-        analyzeSetupPyInsecurely: Boolean
+        analyzeSetupPyInsecurely: Boolean,
+        verbose: Boolean
     ): Result {
         val outputFile = createOrtTempFile(prefix = "python-inspector", suffix = ".json")
 
@@ -79,6 +80,10 @@ internal object PythonInspector : CommandLineTool {
 
             if (analyzeSetupPyInsecurely) {
                 add("--analyze-setup-py-insecurely")
+            }
+
+            if (verbose) {
+                add("--verbose")
             }
 
             if (definitionFile.name == "setup.py") {


### PR DESCRIPTION
Introduce a 'pythonInspectorVerbose' flag in the PIP plugin configuration to enable more informative output from [python-inspector](https://github.com/aboutcode-org/python-inspector). When set to true, it shows additional details such as dependency resolution steps, environment data, repository configuration, and used credentials. This helps diagnose repository access and configuration issues.

**Please note** that **passwords are currently displayed in plain text** in the output of python-inspector. Therefore, please activate this new switch with caution. A feature request to mask passwords in the output has already been submitted:
https://github.com/aboutcode-org/python-inspector/issues/254