### PR TITLE
fix(fossid): Don't create issue for zero pending identifications

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossId.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossId.kt
@@ -924,15 +924,17 @@ class FossId internal constructor(
 
         val fossIdScanUrl = buildFossIdScanUrl(config.serverUrl, result.scanId)
 
-        issues.add(
-            0,
-            Issue(
-                source = descriptor.id,
-                message = "This scan has $pendingFilesCount file(s) pending identification in FossID. " +
-                    "Please review and resolve them at: $fossIdScanUrl",
-                severity = if (config.treatPendingIdentificationsAsError) Severity.ERROR else Severity.HINT
+        if (pendingFilesCount > 0) {
+            issues.add(
+                0,
+                Issue(
+                    source = descriptor.id,
+                    message = "This scan has $pendingFilesCount file(s) pending identification in FossID. " +
+                        "Please review and resolve them at: $fossIdScanUrl",
+                    severity = if (config.treatPendingIdentificationsAsError) Severity.ERROR else Severity.HINT
+                )
             )
-        )
+        }
 
         val ignoredFiles = rawResults.listIgnoredFiles.associateBy { it.path }
 


### PR DESCRIPTION
Don't create an issue about pending identifications in FossID if actually no pending identifications exist. This bug prevents the use of configuration option `treatPendingIdentificationsAsError`, as it reports an issue with severity ERROR even if there are zero pending identifications.

