### PR TITLE
chore(npm): Improve the detection of multi-line hints

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -282,8 +282,13 @@ internal fun List<String>.groupLines(vararg markers: String): List<String> {
         "path ",
         "syscall "
     )
-    val singleLinePrefixes =
-        setOf("deprecated ", "invalid: ", "missing: ", "skipping integrity check for git dependency ")
+    val singleLinePrefixes = setOf(
+        "deprecated ",
+        "gitignore-fallback ",
+        "invalid: ",
+        "missing: ",
+        "skipping integrity check for git dependency "
+    )
     val minCommonPrefixLength = 5
 
     val issueLines = mapNotNull { line ->
@@ -337,6 +342,7 @@ internal fun List<String>.groupLines(vararg markers: String): List<String> {
 
     // If no lines but the last end with a dot, assume the message to be a single sentence.
     val isMultiLineSentence = nonFooterLines.size > 1
+        && nonFooterLines.none { line -> singleLinePrefixes.any { line.startsWith(it) } }
         && nonFooterLines.last().endsWith('.')
         && nonFooterLines.subList(0, nonFooterLines.size - 1).none { it.endsWith('.') }
 


### PR DESCRIPTION
Add "gitignore-fallback " as a pattern and ensure it is not used as a prefix for multi-line hints.