### PR TITLE
ci(github): Use CodeQL nightly for Kotlin 2.3.10 support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,7 @@ jobs:
       uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4
       with:
         languages: java
+        tools: nightly
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5
     - name: Build all classes


### PR DESCRIPTION
CodeQL is quite slow catching up with Kotlin versions, so switch to the nightly releases to get support as quickly as possible, see [1].

[1]: https://github.com/github/codeql/issues/20661#issuecomment-3872361703