### PR TITLE
Revert "fix(git): Use Apache HttpClient for JGit HTTP transport"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,7 +118,6 @@ jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jac
 jakartaMail = { module = "com.sun.mail:jakarta.mail", version.ref = "jakartaMail" }
 jerseyCommon = { module = "org.glassfish.jersey.core:jersey-common", version.ref = "jerseyCommon" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
-jgit-http-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.http.apache", version.ref = "jgit" }
 jgit-ssh-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit" }
 jgit-ssh-apache-agent = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent", version.ref = "jgit" }
 jiraRestClient-api = { module = "com.atlassian.jira:jira-rest-java-client-api", version.ref = "jiraRestClient" }

--- a/plugins/version-control-systems/git/build.gradle.kts
+++ b/plugins/version-control-systems/git/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
 
     implementation(libs.jgit)
 
-    implementation(libs.jgit.http.apache)
-
     implementation(libs.jgit.ssh.apache) {
         exclude(group = "org.apache.sshd", module = "sshd-sftp")
             .because("it is not required for cloning via SSH and causes issues with GraalVM native images")

--- a/plugins/version-control-systems/git/src/main/kotlin/Git.kt
+++ b/plugins/version-control-systems/git/src/main/kotlin/Git.kt
@@ -35,11 +35,9 @@ import org.eclipse.jgit.lib.ObjectIdRef
 import org.eclipse.jgit.lib.SymbolicRef
 import org.eclipse.jgit.transport.CredentialItem
 import org.eclipse.jgit.transport.CredentialsProvider
-import org.eclipse.jgit.transport.HttpTransport
 import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.TagOpt
 import org.eclipse.jgit.transport.URIish
-import org.eclipse.jgit.transport.http.apache.HttpClientConnectionFactory
 import org.eclipse.jgit.transport.sshd.DefaultProxyDataFactory
 import org.eclipse.jgit.transport.sshd.JGitKeyCache
 import org.eclipse.jgit.transport.sshd.ServerKeyDatabase
@@ -101,10 +99,6 @@ class Git(
 ) : VersionControlSystem() {
     companion object {
         init {
-            // Use Apache HttpClient for HTTP transport in JGit instead of the default java.net.HttpURLConnection based
-            // transport. This avoids caching credentials too eagerly for basic authentication.
-            HttpTransport.setConnectionFactory(HttpClientConnectionFactory())
-
             // Make sure that JGit uses the exact same authentication information as ORT itself. This addresses
             // discrepancies in the way .netrc files are interpreted between JGit's and ORT's implementation.
             CredentialsProvider.setDefault(AuthenticatorCredentialsProvider)


### PR DESCRIPTION
The Apache HttpClient–based HTTP transport in JGit does not cache credentials for Git hosts, but it does restrict authentication to a single set of credentials per host. As a result, it becomes impossible to configure different credentials for URLs such as `https://github.com/A` and `https://github.com/B` simultaneously.

This revert restores the use of `java.net.HttpURLConnection`, which allows ORT’s Git implementation to work around credential caching issues programmatically by explicitly clearing the authentication cache when needed.

This reverts commit 04cadf972ed43128acbad2e3426606cdcd5d264a.

