### PR TITLE
feat(ort-utils): Log stacktraces with a logger

### DIFF
--- a/utils/ort/src/main/kotlin/OrtUtils.kt
+++ b/utils/ort/src/main/kotlin/OrtUtils.kt
@@ -25,6 +25,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 
 import org.apache.logging.log4j.kotlin.CoroutineThreadContext
+import org.apache.logging.log4j.kotlin.logger
 
 /**
  * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
@@ -34,7 +35,7 @@ var printStackTrace = false
 /**
  * Print the stack trace of the [Throwable] if [printStackTrace] is set to true.
  */
-fun Throwable.showStackTrace(): Unit = run { if (printStackTrace) printStackTrace() }
+fun Throwable.showStackTrace(): Unit = run { if (printStackTrace) logger.error("An exception has occurred: ", this) }
 
 /**
  * A wrapper for [kotlinx.coroutines.runBlocking] which always adds a [CoroutineThreadContext] to the newly created


### PR DESCRIPTION
When the 'stacktrace' parameter is given, ORT logs the stacktraces by printing them on the standard output. This is a behavior from the time when ORT was only a CLI application. Since some third party projects now use ORT programmatically (e.g. the ORT Server project), the stacktraces need to be properly logged.
