### PR TITLE
fix(cli): Reduce the non-interactive terminal width for Mordant

### DIFF
--- a/cli-helper/src/main/kotlin/HelperMain.kt
+++ b/cli-helper/src/main/kotlin/HelperMain.kt
@@ -74,7 +74,7 @@ internal class HelperMain : CliktCommand(ORTH_NAME) {
     init {
         context {
             helpFormatter = { MordantHelpFormatter(context = it, REQUIRED_OPTION_MARKER, showDefaultValues = true) }
-            terminal = Terminal(nonInteractiveWidth = Int.MAX_VALUE)
+            terminal = Terminal(nonInteractiveWidth = 200)
         }
 
         subcommands(

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -122,7 +122,7 @@ class OrtMain : CliktCommand(ORT_NAME) {
 
         context {
             helpFormatter = { MordantHelpFormatter(context = it, REQUIRED_OPTION_MARKER, showDefaultValues = true) }
-            terminal = Terminal(nonInteractiveWidth = Int.MAX_VALUE)
+            terminal = Terminal(nonInteractiveWidth = 200)
         }
 
         // Pass an empty PluginConfig here as commands are not configurable.


### PR DESCRIPTION
This avoids Mordant to render a massively wide progress bar, running into out of memory issues.

Fixes #11300.