### PR TITLE
fix(node): Add special handling to parse `npm login` error messages

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -311,7 +311,10 @@ internal fun List<String>.groupLines(vararg markers: String): List<String> {
         && nonFooterLines.last().endsWith('.')
         && nonFooterLines.subList(0, nonFooterLines.size - 1).none { it.endsWith('.') }
 
-    return if (isMultiLineSentence) {
+    val isLoginError = nonFooterLines.firstOrNull() == "Incorrect or missing password."
+        && nonFooterLines.lastOrNull() == "npm login"
+
+    return if (isMultiLineSentence || isLoginError) {
         listOf(nonFooterLines.joinToString(" "))
     } else {
         nonFooterLines.map { it.trim() }

--- a/plugins/package-managers/node/src/test/kotlin/npm/NpmTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/npm/NpmTest.kt
@@ -118,5 +118,33 @@ class NpmTest : WordSpec({
                     "with --force to overwrite files recklessly."
             )
         }
+
+        "treat a single block of login error messages as one issue" {
+            val output = """
+                npm error code E401
+                npm error Incorrect or missing password.
+                npm error If you were trying to login, change your password, create an
+                npm error authentication token or enable two-factor authentication then
+                npm error that means you likely typed your password in incorrectly.
+                npm error Please try again, or recover your password at:
+                npm error   https://www.npmjs.com/forgot
+                npm error
+                npm error If you were doing some other operation then your saved credentials are
+                npm error probably out of date. To correct this please try logging in again with:
+                npm error   npm login
+            """.trimIndent()
+
+            output.lines().groupLines("npm error ") shouldBe listOf(
+                "Incorrect or missing password. " +
+                    "If you were trying to login, change your password, create an " +
+                    "authentication token or enable two-factor authentication then " +
+                    "that means you likely typed your password in incorrectly. " +
+                    "Please try again, or recover your password at: " +
+                    "https://www.npmjs.com/forgot " +
+                    "If you were doing some other operation then your saved credentials are " +
+                    "probably out of date. To correct this please try logging in again with: " +
+                    "npm login"
+            )
+        }
     }
 })


### PR DESCRIPTION
This makes it easier to investigate such issues, as previously one ORT issue was created per error message line.