### PR TITLE
fix(renovate): Fix configuration for JRuby

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
       "matchPackageNames": [
         "org.jruby:jruby"
       ],
-      "allowedVersions": "<10.0.0.0"
+      "allowedVersions": "/^9\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
This is a fixup for ce899255. The comparison against a 4-digit version is not accepted by Renovate. So, use a regular expression instead.
