### PR TITLE
fix(fossid-webapp): Do not delete uploaded content after scan

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -670,7 +670,7 @@ suspend fun FossIdRestService.extractArchives(
 
 /**
  * Remove uploaded content for the given [scanCode]. If [fileName] is specified, only this file is removed.
- *
+ * Please note that it removes all uploaded content, the archive and the extracted files.
  * The HTTP request is sent with [user] and [apiKey] as credentials.
  */
 suspend fun FossIdRestService.removeUploadedContent(

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -270,8 +270,6 @@ ort:
 
           treatPendingIdentificationsAsError: false
 
-          deleteUploadedArchiveAfterScan: true
-
         secrets:
           user: user
           apiKey: XYZ

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -246,8 +246,7 @@ class OrtConfigurationTest : WordSpec({
                             "timeout" to "60",
                             "urlMappings" to urlMapping,
                             "sensitivity" to "10",
-                            "treatPendingIdentificationsAsError" to "false",
-                            "deleteUploadedArchiveAfterScan" to "true"
+                            "treatPendingIdentificationsAsError" to "false"
                         )
 
                         secrets should containExactlyEntries(

--- a/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdConfig.kt
@@ -135,14 +135,7 @@ data class FossIdConfig(
 
     /** Treat pending identifications as errors instead of hints. */
     @OrtPluginOption(defaultValue = "false")
-    val treatPendingIdentificationsAsError: Boolean,
-
-    /**
-     * Whether to delete uploaded content after scan completion. When set to false, archives remain on the
-     * FossID server, which can help diagnose archive upload issues.
-     */
-    @OrtPluginOption(defaultValue = "true")
-    val deleteUploadedArchiveAfterScan: Boolean
+    val treatPendingIdentificationsAsError: Boolean
 ) {
     init {
         require(deltaScanLimit > 0) {

--- a/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/events/UploadArchiveHandler.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.plugins.scanners.fossid.events
 
 import java.io.File
-import java.net.SocketTimeoutException
 
 import kotlin.io.path.createTempFile
 
@@ -127,19 +126,6 @@ class UploadArchiveHandler(
         // extraction.
         service.extractArchives(config.user.value, config.apiKey.value, scanCode, sourceArchive.toFile().name)
             .checkResponse("extract archive", true)
-    }
-
-    override suspend fun afterCheckScan(scanCode: String) {
-        if (config.deleteUploadedArchiveAfterScan) {
-            logger.info { "Deleting uploaded archive for scan '$scanCode'." }
-
-            try {
-                service.removeUploadedContent(config.user.value, config.apiKey.value, scanCode)
-                    .checkResponse("remove previously uploaded content 2", false)
-            } catch (e: SocketTimeoutException) {
-                logger.info { "Ignoring timeout while deleting uploaded archive: ${e.message}" }
-            }
-        }
     }
 
     internal fun deleteExcludedFiles(path: File, includes: Includes?, excludes: Excludes?) {

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
@@ -364,7 +364,7 @@ class FossIdSnippetChoiceTest : WordSpec({
             ).summary
 
             summary.snippetFindings should beEmpty()
-            coVerify {
+            coVerify(exactly = 1) {
                 service.createScan(USER, API_KEY, projectCode, scanCode, null, null, comment)
                 service.removeUploadedContent(USER, API_KEY, scanCode)
                 service.uploadFile(USER, API_KEY, scanCode, any())
@@ -876,7 +876,7 @@ class FossIdSnippetChoiceTest : WordSpec({
                 snippets.map { it.purl } shouldBe listOf(PURL_3)
             }
 
-            coVerify {
+            coVerify(exactly = 1) {
                 service.removeUploadedContent(USER, API_KEY, scanCode)
                 service.uploadFile(USER, API_KEY, scanCode, any())
                 service.extractArchives(USER, API_KEY, scanCode, any())

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdTest.kt
@@ -225,7 +225,7 @@ class FossIdTest : WordSpec({
             )
 
             val comment = createOrtScanComment(vcsInfo.url, vcsInfo.revision, branchName).asJsonString()
-            coVerify {
+            coVerify(exactly = 1) {
                 service.createScan(USER, API_KEY, projectCode, scanCode, null, null, comment)
                 service.removeUploadedContent(USER, API_KEY, scanCode)
                 service.uploadFile(USER, API_KEY, scanCode, any())
@@ -275,7 +275,7 @@ class FossIdTest : WordSpec({
             )
 
             val comment = createOrtScanComment(vcsInfo.url, vcsInfo.revision, branchName).asJsonString()
-            coVerify {
+            coVerify(exactly = 1) {
                 service.createScan(USER, API_KEY, projectCode, scanCode, null, null, comment)
                 service.removeUploadedContent(USER, API_KEY, scanCode)
                 service.uploadFile(USER, API_KEY, scanCode, any())
@@ -1214,7 +1214,7 @@ class FossIdTest : WordSpec({
                 mapOf(FossId.PROJECT_REVISION_LABEL to "master")
             )
 
-            coVerify {
+            coVerify(exactly = 1) {
                 service.removeUploadedContent(USER, API_KEY, scanCode)
                 service.uploadFile(USER, API_KEY, scanCode, any())
                 service.extractArchives(USER, API_KEY, scanCode, any())
@@ -1259,7 +1259,7 @@ class FossIdTest : WordSpec({
                 mapOf(FossId.PROJECT_REVISION_LABEL to "master")
             )
 
-            coVerify {
+            coVerify(exactly = 1) {
                 service.removeUploadedContent(USER, API_KEY, scanCode)
                 service.uploadFile(USER, API_KEY, scanCode, any())
                 service.extractArchives(USER, API_KEY, scanCode, any())

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -154,8 +154,7 @@ internal fun createConfig(
         writeToStorage = false,
         logRequests = false,
         isArchiveMode = isArchiveMode,
-        treatPendingIdentificationsAsError = false,
-        deleteUploadedArchiveAfterScan = true
+        treatPendingIdentificationsAsError = false
     )
 
     val namingProvider = createNamingProviderMock()


### PR DESCRIPTION
After an archive was uploaded to FossId, it is extracted and the function `deleteUploadedArchiveAfterScan` is called to supposedly delete the archive.
Unfortunately, this function also removes the extracted files so they are not visible in the UI anymore and their lines cannot be matched. In fact, there is no need to explicitely delete the archive as is deleted after the files have been extracted.
