### PR TITLE
fix(docker): Make importing custom certificates work

### DIFF
--- a/scripts/import_certificates.sh
+++ b/scripts/import_certificates.sh
@@ -55,5 +55,5 @@ fi
 
 # Also add the certificates to the system certificates, e.g. for curl to work.
 echo "Adding certificates to the system certificates..."
-cp -r "$FILE_PREFIX"* /usr/local/share/ca-certificates/
+cp -L -r "$FILE_PREFIX"* /usr/local/share/ca-certificates/
 update-ca-certificates


### PR DESCRIPTION
When custom certificates are passed to the `import_certificates.sh` script that are mounted into the container (which should be the default scenario), the import to the system certificates store does not happen because the `update-ca-certificates` script ignores symbolic links. To fix this, make sure that the custom certificate files are copied to "real" files.

This PR is analogous to https://github.com/eclipse-apoapsis/ort-server/pull/3992 for ORT Server.