### PR TITLE
feat(plugins): Simplify code generation for parsing plugin options

### DIFF
--- a/plugins/api/src/main/kotlin/PluginFactory.kt
+++ b/plugins/api/src/main/kotlin/PluginFactory.kt
@@ -21,10 +21,13 @@ package org.ossreviewtoolkit.plugins.api
 
 import java.util.ServiceLoader
 
+import org.ossreviewtoolkit.utils.common.Options
+
 /**
  * A factory interface for creating plugins of type [PLUGIN]. The different plugin endpoints ORT provides must inherit
  * from this interface.
  */
+@Suppress("TooManyFunctions")
 interface PluginFactory<out PLUGIN : Plugin> {
     companion object {
         /**
@@ -48,6 +51,90 @@ interface PluginFactory<out PLUGIN : Plugin> {
      * Create a new instance of [PLUGIN] from [config].
      */
     fun create(config: PluginConfig): PLUGIN
+
+    private inline fun <T> parseNullableOption(
+        name: String,
+        options: Options,
+        expectedType: PluginOptionType,
+        convert: (String) -> T
+    ): T? {
+        val option = descriptor.options.single { it.name == name }
+
+        require(option.type == expectedType) {
+            "Option '$name' of plugin '${descriptor.id}' is not of type $expectedType."
+        }
+
+        buildList {
+            add(option.name)
+            addAll(option.aliases)
+        }.forEach {
+            options[it]?.let { value -> return convert(value) }
+        }
+
+        option.defaultValue?.let { return convert(it) }
+
+        return null
+    }
+
+    private inline fun <T> parseOption(
+        name: String,
+        options: Options,
+        expectedType: PluginOptionType,
+        convert: (String) -> T
+    ): T =
+        checkNotNull(parseNullableOption(name, options, expectedType, convert)) {
+            "No value found for required option '$name' of plugin '${descriptor.id}'."
+        }
+
+    /** Parse a [boolean][PluginOptionType.BOOLEAN] option from the given [config]. */
+    fun parseBooleanOption(name: String, config: PluginConfig): Boolean =
+        parseOption(name, config.options, PluginOptionType.BOOLEAN) { it.toBooleanStrict() }
+
+    /** Parse a nullable [boolean][PluginOptionType.BOOLEAN] option from the given [config]. */
+    fun parseNullableBooleanOption(name: String, config: PluginConfig): Boolean? =
+        parseNullableOption(name, config.options, PluginOptionType.BOOLEAN) { it.toBooleanStrict() }
+
+    /** Parse an [integer][PluginOptionType.INTEGER] option from the given [config]. */
+    fun parseIntegerOption(name: String, config: PluginConfig): Int =
+        parseOption(name, config.options, PluginOptionType.INTEGER) { it.toInt() }
+
+    /** Parse a nullable [integer][PluginOptionType.INTEGER] option from the given [config]. */
+    fun parseNullableIntegerOption(name: String, config: PluginConfig): Int? =
+        parseNullableOption(name, config.options, PluginOptionType.INTEGER) { it.toInt() }
+
+    /** Parse a [long][PluginOptionType.LONG] option from the given [config]. */
+    fun parseLongOption(name: String, config: PluginConfig): Long =
+        parseOption(name, config.options, PluginOptionType.LONG) { it.toLong() }
+
+    /** Parse a nullable [long][PluginOptionType.LONG] option from the given [config]. */
+    fun parseNullableLongOption(name: String, config: PluginConfig): Long? =
+        parseNullableOption(name, config.options, PluginOptionType.LONG) { it.toLong() }
+
+    /** Parse a [secret][PluginOptionType.SECRET] option from the given [config]. */
+    fun parseSecretOption(name: String, config: PluginConfig): Secret =
+        parseOption(name, config.secrets, PluginOptionType.SECRET) { Secret(it) }
+
+    /** Parse a nullable [secret][PluginOptionType.SECRET] option from the given [config]. */
+    fun parseNullableSecretOption(name: String, config: PluginConfig): Secret? =
+        parseNullableOption(name, config.secrets, PluginOptionType.SECRET) { Secret(it) }
+
+    /** Parse a [string][PluginOptionType.STRING] option from the given [config]. */
+    fun parseStringOption(name: String, config: PluginConfig): String =
+        parseOption(name, config.options, PluginOptionType.STRING) { it }
+
+    /** Parse a nullable [string][PluginOptionType.STRING] option from the given [config]. */
+    fun parseNullableStringOption(name: String, config: PluginConfig): String? =
+        parseNullableOption(name, config.options, PluginOptionType.STRING) { it }
+
+    /** Parse a [string list][PluginOptionType.STRING_LIST] option from the given [config]. */
+    fun parseStringListOption(name: String, config: PluginConfig): List<String> =
+        parseOption(name, config.options, PluginOptionType.STRING_LIST) { it.split(',').map { str -> str.trim() } }
+
+    /** Parse a nullable [string list][PluginOptionType.STRING_LIST] option from the given [config]. */
+    fun parseNullableStringListOption(name: String, config: PluginConfig): List<String>? =
+        parseNullableOption(name, config.options, PluginOptionType.STRING_LIST) {
+            it.split(',').map { str -> str.trim() }
+        }
 }
 
 /**


### PR DESCRIPTION
Add helper functions for the parsing of plugin options to simplify the generated code and the code generation. This will especially be helpful when introducing enum options later.