### PR TITLE
chore(maven): Re-introduce cache eviction by size

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -119,7 +119,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) : Closeable {
 
     val remoteArtifactCache = kottage.cache("remote-artifact-cache") {
         strategy = KottageLruStrategy(maxCacheSize = 1.gibibytes)
-        defaultExpireTime = 6.hours
+        defaultExpireTime = 24.hours
     }
 
     // The MavenSettingsBuilder class is deprecated, but internally it uses its successor SettingsBuilder. Calling


### PR DESCRIPTION
This was temporarily replaced by eviction by count in 886221a as the feature was missing from the cache library. Now that the feature to evict by size is available, make use of it.