### PR TITLE
New ORT project analyzer file format

### DIFF
--- a/analyzer/src/funTest/kotlin/PackageManagerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/PackageManagerFunTest.kt
@@ -65,6 +65,7 @@ class PackageManagerFunTest : WordSpec({
         "npm-pnpm-and-yarn/package.json",
 
         "nuget/packages.config",
+        "ort-project/ortproject.yml",
         "pip-requirements/requirements.txt",
         "pip-setup/setup.py",
         "pipenv/Pipfile.lock",

--- a/integrations/schemas/package-managers-schema.json
+++ b/integrations/schemas/package-managers-schema.json
@@ -20,6 +20,7 @@
         "Mix",
         "NPM",
         "NuGet",
+        "OrtProjectFile",
         "PIP",
         "Pipenv",
         "PNPM",

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -62,6 +62,7 @@ data class AnalyzerConfiguration(
         "Mix",
         "NPM",
         "NuGet",
+        "OrtProjectFile",
         "PIP",
         "Pipenv",
         "PNPM",

--- a/plugins/package-managers/ortproject/build.gradle.kts
+++ b/plugins/package-managers/ortproject/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-plugin-conventions")
+
+    // Apply third-party plugins.
+    alias(libs.plugins.kotlinSerialization)
+}
+
+dependencies {
+    api(projects.analyzer)
+    api(projects.model)
+
+    implementation(projects.downloader)
+
+    implementation(libs.kotlinx.serialization.core)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.yaml)
+
+    ksp(projects.analyzer)
+
+    funTestImplementation(testFixtures(projects.analyzer))
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/ortproject.yml
@@ -1,0 +1,37 @@
+projectName: "project-x"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    description: "Package with fully elaborated model."
+    vcs:
+      type: "Mercurial"
+      url: "https://git.example.com/full/"
+      revision: "master"
+      path: "/"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        algorithm: "SHA1"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"
+    homepageUrl: "https://project_x.example.com/full"
+    labels:
+      label: "value"
+      label2: "value2"
+    authors:
+      - "John Doe"
+      - "Foo Bar"
+    scopes:
+      - "main"
+    isModified: false
+    isMetadataOnly: false
+
+  - purl: "pkg:maven/com.example/minimal@0.1.0"

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/pom.xml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <description>POM file to check if it won't be taken into packages list.</description>
+    <groupId>com.example</groupId>
+    <artifactId>your-project-name</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>your-project-name</name>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject1/configuration.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject1/configuration.yml
@@ -1,0 +1,2 @@
+some:
+  configFile: "Just to have anything in folder other than definition file."

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject1/sub1.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject1/sub1.ortproject.yml
@@ -1,0 +1,17 @@
+projectName: "subproject-x-1"
+description: "Subproject X-1 description"
+homepageUrl: "https://project_x-1.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "Gerard & Son"
+dependencies:
+  - purl: "pkg:maven/com.example/sub-x1@9.98.0"
+    description: "Package of subproject 1"
+    vcs:
+      type: "Mercurial"
+      url: "https://mercurial.example.com/full/"
+      revision: "master"
+      path: "/"
+    declaredLicenses:
+      - "Apache-2.0"

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject2/README.md
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject2/README.md
@@ -1,0 +1,9 @@
+# Synthetic multiproject test
+
+__This test checks that:__
+
+* All of the definition files in subfolders of a multi-project are found.
+* Proper package list is created.
+* None of files having name that does not match the expected definition file names are considered.
+
+Extra files like the one are created to ensure that only the expected definition files are processed.

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject2/configuration.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject2/configuration.json
@@ -1,0 +1,6 @@
+{
+  "description": "Sample, syntactically valid definition file, to check if will be avoided due to unmatched name.",
+  "dependencies": [
+    "purl:pkg:maven/org.apache.commons/commons-lang3@3.12.0"
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject2/ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/multiproject/subproject2/ortproject.json
@@ -1,0 +1,20 @@
+{
+  "projectName": "subproject-x-2",
+  "description": "Project X-2 description",
+  "homepageUrl": "https://project_x-2.example.com",
+  "declaredLicenses": [
+    "Apache-2.0"
+  ],
+  "authors": [
+    "Author with no name"
+  ],
+  "dependencies": [
+    {
+      "purl": "pkg:maven/com.example/sub-x2@1.1.0",
+      "description": "Package of subproject 2",
+      "declaredLicenses": [
+        "Apache-2.0"
+      ]
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/dependencies-empty.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/dependencies-empty.ortproject.yml
@@ -1,0 +1,9 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/invalid-pkg-id.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/invalid-pkg-id.ortproject.yml
@@ -1,0 +1,3 @@
+projectName: "Example ORT project with package id issues"
+dependencies:
+  - id: "Maven:0.1.0"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/invalid-pkg-purl.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/invalid-pkg-purl.ortproject.yml
@@ -1,0 +1,3 @@
+projectName: "Example ORT project with invalid package purl"
+dependencies:
+  - purl: "pkg/maven/com.example/minimal@0.1.0"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/malformed-vcs.ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/malformed-vcs.ortproject.json
@@ -1,0 +1,12 @@
+{
+  "projectName": "Example ORT project with malformed VCS info in package",
+  "dependencies": [
+    {
+      "purl": "pkg:maven/com.example/full@1.1.0",
+      "description": "Package with fully elaborated model.",
+      "vcs": {
+        "url": "https://git.example.com/full/"
+      }
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/malformed.ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/malformed.ortproject.json
@@ -1,0 +1,9 @@
+{
+  "projectName": "Example ORT project with wrong format of file",
+  "dependencies": "OK",
+  "dependencies": [
+    {
+      "purl": "something:maven/com.example/full@1.1.0"
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/malformed.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/malformed.ortproject.yml
@@ -1,0 +1,38 @@
+projectName: "Example ORT project"
+description: "Project X description"
+  homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+- "Apache-2.0"
+    authors:
+      - "John Doe"
+      - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    description: "Package with fully elaborated model."
+    vcs:
+      type: "Mercurial"
+      url: "https://git.example.com/full/"
+      revision: "master"
+      path: "/"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        algorithm: "SHA-1"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"
+    homepageUrl: "https://project_x.example.com/full"
+    labels:
+      label: "value"
+      label2: "value2"
+    authors:
+      - "Doe John"
+      - "Bar Foo"
+    scopes:
+      - "main"
+      - "some_scope"
+    isModified: false
+    isMetadataOnly: false
+
+  - purl: "pkg:maven/com.example/minimal@0.1.0"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/minimal-id.ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/minimal-id.ortproject.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": [
+    {
+      "id": "Maven:com.example:minimal:0.1.0"
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/minimal-purl.ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/minimal-purl.ortproject.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": [
+    {
+      "purl": "pkg:maven/com.example/minimal@0.1.0"
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/no-dependencies.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/no-dependencies.ortproject.yml
@@ -1,0 +1,8 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/no-hash-alg.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/no-hash-alg.ortproject.yml
@@ -1,0 +1,17 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/no-pkg-id-or-purl.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/no-pkg-id-or-purl.ortproject.yml
@@ -1,0 +1,34 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - description: "Package with fully elaborated model."
+    vcs:
+      type: "Mercurial"
+      url: "https://git.example.com/full/"
+      revision: "master"
+      path: "/"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        algorithm: "SHA-1"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"
+    homepageUrl: "https://project_x.example.com/full"
+    labels:
+      label: "value"
+      label2: "value2"
+    authors:
+      - "Doe John"
+      - "Bar Foo"
+    scopes:
+      - "main"
+    isModified: false
+    isMetadataOnly: false

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/ortproject.json
@@ -1,0 +1,54 @@
+{
+  "projectName": "Example ORT project",
+  "description": "Project X description",
+  "homepageUrl": "https://project_x.example.com",
+  "declaredLicenses": [
+    "Apache-2.0"
+  ],
+  "authors": [
+    "John Doe",
+    "Foo Bar"
+  ],
+  "dependencies": [
+    {
+      "purl": "pkg:maven/com.example/full@1.1.0",
+      "description": "Package with fully elaborated model.",
+      "vcs": {
+        "type": "Mercurial",
+        "url": "https://git.example.com/full/",
+        "revision": "master",
+        "path": "/"
+      },
+      "sourceArtifact": {
+        "url": "https://repo.example.com/m2/full-1.1.0-sources.jar",
+        "hash": {
+          "value": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "algorithm": "SHA-1"
+        }
+      },
+
+      "declaredLicenses": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "homepageUrl": "https://project_x.example.com/full",
+      "labels": {
+        "label": "value",
+        "label2": "value2"
+      },
+      "authors": [
+        "Doe John",
+        "Bar Foo"
+      ],
+      "scopes": [
+        "main",
+        "some_scope"
+      ],
+      "isModified": true,
+      "isMetadataOnly": true
+    },
+    {
+      "purl": "pkg:maven/com.example/minimal@0.1.0"
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/ortproject.yml
@@ -1,0 +1,38 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    description: "Package with fully elaborated model."
+    vcs:
+      type: "Mercurial"
+      url: "https://git.example.com/full/"
+      revision: "master"
+      path: "/"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        algorithm: "SHA-1"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"
+    homepageUrl: "https://project_x.example.com/full"
+    labels:
+      label: "value"
+      label2: "value2"
+    authors:
+      - "Doe John"
+      - "Bar Foo"
+    scopes:
+      - "main"
+      - "some_scope"
+    isModified: true
+    isMetadataOnly: true
+
+  - purl: "pkg:maven/com.example/minimal@0.1.0"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/uppercase-hash-val.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/uppercase-hash-val.ortproject.yml
@@ -1,0 +1,18 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709"
+        algorithm: "SHA1"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/wrong-hash-alg.ortproject.yml
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/wrong-hash-alg.ortproject.yml
@@ -1,0 +1,18 @@
+projectName: "Example ORT project"
+description: "Project X description"
+homepageUrl: "https://project_x.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash:
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        algorithm: "JUST_WRONG"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"

--- a/plugins/package-managers/ortproject/src/funTest/assets/projects/wrong-pkg-name.ortproject.json
+++ b/plugins/package-managers/ortproject/src/funTest/assets/projects/wrong-pkg-name.ortproject.json
@@ -1,0 +1,8 @@
+{
+  "projectName": "Example ORT project with wrong package name",
+  "dependencies": [
+    {
+      "purl": "something:maven/com.example/full@1.1.0"
+    }
+  ]
+}

--- a/plugins/package-managers/ortproject/src/funTest/kotlin/OrtProjectFileFunTest.kt
+++ b/plugins/package-managers/ortproject/src/funTest/kotlin/OrtProjectFileFunTest.kt
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2025 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty as beEmptyCollection
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.beEmpty as beEmptyMap
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.beEmpty
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotBeEmpty
+import io.kotest.matchers.string.shouldStartWith
+
+import org.ossreviewtoolkit.analyzer.analyze
+import org.ossreviewtoolkit.analyzer.getAnalyzerResult
+import org.ossreviewtoolkit.analyzer.resolveSingleProject
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.utils.test.getAssetFile
+
+class OrtProjectFileFunTest : WordSpec({
+    "resolveDependencies()" should {
+        "return properly resolved packages list based on json file" {
+            val definitionFile = getAssetFile("projects/ortproject.json")
+            verifyBasicProject(OrtProjectFileFactory.create().resolveSingleProject(definitionFile))
+        }
+
+        "return properly resolved packages list based on yaml file" {
+            val definitionFile = getAssetFile("projects/ortproject.yml")
+            verifyBasicProject(OrtProjectFileFactory.create().resolveSingleProject(definitionFile))
+        }
+
+        "return properly resolved package list for minimal project definition using purl" {
+            val definitionFile = getAssetFile("projects/minimal-purl.ortproject.json")
+            val result = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+
+            with(result) {
+                issues should beEmptyCollection()
+
+                // VCS values may be different depending on the test environment,
+                // so just check for basic validity.
+                with(project.vcs) {
+                    type shouldNotBe VcsType.UNKNOWN
+                    url shouldNot beEmpty()
+                    revision shouldNot beEmpty()
+                    path shouldBe "plugins/package-managers/ortproject/src/funTest/assets/projects"
+                }
+
+                with(project.id) {
+                    name shouldBe "unknown"
+                    type shouldBe "OrtProjectFile"
+                }
+
+                project.authors should beEmptyCollection()
+                project.scopeDependencies.shouldBeEmpty()
+
+                packages.shouldBeSingleton {
+                    it.purl shouldBe "pkg:maven/com.example/minimal@0.1.0"
+                    it.id shouldBe Identifier(
+                        type = "Maven",
+                        namespace = "com.example",
+                        name = "minimal",
+                        version = "0.1.0"
+                    )
+                }
+            }
+        }
+
+        "return properly resolved package list for minimal project definition using id" {
+            val definitionFile = getAssetFile("projects/minimal-id.ortproject.json")
+            val result = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+
+            with(result) {
+                issues should beEmptyCollection()
+
+                // VCS values may be different depending on the test environment,
+                // so just check for basic validity.
+                with(project.vcs) {
+                    type shouldNotBe VcsType.UNKNOWN
+                    url.shouldNotBeEmpty()
+                    revision shouldNot beEmpty()
+                    path shouldBe "plugins/package-managers/ortproject/src/funTest/assets/projects"
+                }
+
+                with(project.id) {
+                    name shouldBe "unknown"
+                    type shouldBe "OrtProjectFile"
+                }
+
+                project.authors should beEmptyCollection()
+                project.scopeDependencies.shouldBeEmpty()
+
+                packages.shouldBeSingleton {
+                    it.purl shouldBe "pkg:maven/com.example/minimal@0.1.0"
+                    it.id shouldBe Identifier(
+                        type = "Maven",
+                        namespace = "com.example",
+                        name = "minimal",
+                        version = "0.1.0"
+                    )
+                }
+            }
+        }
+
+        "return issue when hash has no algorithm defined" {
+            val definitionFile = getAssetFile("projects/no-hash-alg.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain "Property 'algorithm' is required but it is missing"
+            }
+        }
+
+        "return issue when hash algorithm is unknown" {
+            val definitionFile = getAssetFile("projects/wrong-hash-alg.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.issues should beEmptyCollection()
+            project.packages.shouldBeSingleton {
+                it.sourceArtifact.hash.value shouldBe "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+                it.sourceArtifact.hash.algorithm shouldBe HashAlgorithm.UNKNOWN
+            }
+        }
+
+        "return lowercase hash value when input value is uppercase" {
+            val definitionFile = getAssetFile("projects/uppercase-hash-val.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.issues should beEmptyCollection()
+            project.packages.shouldBeSingleton {
+                it.sourceArtifact.hash.value shouldBe "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+                it.sourceArtifact.hash.algorithm shouldBe HashAlgorithm.SHA1
+            }
+        }
+
+        "return issue when json file is wrongly formatted" {
+            val definitionFile = getAssetFile("projects/malformed.ortproject.json")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldStartWith "Unexpected JSON token at offset"
+                it.source shouldBe "OrtProjectFile"
+            }
+        }
+
+        "return issue when yaml file is wrongly formatted" {
+            val definitionFile = getAssetFile("projects/malformed.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldStartWith "while parsing a block mapping"
+                it.source shouldBe "OrtProjectFile"
+            }
+        }
+
+        "return issue when there is no package id or purl defined" {
+            val definitionFile = getAssetFile("projects/no-pkg-id-or-purl.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain "There is no id or purl defined for the package."
+                it.source shouldBe "OrtProjectFile"
+            }
+        }
+
+        "return issue when package id is invalid" {
+            val definitionFile = getAssetFile("projects/invalid-pkg-id.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain "The id 'Maven:0.1.0' is not a valid Identifier."
+                it.source shouldBe "OrtProjectFile"
+            }
+        }
+
+        "return issue when package purl is invalid" {
+            val definitionFile = getAssetFile("projects/invalid-pkg-purl.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain "The purl 'pkg/maven/com.example/minimal@0.1.0' is not a valid PackageURL."
+                it.source shouldBe "OrtProjectFile"
+            }
+        }
+
+        "return UNKNOWN when vcs info type and revision is empty" {
+            val definitionFile = getAssetFile("projects/malformed-vcs.ortproject.json")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain "Fields [type, revision] are required"
+            }
+        }
+
+        "return issue when there are no dependencies section" {
+            val definitionFile = getAssetFile("projects/no-dependencies.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain "Property 'dependencies' is required but it is missing."
+            }
+        }
+
+        "return issue when there are no dependencies defined" {
+            val definitionFile = getAssetFile("projects/dependencies-empty.ortproject.yml")
+            val project = OrtProjectFileFactory.create().resolveSingleProject(definitionFile)
+            project.packages should beEmptyCollection()
+            project.issues.shouldBeSingleton {
+                it.message shouldContain
+                    "Value for 'dependencies' is invalid: Unexpected null or empty value for non-null field."
+            }
+        }
+
+        "use all of files in structure for package mapping" {
+            val definitionFile = getAssetFile("multiproject/ortproject.yml")
+            val result = analyze(projectDir = definitionFile.parentFile).getAnalyzerResult()
+
+            with(result) {
+                projects.map { it.id.name }
+                    .shouldContainExactlyInAnyOrder(
+                        setOf(
+                            "project-x",
+                            "subproject-x-1",
+                            "subproject-x-2"
+                        )
+                    )
+
+                packages.map { it.purl }
+                    .shouldContainExactlyInAnyOrder(
+                        setOf(
+                            "pkg:maven/com.example/sub-x1@9.98.0",
+                            "pkg:maven/com.example/sub-x2@1.1.0",
+                            "pkg:maven/com.example/full@1.1.0",
+                            "pkg:maven/com.example/minimal@0.1.0"
+                        )
+                    )
+            }
+        }
+    }
+})
+
+private fun verifyBasicProject(result: ProjectAnalyzerResult) {
+    with(result) {
+        issues should beEmptyCollection()
+
+        with(project.id) {
+            name shouldBe "Example ORT project"
+            type shouldBe "OrtProjectFile"
+        }
+
+        project.authors shouldContainExactlyInAnyOrder setOf("John Doe", "Foo Bar")
+
+        project.vcs shouldNotBeNull {
+            type shouldNotBe VcsType.UNKNOWN
+            url shouldNot beEmpty()
+            revision shouldNot beEmpty()
+            path shouldBe "plugins/package-managers/ortproject/src/funTest/assets/projects"
+        }
+
+        project.homepageUrl shouldBe "https://project_x.example.com"
+
+        project.scopeDependencies shouldNotBeNull {
+            map { it.name } shouldContainExactlyInAnyOrder setOf("main", "some_scope")
+
+            find { it.name == "main" } shouldNotBeNull {
+                dependencies.shouldBeSingleton()
+                dependencies.map { dep -> dep.id.name } shouldContainExactly setOf("full")
+            }
+
+            find { it.name == "some_scope" } shouldNotBeNull {
+                dependencies.shouldBeSingleton()
+                dependencies.map { dep -> dep.id.name } shouldContainExactly setOf("full")
+            }
+        }
+
+        packages.map { it.purl } shouldContainExactlyInAnyOrder setOf(
+            "pkg:maven/com.example/full@1.1.0",
+            "pkg:maven/com.example/minimal@0.1.0"
+        )
+
+        packages.find { it.purl == "pkg:maven/com.example/full@1.1.0" }
+            .shouldNotBeNull {
+                description shouldBe "Package with fully elaborated model."
+
+                declaredLicenses shouldNotBeNull {
+                    containExactlyInAnyOrder(setOf("Apache-2.0", "MIT"))
+                }
+
+                vcs shouldNotBeNull {
+                    type shouldBe VcsType.MERCURIAL
+                    url shouldBe "https://git.example.com/full/"
+                    revision shouldBe "master"
+                    path shouldBe "/"
+                }
+
+                homepageUrl shouldBe "https://project_x.example.com/full"
+
+                sourceArtifact shouldNotBeNull {
+                    url shouldBe "https://repo.example.com/m2/full-1.1.0-sources.jar"
+                    hash.value shouldBe "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+                    hash.algorithm.name shouldBe "SHA1"
+                }
+
+                authors.shouldContainExactlyInAnyOrder(setOf("Doe John", "Bar Foo"))
+                isModified shouldBe true
+                isMetadataOnly shouldBe true
+            }
+
+        packages.find { it.purl == "pkg:maven/com.example/minimal@0.1.0" }
+            .shouldNotBeNull {
+                description should beEmpty()
+                declaredLicenses should beEmptyCollection()
+
+                vcs shouldBe VcsInfo.EMPTY
+                sourceArtifact shouldBe RemoteArtifact.EMPTY
+
+                labels should beEmptyMap()
+                authors should beEmptyCollection()
+                isModified shouldBe false
+                isMetadataOnly shouldBe false
+            }
+    }
+}

--- a/plugins/package-managers/ortproject/src/main/kotlin/OrtProjectFile.kt
+++ b/plugins/package-managers/ortproject/src/main/kotlin/OrtProjectFile.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+
+import com.charleskorn.kaml.Yaml
+
+import java.io.File
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.PackageManagerFactory
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.Includes
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+
+@OrtPlugin(
+    displayName = "OrtProjectFile",
+    description = "A package manager that uses an ORT-specific file format as package list source.",
+    factory = PackageManagerFactory::class
+)
+class OrtProjectFile(override val descriptor: PluginDescriptor = OrtProjectFileFactory.descriptor) :
+    PackageManager("OrtProjectFile") {
+    override val globsForDefinitionFiles = listOf(
+        "ortproject.yml",
+        "ortproject.yaml",
+        "ortproject.json",
+        "*.ortproject.yml",
+        "*.ortproject.yaml",
+        "*.ortproject.json"
+    )
+
+    override fun resolveDependencies(
+        analysisRoot: File,
+        definitionFile: File,
+        excludes: Excludes,
+        includes: Includes,
+        analyzerConfig: AnalyzerConfiguration,
+        labels: Map<String, String>
+    ): List<ProjectAnalyzerResult> {
+        val parsedProject = try {
+            when (definitionFile.extension) {
+                "json" -> Json.decodeFromString<OrtProjectFileDto>(definitionFile.readText())
+                "yml", "yaml" -> Yaml.default.decodeFromString<OrtProjectFileDto>(definitionFile.readText())
+                else -> error("Unknown file format for file '${definitionFile.absolutePath}'.")
+            }
+        } catch (e: SerializationException) {
+            logger.error {
+                "Could not parse the ORT project file at '${definitionFile.absolutePath}': ${e.message}"
+            }
+
+            return listOf(
+                ProjectAnalyzerResult(
+                    project = Project.EMPTY,
+                    packages = emptySet(),
+                    issues = listOf(Issue(source = "OrtProjectFile", message = e.message.toString()))
+                )
+            )
+        }
+
+        val project = OrtProjectFileMapper.extractAndMapProject(
+            parsedProject,
+            processProjectVcs(definitionFile.parentFile),
+            definitionFile
+        )
+
+        val packagesWithIssues = OrtProjectFileMapper.extractAndMapPackages(parsedProject)
+        val projectAnalyzerResult = ProjectAnalyzerResult(
+            project = project,
+            packages = packagesWithIssues.first,
+            issues = packagesWithIssues.second
+        )
+
+        return listOf(projectAnalyzerResult)
+    }
+}

--- a/plugins/package-managers/ortproject/src/main/kotlin/OrtProjectFileDto.kt
+++ b/plugins/package-managers/ortproject/src/main/kotlin/OrtProjectFileDto.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class OrtProjectFileDto(
+    val projectName: String? = null,
+    val declaredLicenses: Set<String> = emptySet(),
+    val description: String? = null,
+    val homepageUrl: String? = null,
+    val authors: Set<String> = emptySet(),
+    val dependencies: List<DependencyDto>
+)
+
+@Serializable
+internal data class DependencyDto(
+    val id: String? = null,
+    val purl: String? = null,
+    val description: String? = null,
+    val vcs: VcsDto? = null,
+    val sourceArtifact: SourceArtifactDto? = null,
+    val declaredLicenses: Set<String> = emptySet(),
+    val homepageUrl: String? = null,
+    val labels: Map<String, String> = emptyMap(),
+    val authors: Set<String> = emptySet(),
+    val scopes: Set<String>? = null,
+    val isModified: Boolean? = null,
+    val isMetadataOnly: Boolean? = null
+)
+
+@Serializable
+internal data class VcsDto(
+    val type: String,
+    val url: String,
+    val revision: String,
+    val path: String = ""
+)
+
+@Serializable
+internal data class SourceArtifactDto(
+    val url: String,
+    val hash: HashDto
+)
+
+@Serializable
+internal data class HashDto(
+    val value: String,
+    val algorithm: String
+)

--- a/plugins/package-managers/ortproject/src/main/kotlin/OrtProjectFileMapper.kt
+++ b/plugins/package-managers/ortproject/src/main/kotlin/OrtProjectFileMapper.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2025 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+
+import java.io.File
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.utils.toIdentifier
+import org.ossreviewtoolkit.model.utils.toPackageUrl
+import org.ossreviewtoolkit.model.utils.toPurl
+
+internal object OrtProjectFileMapper {
+    private const val DEFAULT_PROJECT_NAME = "unknown"
+    private const val PROJECT_TYPE = "OrtProjectFile"
+
+    internal fun extractAndMapProject(projectDto: OrtProjectFileDto, vcsInfo: VcsInfo, definitionFile: File) =
+        Project(
+            id = Identifier(
+                name = projectDto.projectName?.takeUnless { it.isBlank() } ?: DEFAULT_PROJECT_NAME,
+                type = PROJECT_TYPE,
+                namespace = "",
+                version = ""
+            ),
+            vcs = vcsInfo,
+            description = projectDto.description.orEmpty(),
+            authors = projectDto.authors,
+            homepageUrl = projectDto.homepageUrl.orEmpty(),
+            definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            declaredLicenses = projectDto.declaredLicenses,
+            scopeDependencies = projectDto.dependencies.toScopes()
+        )
+
+    internal fun extractAndMapPackages(project: OrtProjectFileDto): Pair<Set<Package>, List<Issue>> {
+        val issues = mutableListOf<Issue>()
+        val packages = mutableSetOf<Package>()
+
+        project.dependencies.forEach {
+            val packageWithIssues = it.toPackage()
+
+            packageWithIssues.first?.let { pkg -> packages.add(pkg) }
+            issues.addAll(packageWithIssues.second)
+        }
+
+        return Pair(packages, issues)
+    }
+
+    private fun DependencyDto.toPackage(): Pair<Package?, List<Issue>> {
+        try {
+            val identifiers = getIdentifiers()
+            val pkg = Package(
+                id = identifiers.first,
+                purl = identifiers.second,
+                sourceArtifact = sourceArtifact?.toRemoteArtifact().orEmpty(),
+                vcs = vcs?.toVcsInfo().orEmpty(),
+                declaredLicenses = declaredLicenses,
+                description = description.orEmpty(),
+                homepageUrl = homepageUrl.orEmpty(),
+                binaryArtifact = RemoteArtifact.EMPTY,
+                authors = authors,
+                labels = labels,
+                isModified = isModified ?: false,
+                isMetadataOnly = isMetadataOnly ?: false
+            )
+
+            return Pair(pkg, emptyList())
+        } catch (e: IllegalArgumentException) {
+            val issue = Issue(
+                message = e.message.orEmpty(),
+                source = "OrtProjectFile"
+            )
+            return Pair(null, listOf(issue))
+        }
+    }
+
+    private fun VcsDto.toVcsInfo(): VcsInfo =
+        VcsInfo(
+            type = VcsType.forName(type.uppercase()),
+            url = url,
+            revision = revision,
+            path = path
+        )
+
+    private fun SourceArtifactDto.toRemoteArtifact(): RemoteArtifact =
+        RemoteArtifact(
+            url = url,
+            hash = Hash(hash.value.lowercase(), hash.algorithm)
+        )
+
+    private fun DependencyDto.getIdentifiers(): Pair<Identifier, String> {
+        validateIdentifiers()
+        val packageUrl = purl.toPackageUrl()
+
+        when {
+            id.isNullOrBlank() && packageUrl == null ->
+                throw IllegalArgumentException("There is no id or purl defined for the package.")
+
+            !id.isNullOrBlank() && packageUrl != null ->
+                return Pair(Identifier(id), packageUrl.toString())
+
+            !id.isNullOrBlank() -> {
+                val identifier = Identifier(id)
+                return Pair(identifier, identifier.toPurl())
+            }
+
+            packageUrl != null ->
+                return Pair(packageUrl.toIdentifier(), packageUrl.toString())
+
+            else ->
+                throw IllegalArgumentException(
+                    "There is something wrong in dependency id/purl declaration for '$this'."
+                )
+        }
+    }
+
+    private fun DependencyDto.validateIdentifiers() {
+        if (!id.isNullOrBlank()) {
+            val identifier = Identifier(id)
+            require(!identifier.type.isBlank() && !identifier.name.isBlank() && !identifier.version.isBlank()) {
+                "The id '$id' is not a valid Identifier."
+            }
+        }
+
+        require(purl.isNullOrBlank() || purl.toPackageUrl() != null) {
+            throw IllegalArgumentException("The purl '$purl' is not a valid PackageURL.")
+        }
+    }
+
+    private fun Collection<DependencyDto>.toScopes(): Set<Scope> {
+        val scopeMap = mutableMapOf<String, MutableList<Identifier>>()
+        forEach { dependency ->
+            if (dependency.scopes?.isNotEmpty() == true) {
+                dependency.scopes.forEach { scopeName ->
+                    scopeMap.getOrPut(scopeName) { mutableListOf() }
+                        .add(dependency.getIdentifiers().first)
+                }
+            }
+        }
+
+        return scopeMap.mapTo(mutableSetOf()) { (scopeName, identifiers) ->
+            Scope(
+                name = scopeName,
+                dependencies = identifiers.map { id -> PackageReference(id = id) }.toSet()
+            )
+        }
+    }
+}

--- a/website/docs/guides/ort-project-package-manager.md
+++ b/website/docs/guides/ort-project-package-manager.md
@@ -1,0 +1,159 @@
+# Ort Project Package Manager
+
+The ORT Project package manager can be used to manually define projects in situations like:
+
+* Package manager is not supported by ORT yet.
+* Project is using a custom or in-house package manager.
+* Project has no package manager at all.
+* Project contains additional packages that are not detected by the main package manager.
+
+## Definition file location, naming and format
+
+### Location
+
+To use the ORT Project Package Manager, just place the definition file(s) in any directory of your project.
+If you have multiple projects in a mono-repo, it's possible to place multiple definition files in the project
+sub-directories.
+
+### File naming
+
+The ORT Project definition file must be named, or end with `ortproject.yml`, `ortproject.yaml`, or `ortproject.json`.
+For example, all of the following names are valid:
+
+* `ortproject.yml`
+* `my.ortproject.yaml`
+* `custom-name.ortproject.json`
+
+## Definition file format
+
+ORT Project package manager uses an ORT Project definition file to define projects and their dependencies.
+Example definition files can be found below:
+
+### Example files
+
+~~~yaml
+projectName: "Example ORT project"
+description: "Project description"
+homepageUrl: "https://project.example.com"
+declaredLicenses:
+  - "Apache-2.0"
+authors:
+  - "John Doe"
+  - "Foo Bar"
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+    description: "Package with fully elaborated model."
+    vcs:
+      type: "Mercurial"
+      url: "https://example.com/hg/full"
+      revision: "master"
+      path: "/"
+    sourceArtifact:
+      url: "https://repo.example.com/m2/full-1.1.0-sources.jar"
+      hash: 
+        value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        algorithm: "SHA-1"
+    declaredLicenses:
+      - "Apache-2.0"
+      - "MIT"
+    homepageUrl: "https://project.example.com/full"
+    labels:
+      label: "value"
+      label2: "value2"
+    authors:
+      - "Doe John"
+      - "Bar Foo"
+    scopes:
+      - "main"
+      - "some_scope"
+    isModified: false
+    isMetadataOnly: false
+  - purl: "pkg:maven/com.example/minimal@0.1.0"
+  - id: "Maven:com.example:partial:1.0.1"
+~~~
+
+Minimal example file:
+
+~~~yaml
+dependencies:
+  - purl: "pkg:maven/com.example/full@1.1.0"
+~~~
+
+### Definition file schema
+
+#### Project schema
+
+The ORT Project definition file uses the following schema:
+
+~~~yaml
+projectName: String (optional) Project name.
+description: String (optional) Project brief description.
+homepageUrl: String (optional) URL to the project homepage.
+# (optional) List of declared licenses for the project.
+declaredLicenses:
+  - String list (optional) List of declared licenses in SPDX format (see remarks below).
+# (optional) List of authors of the project.
+authors:
+  - String Author name.
+# (mandatory) List of dependency packages for the project.
+dependencies: 
+  - Dependency element schema (see below)
+~~~
+
+#### Dependency element schema
+
+Single dependency package schema:
+
+~~~yaml
+
+purl: String (mandatory at least one of the id or purl) Package URL in purl format (see remarks below).
+id: String (mandatory at least one of the purl or id) Package identifier in the "ORT" format (see remarks below).
+description: String (optional) Package brief description.
+# (optional) Definition of the package's version control system location.
+vcs: 
+  type: String (mandatory) VCS type, e.g., "Git", "Subversion", "Mercurial".
+  url: String (mandatory) VCS repository URL.
+  revision: String (mandatory) VCS revision (branch).
+  path: String (optional) VCS path within the repository. Default is empty string.
+# (optional) The remote artifact where the source package can be downloaded.
+sourceArtifact: 
+  url: String (mandatory) URL to the source artifact.
+  # (optional) Hash of the source artifact.
+  hash: 
+    value: String (mandatory) hash value.
+    algorithm: String (mandatory) hash algorithm. Check remarks below for supported algorithms.
+# (optional) List of declared licenses for the dependency.
+declaredLicenses: 
+  - String Declared license in SPDX format (see remarks below).
+homepageUrl: String (optional) URL to the package homepage.
+labels: (optional) User defined labels associated with this package. The labels are not interpreted by the core of ORT
+  itself, but can be used in parts of ORT such as plugins, in evaluator rules, or in reporter templates. Labels are key-value
+  pairs where both the key and value are strings.
+# (optional) List of authors of the dependency.
+authors: 
+  - String Author name.
+# (optional) List of scopes the package belongs to.
+scopes: 
+  - String Package's scope.
+isModified: Boolean (optional) Flag indicating whether the source code of the package has been modified compared to
+  the original source code, e.g., in case of a fork of an upstream Open Source project. Default is false.
+isMetadataOnly: Boolean (optional) Flag indicating whether the package is just metadata, like e.g. Maven BOM artifacts
+  which only define constraints for dependency versions. Default is false.
+~~~
+
+### Remarks
+
+* Each dependency package must at least define either a `purl` or an `id`.
+* The `purl` field must contain a valid package identifier in [PURL format](https://github.com/package-url/purl-spec).
+  Only purls starting with `pkg:` are supported.
+  Also, `qualifier` and `subpath` components are not supported.
+* The `id` field must contain a valid ORT package identifier in the format:
+  `<package-manager>/<namespace>/<name>/<version>`.
+* The following hash algorithms are supported in the `sourceArtifact.hash.algorithm` field:
+  * `MD5`
+  * `SHA-1`
+  * `SHA-256`
+  * `SHA-384`
+  * `SHA-512`
+  * `SHA-1-GIT`
+* All license names must be in [SPDX format](https://spdx.org/licenses/).

--- a/website/docs/tools/analyzer.md
+++ b/website/docs/tools/analyzer.md
@@ -20,7 +20,7 @@ Currently, the following package managers (grouped by the programming language t
 * C / C++
   * [Bazel](https://bazel.build/) (limitations: see [open tasks](https://github.com/oss-review-toolkit/ort/issues/264))
   * [Conan 1.x and 2.x](https://conan.io/)
-  * Also see: [SPDX documents](#spdx-as-fallback-package-manager)
+  * Also see: [Fallback Package Managers](#fallback-package-managers)
 * Dart / Flutter
   * [Pub](https://pub.dev/)
 * Elixir
@@ -65,6 +65,16 @@ Currently, the following package managers (grouped by the programming language t
 * Unmanaged
   * This is a special "package manager" that manages all files that cannot be associated with any of the other package managers.
 
-## SPDX as Fallback Package Manager
+## Fallback Package Managers
 
-If another package manager that is not part of the list above is used (or no package manager at all), the generic fallback to [SPDX documents](https://spdx.dev/specifications/) can be leveraged to describe [projects](https://github.com/oss-review-toolkit/ort/blob/main/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/inline-packages/project-xyz.spdx.yml) or [packages](https://github.com/oss-review-toolkit/ort/blob/main/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/curl/package.spdx.yml).
+If another package manager that is not part of the list above is used (or no package manager at all),
+the generic fallbacks can be used:
+
+### ORT Project package manager
+
+The [ORT Project package manager](../guides/ort-project-package-manager.md) can be used to manually define projects and
+their dependencies in an ORT Project definition file.
+
+### SPDX
+
+The [SPDX documents](https://spdx.dev/specifications/) can be leveraged to describe [projects](https://github.com/oss-review-toolkit/ort/blob/main/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/inline-packages/project-xyz.spdx.yml) or [packages](https://github.com/oss-review-toolkit/ort/blob/main/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/curl/package.spdx.yml).


### PR DESCRIPTION
This commit creates new analyzer plugin that consumes ort specific 
list of packages in form of definition file(s). 

It helps in cases like:
* Package manager is not supported by ORT yet.
* Project is using a custom or in-house package manager.
* Project has no package manager at all.
* Project contains packages that are not detected by the main package
  manager.
  
Implements: https://github.com/oss-review-toolkit/ort/issues/10182


