### PR TITLE
test(ort-utils): Make `JavaBootstrapperTest` a "funTest"

### DIFF
--- a/utils/ort/src/funTest/kotlin/JavaBootstrapperFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/JavaBootstrapperFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.utils.common.Os
 
-class JavaBootstrapperTest : StringSpec({
+class JavaBootstrapperFunTest : StringSpec({
     "The Java version running the test should be detected as a JDK" {
         JavaBootstrapper.isRunningOnJdk(Environment.JAVA_VERSION) shouldBe true
     }


### PR DESCRIPTION
The test for `findJdkPackage()` actually makes a network connection, so this should be a "funTest".