### PR TITLE
docs: fix ScanCode plugin commandLine default badge

### DIFF
--- a/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
+++ b/buildSrc/src/main/kotlin/GeneratePluginDocsTask.kt
@@ -188,7 +188,8 @@ abstract class GeneratePluginDocsTask : DefaultTask() {
                     }
 
                     option["default"]?.also {
-                        appendLine("![Default](https://img.shields.io/badge/Default-$it-darkgreen)")
+                        val escaped = it.toString().replace("-", "--")
+                        appendLine("![Default](https://img.shields.io/badge/Default-$escaped-darkgreen)")
                     }
 
                     appendLine()


### PR DESCRIPTION
Fixes a 404 from shields.io because `-` need to be escaped. See https://shields.io/badges/static-badge

Before:

<img width="292" height="91" alt="image" src="https://github.com/user-attachments/assets/b9c4e5da-6e51-4d80-ad71-856c00828d68" />

After:

<img width="514" height="91" alt="image" src="https://github.com/user-attachments/assets/49a56954-b48a-4e37-abb9-8f24393dba46" />
