### PR TITLE
test: Use the more generic Testcontainers instead of `otj-pg-embedded`

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -74,7 +74,7 @@ repositories {
 
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute(module("org.lz4:lz4-java:1.4.1"))
+        substitute(module("org.lz4:lz4-java"))
             .using(module("at.yawk.lz4:lz4-java:1.10.3"))
             .because("lz4-java is unmaintained and vulnerable to CVE‐2025‐12183")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ mockk = "1.14.9"
 mordant = "3.0.2"
 okhttp = "5.3.2"
 postgres = "42.7.10"
-postgresEmbedded = "1.1.1"
 reflections = "0.10.2"
 retrofit = "3.0.0"
 s3 = "2.41.27"
@@ -131,6 +130,7 @@ kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.
 kotest-assertions-table = { module = "io.kotest:kotest-assertions-table", version.ref = "kotest" }
 kotest-extensions = { module = "io.kotest:kotest-extensions", version.ref = "kotest" }
 kotest-extensions-junitXml = { module = "io.kotest:kotest-extensions-junitxml", version.ref = "kotest" }
+kotest-extensions-testcontainers = { module = "io.kotest:kotest-extensions-testcontainers", version.ref = "kotest" }
 kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
@@ -169,7 +169,6 @@ mordantCoroutines = { module = "com.github.ajalt.mordant:mordant-coroutines", ve
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
-postgresEmbedded = { module = "com.opentable.components:otj-pg-embedded", version.ref = "postgresEmbedded" }
 reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converter-jackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "retrofit" }

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     api(projects.model)
     api(projects.plugins.versionControlSystems.gitVersionControlSystem)
 
+    api(libs.hikari)
     api(libs.kotest.assertions.core)
     api(libs.kotest.extensions)
     api(libs.logbackClassic) {
@@ -35,18 +36,13 @@ dependencies {
     implementation(projects.downloader)
     implementation(projects.utils.ortUtils)
 
-    implementation(libs.diffUtils)
     implementation(jacksonLibs.jacksonModuleKotlin)
+    implementation(libs.diffUtils)
     implementation(libs.jsonSchemaValidator)
     implementation(libs.kotest.extensions.junitXml)
+    implementation(libs.kotest.extensions.testcontainers)
     implementation(libs.kotest.framework.engine)
-    implementation(libs.postgresEmbedded)
-
-    constraints {
-        implementation(libs.testcontainers.postgresql) {
-            because("A newer version is required for Docker 29.0.0 compatibility.")
-        }
-    }
+    implementation(libs.testcontainers.postgresql)
 
     runtimeOnly(libs.log4j.api.slf4j)
 }


### PR DESCRIPTION
This requires to generalize the `lz4-java` substitution as another version is taken into use transitively.