### PR TITLE
ci(renovate): Switch to the `pinGitHubActionDigestsToSemver` preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     "docker:disable",
-    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver",
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)"
   ],


### PR DESCRIPTION
The preset [1] adds comments with the full semver instead of only the major version next to the digests. This also improves the Renovate commit messages to include the version instead of the digest, and the PR description will also include the changelog of the version.

[1]: https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
