### PR TITLE
chore(buildSrc): Consistently call `add` on `freeCompilerArgs`

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -226,10 +226,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
     compilerOptions {
         allWarningsAsErrors = true
-        freeCompilerArgs = listOf(
-            "-Xannotation-default-target=param-property",
-            "-Xconsistent-data-class-copy-visibility"
-        )
+        freeCompilerArgs.addAll("-Xannotation-default-target=param-property", "-Xconsistent-data-class-copy-visibility")
         jvmTarget = maxKotlinJvmTarget
         optIn = optInRequirements
     }

--- a/plugins/package-managers/gradle-plugin/build.gradle.kts
+++ b/plugins/package-managers/gradle-plugin/build.gradle.kts
@@ -57,7 +57,7 @@ tasks.named<KotlinCompile>("compileKotlin") {
         jvmTarget = gradleToolingApiLowestSupportedJavaVersion
 
         // See https://docs.gradle.org/current/userguide/compatibility.html#kotlin.
-        freeCompilerArgs = listOf("-Xsuppress-version-warnings")
+        freeCompilerArgs.add("-Xsuppress-version-warnings")
         languageVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_8
         apiVersion = @Suppress("DEPRECATION") KotlinVersion.KOTLIN_1_8
     }


### PR DESCRIPTION
Avoid accidental overwriting of values added before, e.g. by Gradle plugins. Note that `freeCompilerArgs` is a provider that does not support operator overloading yet.

While at it, unwrap lines that fit into one, to more easily see `freeCompilerArgs` matches in one-line search results.