### PR TITLE
docs(cli): Improve the documentation of `ort analyze -i`

### DIFF
--- a/integrations/completions/ort-completion.fish
+++ b/integrations/completions/ort-completion.fish
@@ -34,7 +34,7 @@ complete -c ort -n "__fish_seen_subcommand_from advise" -s h -l help -d 'Show th
 complete -c ort -f -n __fish_use_subcommand -a analyze -d 'Determine dependencies of a software project.'
 
 ## Options for analyze
-complete -c ort -n "__fish_seen_subcommand_from analyze" -l input-dir -s i -r -F -d 'The project directory to analyze. May point to a definition file if only a single package manager is enabled.'
+complete -c ort -n "__fish_seen_subcommand_from analyze" -l input-dir -s i -r -F -d 'The project directory to analyze. May point to a definition file, but only if just a single packagemanager is enabled, and the definition file does not depend on any further definition files.'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l output-dir -s o -r -F -d 'The directory to write the ORT result file with analyzer results to.'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l output-formats -s f -r -fa "JSON YAML" -d 'The list of output formats to be used for the ORT result file(s).'
 complete -c ort -n "__fish_seen_subcommand_from analyze" -l repository-configuration-file -r -F -d 'A file containing the repository configuration. If set, overrides any repository configuration contained in a \'.ort.yml\' file in the repository.'

--- a/plugins/commands/analyzer/src/main/kotlin/AnalyzeCommand.kt
+++ b/plugins/commands/analyzer/src/main/kotlin/AnalyzeCommand.kt
@@ -74,8 +74,8 @@ import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 class AnalyzeCommand(descriptor: PluginDescriptor = AnalyzeCommandFactory.descriptor) : OrtCommand(descriptor) {
     private val inputDir by option(
         "--input-dir", "-i",
-        help = "The project directory to analyze. May point to a definition file if only a single package manager is " +
-            "enabled."
+        help = "The project directory to analyze. May point to a definition file, but only if just a single package" +
+            "manager is enabled, and the definition file does not depend on any further definition files."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
         .convert { it.absoluteFile.normalize() }


### PR DESCRIPTION
Make clear that it is not supported to pass a single definition file as argument, in case that definition file depends on further definition files. Implementing support for this might be impossible, or at least introduce complexity, and as multiple files are supposed to be analyzed anyway, the user should simply pass a directory to `-i`, which works fine already. Also note that there is a common requirement in multiple places in the code, that all linked definition files are supposed to be under the `analysisRoot`.

Closes #11136.
