### PR TITLE
Support setting dependency's authors in package list files

### DIFF
--- a/cli-helper/src/funTest/resources/create-analyzer-result-from-pkg-list-expected-output.yml
+++ b/cli-helper/src/funTest/resources/create-analyzer-result-from-pkg-list-expected-output.yml
@@ -86,6 +86,9 @@ analyzer:
         path: "vcs-path/dependency-one"
     - id: "NPM::example-dependency-two:2.0.0"
       purl: "pkg:github/example-org/example-dependency-two@v2.0.0"
+      authors:
+      - "Author One"
+      - "Author Two"
       declared_licenses: []
       declared_licenses_processed: {}
       concluded_license: "MIT-Festival"

--- a/cli-helper/src/funTest/resources/package-list.yml
+++ b/cli-helper/src/funTest/resources/package-list.yml
@@ -31,6 +31,9 @@ dependencies:
     concludedLicense: "MIT-Festival"
     description: "Package description."
     homepageUrl: "https://example.com/example-dependency-two"
+    authors:
+      - "Author One"
+      - "Author Two"
     isExcluded: false
     isDynamicallyLinked: false
     labels:

--- a/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -155,6 +155,7 @@ private data class Dependency(
     val concludedLicense: SpdxExpression? = null,
     val description: String? = null,
     val homepageUrl: String? = null,
+    val authors: Set<String> = emptySet(),
     val isExcluded: Boolean = false,
     val isDynamicallyLinked: Boolean = false,
     val labels: Map<String, String> = emptyMap()
@@ -201,6 +202,7 @@ private fun Dependency.toPackage(): Package {
     return Package(
         id = id,
         purl = purl ?: id.toPurl(),
+        authors = authors,
         sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash ?: Hash.NONE) }.orEmpty(),
         vcs = vcsInfo,
         declaredLicenses = declaredLicenses,


### PR DESCRIPTION
Currently, the `package-list.yml` format does not support specifying authors for dependencies. This limits the completeness of the analyzer result generated from such lists.

Add an `authors` field to the `Dependency` data class and map it to the `Package` object in `CreateAnalyzerResultFromPackageListCommand`. This allows users to define authors in their package lists, which are then included in the generated analyzer result.
