### PR TITLE
ci(renovate): Pin NPM dependenies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,10 @@
       "recreateWhen": "never"
     },
     {
+      "matchManagers": ["npm"],
+      "rangeStrategy": "pin"
+    },
+    {
       "matchPackageNames": [
         "com.atlassian.jira:jira-rest-java-client-api",
         "com.atlassian.jira:jira-rest-java-client-app"


### PR DESCRIPTION
Configure Renovate to convert version ranges in `package.json` files to exact versions [1]. This makes it visible in the `package.json` files which versions of direct dependencies are used and prevents unintentional version upgrades during development.

Note that this currently only affects the website because test projects and the web app reporter are excluded from Renovate.

[1]: https://docs.renovatebot.com/configuration-options/#rangestrategy
