### PR TITLE
fix(downloader): Do not re-throw if `unpackTryAllTypes()` failed

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     implementation(libs.kotlinx.coroutines)
+    implementation(libs.tika)
 
     funTestImplementation(platform(projects.plugins.versionControlSystems))
 


### PR DESCRIPTION
There are valid cases when a source artifact URL points to a single source code file that cannot be unpacked but still should be scanned.