### PR TITLE
fix(conan): Fix Conan profile path and file Analyzer roots

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -222,7 +222,8 @@ class Conan(
             }
 
             val resolvedProfilePath = config.conanProfilePath?.let { profilePath ->
-                analysisRoot / profilePath
+                val analysisRootDir = if (analysisRoot.isFile) analysisRoot.parentFile else analysisRoot
+                analysisRootDir / profilePath
             }
 
             val handlerResults = handler.process(definitionFile, config.lockfileName, resolvedProfilePath)


### PR DESCRIPTION
This fixes a bug when the Analyzer is called on a single definition file, not on a directory.

This is a fixup for f4aa910deaa744877cabab1ecd0dc55cd38b71cb.
