### PR TITLE
chore(license-fact-providers): Separate fallback dir from export dir

### DIFF
--- a/plugins/license-fact-providers/scancode/build.gradle.kts
+++ b/plugins/license-fact-providers/scancode/build.gradle.kts
@@ -26,4 +26,6 @@ dependencies {
     api(projects.plugins.licenseFactProviders.licenseFactProviderApi)
 
     ksp(projects.plugins.licenseFactProviders.licenseFactProviderApi)
+
+    implementation(projects.utils.ortUtils)
 }


### PR DESCRIPTION
Export the license data to a different directory than the fallback directory, which might not be writable.

This partly reverts changes from 65dbe30 to reintroduce logging and variable naming.