### PR TITLE
fix(fossid): Avoid parsing plain text comments as ORT JSON

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -63,6 +63,12 @@ import org.ossreviewtoolkit.utils.spdx.toSpdx
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())
 
 /**
+ * The JSON key for ORT comments. This is more specific than [ORT_NAME] to avoid matching plain text comments that
+ * happen to contain the word "ort".
+ */
+private const val ORT_COMMENT_KEY = "\"$ORT_NAME\":"
+
+/**
  * A data class to hold FossID raw results.
  */
 internal data class RawResults(
@@ -148,7 +154,7 @@ internal fun <T : Summarizable> List<T>.mapSummary(
 
         if (summarizable is MarkedAsIdentifiedFile) {
             summarizable.comments.value?.values?.firstOrNull {
-                ORT_NAME in it.comment
+                ORT_COMMENT_KEY in it.comment
             }?.also {
                 runCatching {
                     fileComment = jsonMapper.readValue(it.comment, OrtComment::class.java)
@@ -453,7 +459,7 @@ internal fun listUnmatchedSnippetChoices(
         }
 
         val comment = markedAsIdentifiedFile.comments.value?.values?.firstOrNull {
-            ORT_NAME in it.comment
+            ORT_COMMENT_KEY in it.comment
         }?.runCatching {
             jsonMapper.readValue(this.comment, OrtComment::class.java)
         }?.onFailure {

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdLicenseMappingTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.plugins.scanners.fossid
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -148,6 +149,25 @@ class FossIdLicenseMappingTest : WordSpec({
                 snippets.first() shouldNotBeNull {
                     license shouldBe SpdxConstants.NOASSERTION.toSpdx()
                 }
+            }
+        }
+
+        "ignore plain text comments containing 'ort' substring" {
+            val testCases = listOf(
+                "MIT" to "See report for details",
+                "Apache-2.0" to "Please export this report"
+            )
+
+            testCases.forEach { (license, comment) ->
+                val sampleFile = createMarkAsIdentifiedFile(
+                    license, FILE_PATH, comment, includeLicensesWithComment = true
+                )
+                val issues = mutableListOf<Issue>()
+
+                val findings = listOf(sampleFile).mapSummary(emptyMap(), issues, emptyMap())
+
+                issues should beEmpty()
+                findings.licenseFindings.map { it.license.toString() } should containExactly(license)
             }
         }
     }

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -386,12 +386,16 @@ private fun createMarkedIdentifiedFile(index: Int): MarkedAsIdentifiedFile {
 }
 
 /**
- * Create a [MarkedAsIdentifiedFile] with the give [license] and [path].
+ * Create a [MarkedAsIdentifiedFile] with the given [license] and [path]. When [comment] is provided and
+ * [includeLicensesWithComment] is false (the default), the file's licenses will be set to null, as is expected when
+ * the comment contains ORT JSON with authoritative license information. Set [includeLicensesWithComment] to true
+ * when testing plain text comments that should not override the file's license.
  */
 internal fun createMarkAsIdentifiedFile(
     license: String,
     path: String,
-    comment: String? = null
+    comment: String? = null,
+    includeLicensesWithComment: Boolean = false
 ): MarkedAsIdentifiedFile {
     val fileLicense = License(
         id = 1,
@@ -413,6 +417,8 @@ internal fun createMarkAsIdentifiedFile(
         )
     }
 
+    val includeLicenses = comment == null || includeLicensesWithComment
+
     return MarkedAsIdentifiedFile(
         comment = "comment",
         comments = PolymorphicData(if (comment == null) emptyMap() else mapOf(1 to Comment(1, 1, comment))),
@@ -428,7 +434,7 @@ internal fun createMarkAsIdentifiedFile(
             sha1 = "fileSha1",
             sha256 = "fileSha256",
             size = 0,
-            licenses = PolymorphicData(if (comment != null) null else mutableMapOf(1 to fileLicense))
+            licenses = PolymorphicData(if (includeLicenses) mutableMapOf(1 to fileLicense) else null)
         )
     }
 }


### PR DESCRIPTION
Previously, comments containing the substring "ort" (e.g., "See report for details" or "Please export this report") would incorrectly trigger JSON parsing, causing deserialization errors. The fix checks for the JSON property key format `"ort":` instead of just the substring "ort".