### PR TITLE
chore(plugins): Make `PluginOptionType` know their type names

### DIFF
--- a/plugins/api/src/main/kotlin/PluginDescriptor.kt
+++ b/plugins/api/src/main/kotlin/PluginDescriptor.kt
@@ -47,24 +47,26 @@ data class PluginDescriptor(
 /**
  * The supported types of plugin options.
  */
-enum class PluginOptionType {
+enum class PluginOptionType(val typeName: String) {
     /** A [Boolean] option. */
-    BOOLEAN,
+    BOOLEAN("Boolean"),
 
     /** An [Int] option. */
-    INTEGER,
+    INTEGER("Integer"),
 
     /** A [Long] option. */
-    LONG,
+    LONG("Long"),
 
     /** A [Secret] option. */
-    SECRET,
+    SECRET("Secret"),
 
     /** A [String] option. */
-    STRING,
+    STRING("String"),
 
     /** A [List]<[String]> option. */
-    STRING_LIST
+    STRING_LIST("StringList");
+
+    override fun toString() = typeName
 }
 
 /**

--- a/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
+++ b/plugins/compiler/src/main/kotlin/PluginFactoryGenerator.kt
@@ -138,23 +138,9 @@ class PluginFactoryGenerator(private val codeGenerator: CodeGenerator) {
                 add("    ${option.name} = ")
 
                 if (option.isNullable) {
-                    when (option.type) {
-                        PluginOptionType.BOOLEAN -> add("parseNullableBooleanOption(%S, config)", option.name)
-                        PluginOptionType.INTEGER -> add("parseNullableIntegerOption(%S, config)", option.name)
-                        PluginOptionType.LONG -> add("parseNullableLongOption(%S, config)", option.name)
-                        PluginOptionType.SECRET -> add("parseNullableSecretOption(%S, config)", option.name)
-                        PluginOptionType.STRING -> add("parseNullableStringOption(%S, config)", option.name)
-                        PluginOptionType.STRING_LIST -> add("parseNullableStringListOption(%S, config)", option.name)
-                    }
+                    add("parseNullable${option.type}Option(%S, config)", option.name)
                 } else {
-                    when (option.type) {
-                        PluginOptionType.BOOLEAN -> add("parseBooleanOption(%S, config)", option.name)
-                        PluginOptionType.INTEGER -> add("parseIntegerOption(%S, config)", option.name)
-                        PluginOptionType.LONG -> add("parseLongOption(%S, config)", option.name)
-                        PluginOptionType.SECRET -> add("parseSecretOption(%S, config)", option.name)
-                        PluginOptionType.STRING -> add("parseStringOption(%S, config)", option.name)
-                        PluginOptionType.STRING_LIST -> add("parseStringListOption(%S, config)", option.name)
-                    }
+                    add("parse${option.type}Option(%S, config)", option.name)
                 }
 
                 add(",\n")


### PR DESCRIPTION
This way two `when` distinctions can be avoided.