### PR TITLE
refactor!: Maintain the name of a script in result messages, if possible

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -155,9 +155,9 @@ class ExamplesFunTest : StringSpec({
             licenseClassifications = licenseFile.readValue()
         )
 
-        val script = takeExampleFile("example.rules.kts").readText()
+        val script = takeExampleFile("example.rules.kts")
 
-        val result = evaluator.run(script)
+        val result = evaluator.runScript(script)
 
         result.violations.map { it.rule } should containExactlyInAnyOrder(
             "COPYLEFT_LIMITED_IN_SOURCE",
@@ -190,9 +190,9 @@ class ExamplesFunTest : StringSpec({
             )
         )
 
-        val script = takeExampleFile("example.notifications.kts").readText()
+        val script = takeExampleFile("example.notifications.kts")
 
-        notifier.run(script)
+        notifier.runScript(script)
 
         greenMail.waitForIncomingEmail(1000, 1) shouldBe true
         val actualBody = GreenMailUtil.getBody(greenMail.receivedMessages.first())

--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.evaluator
 import java.time.Instant
 
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
+import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
@@ -42,7 +43,7 @@ class Evaluator(
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider.create(),
     licenseClassifications: LicenseClassifications = LicenseClassifications(),
     time: Instant = Instant.now()
-) : ScriptRunner() {
+) : ScriptRunner<EvaluatorRun>() {
     override val compConfig = createJvmCompilationConfigurationFromTemplate<RulesScriptTemplate>()
 
     override val evalConfig = ScriptEvaluationConfiguration {
@@ -50,11 +51,13 @@ class Evaluator(
         scriptsInstancesSharing(true)
     }
 
-    fun run(vararg scripts: String): EvaluatorRun {
+    override fun runScript(script: SourceCode) = runScripts(listOf(script))
+
+    fun runScripts(scripts: Collection<SourceCode>): EvaluatorRun {
         val startTime = Instant.now()
 
         val violations = scripts.flatMapTo(mutableListOf()) {
-            val scriptInstance = runScript(it).scriptInstance as RulesScriptTemplate
+            val scriptInstance = run(it).scriptInstance as RulesScriptTemplate
             scriptInstance.ruleViolations
         }
 

--- a/evaluator/src/test/kotlin/EvaluatorTest.kt
+++ b/evaluator/src/test/kotlin/EvaluatorTest.kt
@@ -30,13 +30,14 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.spdx.toSpdx
+import org.ossreviewtoolkit.utils.test.getResource
 import org.ossreviewtoolkit.utils.test.ortResult
 import org.ossreviewtoolkit.utils.test.readResource
 
 class EvaluatorTest : WordSpec({
     "checkSyntax" should {
         "succeed if the script can be compiled" {
-            val script = readResource("/rules/osadl.rules.kts")
+            val script = getResource("/rules/osadl.rules.kts")
 
             val result = Evaluator(ortResult).checkSyntax(script)
 
@@ -56,13 +57,13 @@ class EvaluatorTest : WordSpec({
 
     "evaluate" should {
         "return no rule violations for an empty script" {
-            val result = Evaluator(ortResult).run("")
+            val result = Evaluator(ortResult).runScript("")
 
             result.violations should beEmpty()
         }
 
         "be able to access the ORT result" {
-            val result = Evaluator(ortResult).run(
+            val result = Evaluator(ortResult).runScript(
                 """
                 require(ortResult.labels["label"] == "value") { "Failed to verify the ORT result." }
                 """.trimIndent()
@@ -72,7 +73,7 @@ class EvaluatorTest : WordSpec({
         }
 
         "contain rule violations in the result" {
-            val result = Evaluator(ortResult).run(
+            val result = Evaluator(ortResult).runScript(
                 """
                 ruleViolations += RuleViolation(
                     rule = "rule 1",
@@ -150,7 +151,7 @@ class EvaluatorTest : WordSpec({
 
             val script = readResource("/rules/osadl.rules.kts")
 
-            val result = Evaluator(compatibleOrtResult).run(script)
+            val result = Evaluator(compatibleOrtResult).runScript(script)
 
             result.violations should beEmpty()
         }
@@ -184,7 +185,7 @@ class EvaluatorTest : WordSpec({
 
             val script = readResource("/rules/osadl.rules.kts")
 
-            val result = Evaluator(incompatibleOrtResult).run(script)
+            val result = Evaluator(incompatibleOrtResult).runScript(script)
 
             result.violations.map { it.message } should containExactlyInAnyOrder(
                 "The outbound license AGPL-3.0-or-later of project 'Maven:group:project-foo:1' is incompatible " +
@@ -218,7 +219,7 @@ class EvaluatorTest : WordSpec({
 
             val script = readResource("/rules/osadl.rules.kts")
 
-            val result = Evaluator(incompatibleOrtResult).run(script)
+            val result = Evaluator(incompatibleOrtResult).runScript(script)
 
             result.violations should haveSize(1)
             result.violations.first().message shouldBe "The outbound license Apache-2.0 of project " +

--- a/notifier/src/main/kotlin/Notifier.kt
+++ b/notifier/src/main/kotlin/Notifier.kt
@@ -23,6 +23,7 @@ import java.time.Instant
 
 import kotlin.script.experimental.api.KotlinType
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
+import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.providedProperties
 import kotlin.script.experimental.api.scriptsInstancesSharing
@@ -41,7 +42,7 @@ class Notifier(
     ortResult: OrtResult = OrtResult.EMPTY,
     config: NotifierConfiguration = NotifierConfiguration(),
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider()
-) : ScriptRunner() {
+) : ScriptRunner<NotifierRun>() {
     private val customProperties = buildMap {
         config.mail?.let { put("mailClient", MailNotifier(it)) }
         config.jira?.let { put("jiraClient", JiraNotifier(it)) }
@@ -60,9 +61,9 @@ class Notifier(
         providedProperties(customProperties)
     }
 
-    fun run(script: String): NotifierRun {
+    override fun runScript(script: SourceCode): NotifierRun {
         val startTime = Instant.now()
-        runScript(script)
+        run(script)
         val endTime = Instant.now()
 
         return NotifierRun(startTime, endTime)

--- a/notifier/src/test/kotlin/NotifierTest.kt
+++ b/notifier/src/test/kotlin/NotifierTest.kt
@@ -26,8 +26,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.types.beInstanceOf
 
-import kotlin.script.experimental.api.ResultValue
-
+import org.ossreviewtoolkit.model.NotifierRun
 import org.ossreviewtoolkit.model.config.JiraConfiguration
 import org.ossreviewtoolkit.model.config.NotifierConfiguration
 import org.ossreviewtoolkit.model.config.SendMailConfiguration
@@ -46,7 +45,7 @@ class NotifierTest : WordSpec({
                         resolutionProvider as ResolutionProvider
                         """.trimIndent()
                     )
-                    result should beInstanceOf<ResultValue.Value>()
+                    result should beInstanceOf<NotifierRun>()
                 }
 
                 shouldThrow<RuntimeException> {
@@ -66,7 +65,7 @@ class NotifierTest : WordSpec({
                         resolutionProvider as ResolutionProvider
                         """.trimIndent()
                     )
-                    result should beInstanceOf<ResultValue.Value>()
+                    result should beInstanceOf<NotifierRun>()
                 }
             }
         }

--- a/plugins/commands/evaluator/src/main/kotlin/EvaluateCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluateCommand.kt
@@ -36,6 +36,7 @@ import java.io.File
 import java.net.URI
 import java.time.Duration
 
+import kotlin.script.experimental.host.UrlScriptSource
 import kotlin.time.toKotlinDuration
 
 import org.apache.logging.log4j.kotlin.logger
@@ -255,7 +256,7 @@ class EvaluateCommand(descriptor: PluginDescriptor = EvaluateCommandFactory.desc
             var allChecksSucceeded = true
 
             scriptUris.forEach {
-                if (evaluator.checkSyntax(it.toURL().readText())) {
+                if (evaluator.checkSyntax(it.toURL())) {
                     echo("Syntax check for $it succeeded.")
                 } else {
                     echo("Syntax check for $it failed.")
@@ -331,8 +332,7 @@ class EvaluateCommand(descriptor: PluginDescriptor = EvaluateCommandFactory.desc
             licenseClassificationsFile.takeIf { it.isFile }?.readValue<LicenseClassifications>().orEmpty()
         val evaluator = Evaluator(ortResultInput, licenseInfoResolver, resolutionProvider, licenseClassifications)
 
-        val scripts = scriptUris.map { it.toURL().readText() }
-        val evaluatorRun = evaluator.run(*scripts.toTypedArray())
+        val evaluatorRun = evaluator.runScripts(scriptUris.map { UrlScriptSource(it.toURL()) })
 
         if (evaluatorRun.violations.isNotEmpty()) {
             echo("The following ${evaluatorRun.violations.size} rule violations have been found:")

--- a/plugins/commands/notifier/src/main/kotlin/NotifyCommand.kt
+++ b/plugins/commands/notifier/src/main/kotlin/NotifyCommand.kt
@@ -92,20 +92,15 @@ class NotifyCommand(descriptor: PluginDescriptor = NotifyCommandFactory.descript
 
         val notifier = Notifier(ortResult, ortConfig.notifier, resolutionProvider)
 
-        val script = notificationsFile?.readText() ?: readDefaultNotificationsFile()
-        notifier.run(script)
-    }
-
-    private fun readDefaultNotificationsFile(): String {
-        val notificationsFile = ortConfigDirectory / ORT_NOTIFIER_SCRIPT_FILENAME
-
-        if (!notificationsFile.isFile) {
-            throw UsageError(
-                "No notifications file option specified and no default notifications file found at " +
-                    "'$notificationsFile'."
-            )
+        val script = notificationsFile ?: (ortConfigDirectory / ORT_NOTIFIER_SCRIPT_FILENAME).also {
+            if (!it.isFile) {
+                throw UsageError(
+                    "No notifications file option specified and no default notifications file found at " +
+                        "'$notificationsFile'."
+                )
+            }
         }
 
-        return notificationsFile.readText()
+        notifier.runScript(script)
     }
 }

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.reporter
 
 import kotlin.script.experimental.api.ResultValue
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
+import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
@@ -43,7 +44,7 @@ fun interface HowToFixTextProvider {
          * Return the [HowToFixTextProvider] which in-turn has to be returned by the given [script].
          */
         fun fromKotlinScript(script: String, ortResult: OrtResult): HowToFixTextProvider =
-            HowToFixScriptRunner(ortResult).run(script)
+            HowToFixScriptRunner(ortResult).runScript(script)
     }
 
     /**
@@ -53,7 +54,7 @@ fun interface HowToFixTextProvider {
     fun getHowToFixText(issue: Issue): String?
 }
 
-private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner() {
+private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner<HowToFixTextProvider>() {
     override val compConfig = createJvmCompilationConfigurationFromTemplate<HowToFixTextProviderScriptTemplate>()
 
     override val evalConfig = ScriptEvaluationConfiguration {
@@ -61,8 +62,8 @@ private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner() {
         scriptsInstancesSharing(true)
     }
 
-    fun run(script: String): HowToFixTextProvider {
-        val scriptValue = runScript(script) as ResultValue.Value
+    override fun runScript(script: SourceCode): HowToFixTextProvider {
+        val scriptValue = run(script) as ResultValue.Value
         return scriptValue.value as HowToFixTextProvider
     }
 }

--- a/utils/scripting/src/main/kotlin/ScriptRunner.kt
+++ b/utils/scripting/src/main/kotlin/ScriptRunner.kt
@@ -19,13 +19,19 @@
 
 package org.ossreviewtoolkit.utils.scripting
 
+import java.io.File
+import java.net.URL
+
 import kotlin.script.experimental.api.ResultValue
 import kotlin.script.experimental.api.ResultWithDiagnostics
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.ScriptDiagnostic
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
+import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.api.valueOrThrow
-import kotlin.script.experimental.host.toScriptSource
+import kotlin.script.experimental.host.FileScriptSource
+import kotlin.script.experimental.host.StringScriptSource
+import kotlin.script.experimental.host.UrlScriptSource
 import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
 import kotlin.time.measureTimedValue
 
@@ -36,7 +42,7 @@ import org.ossreviewtoolkit.utils.ort.runBlocking
 /**
  * A class providing the framework to run Kotlin scripts.
  */
-abstract class ScriptRunner {
+abstract class ScriptRunner<T> {
     /** The scripting host instance. */
     private val scriptingHost = BasicJvmScriptingHost()
 
@@ -49,9 +55,9 @@ abstract class ScriptRunner {
     /**
      * Check the syntax of the [script] without evaluating it. Return true if syntax is correct, false otherwise.
      */
-    fun checkSyntax(script: String): Boolean {
+    fun checkSyntax(script: SourceCode): Boolean {
         val (result, duration) = measureTimedValue {
-            runBlocking { scriptingHost.compiler.invoke(script.toScriptSource(), compConfig) }
+            runBlocking { scriptingHost.compiler.invoke(script, compConfig) }
         }
 
         logger.info { "Compiling the script took $duration." }
@@ -61,11 +67,25 @@ abstract class ScriptRunner {
         return result is ResultWithDiagnostics.Success
     }
 
+    fun checkSyntax(script: File) = checkSyntax(FileScriptSource(script))
+
+    fun checkSyntax(script: String) = checkSyntax(StringScriptSource(script))
+
+    fun checkSyntax(script: URL) = checkSyntax(UrlScriptSource(script))
+
     /**
-     * Run the given [script], returning a [ResultValue].
+     * Run the given [script], returning a value of type [T].
      */
-    fun runScript(script: String): ResultValue {
-        val result = scriptingHost.eval(script.toScriptSource(), compConfig, evalConfig)
+    abstract fun runScript(script: SourceCode): T
+
+    fun runScript(script: File) = runScript(FileScriptSource(script))
+
+    fun runScript(script: String) = runScript(StringScriptSource(script))
+
+    fun runScript(script: URL) = runScript(UrlScriptSource(script))
+
+    protected fun run(script: SourceCode): ResultValue {
+        val result = scriptingHost.eval(script, compConfig, evalConfig)
 
         logReports(result.reports)
 


### PR DESCRIPTION
Using `SourceCode` instead of a plain string allows the compiler to know about the script name, which is useful in result messages.