### PR TITLE
Bugfix: Conans Header only Libraries are excluded from dependency graph

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
@@ -110,7 +110,7 @@ private data class PackageInfoV2Raw(
                 homepage = it.homepage,
                 label = it.label,
                 requires = it.dependencies.values.filter { dep ->
-                    dep.direct && dep.libs && dep.visible
+                    dep.direct && dep.visible
                 }.map { dep2 -> dep2.ref },
                 buildRequires = it.dependencies.values.filter { dep ->
                     dep.build && dep.direct


### PR DESCRIPTION
Closes #11381.

The problem was that in parseDependencyTree the contents were filtered by dep.libs which is false for header only libraries. But because we are filtering beforehand what we even want in our findings i think its safe to remove that flag.

In conan 1 handler there is no filtering at all implemented. There the dependencies are taken as is
