### PR TITLE
test(pnpm): Ensure to use a consistent PNPM version

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/babel/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/oss-review-toolkit/ort.git"
   },
+  "packageManager": "pnpm@10.29.2",
   "dependencies": {
     "babel-cli": "6.26.0"
   }

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/nested-project/package.json
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "author": "The Author <the.author@mail.example> (https://www.the.author.example/index.html)",
   "private": true,
+  "packageManager": "pnpm@10.29.2",
   "dependencies": {
     "cheerio": "1.0.0-rc.1",
     "long": "^3.2.0",

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/project-with-lockfile/package.json
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "author": "The Author <the.author@mail.example> (https://www.the.author.example/index.html)",
   "private": true,
+  "packageManager": "pnpm@10.29.2",
   "dependencies": {
     "cheerio": "1.0.0-rc.1",
     "long": "^3.2.0",

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/pnpm/workspaces/package.json
@@ -7,9 +7,9 @@
   "license": "MIT",
   "main": "index.js",
   "engines": {
-    "node": ">16.0.0",
-    "pnpm": ">=5"
+    "node": ">16.0.0"
   },
+  "packageManager": "pnpm@10.29.2",
   "scripts": {},
   "dependencies": {
     "json-stable-stringify": "1.0.1",


### PR DESCRIPTION
Use the Corepack feature to bootstrap PNPM in fixed version 10.29.2 for reproducibility. Note that this deliberately does not use current version 10.29.3 yet (which fixes out of memory issues) as taking that into use requires more changes to compensate for dependency deduplication now done on the PNPM side.