### PR TITLE
feat(docker): Set the `ANDROID_SDK_ROOT` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -526,6 +526,7 @@ ARG PHP_VERSION
 
 # Repo and Android
 ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=$ANDROID_HOME
 ENV ANDROID_USER_HOME=$HOME/.android
 ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/cmdline-tools/bin
 ENV PATH=$PATH:$ANDROID_HOME/platform-tools


### PR DESCRIPTION
The variable is required by old Android projects which use a version of the Gradle Android plugin that does not yet support `ANDROID_HOME`.