### PR TITLE
evaluated-model: Include entire curations instead of just curation data

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -37,11 +37,15 @@ package_configurations:
   - 0
 package_curations:
 - _id: 0
-  comment: "Foobar is an imaginary dependency and offers a license choice"
-  concluded_license: "GPL-2.0-only OR MIT"
+  id: "Maven:com.foobar:foobar:1.0"
+  curations:
+    comment: "Foobar is an imaginary dependency and offers a license choice"
+    concluded_license: "GPL-2.0-only OR MIT"
 - _id: 1
-  comment: "H2 database offers a license choice"
-  concluded_license: "MPL-2.0 OR EPL-1.0"
+  id: "Maven:com.h2database:h2:1.4.200"
+  curations:
+    comment: "H2 database offers a license choice"
+    concluded_license: "MPL-2.0 OR EPL-1.0"
 copyrights:
 - _id: 0
   statement: "Copyright (c) example authors."

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
@@ -42,12 +42,18 @@
   } ],
   "package_curations" : [ {
     "_id" : 0,
-    "comment" : "Foobar is an imaginary dependency and offers a license choice",
-    "concluded_license" : "GPL-2.0-only OR MIT"
+    "id" : "Maven:com.foobar:foobar:1.0",
+    "curations" : {
+      "comment" : "Foobar is an imaginary dependency and offers a license choice",
+      "concluded_license" : "GPL-2.0-only OR MIT"
+    }
   }, {
     "_id" : 1,
-    "comment" : "H2 database offers a license choice",
-    "concluded_license" : "MPL-2.0 OR EPL-1.0"
+    "id" : "Maven:com.h2database:h2:1.4.200",
+    "curations" : {
+      "comment" : "H2 database offers a license choice",
+      "concluded_license" : "MPL-2.0 OR EPL-1.0"
+    }
   } ],
   "copyrights" : [ {
     "_id" : 0,

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
@@ -37,11 +37,15 @@ package_configurations:
   - 0
 package_curations:
 - _id: 0
-  comment: "Foobar is an imaginary dependency and offers a license choice"
-  concluded_license: "GPL-2.0-only OR MIT"
+  id: "Maven:com.foobar:foobar:1.0"
+  curations:
+    comment: "Foobar is an imaginary dependency and offers a license choice"
+    concluded_license: "GPL-2.0-only OR MIT"
 - _id: 1
-  comment: "H2 database offers a license choice"
-  concluded_license: "MPL-2.0 OR EPL-1.0"
+  id: "Maven:com.h2database:h2:1.4.200"
+  curations:
+    comment: "H2 database offers a license choice"
+    concluded_license: "MPL-2.0 OR EPL-1.0"
 copyrights:
 - _id: 0
   statement: "Copyright (c) example authors."

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModel.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModel.kt
@@ -33,7 +33,7 @@ import java.io.Writer
 
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.PackageCurationData
+import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
@@ -96,7 +96,7 @@ data class EvaluatedModel(
     val scopeExcludes: List<ScopeExclude>,
     val licenseFindingCurations: List<LicenseFindingCuration>,
     val packageConfigurations: List<PackageConfiguration>,
-    val packageCurations: List<PackageCurationData>,
+    val packageCurations: List<PackageCuration>,
     val copyrights: List<CopyrightStatement>,
     val licenses: List<LicenseId>,
     val scopes: List<EvaluatedScope>,
@@ -139,7 +139,7 @@ data class EvaluatedModel(
             LicenseFindingCuration::class.java,
             LicenseId::class.java,
             PackageConfiguration::class.java,
-            PackageCurationData::class.java,
+            PackageCuration::class.java,
             PathExclude::class.java,
             RuleViolationResolution::class.java,
             ScopeExclude::class.java,

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedPackage.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedPackage.kt
@@ -26,7 +26,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
-import org.ossreviewtoolkit.model.PackageCurationData
+import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.PackageConfiguration
@@ -65,7 +65,7 @@ data class EvaluatedPackage(
     val vcs: VcsInfo,
     val vcsProcessed: VcsInfo = vcs.normalize(),
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val curations: List<PackageCurationData>,
+    val curations: List<PackageCuration>,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val packageConfigurations: List<PackageConfiguration>,
     @JsonIdentityReference(alwaysAsId = true)


### PR DESCRIPTION
See individual commits.