### PR TITLE
feat(scanner): Optimize creation of file archives

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -754,10 +754,15 @@ class Scanner(
 
         if (provenancesWithMissingArchives.isEmpty()) return
 
-        logger.info { "Creating file archives for ${provenancesWithMissingArchives.size} package(s)." }
+        val packagesByProvenance = provenancesWithMissingArchives.entries.groupBy { it.value }
+            .mapValues { e -> e.value.map { it.key } }
+        logger.info {
+            "Creating file archives for ${provenancesWithMissingArchives.size} package(s) from " +
+                "${packagesByProvenance.size} provenance(s)."
+        }
 
         val duration = measureTime {
-            provenancesWithMissingArchives.forEach { (pkg, nestedProvenance) ->
+            packagesByProvenance.forEach { (nestedProvenance, packages) ->
                 var dir: File? = null
 
                 // runCatching has a bug with smart-cast, see https://youtrack.jetbrains.com/issue/KT-27748.
@@ -765,21 +770,26 @@ class Scanner(
                     dir = provenanceDownloader.downloadRecursively(nestedProvenance)
                     archiver.archive(dir, nestedProvenance.root)
                 } catch (e: DownloadException) {
-                    controller.addIssue(
-                        pkg.id,
-                        Issue(
-                            source = "Scanner",
-                            message = "Could not create file archive for '${pkg.id.toCoordinates()}': "
-                                + e.collectMessages()
+                    packages.forEach { pkg ->
+                        controller.addIssue(
+                            pkg.id,
+                            Issue(
+                                source = "Scanner",
+                                message = "Could not create file archive for '${pkg.id.toCoordinates()}': "
+                                    + e.collectMessages()
+                            )
                         )
-                    )
+                    }
                 } finally {
                     dir?.safeDeleteRecursively()
                 }
             }
         }
 
-        logger.info { "Created file archives for ${provenancesWithMissingArchives.size} package(s) in $duration." }
+        logger.info {
+            "Created file archives for ${provenancesWithMissingArchives.size} package(s) from " +
+                "${packagesByProvenance.size} provenance(s) in $duration."
+        }
     }
 }
 


### PR DESCRIPTION
When processing provenances with multiple packages, for each package, the provenance was downloaded to create the file archive. Prevent this by grouping the packages by provenance and do only a single download. This can have a significant effect for large repositories containing many submodules.
