### PR TITLE
refactor(gleam): Use a custom deserializer for dependencies

### DIFF
--- a/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
+++ b/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
@@ -139,8 +139,8 @@ class Gleam internal constructor(
         dependencyHandler.setContext(context)
 
         Scope.entries.forEach { scope ->
-            val dependencies = gleamToml.getScopeDependencies(scope).map { (name, element) ->
-                DependencyPackageInfo(name, GleamToml.Dependency.fromToml(element))
+            val dependencies = gleamToml.getScopeDependencies(scope).map { (name, dep) ->
+                DependencyPackageInfo(name, dep)
             }
 
             graphBuilder.addDependencies(project.id, scope.descriptor, dependencies)


### PR DESCRIPTION
Do not expose the internal `TomlElement` type of the TOML serialization library as part of the `GleamToml` data model by using a custom deserializer for `Dependency` types.