### PR TITLE
ci(release): Fix setting the Sonatype connect timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           ORG_GRADLE_PROJECT_signAllPublications: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
+          ORG_GRADLE_PROJECT_SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
         run: ./gradlew publishAndReleaseToMavenCentral
       - name: Build ORT Distributions
         env:


### PR DESCRIPTION
The variable mentioned in the docs [1] refers to a Gradle property, not an environment variable.

[1]: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#deployment-validation