### PR TITLE
Revert "ci(github): Downgrade Flox to 1.8.4"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,7 +72,6 @@ jobs:
       uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # v2.3.0
       with:
         disable-metrics: true
-        version: 1.8.4
       if: runner.os != 'Windows'
     - name: Run unit tests in a minimal environment
       run: ./flox/run_isolated.sh minimal ./gradlew --scan test jacocoTestReport
@@ -102,7 +101,6 @@ jobs:
       uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # v2.3.0
       with:
         disable-metrics: true
-        version: 1.8.4
     - name: Run functional tests that do not require external tools
       run: ./flox/run_isolated.sh minimal ./gradlew --scan -Dkotest.tags=!RequiresExternalTool funTest jacocoFunTestReport
     - name: Create Test Summary


### PR DESCRIPTION
This reverts commit 2951d4d. The issue with `env -i` has been fixed with current Flox 1.9.1, see [1].

[1]: https://github.com/flox/flox/releases/tag/v1.9.1