### PR TITLE
refactor(docker): Use cosign image instead of downloading binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -461,32 +461,33 @@ COPY --from=bazelbuild /opt/bazel /opt/bazel
 COPY --from=bazelbuild /opt/go/bin/buildozer /opt/go/bin/buildozer
 
 #------------------------------------------------------------------------
+# Cosign for signature verification
+FROM ghcr.io/sigstore/cosign/cosign:v$COSIGN_VERSION AS cosign
+
+#------------------------------------------------------------------------
 # Elixir (Mix SBoM)
 FROM base AS mix_sbom_build
 
-ARG COSIGN_VERSION
+COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
+
 ARG MIX_SBOM_VERSION
 
 ENV MIX_SBOM_HOME=/opt/mix_sbom
 
-# Download cosign binary, verify mix_sbom binary signature, then clean up
-RUN COSIGN_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-    && curl -sSL "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${COSIGN_ARCH}" \
-       -o /tmp/cosign \
-    && chmod +x /tmp/cosign \
-    && mkdir -p $MIX_SBOM_HOME/bin \
+# Download and verify mix_sbom binary signature
+RUN mkdir -p $MIX_SBOM_HOME/bin \
     && ARCH=$(arch | sed s/aarch64/ARM64/ | sed s/x86_64/X64/) \
     && curl -sSL "https://github.com/erlef/mix_sbom/releases/download/v${MIX_SBOM_VERSION}/mix_sbom_Linux_${ARCH}" \
        -o $MIX_SBOM_HOME/bin/mix_sbom \
     && curl -sSL "https://github.com/erlef/mix_sbom/releases/download/v${MIX_SBOM_VERSION}/mix_sbom_Linux_${ARCH}.sigstore" \
        -o /tmp/mix_sbom.sigstore \
-    && /tmp/cosign verify-blob \
+    && cosign verify-blob \
        --bundle /tmp/mix_sbom.sigstore \
        --certificate-identity-regexp "^https://github.com/erlef/mix_sbom/.*@refs/tags/v${MIX_SBOM_VERSION}$" \
        --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
        $MIX_SBOM_HOME/bin/mix_sbom \
     && chmod a+x $MIX_SBOM_HOME/bin/mix_sbom \
-    && rm /tmp/mix_sbom.sigstore /tmp/cosign \
+    && rm /tmp/mix_sbom.sigstore \
     && $MIX_SBOM_HOME/bin/mix_sbom --version
 
 FROM scratch AS elixir
@@ -496,28 +497,26 @@ COPY --from=mix_sbom_build /opt/mix_sbom /opt/mix_sbom
 # Erlang (Rebar3 SBoM wrapped in Bombom)
 FROM base AS rebar3_sbom_build
 
+COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
+
 ARG BOMBOM_VERSION
-ARG COSIGN_VERSION
 
 ENV BOMBOM_HOME=/opt/bombom
 
-# Download cosign binary, verify bombom binary signature, then clean up
-RUN ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-    && curl -sSL "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${ARCH}" \
-       -o /tmp/cosign \
-    && chmod +x /tmp/cosign \
-    && mkdir -p $BOMBOM_HOME/bin \
+# Download and verify bombom binary signature
+RUN mkdir -p $BOMBOM_HOME/bin \
+    && ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && curl -sSL "https://github.com/erlef/bombom/releases/download/${BOMBOM_VERSION}/bombom-linux-${ARCH}.bin" \
        -o $BOMBOM_HOME/bin/bombom \
     && curl -sSL "https://github.com/erlef/bombom/releases/download/${BOMBOM_VERSION}/bombom-linux-${ARCH}.bin.sigstore" \
        -o /tmp/bombom.sigstore \
-    && /tmp/cosign verify-blob \
+    && cosign verify-blob \
        --bundle /tmp/bombom.sigstore \
        --certificate-identity-regexp "^https://github.com/erlef/bombom/.*@refs/tags/${BOMBOM_VERSION}$" \
        --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
        $BOMBOM_HOME/bin/bombom \
     && chmod a+x $BOMBOM_HOME/bin/bombom \
-    && rm /tmp/bombom.sigstore /tmp/cosign
+    && rm /tmp/bombom.sigstore
 
 FROM scratch AS erlang
 COPY --from=rebar3_sbom_build /opt/bombom /opt/bombom
@@ -554,30 +553,27 @@ COPY --from=ortbuild /opt/ort /opt/ort
 # Gleam
 FROM base AS gleambuild
 
-ARG COSIGN_VERSION
+COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
+
 ARG GLEAM_VERSION
 
 ENV GLEAM_HOME=/opt/gleam
 
-# Download cosign binary, verify Gleam binary signature, then clean up
-RUN COSIGN_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-    && curl -sSL "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${COSIGN_ARCH}" \
-       -o /tmp/cosign \
-    && chmod +x /tmp/cosign \
-    && mkdir -p $GLEAM_HOME/bin \
+# Download and verify Gleam binary signature
+RUN mkdir -p $GLEAM_HOME/bin \
     && ARCH=$(arch) \
     && curl -sSL "https://github.com/gleam-lang/gleam/releases/download/v${GLEAM_VERSION}/gleam-v${GLEAM_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
        -o /tmp/gleam.tar.gz \
     && curl -sSL "https://github.com/gleam-lang/gleam/releases/download/v${GLEAM_VERSION}/gleam-v${GLEAM_VERSION}-${ARCH}-unknown-linux-musl.tar.gz.sigstore" \
        -o /tmp/gleam.sigstore \
-    && /tmp/cosign verify-blob \
+    && cosign verify-blob \
        --bundle /tmp/gleam.sigstore \
        --certificate-identity-regexp "^https://github.com/gleam-lang/gleam/.*@refs/tags/v${GLEAM_VERSION}$" \
        --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
        /tmp/gleam.tar.gz \
     && tar -xzf /tmp/gleam.tar.gz -C $GLEAM_HOME/bin \
     && chmod a+x $GLEAM_HOME/bin/gleam \
-    && rm /tmp/gleam.tar.gz /tmp/gleam.sigstore /tmp/cosign \
+    && rm /tmp/gleam.tar.gz /tmp/gleam.sigstore \
     && $GLEAM_HOME/bin/gleam --version
 
 FROM scratch AS gleam


### PR DESCRIPTION
Copy the cosign binary directly from the official sigstore cosign image instead of downloading it via curl in each build stage.
