### PR TITLE
build(gradle): Use the Kotlin BOM to align `kotlin-reflect` versions

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -77,13 +77,11 @@ dependencies {
 
     detektPlugins(libs.plugin.detekt.formatting)
 
+    implementation(enforcedPlatform(libs.kotlin.bom))
+
     implementation(libs.log4j.api.kotlin)
 
     constraints {
-        implementation("org.jetbrains.kotlin:kotlin-reflect:${libs.versions.kotlinPlugin.get()}") {
-            because("All transitive versions of Kotlin reflect need to match ORT's version of Kotlin.")
-        }
-
         implementation(libs.jruby) {
             because("JRuby used by Bundler directly and by AsciidoctorJ transitively must match.")
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -134,6 +134,7 @@ kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", ve
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinPlugin" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet"}
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet"}
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }


### PR DESCRIPTION
Instead of just aligning `kotlin-reflect` versions, play safe and use Kotlin's BOM to align all Kotlin library versions.

Also see [1].

[1]: https://github.com/eclipse-apoapsis/ort-server/pull/4427