### PR TITLE
fix(gleam): Increase severity of an issue

### DIFF
--- a/plugins/package-managers/gleam/src/funTest/assets/projects/synthetic/gleam-no-lockfile-expected-output-allow-dynamic-versions.yml
+++ b/plugins/package-managers/gleam/src/funTest/assets/projects/synthetic/gleam-no-lockfile-expected-output-allow-dynamic-versions.yml
@@ -121,4 +121,4 @@ issues:
     \ the latest matching versions of direct dependencies were resolved without transitive\
     \ dependency resolution. The results are not reproducible. Consider running 'gleam\
     \ deps download' to generate a manifest.toml lockfile."
-  severity: "WARNING"
+  severity: "ERROR"

--- a/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
+++ b/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
@@ -30,7 +30,6 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
-import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
@@ -123,8 +122,7 @@ class Gleam internal constructor(
                 message = "Dependencies were resolved dynamically as no lockfile was present. " +
                     "Only the latest matching versions of direct dependencies were resolved without " +
                     "transitive dependency resolution. The results are not reproducible. " +
-                    "Consider running 'gleam deps download' to generate a manifest.toml lockfile.",
-                severity = Severity.WARNING
+                    "Consider running 'gleam deps download' to generate a manifest.toml lockfile."
             )
             GleamManifest.EMPTY
         }


### PR DESCRIPTION
As transitive dependencies are not resolved, it is likley that dependencies are missing. In such case, ORT normally creates an error.
