### PR TITLE
fix(plugins): Filter empty strings when parsing string list options

### DIFF
--- a/plugins/api/src/main/kotlin/PluginFactory.kt
+++ b/plugins/api/src/main/kotlin/PluginFactory.kt
@@ -128,12 +128,14 @@ interface PluginFactory<out PLUGIN : Plugin> {
 
     /** Parse a [string list][PluginOptionType.STRING_LIST] option from the given [config]. */
     fun parseStringListOption(name: String, config: PluginConfig): List<String> =
-        parseOption(name, config.options, PluginOptionType.STRING_LIST) { it.split(',').map { str -> str.trim() } }
+        parseOption(name, config.options, PluginOptionType.STRING_LIST) { value ->
+            value.split(',').mapNotNull { it.trim().ifEmpty { null } }
+        }
 
     /** Parse a nullable [string list][PluginOptionType.STRING_LIST] option from the given [config]. */
     fun parseNullableStringListOption(name: String, config: PluginConfig): List<String>? =
-        parseNullableOption(name, config.options, PluginOptionType.STRING_LIST) {
-            it.split(',').map { str -> str.trim() }
+        parseNullableOption(name, config.options, PluginOptionType.STRING_LIST) { value ->
+            value.split(',').mapNotNull { it.trim().ifEmpty { null } }
         }
 }
 

--- a/plugins/api/src/test/kotlin/PluginFactoryTest.kt
+++ b/plugins/api/src/test/kotlin/PluginFactoryTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.api
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+private val testDescriptor = PluginDescriptor(
+    id = "test",
+    displayName = "Test",
+    description = "Test plugin",
+    options = listOf(
+        PluginOption(
+            name = "stringList",
+            description = "A string list option",
+            type = PluginOptionType.STRING_LIST,
+            defaultValue = "",
+            aliases = emptyList(),
+            isNullable = false,
+            isRequired = false
+        )
+    )
+)
+
+private val testFactory = object : PluginFactory<Plugin> {
+    override val descriptor = testDescriptor
+    override fun create(config: PluginConfig) =
+        object : Plugin {
+            override val descriptor = testDescriptor
+        }
+}
+
+class PluginFactoryTest : WordSpec({
+    "parseStringListOption()" should {
+        "return an empty list for an empty default value" {
+            val result = testFactory.parseStringListOption("stringList", PluginConfig.EMPTY)
+
+            result should beEmpty()
+        }
+
+        "return a list with trimmed values" {
+            val config = PluginConfig(options = mapOf("stringList" to " a , b , c "))
+
+            val result = testFactory.parseStringListOption("stringList", config)
+
+            result shouldBe listOf("a", "b", "c")
+        }
+
+        "filter out empty strings from the result" {
+            val config = PluginConfig(options = mapOf("stringList" to "a,,b, ,c"))
+
+            val result = testFactory.parseStringListOption("stringList", config)
+
+            result shouldBe listOf("a", "b", "c")
+        }
+    }
+})

--- a/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
+++ b/plugins/scanners/scancode/src/test/kotlin/ScanCodeTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.scanners.scancode
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldMatch
@@ -34,6 +35,7 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.extractResource
@@ -73,6 +75,12 @@ class ScanCodeTest : WordSpec({
 
             scannerWithConfig.getCommandLineOptions("31.2.4").joinToString(" ") shouldMatch
                 "--command --line --commandLineNonConfig"
+        }
+
+        "not contain empty strings when created from PluginConfig with default commandLineNonConfig" {
+            val scannerFromConfig = ScanCodeFactory().create(PluginConfig.EMPTY)
+
+            scannerFromConfig.getCommandLineOptions("32.0.0") shouldNotContain ""
         }
     }
 


### PR DESCRIPTION
Empty default values for STRING_LIST options resulted in a list with one empty string instead of an empty list, causing scanners to fail with invalid empty path arguments.


Resulting Issue: https://github.com/erlef/mix_sbom/actions/runs/21065224699/job/60580853902

```
11:34:02.569 [main] ERROR org.ossreviewtoolkit.scanner.PathScannerWrapper - Failed to scan RepositoryProvenance(vcsInfo=VcsInfo(type=Git, url=https://github.com/erlef/mix_sbom, revision=bf082b2ba45730df94121a35ce6952ab90f7881c, path=), resolvedRevision=bf082b2ba45730df94121a35ce6952ab90f7881c) with path scanner 'ScanCode': ScanException: Running 'scancode --copyright --license --info --strip-root --timeout 300  --license-references --json /tmp/ort-ScanCode6066276160176620453/result.json /tmp/ort-DefaultProvenanceDownloader5469946066434090707' in '/home/ort' failed with exit code 2:
Usage: scancode [OPTIONS] <OUTPUT FORMAT OPTION(s)> <input>...
Try the 'scancode --help' option for help on options and arguments.

Error: Invalid value for '<OUTPUT FORMAT OPTION(s)> <input>...': Path '' does not exist.
```