### PR TITLE
fix(downloader): Support (Git) working trees without a remote

### DIFF
--- a/downloader/src/main/kotlin/WorkingTree.kt
+++ b/downloader/src/main/kotlin/WorkingTree.kt
@@ -37,7 +37,13 @@ abstract class WorkingTree(val workingDir: File, val vcsType: VcsType) {
      * [workingDir] to [getRootPath]. It is not related to the path argument that was used for downloading, and at the
      * example of Git, it does not reflect the (single) path that was cloned in a sparse checkout.
      */
-    open fun getInfo() = VcsInfo(vcsType, getRemoteUrl(), getRevision(), path = getPathToRoot(workingDir))
+    open fun getInfo() =
+        VcsInfo(
+            type = vcsType,
+            url = runCatching { getRemoteUrl() }.getOrDefault(""),
+            revision = getRevision(),
+            path = getPathToRoot(workingDir)
+        )
 
     /**
      * Return the map of nested repositories, for example Git submodules or Git-Repo modules. The key is the path to the


### PR DESCRIPTION
Even if provenance is not really known / comprehensible when a (Git) working tree has no remote / public copy of the revision, there is not strict technical reason to not support this edge-case.

Fixes #11370.