### PR TITLE
chore(cli): Use unlimited width for non-interactive terminals

### DIFF
--- a/cli-helper/src/main/kotlin/HelperMain.kt
+++ b/cli-helper/src/main/kotlin/HelperMain.kt
@@ -27,11 +27,13 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.output.MordantHelpFormatter
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.switch
+import com.github.ajalt.mordant.terminal.Terminal
 
 import kotlin.system.exitProcess
 
@@ -72,6 +74,7 @@ internal class HelperMain : CliktCommand(ORTH_NAME) {
     init {
         context {
             helpFormatter = { MordantHelpFormatter(context = it, REQUIRED_OPTION_MARKER, showDefaultValues = true) }
+            terminal = Terminal(nonInteractiveWidth = Int.MAX_VALUE)
         }
 
         subcommands(

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -28,6 +28,7 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.output.MordantHelpFormatter
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
@@ -43,6 +44,7 @@ import com.github.ajalt.mordant.rendering.VerticalAlign
 import com.github.ajalt.mordant.rendering.Widget
 import com.github.ajalt.mordant.table.ColumnWidth
 import com.github.ajalt.mordant.table.grid
+import com.github.ajalt.mordant.terminal.Terminal
 
 import kotlin.system.exitProcess
 
@@ -120,6 +122,7 @@ class OrtMain : CliktCommand(ORT_NAME) {
 
         context {
             helpFormatter = { MordantHelpFormatter(context = it, REQUIRED_OPTION_MARKER, showDefaultValues = true) }
+            terminal = Terminal(nonInteractiveWidth = Int.MAX_VALUE)
         }
 
         // Pass an empty PluginConfig here as commands are not configurable.


### PR DESCRIPTION
This avoids truncation of lines in CI logs or when redirecting output due to Mordant's built-in default terminal width of 79 [1].

[1]: https://github.com/ajalt/mordant/blob/3.0.2/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/TerminalDetection.kt#L203