### PR TITLE
fix(Maven): Handle automatically wrapped p2 dependencies

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/tycho/TargetHandler.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/TargetHandler.kt
@@ -117,13 +117,18 @@ internal class TargetHandler(
      * to find the original Maven coordinates for affected artifacts. They are needed to retrieve the correct metadata.
      * Result is *null* if no matching Maven dependency is found.
      */
-    fun mapToMavenDependency(tychoArtifact: Artifact): Artifact? =
-        mavenDependencies[tychoArtifact.artifactId]?.also { dep ->
+    fun mapToMavenDependency(tychoArtifact: Artifact): Artifact? {
+        // Strip the "wrapped." prefix that might have been added by Tycho's automatic bundle wrapping mechanism
+        // (missingManifest="generate") to find the original Maven artifact.
+        val unwrappedArtifactId = tychoArtifact.artifactId.removePrefix("wrapped.")
+
+        return mavenDependencies[unwrappedArtifactId]?.also { dep ->
             logger.info {
                 "Mapping Tycho artifact '${tychoArtifact.groupId}:${tychoArtifact.artifactId}' to Maven " +
                     "dependency '${dep.groupId}:${dep.artifactId}'."
             }
         }
+    }
 }
 
 /**

--- a/plugins/package-managers/maven/src/test/assets/tycho.target
+++ b/plugins/package-managers/maven/src/test/assets/tycho.target
@@ -43,6 +43,15 @@
                     <version>2.15.2</version>
                     <type>jar</type>
                 </dependency>
+
+                <!-- This dependency has a missing manifest in its jar, so Tycho will generate one and wrap a
+                     p2 bundle around it. -->
+                <dependency>
+                    <groupId>org.apache.xmlbeans</groupId>
+                    <artifactId>xmlbeans</artifactId>
+                    <version>3.1.0</version>
+                    <type>jar</type>
+                </dependency>
             </dependencies>
         </location>
     </locations>


### PR DESCRIPTION
The dependency resolution logic failed to process dependencies that were automatically converted from Maven to p2 by Tycho.

When using the `missingManifest="generate"` feature, Tycho creates a p2 bundle for a Maven artifact that lacks an OSGi manifest. This process involves adding a "wrapped." prefix to the artifact's ID.

Update the resolution mechanism to detect and strip this "wrapped." prefix. This allows the Tycho package manager to correctly map the generated p2 dependency back to its original Maven coordinates, fixing the resolution failure.

Fixes #11174.
