### PR TITLE
feat(conan): Add configurable optional path of a Conan profile

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -96,7 +96,13 @@ data class ConanConfig(
      * development environment.
      */
     @OrtPluginOption(defaultValue = "false")
-    val useConan2: Boolean
+    val useConan2: Boolean,
+
+    /**
+     * The path, relative to the root of the analysis, of a Conan profile to use during dependency resolution.
+     * If not specified, the default profile is used instead.
+     */
+    val conanProfilePath: String?
 )
 
 /**
@@ -215,7 +221,11 @@ class Conan(
                 config.lockfileName?.let { hasLockfile(workingDir.resolve(it).path) } == true
             }
 
-            val handlerResults = handler.process(definitionFile, config.lockfileName)
+            val resolvedProfilePath = config.conanProfilePath?.let { profilePath ->
+                analysisRoot / profilePath
+            }
+
+            val handlerResults = handler.process(definitionFile, config.lockfileName, resolvedProfilePath)
 
             val result = with(handlerResults) {
                 val scopes = setOfNotNull(dependenciesScope, devDependenciesScope, testDependenciesScope)

--- a/plugins/package-managers/conan/src/main/kotlin/ConanVersionHandler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanVersionHandler.kt
@@ -42,10 +42,10 @@ internal interface ConanVersionHandler {
     fun getConanStoragePath(): File
 
     /**
-     * Resolve the dependencies defined in the [definitionFile] and given the lockfile [lockfileName], and return them
-     * as [HandlerResults].
+     * Resolve the dependencies defined in the [definitionFile], with optional [lockfileName] / [conanProfile], and
+     * return them as [HandlerResults].
      */
-    fun process(definitionFile: File, lockfileName: String?): HandlerResults
+    fun process(definitionFile: File, lockfileName: String?, conanProfile: File?): HandlerResults
 
     /**
      * Get the Conan data file for a package with the given [name] and [version] from the [conanStorageDir]. This file


### PR DESCRIPTION
Some Conan projects are not compatible with the default build parameters
passed by ORT. Additionally, some projects maintain an external profile
file to configure the build properties.
This commit adds an extra configuration parameter to the Conan package
manager to allow passing such profile files. This parameter should contain
a relative file path that will be resolved against the repository's root.

Please have a look at the individual commit messages for the details.