### PR TITLE
style(package-managers): Trivially align `setContext()` functions

### DIFF
--- a/plugins/package-managers/cocoapods/src/main/kotlin/PodDependencyHandler.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/PodDependencyHandler.kt
@@ -39,11 +39,13 @@ import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.searchUpwardFor
 
 internal class PodDependencyHandler : DependencyHandler<Lockfile.Pod> {
+    private lateinit var lockfile: Lockfile
     private val podspecCache = mutableMapOf<String, Podspec>()
     private val podsForName = mutableMapOf<String, Lockfile.Pod>()
-    private lateinit var lockfile: Lockfile
 
     fun setContext(lockfile: Lockfile) {
+        this.lockfile = lockfile
+
         // The cache entries are not re-usable across definition files because the keys do not contain the
         // dependency version. If non-default Specs repositories were supported, then these would also need to
         // be part of the key. As that's more complicated and not giving much performance prefer the more memory
@@ -52,7 +54,6 @@ internal class PodDependencyHandler : DependencyHandler<Lockfile.Pod> {
         podsForName.clear()
 
         lockfile.pods.associateByTo(podsForName) { it.name }
-        this.lockfile = lockfile
     }
 
     override fun identifierFor(dependency: Lockfile.Pod): Identifier =

--- a/plugins/package-managers/gleam/src/main/kotlin/GleamDependencyHandler.kt
+++ b/plugins/package-managers/gleam/src/main/kotlin/GleamDependencyHandler.kt
@@ -34,6 +34,7 @@ internal class GleamDependencyHandler : DependencyHandler<GleamPackageInfo> {
 
     fun setContext(context: GleamProjectContext) {
         this.context = context
+
         manifestPackagesByName.apply {
             clear()
             context.manifest.packages.associateByTo(this) { it.name }

--- a/plugins/package-managers/node/src/main/kotlin/yarn/YarnDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn/YarnDependencyHandler.kt
@@ -36,10 +36,10 @@ import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackageJson
 internal class YarnDependencyHandler(
     private val moduleInfoResolver: ModuleInfoResolver
 ) : DependencyHandler<YarnListNode> {
+    private lateinit var workingDir: File
+    private val projectDirs = mutableSetOf<File>()
     private val packageJsonForModuleId = mutableMapOf<String, PackageJson>()
     private val moduleDirForModuleId = mutableMapOf<String, File>()
-    private val projectDirs = mutableSetOf<File>()
-    private lateinit var workingDir: File
 
     fun setContext(workingDir: File, moduleDirs: Set<File>, projectDirs: Set<File>) {
         this.workingDir = workingDir

--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2DependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2DependencyHandler.kt
@@ -34,9 +34,9 @@ import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackage
 internal class Yarn2DependencyHandler(
     private val moduleInfoResolver: ModuleInfoResolver
 ) : DependencyHandler<PackageInfo> {
+    private lateinit var workingDir: File
     private val packageJsonForModuleId = mutableMapOf<String, PackageJson>()
     private val packageInfoForLocator = mutableMapOf<String, PackageInfo>()
-    private lateinit var workingDir: File
 
     fun setContext(
         workingDir: File,


### PR DESCRIPTION
Align the style of `setContext()` functions and related variables in dependency handlers a bit to follow a similar pattern and ordering.