### PR TITLE
ci(release): Increase timeout for validating Maven Central deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
+          ORG_GRADLE_PROJECT_SONATYPE_CLOSE_TIMEOUT_SECONDS: 3600
         run: ./gradlew publishAndReleaseToMavenCentral
       - name: Build ORT Distributions
         env:


### PR DESCRIPTION
Sometimes it can take longer than the default 15 minutes [1] to validate the deployment, so increase the timeout to 60 minutes.

[1]: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#deployment-validation