### PR TITLE
ci(renovate): Merge two NPM related configs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,10 +21,6 @@
       "recreateWhen": "never"
     },
     {
-      "matchManagers": ["npm"],
-      "rangeStrategy": "pin"
-    },
-    {
       "matchPackageNames": [
         "com.atlassian.jira:jira-rest-java-client-api",
         "com.atlassian.jira:jira-rest-java-client-app"
@@ -46,6 +42,7 @@
     },
     {
       "matchManagers": ["npm"],
+      "rangeStrategy": "pin",
       "schedule": "after 9pm on wednesday"
     }
   ],


### PR DESCRIPTION
This is a fixup for 360b9cf.

I was wondering why Renovate didn't start pinning the dependencies, the merge makes the reason obvious.