### PR TITLE
Optionally set SPDX `licenseConcluded` to ORT's effective license

### DIFF
--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -153,6 +153,7 @@ private fun TestConfiguration.generateReport(
         creationInfoOrganization = "some creation info organization",
         documentComment = "some document comment",
         documentName = documentName,
+        autoConcludeToEffectiveLicense = false,
         fileInformationEnabled = fileInformationEnabled,
         outputFileFormats = listOf(format)
     )

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
@@ -45,6 +46,7 @@ import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.prependedPath
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
@@ -147,7 +149,8 @@ internal enum class SpdxPackageType(val infix: String, val suffix: String = "") 
 internal fun Package.toSpdxPackage(
     type: SpdxPackageType,
     licenseInfoResolver: LicenseInfoResolver,
-    ortResult: OrtResult
+    ortResult: OrtResult,
+    autoConcludeToEffectiveLicense: Boolean
 ): SpdxPackage {
     val packageVerificationCode = ortResult.getPackageVerificationCode(id, type)?.let {
         SpdxPackageVerificationCode(packageVerificationCodeValue = it)
@@ -158,6 +161,14 @@ internal fun Package.toSpdxPackage(
         .applyChoices(ortResult.getRepositoryLicenseChoices())
 
     val licenseDeclared = resolvedLicenseInfo.mainLicense()?.simplify()
+
+    val licenseConcluded = concludedLicense ?: run {
+        // Do not use `CONCLUDED_OR_DECLARED_AND_DETECTED` here to support explicitly setting the `concludedLicense` to
+        // the `licenseDeclared` in order to acknowledge the latter and record it as the license concluded in SPDX.
+        val licenseView = LicenseView(enumSetOf(LicenseSource.DECLARED, LicenseSource.DETECTED))
+        resolvedLicenseInfo.effectiveLicense(licenseView)
+            .takeIf { autoConcludeToEffectiveLicense && it != licenseDeclared }
+    }
 
     return SpdxPackage(
         spdxId = id.toSpdxId(type),
@@ -184,9 +195,9 @@ internal fun Package.toSpdxPackage(
             // Clear the concluded license as it might need to be different for the VCS location.
             SpdxPackageType.VCS_PACKAGE -> SpdxConstants.NOASSERTION
 
-            SpdxPackageType.PROJECT -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
+            SpdxPackageType.PROJECT -> licenseConcluded.nullOrBlankToSpdxNoassertionOrNone()
 
-            else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
+            else -> licenseConcluded.nullOrBlankToSpdxNoassertionOrNone()
         },
         licenseDeclared = licenseDeclared
             ?.sorted()

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -157,6 +157,8 @@ internal fun Package.toSpdxPackage(
         .applyChoices(ortResult.getPackageLicenseChoices(id))
         .applyChoices(ortResult.getRepositoryLicenseChoices())
 
+    val licenseDeclared = resolvedLicenseInfo.mainLicense()?.simplify()
+
     return SpdxPackage(
         spdxId = id.toSpdxId(type),
         checksums = when (type) {
@@ -186,8 +188,7 @@ internal fun Package.toSpdxPackage(
 
             else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
         },
-        licenseDeclared = resolvedLicenseInfo.mainLicense()
-            ?.simplify()
+        licenseDeclared = licenseDeclared
             ?.sorted()
             ?.nullOrBlankToSpdxNoassertionOrNone()
             ?: SpdxConstants.NONE,

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -164,6 +164,8 @@ internal fun Package.toSpdxPackage(
         ortResult.getRepositoryLicenseChoices()
     )
 
+    val licenseDeclared = resolvedLicenseInfo.mainLicense()?.simplify()
+
     return SpdxPackage(
         spdxId = id.toSpdxId(type),
         checksums = when (type) {
@@ -194,8 +196,7 @@ internal fun Package.toSpdxPackage(
 
             else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
         },
-        licenseDeclared = resolvedLicenseInfo.mainLicense()
-            ?.simplify()
+        licenseDeclared = licenseDeclared
             ?.sorted()
             ?.nullOrBlankToSpdxNoassertionOrNone()
             ?: SpdxConstants.NONE,

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
@@ -45,6 +46,7 @@ import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.prependedPath
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
@@ -148,7 +150,8 @@ internal enum class SpdxPackageType(val infix: String, val suffix: String = "") 
 internal fun Package.toSpdxPackage(
     type: SpdxPackageType,
     licenseInfoResolver: LicenseInfoResolver,
-    ortResult: OrtResult
+    ortResult: OrtResult,
+    autoConcludeToEffectiveLicense: Boolean
 ): SpdxPackage {
     val packageVerificationCode = ortResult.getPackageVerificationCode(id, type)?.let {
         SpdxPackageVerificationCode(packageVerificationCodeValue = it)
@@ -158,13 +161,24 @@ internal fun Package.toSpdxPackage(
         .applyChoices(ortResult.getPackageLicenseChoices(id))
         .applyChoices(ortResult.getRepositoryLicenseChoices())
 
-    val effectiveLicense = resolvedLicenseInfo.effectiveLicense(
-        LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
-        ortResult.getPackageLicenseChoices(id),
-        ortResult.getRepositoryLicenseChoices()
-    )
-
     val licenseDeclared = resolvedLicenseInfo.mainLicense()?.simplify()
+
+    val (licenseConcluded, licenseComments) = if (concludedLicense == null && autoConcludeToEffectiveLicense) {
+        // Do not use `CONCLUDED_OR_DECLARED_AND_DETECTED` here to support explicitly setting the `concludedLicense` to
+        // the `licenseDeclared` in order to acknowledge the latter and record it as the license concluded in SPDX.
+        val licenseView = LicenseView(enumSetOf(LicenseSource.DECLARED, LicenseSource.DETECTED))
+        val effectiveLicense = resolvedLicenseInfo.effectiveLicense(licenseView).takeIf { it != licenseDeclared }
+
+        effectiveLicense to "licenseConcluded has been set to the effective license."
+    } else {
+        val effectiveLicense = resolvedLicenseInfo.effectiveLicense(
+            LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+            ortResult.getPackageLicenseChoices(id),
+            ortResult.getRepositoryLicenseChoices()
+        )
+
+        concludedLicense to "effectiveLicense: ${effectiveLicense?.toString().nullOrBlankToSpdxNone()}"
+    }
 
     return SpdxPackage(
         spdxId = id.toSpdxId(type),
@@ -184,7 +198,7 @@ internal fun Package.toSpdxPackage(
         externalRefs = if (type == SpdxPackageType.PROJECT) emptyList() else toSpdxExternalReferences(),
         filesAnalyzed = packageVerificationCode != null,
         homepage = homepageUrl.nullOrBlankToSpdxNone(),
-        licenseComments = "effectiveLicense: ${effectiveLicense?.toString().nullOrBlankToSpdxNone()}",
+        licenseComments = licenseComments,
         licenseConcluded = when (type) {
             // Clear the concluded license as it might need to be different for the source artifact.
             SpdxPackageType.SOURCE_PACKAGE -> SpdxConstants.NOASSERTION
@@ -192,9 +206,9 @@ internal fun Package.toSpdxPackage(
             // Clear the concluded license as it might need to be different for the VCS location.
             SpdxPackageType.VCS_PACKAGE -> SpdxConstants.NOASSERTION
 
-            SpdxPackageType.PROJECT -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
+            SpdxPackageType.PROJECT -> licenseConcluded.nullOrBlankToSpdxNoassertionOrNone()
 
-            else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
+            else -> licenseConcluded.nullOrBlankToSpdxNoassertionOrNone()
         },
         licenseDeclared = licenseDeclared
             ?.sorted()

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -65,7 +65,8 @@ internal object SpdxDocumentModelMapper {
             val spdxProjectPackage = project.toPackage().toSpdxPackage(
                 SpdxPackageType.PROJECT,
                 licenseInfoResolver,
-                ortResult
+                ortResult,
+                config.autoConcludeToEffectiveLicense
             ).copy(hasFiles = filesForProject.map { it.spdxId })
 
             ortResult.getDependencies(
@@ -89,7 +90,8 @@ internal object SpdxDocumentModelMapper {
             val binaryPackage = pkg.toSpdxPackage(
                 SpdxPackageType.BINARY_PACKAGE,
                 licenseInfoResolver,
-                ortResult
+                ortResult,
+                config.autoConcludeToEffectiveLicense
             )
 
             ortResult.getDependencies(
@@ -117,7 +119,8 @@ internal object SpdxDocumentModelMapper {
                 val vcsPackage = pkg.toSpdxPackage(
                     SpdxPackageType.VCS_PACKAGE,
                     licenseInfoResolver,
-                    ortResult
+                    ortResult,
+                    config.autoConcludeToEffectiveLicense
                 ).copy(hasFiles = filesForPackage.map { it.spdxId })
 
                 val vcsPackageRelationShip = SpdxRelationship(
@@ -142,7 +145,8 @@ internal object SpdxDocumentModelMapper {
                 val sourceArtifactPackage = pkg.toSpdxPackage(
                     SpdxPackageType.SOURCE_PACKAGE,
                     licenseInfoResolver,
-                    ortResult
+                    ortResult,
+                    config.autoConcludeToEffectiveLicense
                 ).copy(hasFiles = filesForPackage.map { it.spdxId })
 
                 val sourceArtifactPackageRelationship = SpdxRelationship(

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -94,7 +94,8 @@ internal object SpdxDocumentModelMapper {
             val spdxProjectPackage = project.toPackage().toSpdxPackage(
                 SpdxPackageType.PROJECT,
                 licenseInfoResolver,
-                ortResult
+                ortResult,
+                config.autoConcludeToEffectiveLicense
             ).copy(hasFiles = filesForProject.map { it.spdxId })
 
             ortResult.getDependencies(
@@ -114,7 +115,8 @@ internal object SpdxDocumentModelMapper {
             val binaryPackage = pkg.toSpdxPackage(
                 SpdxPackageType.BINARY_PACKAGE,
                 licenseInfoResolver,
-                ortResult
+                ortResult,
+                config.autoConcludeToEffectiveLicense
             )
 
             ortResult.getDependencies(
@@ -138,7 +140,8 @@ internal object SpdxDocumentModelMapper {
                 val vcsPackage = pkg.toSpdxPackage(
                     SpdxPackageType.VCS_PACKAGE,
                     licenseInfoResolver,
-                    ortResult
+                    ortResult,
+                    config.autoConcludeToEffectiveLicense
                 ).copy(hasFiles = filesForPackage.map { it.spdxId })
 
                 val vcsPackageRelationShip = SpdxRelationship(
@@ -163,7 +166,8 @@ internal object SpdxDocumentModelMapper {
                 val sourceArtifactPackage = pkg.toSpdxPackage(
                     SpdxPackageType.SOURCE_PACKAGE,
                     licenseInfoResolver,
-                    ortResult
+                    ortResult,
+                    config.autoConcludeToEffectiveLicense
                 ).copy(hasFiles = filesForPackage.map { it.spdxId })
 
                 val sourceArtifactPackageRelationship = SpdxRelationship(

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -39,6 +39,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
 import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper.FileFormat
 import org.ossreviewtoolkit.utils.spdxdocument.model.SPDX_VERSION_2_2
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxDocument
+import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxPackage
 
 @Suppress("EnumEntryNameCase", "EnumNaming")
 enum class SpdxVersion {
@@ -85,6 +86,15 @@ data class SpdxDocumentReporterConfig(
      */
     @OrtPluginOption(aliases = ["document.name"])
     val documentName: String?,
+
+    /**
+     * Set the [SpdxPackage.licenseConcluded] to the effective license as determined by ORT if there is no concluded
+     * license from a package curation. This is useful in workflows where it is discouraged to set a concluded license
+     * as it unconditionally overwrites any other license, in instead liense findings should be curated to make the
+     * effective license match the license conclusion.
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val autoConcludeToEffectiveLicense: Boolean,
 
     /**
      * Toggle whether the output document should contain information on file granularity about files containing

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -87,17 +87,17 @@ data class SpdxDocumentReporterConfig(
     val documentName: String?,
 
     /**
-     * The list of file formats to generate.
-     */
-    @OrtPluginOption(defaultValue = "YAML", aliases = ["output.file.formats"])
-    val outputFileFormats: List<FileFormat>,
-
-    /**
      * Toggle whether the output document should contain information on file granularity about files containing
      * findings.
      */
     @OrtPluginOption(defaultValue = "true", aliases = ["file.information.enabled"])
-    val fileInformationEnabled: Boolean
+    val fileInformationEnabled: Boolean,
+
+    /**
+     * The list of file formats to generate.
+     */
+    @OrtPluginOption(defaultValue = "YAML", aliases = ["output.file.formats"])
+    val outputFileFormats: List<FileFormat>
 )
 
 /**

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxConstants.LICENSE_REF_PREFIX
 import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper.FileFormat
 import org.ossreviewtoolkit.utils.spdxdocument.model.SPDX_VERSION_2_2
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxDocument
+import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxPackage
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxCompoundExpression
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseWithExceptionExpression
@@ -85,6 +86,15 @@ data class SpdxDocumentReporterConfig(
      */
     @OrtPluginOption(aliases = ["document.name"])
     val documentName: String?,
+
+    /**
+     * Set the [SpdxPackage.licenseConcluded] to the effective license as determined by ORT if there is no concluded
+     * license from a package curation. This is useful in workflows where it is discouraged to set a concluded license
+     * as it unconditionally overwrites any other license, in instead liense findings should be curated to make the
+     * effective license match the license conclusion.
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val autoConcludeToEffectiveLicense: Boolean,
 
     /**
      * Toggle whether the output document should contain information on file granularity about files containing


### PR DESCRIPTION
Previously, only ORT's `concludedLicense` from a package curation was taken into account. However, if solely detected license findings were cleared via license finding curations from package configurations, that did not have any impact at all until now.

To fix this, use the effective license with a custom license view of the declared and detected licenses as a fallback if no concluded license is set.

Finally, the `licenseConcluded` should only be set if (human) clearance work was involved, so only set it if it differs from the `licenseDeclared`. If `licenseDeclared` already was correct from the start, then this needs to be "acknowledged" by manually setting the concluded license to the same expression.