### PR TITLE
build(subversion): Substitute the vulnerable lz4-java dependency

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -72,6 +72,14 @@ repositories {
     }
 }
 
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute(module("org.lz4:lz4-java:1.4.1"))
+            .using(module("at.yawk.lz4:lz4-java:1.10.2"))
+            .because("lz4-java is unmaintained and vulnerable to CVE‐2025‐12183")
+    }
+}
+
 tasks.withType<Jar>().configureEach {
     manifest {
         attributes["Implementation-Version"] = version


### PR DESCRIPTION
Substitute with a maintained community fork that patches the vulnerability, see [1].

[1]: https://nvd.nist.gov/vuln/detail/CVE-2025-12183