### PR TITLE
test(spdx): Upgrade assets to SPDX 2.3 and "PACKAGE-MANAGER" spelling

### DIFF
--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/DEPENDS_ON-packages/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/DEPENDS_ON-packages/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -50,7 +50,7 @@ packages:
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
   downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
   externalRefs:
-  - referenceCategory: "PACKAGE_MANAGER"
+  - referenceCategory: "PACKAGE-MANAGER"
     referenceLocator: "pkg:a-name/openssl@1.1.1g"
     referenceType: "purl"
   - referenceCategory: "SECURITY"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/cyclic-references/project-cyclic.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/cyclic-references/project-cyclic.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -72,7 +72,7 @@ packages:
     copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
     downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
     externalRefs:
-      - referenceCategory: "PACKAGE_MANAGER"
+      - referenceCategory: "PACKAGE-MANAGER"
         referenceLocator: "pkg:a-name/openssl@1.1.1g"
         referenceType: "purl"
       - referenceCategory: "SECURITY"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/illegal-chars-external-refs/illegal_chars/package.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/illegal-chars-external-refs/illegal_chars/package.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2022-06-29T00:00:00Z"
   creators:

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/illegal-chars-external-refs/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/illegal-chars-external-refs/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2024-07-08T18:30:22Z"
   creators:

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/inline-packages/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/inline-packages/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -50,7 +50,7 @@ packages:
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
   downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
   externalRefs:
-  - referenceCategory: "PACKAGE_MANAGER"
+  - referenceCategory: "PACKAGE-MANAGER"
     referenceLocator: "pkg:a-name/openssl@1.1.1g"
     referenceType: "purl"
   - referenceCategory: "SECURITY"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/curl/package.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/curl/package.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/my-lib/package.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/my-lib/package.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2021-12-10T14:25:11Z"
   creators:
@@ -16,17 +16,17 @@ externalDocumentRefs:
     spdxDocument: "../curl/package.spdx.yml"
     checksum:
       algorithm: "SHA1"
-      checksumValue: "73d64ad650d6e1fa418b70985f24d937d1151186"
+      checksumValue: "8cbc8f1717ed9e8927d404ec5ebd5fc44c4ba2b4"
   - externalDocumentId: "DocumentRef-openssl-1.1.1g"
     spdxDocument: "../openssl/package.spdx.yml"
     checksum:
       algorithm: "SHA1"
-      checksumValue: "3d38c716b5d7f75c893b8b2720b7c85aca7776ae"
+      checksumValue: "b7465918efa625d4c1aac9e6d7875b7d6f0883dc"
   - externalDocumentId: "DocumentRef-zlib-1.2.11"
     spdxDocument: "../zlib/package.spdx.yml"
     checksum:
       algorithm: "SHA1"
-      checksumValue: "c3d22d3fbff30a845d57e9fa19e0b5f453b7b0ee"
+      checksumValue: "ae9c109f887e7afd1f41a12c9d4ec0b30b4078a6"
 packages:
 - SPDXID: "SPDXRef-Package-my-lib"
   description: "A custom library that does nothing, but depend on other packages"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/openssl/package.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/openssl/package.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -20,7 +20,7 @@ packages:
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
   downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
   externalRefs:
-  - referenceCategory: "PACKAGE_MANAGER"
+  - referenceCategory: "PACKAGE-MANAGER"
     referenceLocator: "pkg:a-name/openssl@1.1.1g"
     referenceType: "purl"
   - referenceCategory: "SECURITY"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/zlib/package.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/libs/zlib/package.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2021-03-05T13:43:22Z"
   creators:

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/package-references/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/package-references/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -16,17 +16,17 @@ externalDocumentRefs:
   spdxDocument: "../libs/curl/package.spdx.yml"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "73d64ad650d6e1fa418b70985f24d937d1151186"
+    checksumValue: "8cbc8f1717ed9e8927d404ec5ebd5fc44c4ba2b4"
 - externalDocumentId: "DocumentRef-openssl-1.1.1g"
   spdxDocument: "../libs/openssl/package.spdx.yml"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "3d38c716b5d7f75c893b8b2720b7c85aca7776ae"
+    checksumValue: "b7465918efa625d4c1aac9e6d7875b7d6f0883dc"
 - externalDocumentId: "DocumentRef-zlib-1.2.11"
   spdxDocument: "../libs/zlib/package.spdx.yml"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "c3d22d3fbff30a845d57e9fa19e0b5f453b7b0ee"
+    checksumValue: "ae9c109f887e7afd1f41a12c9d4ec0b30b4078a6"
 packages:
 - SPDXID: "SPDXRef-Package-xyz"
   description: "Awesome product created by Example Inc."

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-conan/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-conan/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -16,7 +16,7 @@ externalDocumentRefs:
     spdxDocument: "./subproject/subproject-with-conan-reference.spdx.yml"
     checksum:
       algorithm: "SHA1"
-      checksumValue: "032a087b0da8f353c03671a72179b807b4ec7eb3"
+      checksumValue: "2ecc1c19d9f91fed1cae5ec24d082068c2137307"
 packages:
   - SPDXID: "SPDXRef-Package-xyz"
     description: "Awesome product created by Example Inc."

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-conan/subproject/subproject-with-conan-reference.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-conan/subproject/subproject-with-conan-reference.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2022-07-06T12:00:00Z"
   creators:
@@ -20,6 +20,6 @@ packages:
     versionInfo: "1.0.0"
     packageFileName: "./conanfile.py"
     externalRefs:
-    - referenceCategory: "PACKAGE_MANAGER"
+    - referenceCategory: "PACKAGE-MANAGER"
       referenceLocator: "pkg:conan/example.org/sub-conan@0.1.0?scope=requires"
       referenceType: "purl"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-dependencies/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-dependencies/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-dependencies/subproject/subproject-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/subproject-dependencies/subproject/subproject-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2022-06-29T08:57:22Z"
   creators:
@@ -49,7 +49,7 @@ packages:
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
   downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
   externalRefs:
-  - referenceCategory: "PACKAGE_MANAGER"
+  - referenceCategory: "PACKAGE-MANAGER"
     referenceLocator: "pkg:a-name/openssl@1.1.1g"
     referenceType: "purl"
   - referenceCategory: "SECURITY"

--- a/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/transitive-dependencies/project-xyz.spdx.yml
+++ b/plugins/package-managers/spdx/src/funTest/assets/projects/synthetic/transitive-dependencies/project-xyz.spdx.yml
@@ -1,5 +1,5 @@
 SPDXID: "SPDXRef-DOCUMENT"
-spdxVersion: "SPDX-2.2"
+spdxVersion: "SPDX-2.3"
 creationInfo:
   created: "2020-07-23T18:30:22Z"
   creators:
@@ -21,7 +21,7 @@ externalDocumentRefs:
   spdxDocument: "../libs/zlib/package.spdx.yml"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "c3d22d3fbff30a845d57e9fa19e0b5f453b7b0ee"
+    checksumValue: "ae9c109f887e7afd1f41a12c9d4ec0b30b4078a6"
 packages:
 - SPDXID: "SPDXRef-Package-xyz"
   description: "Awesome product created by Example Inc."


### PR DESCRIPTION
This silences and IntelliJ IDEA inspection hint when validating the schema. Also see ec93c3c.