### PR TITLE
chore(plugins): Address an "upper bound violated" inspection hint

### DIFF
--- a/plugins/api/src/main/kotlin/PluginFactory.kt
+++ b/plugins/api/src/main/kotlin/PluginFactory.kt
@@ -30,7 +30,7 @@ interface PluginFactory<out PLUGIN : Plugin> {
         /**
          * Return all plugin factories of type [FACTORY].
          */
-        inline fun <reified FACTORY : PluginFactory<PLUGIN>, PLUGIN> getAll() =
+        inline fun <reified FACTORY : PluginFactory<PLUGIN>, PLUGIN : Plugin> getAll() =
             getLoaderFor<FACTORY>()
                 .iterator()
                 .asSequence()


### PR DESCRIPTION
This will become a warning with Kotlin 2.3, also see [1].

[1]: https://youtrack.jetbrains.com/issue/KTLC-358