### PR TITLE
python: Add uv package manager support

### DIFF
--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv-expected-output.yml
@@ -1,0 +1,214 @@
+---
+project:
+  id: "UV::uv.lock:<REPLACE_REVISION>"
+  definition_file_path: "plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv/uv.lock"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "dev"
+    dependencies:
+    - id: "PyPI::pytest:8.3.3"
+      dependencies:
+      - id: "PyPI::iniconfig:2.0.0"
+      - id: "PyPI::packaging:24.2"
+      - id: "PyPI::pluggy:1.5.0"
+  - name: "main"
+    dependencies:
+    - id: "PyPI::anyio:4.6.2.post1"
+      dependencies:
+      - id: "PyPI::idna:3.10"
+      - id: "PyPI::sniffio:1.3.1"
+packages:
+- id: "PyPI::anyio:4.6.2.post1"
+  purl: "pkg:pypi/anyio@4.6.2.post1"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl"
+    hash:
+      value: "6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/9f/09/45b9b7a6d4e45c6bcb5bf61d19e3ab87df68e0601fa8c5293de3542546cc/anyio-4.6.2.post1.tar.gz"
+    hash:
+      value: "4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"
+      algorithm: "SHA-256"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::idna:3.10"
+  purl: "pkg:pypi/idna@3.10"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+    hash:
+      value: "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::iniconfig:2.0.0"
+  purl: "pkg:pypi/iniconfig@2.0.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
+    hash:
+      value: "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::packaging:24.2"
+  purl: "pkg:pypi/packaging@24.2"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl"
+    hash:
+      value: "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::pluggy:1.5.0"
+  purl: "pkg:pypi/pluggy@1.5.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl"
+    hash:
+      value: "44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::pytest:8.3.3"
+  purl: "pkg:pypi/pytest@8.3.3"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl"
+    hash:
+      value: "a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::sniffio:1.3.1"
+  purl: "pkg:pypi/sniffio@1.3.1"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl"
+    hash:
+      value: "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"
+      algorithm: "SHA-256"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv/pyproject.toml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "built-by-uv"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["anyio>=4,<5"]
+
+[tool.uv]
+dev-dependencies = ["pytest>=8.3.3"]

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv/uv.lock
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/uv/uv.lock
@@ -1,0 +1,81 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "built-by-uv"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "anyio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.6.2.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/09/45b9b7a6d4e45c6bcb5bf61d19e3ab87df68e0601fa8c5293de3542546cc/anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759" },
+]

--- a/plugins/package-managers/python/src/funTest/kotlin/UvFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/UvFunTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.python
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.analyzer.resolveSingleProject
+import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.utils.test.getAssetFile
+import org.ossreviewtoolkit.utils.test.matchExpectedResult
+
+class UvFunTest : WordSpec({
+    "Resolving project dependencies" should {
+        "interpret synthetic uv.lock files" {
+            val definitionFile = getAssetFile("projects/synthetic/uv/uv.lock")
+            val expectedResultFile = getAssetFile("projects/synthetic/uv-expected-output.yml")
+
+            val result = UvFactory.create().resolveSingleProject(definitionFile)
+
+            result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+        }
+    }
+})

--- a/plugins/package-managers/python/src/main/kotlin/Uv.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Uv.kt
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2024 The ORT Project Copyright Holders
+ * <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.python
+
+import java.io.File
+import java.lang.invoke.MethodHandles
+
+import net.peanuuutz.tomlkt.Toml
+import net.peanuuutz.tomlkt.getStringOrNull
+import net.peanuuutz.tomlkt.getTableOrNull
+import net.peanuuutz.tomlkt.parseToTomlTable
+
+import org.apache.logging.log4j.kotlin.loggerOf
+
+import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.PackageManagerFactory
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.utils.common.collectMessages
+import org.ossreviewtoolkit.utils.common.div
+import org.ossreviewtoolkit.utils.ort.showStackTrace
+
+private const val PYPI_TYPE = "PyPI"
+
+private val pyProjectToml = Toml {
+    ignoreUnknownKeys = true
+}
+
+private val logger = loggerOf(MethodHandles.lookup().lookupClass())
+
+@OrtPlugin(
+    id = "UV",
+    displayName = "uv",
+    description = "The uv package manager for Python.",
+    factory = PackageManagerFactory::class
+)
+class Uv(
+    override val descriptor: PluginDescriptor = UvFactory.descriptor
+) : PackageManager("UV") {
+    override val globsForDefinitionFiles = listOf("uv.lock")
+
+    override fun resolveDependencies(
+        analysisRoot: File,
+        definitionFile: File,
+        excludes: org.ossreviewtoolkit.model.config.Excludes,
+        analyzerConfig: org.ossreviewtoolkit.model.config.AnalyzerConfiguration,
+        labels: Map<String, String>
+    ): List<ProjectAnalyzerResult> {
+        val lockfile = runCatching { definitionFile.parseUvLockfile() }.getOrElse { failure ->
+            failure.showStackTrace()
+
+            val message = buildString {
+                appendLine("Unable to parse '${definitionFile.invariantSeparatorsPath}':")
+                appendLine(failure.collectMessages())
+            }
+
+            throw IllegalArgumentException(message, failure)
+        }
+
+        val pyProject = definitionFile.parentFile.resolve("pyproject.toml")
+        val pyProjectMetadata = pyProject.readMetadata()
+
+        val projectPackage = lockfile.findProjectPackage(pyProjectMetadata?.name, definitionFile.parentFile)
+            ?: throw IllegalStateException(
+                "No entry representing the current project was found in '${definitionFile.invariantSeparatorsPath}'."
+            )
+
+        val packageIndex = PackageIndex(lockfile.packages)
+
+        val packages = lockfile.packages
+            .filterNot { it === projectPackage }
+            .mapNotNullTo(mutableSetOf()) { pkg ->
+                val identifier = pkg.toIdentifier()
+                packageIndex.registerOrtId(pkg, identifier)
+                pkg.toOrtPackage(definitionFile.parentFile, identifier)
+            }
+
+        val projectScopes = projectPackage.collectScopeDependencies().mapTo(mutableSetOf()) { (name, deps) ->
+            Scope(name, deps.toPackageReferences(packageIndex))
+        }
+
+        val project = createProject(analysisRoot, definitionFile, pyProjectMetadata, projectScopes)
+
+        return listOf(ProjectAnalyzerResult(project, packages))
+    }
+
+    private fun createProject(
+        analysisRoot: File,
+        definitionFile: File,
+        metadata: PyProjectMetadata?,
+        scopes: Set<Scope>
+    ): Project {
+        val definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path
+        val projectId = Identifier(
+            type = projectType,
+            namespace = "",
+            name = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath,
+            version = VersionControlSystem.getCloneInfo(definitionFile.parentFile).revision
+        )
+
+        return Project(
+            id = projectId,
+            definitionFilePath = definitionFilePath,
+            declaredLicenses = emptySet(),
+            vcs = VcsInfo.EMPTY,
+            vcsProcessed = processProjectVcs(definitionFile.parentFile),
+            homepageUrl = metadata?.homepageUrl.orEmpty(),
+            scopeDependencies = scopes
+        )
+    }
+}
+
+private data class PyProjectMetadata(
+    val name: String?,
+    val version: String?,
+    val homepageUrl: String?
+)
+
+private fun File.readMetadata(): PyProjectMetadata? {
+    if (!isFile) return null
+
+    val table = runCatching { pyProjectToml.parseToTomlTable(reader()) }.getOrElse { return null }
+    val project = table.getTableOrNull("project")
+
+    val homepage = project?.getStringOrNull("homepage")
+        ?: project?.getTableOrNull("urls")?.entries?.firstOrNull()?.value?.toString()
+
+    return PyProjectMetadata(
+        name = project?.getStringOrNull("name"),
+        version = project?.getStringOrNull("version"),
+        homepageUrl = homepage
+    )
+}
+
+private class PackageIndex(packages: List<UvPackage>) {
+    private val packagesByName = packages.groupBy { it.name.lowercase() }
+    private val ortIds = mutableMapOf<UvPackage, Identifier>()
+
+    fun findPackage(dependency: UvDependency): UvPackage? {
+        val candidates = packagesByName[dependency.name.lowercase()].orEmpty()
+        if (candidates.isEmpty()) return null
+
+        val versionFiltered = dependency.version?.let { version ->
+            candidates.filter { it.version == version }
+        }.orEmpty().ifEmpty { candidates }
+
+        val sourceFiltered = dependency.source?.let { source ->
+            versionFiltered.filter { it.source.isEquivalentTo(source) }
+        }.orEmpty().ifEmpty { versionFiltered }
+
+        return sourceFiltered.singleOrNull()
+    }
+
+    fun registerOrtId(pkg: UvPackage, identifier: Identifier) {
+        ortIds[pkg] = identifier
+    }
+
+    fun identifierFor(pkg: UvPackage): Identifier =
+        ortIds[pkg] ?: Identifier(
+            type = PYPI_TYPE,
+            namespace = "",
+            name = pkg.name,
+            version = pkg.version.orEmpty()
+        )
+}
+
+private fun List<UvDependency>.toPackageReferences(
+    packageIndex: PackageIndex,
+    visited: Set<Identifier> = emptySet()
+): Set<PackageReference> =
+    mapNotNullTo(mutableSetOf()) { dependency ->
+        val pkg = packageIndex.findPackage(dependency)
+
+        if (pkg == null) {
+            logger.warn { "Unable to find package information for dependency '${dependency.name}'." }
+            null
+        } else {
+            pkg.toPackageReference(packageIndex, visited)
+        }
+    }
+
+private fun UvPackage.toPackageReference(
+    packageIndex: PackageIndex,
+    visited: Set<Identifier>
+): PackageReference {
+    val id = packageIndex.identifierFor(this)
+    if (id in visited) return PackageReference(id = id)
+
+    val nextVisited = visited + id
+    return PackageReference(
+        id = id,
+        dependencies = dependencies.toPackageReferences(packageIndex, nextVisited)
+    )
+}
+
+private fun UvPackage.collectScopeDependencies(): Map<String, List<UvDependency>> {
+    val scopes = mutableMapOf<String, List<UvDependency>>()
+
+    if (dependencies.isNotEmpty()) scopes["main"] = dependencies
+
+    fun Map<String, List<UvDependency>>.mergeInto(target: MutableMap<String, List<UvDependency>>) {
+        for ((name, deps) in this) {
+            if (deps.isEmpty()) continue
+
+            val existing = target[name].orEmpty()
+            target[name] = existing + deps
+        }
+    }
+
+    devDependencies.mergeInto(scopes)
+    dependencyGroups.mergeInto(scopes)
+    metadata?.dependencyGroups?.mergeInto(scopes)
+    metadata?.requiresDev?.mergeInto(scopes)
+
+    return scopes.ifEmpty { mapOf("main" to emptyList()) }
+}
+
+private fun UvPackage.toIdentifier(): Identifier {
+    val versionValue = version.orEmpty()
+    if (versionValue.isEmpty()) {
+        return Identifier(type = PYPI_TYPE, namespace = "", name = name, version = "")
+    }
+
+    return Identifier(type = PYPI_TYPE, namespace = "", name = name, version = versionValue)
+}
+
+private fun UvPackage.toOrtPackage(definitionDir: File, id: Identifier): Package? {
+    if (id.version.isEmpty()) {
+        logger.warn { "Skipping package '$name' because it does not declare a version." }
+        return null
+    }
+
+    val binaryArtifact = wheels.firstOrNull()?.toRemoteArtifact()
+    val sourceArtifact = sdist?.toRemoteArtifact()
+
+    val vcsInfo = source.toVcsInfo(definitionDir)
+    val processedVcs = PackageManager.processPackageVcs(vcsInfo)
+
+    return Package(
+        id = id,
+        declaredLicenses = emptySet(),
+        description = "",
+        homepageUrl = "",
+        binaryArtifact = binaryArtifact ?: RemoteArtifact.EMPTY,
+        sourceArtifact = sourceArtifact ?: RemoteArtifact.EMPTY,
+        vcs = vcsInfo,
+        vcsProcessed = processedVcs
+    )
+}
+
+private fun UvDistribution.toRemoteArtifact(): RemoteArtifact {
+    val hashValue = hash.orEmpty()
+    val parsedHash = when {
+        hashValue.isBlank() -> Hash.NONE
+        ":" in hashValue -> {
+            val (algorithm, value) = hashValue.split(':', limit = 2)
+            Hash(value, algorithm)
+        }
+        else -> Hash.create(hashValue)
+    }
+
+    return RemoteArtifact(
+        url = url.orEmpty(),
+        hash = parsedHash
+    )
+}
+
+private fun UvSource?.isEquivalentTo(other: UvSource): Boolean {
+    if (this == null) return false
+
+    return registry == other.registry &&
+        url == other.url &&
+        normalizeGitUrl(git) == normalizeGitUrl(other.git) &&
+        rev == other.rev &&
+        resolved == other.resolved &&
+        path == other.path &&
+        editable == other.editable &&
+        virtual == other.virtual &&
+        workspace == other.workspace &&
+        subdirectory == other.subdirectory
+}
+
+private fun UvSource?.toVcsInfo(definitionDir: File): VcsInfo {
+    if (this == null) return VcsInfo.EMPTY
+
+    git?.let { gitUrl ->
+        val (url, revision) = gitUrl.split('#', limit = 2).let { segments ->
+            val base = normalizeGitUrl(segments.first()) ?: segments.first()
+            val rev = segments.getOrNull(1)?.takeIf { it.isNotBlank() } ?: resolved ?: rev
+            base to rev
+        }
+
+        return VcsInfo(
+            type = VcsType.GIT,
+            url = url,
+            revision = revision.orEmpty(),
+            path = subdirectory.orEmpty()
+        )
+    }
+
+    if (url != null) {
+        return VcsInfo(VcsType.UNKNOWN, url, revision = resolved.orEmpty(), path = subdirectory.orEmpty())
+    }
+
+    fun resolveLocal(pathValue: String?): File? {
+        if (pathValue.isNullOrBlank()) return null
+        val pathFile = File(pathValue)
+        return if (pathFile.isAbsolute) pathFile.normalize() else (definitionDir / pathFile).normalize()
+    }
+
+    resolveLocal(editable)?.let {
+        return VcsInfo(VcsType.UNKNOWN, it.toURI().toString(), revision = resolved.orEmpty(), path = "")
+    }
+
+    resolveLocal(path)?.let {
+        return VcsInfo(VcsType.UNKNOWN, it.toURI().toString(), revision = resolved.orEmpty(), path = "")
+    }
+
+    resolveLocal(virtual)?.let {
+        return VcsInfo(VcsType.UNKNOWN, it.toURI().toString(), revision = resolved.orEmpty(), path = "")
+    }
+
+    return VcsInfo.EMPTY
+}
+
+private fun normalizeGitUrl(url: String?): String? =
+    url?.substringBefore('?')
+
+private fun UvLockfile.findProjectPackage(projectName: String?, definitionDir: File): UvPackage? {
+    if (projectName != null) {
+        packages.find { it.name == projectName }?.let { return it }
+    }
+
+    return packages.find { pkg ->
+        pkg.source?.pointsTo(definitionDir) == true
+    }
+}
+
+private fun UvSource.pointsTo(directory: File): Boolean {
+    val candidates = listOfNotNull(editable, path, virtual)
+    if (candidates.isEmpty()) return false
+
+    return candidates.any {
+        val candidatePath = File(it)
+        val resolved = if (candidatePath.isAbsolute) candidatePath.normalize() else directory.resolve(candidatePath).normalize()
+        resolved == directory.normalize()
+    }
+}

--- a/plugins/package-managers/python/src/main/kotlin/UvLockfile.kt
+++ b/plugins/package-managers/python/src/main/kotlin/UvLockfile.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 The ORT Project Copyright Holders
+ * <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.python
+
+import java.io.File
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+import net.peanuuutz.tomlkt.Toml
+import net.peanuuutz.tomlkt.decodeFromString
+
+private val uvToml = Toml {
+    ignoreUnknownKeys = true
+}
+
+internal fun File.parseUvLockfile(): UvLockfile = uvToml.decodeFromString(readText())
+
+@Serializable
+internal data class UvLockfile(
+    val version: Int,
+    val revision: Int? = null,
+    @SerialName("requires-python")
+    val requiresPython: String? = null,
+    @SerialName("package")
+    val packages: List<UvPackage> = emptyList()
+)
+
+@Serializable
+internal data class UvPackage(
+    val name: String,
+    val version: String? = null,
+    val source: UvSource? = null,
+    val dependencies: List<UvDependency> = emptyList(),
+    @SerialName("dev-dependencies")
+    val devDependencies: Map<String, List<UvDependency>> = emptyMap(),
+    @SerialName("dependency-groups")
+    val dependencyGroups: Map<String, List<UvDependency>> = emptyMap(),
+    @SerialName("optional-dependencies")
+    val optionalDependencies: Map<String, List<UvDependency>> = emptyMap(),
+    val metadata: UvPackageMetadata? = null,
+    val sdist: UvDistribution? = null,
+    val wheels: List<UvDistribution> = emptyList()
+)
+
+@Serializable
+internal data class UvPackageMetadata(
+    @SerialName("requires-dist")
+    val requiresDist: List<UvDependency> = emptyList(),
+    @SerialName("requires-dev")
+    val requiresDev: Map<String, List<UvDependency>> = emptyMap(),
+    @SerialName("dependency-groups")
+    val dependencyGroups: Map<String, List<UvDependency>> = emptyMap()
+)
+
+@Serializable
+internal data class UvDependency(
+    val name: String,
+    val version: String? = null,
+    val marker: String? = null,
+    val extra: List<String> = emptyList(),
+    val optional: Boolean = false,
+    val source: UvSource? = null
+)
+
+@Serializable
+internal data class UvSource(
+    val registry: String? = null,
+    val url: String? = null,
+    val git: String? = null,
+    val rev: String? = null,
+    val resolved: String? = null,
+    val path: String? = null,
+    val editable: String? = null,
+    val virtual: String? = null,
+    val workspace: String? = null,
+    val subdirectory: String? = null
+)
+
+@Serializable
+internal data class UvDistribution(
+    val url: String? = null,
+    val hash: String? = null,
+    val size: Long? = null
+)

--- a/website/docs/tools/analyzer.md
+++ b/website/docs/tools/analyzer.md
@@ -52,6 +52,7 @@ Currently, the following package managers (grouped by the programming language t
   * [PIP](https://pip.pypa.io/)
   * [Pipenv](https://pipenv.pypa.io/en/latest/)
   * [Poetry](https://python-poetry.org/)
+  * [uv](https://docs.astral.sh/uv/)
 * Ruby
   * [Bundler](https://bundler.io/) (limitations: [restricted to the version available on the host](https://github.com/oss-review-toolkit/ort/issues/1308))
 * Rust


### PR DESCRIPTION
  - add a new `UV` package manager implementation that parses `uv.lock`, derives scope dependencies, and maps sources / artifacts into ORT packages
  - add a synthetic `uv` fixture plus `UvFunTest` to verify analyzer behavior
  - mention UV in the analyzer documentation’s supported-package-managers list
  
   ```bash
  docker run --rm -e GRADLE_USER_HOME=/workspace/.gradle \
    -v "$PWD":/workspace -w /workspace gradle:9.2.1-jdk21-ubi \
    ./gradlew --no-configuration-cache -Dorg.gradle.wrapper.timeout=60000 \
    :plugins:package-managers:python:funTest \
    --tests org.ossreviewtoolkit.plugins.packagemanagers.python.UvFunTest
