### PR TITLE
docs(evaluated-model): Fix-up and improve comments

### DIFF
--- a/plugins/reporters/evaluated-model/src/main/kotlin/ToolsMetadata.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/ToolsMetadata.kt
@@ -49,12 +49,12 @@ data class ToolsMetadata(
 ) {
     data class Run(
         /**
-         * The time the run started.
+         * The time the run has started.
          */
         val startTime: Instant,
 
         /**
-         * The time the run started.
+         * The time the run has finished.
          */
         val endTime: Instant,
 


### PR DESCRIPTION
Align the comment with the `*Run` classes, like for example `AnalyzerRun` and mention "finished" instead of "started".


