### PR TITLE
Revert "fix(docker): Copy only cargo directory instead of full Rust installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -585,8 +585,9 @@ COPY --from=nodejs --chown=$USER:$USER $NVM_DIR $NVM_DIR
 # Rust
 ENV RUST_HOME=/opt/rust
 ENV CARGO_HOME=$RUST_HOME/cargo
-ENV PATH=$PATH:$CARGO_HOME/bin
-COPY --from=rust --chown=$USER:$USER $CARGO_HOME $CARGO_HOME
+ENV RUSTUP_HOME=$RUST_HOME/rustup
+ENV PATH=$PATH:$CARGO_HOME/bin:$RUSTUP_HOME/bin
+COPY --from=rust --chown=$USER:$USER $RUST_HOME $RUST_HOME
 RUN chmod o+rwx $CARGO_HOME
 
 # cargo-credential-netrc


### PR DESCRIPTION
This reverts commit d7f1669 as it breaks Cargo analysis with:

```
error: rustup could not choose a version of cargo to run, because one
wasn't specified explicitly, and no default is configured.

help: run 'rustup default stable' to download the latest stable release of
Rust and set it as your default toolchain.
```