### PR TITLE
fix(git): Use Apache HttpClient for JGit HTTP transport

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jac
 jakartaMail = { module = "com.sun.mail:jakarta.mail", version.ref = "jakartaMail" }
 jerseyCommon = { module = "org.glassfish.jersey.core:jersey-common", version.ref = "jerseyCommon" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
+jgit-http-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.http.apache", version.ref = "jgit" }
 jgit-ssh-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit" }
 jgit-ssh-apache-agent = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent", version.ref = "jgit" }
 jiraRestClient-api = { module = "com.atlassian.jira:jira-rest-java-client-api", version.ref = "jiraRestClient" }

--- a/plugins/version-control-systems/git/build.gradle.kts
+++ b/plugins/version-control-systems/git/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 
     implementation(libs.jgit)
 
+    implementation(libs.jgit.http.apache)
+
     implementation(libs.jgit.ssh.apache) {
         exclude(group = "org.apache.sshd", module = "sshd-sftp")
             .because("it is not required for cloning via SSH and causes issues with GraalVM native images")

--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -35,9 +35,11 @@ import org.eclipse.jgit.lib.ObjectIdRef
 import org.eclipse.jgit.lib.SymbolicRef
 import org.eclipse.jgit.transport.CredentialItem
 import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.HttpTransport
 import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.TagOpt
 import org.eclipse.jgit.transport.URIish
+import org.eclipse.jgit.transport.http.apache.HttpClientConnectionFactory
 import org.eclipse.jgit.transport.sshd.DefaultProxyDataFactory
 import org.eclipse.jgit.transport.sshd.JGitKeyCache
 import org.eclipse.jgit.transport.sshd.ServerKeyDatabase
@@ -104,6 +106,10 @@ class Git(
 ) : VersionControlSystem() {
     companion object {
         init {
+            // Use Apache HttpClient for HTTP transport in JGit instead of the default java.net.HttpURLConnection based
+            // transport. This avoids caching credentials too eagerly for basic authentication.
+            HttpTransport.setConnectionFactory(HttpClientConnectionFactory())
+
             // Make sure that JGit uses the exact same authentication information as ORT itself. This addresses
             // discrepancies in the way .netrc files are interpreted between JGit's and ORT's implementation.
             CredentialsProvider.setDefault(AuthenticatorCredentialsProvider)


### PR DESCRIPTION
JGit defaults to `java.net.HttpURLConnection` for HTTP(S) connections [1]. This implementation caches Basic Auth credentials [2] [3], which causes problems when accessing multiple repositories on the same host with different credentials.

For example, when cloning GitHub repositories over HTTPS, `HttpURLConnection` stores credentials under the cache key `s:BASIC:https:github.com:443:GitHub`. Cloning a second repository with different credentials then reuses the cached credentials from the first clone, resulting in authentication failures.

Switch JGit's HTTP transport to Apache HttpClient, which does not exhibit this credential caching behavior.

[1]: https://github.com/eclipse-jgit/jgit/blob/v7.4.0.202509020913-r/org.eclipse.jgit/src/org/eclipse/jgit/transport/http/JDKHttpConnection.java
[2]: https://bugs.openjdk.org/browse/JDK-6626700
[3]: https://github.com/openjdk/jdk/blob/676e6fd8d5152f4e0d14ae59ddd7aa0a7127ea58/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java#L306-L308
