### PR TITLE
chore(package-managers): Move project / package types to constants

### DIFF
--- a/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
@@ -78,6 +78,9 @@ import org.ossreviewtoolkit.utils.ort.runBlocking
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Bazel"
+private const val PACKAGE_TYPE = "Bazel"
+
 private const val BAZEL_FALLBACK_VERSION = "7.0.1"
 private const val BAZEL_RC_FILE = ".bazelrc"
 private const val BAZEL_RC_REGISTRY_PATTERN = "common --registry="
@@ -152,7 +155,7 @@ internal object BuildozerCommand : CommandLineTool {
 class Bazel(
     override val descriptor: PluginDescriptor = BazelFactory.descriptor,
     private val config: BazelConfig
-) : PackageManager("Bazel") {
+) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("MODULE", "MODULE.bazel")
 
     /**
@@ -555,7 +558,7 @@ class Bazel(
     private fun BazelModule.toPackageReference(archiveOverrides: Map<String, ArchiveOverride>): PackageReference =
         PackageReference(
             id = Identifier(
-                type = "Bazel",
+                type = PACKAGE_TYPE,
                 namespace = "",
                 name = key.substringBefore("@", ""),
                 version = key.substringAfter("@", "")

--- a/plugins/package-managers/bower/src/main/kotlin/Bower.kt
+++ b/plugins/package-managers/bower/src/main/kotlin/Bower.kt
@@ -40,6 +40,9 @@ import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Bower"
+internal const val PACKAGE_TYPE = "Bower"
+
 internal object BowerCommand : CommandLineTool {
     override fun command(workingDir: File?) = if (Os.isWindows) "bower.cmd" else "bower"
 
@@ -54,7 +57,7 @@ internal object BowerCommand : CommandLineTool {
     description = "The Bower package manager for JavaScript.",
     factory = PackageManagerFactory::class
 )
-class Bower(override val descriptor: PluginDescriptor = BowerFactory.descriptor) : PackageManager("Bower") {
+class Bower(override val descriptor: PluginDescriptor = BowerFactory.descriptor) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("bower.json")
 
     private val graphBuilder = DependencyGraphBuilder(BowerDependencyHandler())

--- a/plugins/package-managers/bower/src/main/kotlin/BowerDependencyHandler.kt
+++ b/plugins/package-managers/bower/src/main/kotlin/BowerDependencyHandler.kt
@@ -46,7 +46,7 @@ internal class BowerDependencyHandler : DependencyHandler<PackageInfo> {
 
 internal fun PackageInfo.toIdentifier() =
     Identifier(
-        type = "Bower",
+        type = PACKAGE_TYPE,
         namespace = "",
         name = pkgMeta.name.orEmpty(),
         version = pkgMeta.version.orEmpty()

--- a/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
+++ b/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
@@ -58,6 +58,9 @@ import org.ossreviewtoolkit.utils.ort.downloadText
 import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
+private const val PROJECT_TYPE = "Bundler"
+private const val PACKAGE_TYPE = "Gem"
+
 /** The name of the helper script resource that resolves a `Gemfile`'s top-level dependencies with group information. */
 private const val ROOT_DEPENDENCIES_SCRIPT_RESOURCE_NAME = "root_dependencies.rb"
 
@@ -119,7 +122,7 @@ data class BundlerConfig(
 class Bundler(
     override val descriptor: PluginDescriptor = BundlerFactory.descriptor,
     private val config: BundlerConfig
-) : PackageManager("Bundler") {
+) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("Gemfile")
 
     override fun beforeResolution(
@@ -254,7 +257,7 @@ class Bundler(
 
         runCatching {
             val gemInfo = gemsInfo.getValue(gemName)
-            val gemId = Identifier("Gem", "", gemInfo.name, gemInfo.version)
+            val gemId = Identifier(PACKAGE_TYPE, "", gemInfo.name, gemInfo.version)
 
             // The project itself can be listed as a dependency if the project is a gem (i.e. there is a .gemspec file
             // for it, and the Gemfile refers to it). In that case, skip querying RubyGems and adding Package and
@@ -322,7 +325,7 @@ class Bundler(
         )
 
     private fun getPackageFromGemInfo(gemInfo: GemInfo): Package {
-        val gemId = Identifier("Gem", "", gemInfo.name, gemInfo.version)
+        val gemId = Identifier(PACKAGE_TYPE, "", gemInfo.name, gemInfo.version)
 
         return Package(
             id = gemId,

--- a/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
@@ -55,6 +55,9 @@ import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxOperator
 
+private const val PROJECT_TYPE = "Cargo"
+private const val PACKAGE_TYPE = "Crate"
+
 private const val DEFAULT_KIND_NAME = "normal"
 private const val DEV_KIND_NAME = "dev"
 private const val BUILD_KIND_NAME = "build"
@@ -76,7 +79,7 @@ internal object CargoCommand : CommandLineTool {
     description = "The Cargo package manager for Rust.",
     factory = PackageManagerFactory::class
 )
-class Cargo(override val descriptor: PluginDescriptor = CargoFactory.descriptor) : PackageManager("Cargo") {
+class Cargo(override val descriptor: PluginDescriptor = CargoFactory.descriptor) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("Cargo.toml")
 
     /**
@@ -188,7 +191,7 @@ class Cargo(override val descriptor: PluginDescriptor = CargoFactory.descriptor)
 
                 val pkg = packageById.getValue(node.id)
                 PackageReference(
-                    id = Identifier("Crate", "", pkg.name, pkg.version),
+                    id = Identifier(PACKAGE_TYPE, "", pkg.name, pkg.version),
                     linkage = if (pkg.isProject(analysisRoot)) PackageLinkage.PROJECT_STATIC else PackageLinkage.STATIC,
                     dependencies = dependencyNodes.toPackageReferences()
                 )
@@ -257,7 +260,7 @@ private fun CargoMetadata.Package.toPackage(hashes: Map<String, String>): Packag
 
     return Package(
         id = Identifier(
-            type = "Crate",
+            type = PACKAGE_TYPE,
             // Note that Rust / Cargo do not support package namespaces, see:
             // https://samsieber.tech/posts/2020/09/registry-structure-influence/
             namespace = "",

--- a/plugins/package-managers/carthage/src/main/kotlin/Carthage.kt
+++ b/plugins/package-managers/carthage/src/main/kotlin/Carthage.kt
@@ -46,6 +46,9 @@ import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.unquote
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 
+private const val PROJECT_TYPE = "Carthage"
+internal const val PACKAGE_TYPE = "Carthage"
+
 /**
  * The [Carthage](https://github.com/Carthage/Carthage) package manager for Objective-C / Swift.
  */
@@ -54,7 +57,7 @@ import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
     description = "The Carthage package manager for Objective-C / Swift.",
     factory = PackageManagerFactory::class
 )
-class Carthage(override val descriptor: PluginDescriptor = CarthageFactory.descriptor) : PackageManager("Carthage") {
+class Carthage(override val descriptor: PluginDescriptor = CarthageFactory.descriptor) : PackageManager(PROJECT_TYPE) {
     // TODO: Add support for the Cartfile.
     //       This would require to resolve the actual dependency versions as a Cartfile supports dynamic versions.
     override val globsForDefinitionFiles = listOf("Cartfile.resolved")
@@ -185,7 +188,7 @@ class Carthage(override val descriptor: PluginDescriptor = CarthageFactory.descr
 
         return Package(
             id = Identifier(
-                type = "Carthage",
+                type = PACKAGE_TYPE,
                 namespace = vcsHost?.getUserOrOrganization(projectUrl).orEmpty(),
                 name = vcsHost?.getProject(projectUrl).orEmpty(),
                 version = revision
@@ -209,7 +212,7 @@ class Carthage(override val descriptor: PluginDescriptor = CarthageFactory.descr
 
         return Package(
             id = Identifier(
-                type = "Carthage",
+                type = PACKAGE_TYPE,
                 namespace = "",
                 name = fileUrl.substringAfterLast("/"),
                 version = revision
@@ -227,7 +230,7 @@ class Carthage(override val descriptor: PluginDescriptor = CarthageFactory.descr
     private fun createPackageFromBinarySpec(binarySpec: Map<String, String>, id: String, revision: String) =
         Package(
             id = Identifier(
-                type = "Carthage",
+                type = PACKAGE_TYPE,
                 namespace = "",
                 name = id.substringAfterLast("/").removeSuffix(".json"),
                 version = revision

--- a/plugins/package-managers/carthage/src/test/kotlin/CarthageTest.kt
+++ b/plugins/package-managers/carthage/src/test/kotlin/CarthageTest.kt
@@ -55,7 +55,7 @@ class CarthageTest : WordSpec() {
                 with(result.packages) {
                     size shouldBe 1
                     single().apply {
-                        id.type shouldBe "Carthage"
+                        id.type shouldBe PACKAGE_TYPE
                         vcs.url shouldBe "https://github.com/Alamofire/AlamofireImage.git"
                         vcs.revision shouldBe "3.2.0"
                     }
@@ -70,7 +70,7 @@ class CarthageTest : WordSpec() {
                 with(result.packages) {
                     size shouldBe 1
                     single().apply {
-                        id.type shouldBe "Carthage"
+                        id.type shouldBe PACKAGE_TYPE
                         vcs.type shouldBe VcsType.GIT
                         vcs.url shouldBe "https://host.tld/path/to/project.git"
                         vcs.revision shouldBe "1.0.0"
@@ -89,7 +89,7 @@ class CarthageTest : WordSpec() {
                 with(result.packages) {
                     size shouldBe 1
                     single().apply {
-                        id.type shouldBe "Carthage"
+                        id.type shouldBe PACKAGE_TYPE
                         id.name shouldBe "spec"
                         binaryArtifact.url shouldBe "https://host.tld/path/to/binary/dependency.zip"
                     }
@@ -108,7 +108,7 @@ class CarthageTest : WordSpec() {
                 with(result.packages) {
                     size shouldBe 3
                     forEach {
-                        it.id.type shouldBe "Carthage"
+                        it.id.type shouldBe PACKAGE_TYPE
                     }
 
                     count { "user/project" in it.vcs.url } shouldBe 1

--- a/plugins/package-managers/cocoapods/src/funTest/kotlin/CocoaPodsFunTest.kt
+++ b/plugins/package-managers/cocoapods/src/funTest/kotlin/CocoaPodsFunTest.kt
@@ -101,8 +101,8 @@ class CocoaPodsFunTest : WordSpec({
             // The NPM-related results are not relevant, because this test checks if the Pod packages can be filled with
             // information coming from the podspec files present in the 'node_modules' directory.
             val analyzerResult = result.copy(
-                projects = result.projects.filterTo(mutableSetOf()) { it.id.type == "CocoaPods" },
-                packages = result.packages.filterTo(mutableSetOf()) { it.id.type == "Pod" },
+                projects = result.projects.filterTo(mutableSetOf()) { it.id.type == PROJECT_TYPE },
+                packages = result.packages.filterTo(mutableSetOf()) { it.id.type == PACKAGE_TYPE },
                 issues = emptyMap()
             )
 

--- a/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/CocoaPods.kt
@@ -47,6 +47,9 @@ import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+internal const val PROJECT_TYPE = "CocoaPods"
+internal const val PACKAGE_TYPE = "Pod"
+
 private const val LOCKFILE_FILENAME = "Podfile.lock"
 private const val SCOPE_NAME = "dependencies"
 
@@ -74,7 +77,9 @@ internal object CocoaPodsCommand : CommandLineTool {
     description = "The CocoaPods package manager for Objective-C.",
     factory = PackageManagerFactory::class
 )
-class CocoaPods(override val descriptor: PluginDescriptor = CocoaPodsFactory.descriptor) : PackageManager("CocoaPods") {
+class CocoaPods(
+    override val descriptor: PluginDescriptor = CocoaPodsFactory.descriptor
+) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("Podfile")
 
     private val dependencyHandler = PodDependencyHandler()

--- a/plugins/package-managers/cocoapods/src/main/kotlin/PodDependencyHandler.kt
+++ b/plugins/package-managers/cocoapods/src/main/kotlin/PodDependencyHandler.kt
@@ -64,7 +64,7 @@ internal class PodDependencyHandler : DependencyHandler<Lockfile.Pod> {
             val checkoutOption = lockfile.checkoutOptions[dependency.name]
             val revision = checkoutOption?.commit ?: checkoutOption?.tag ?: checkoutOption?.branch
             val uniqueVersion = listOfNotNull(version, revision).joinToString("-")
-            Identifier("Pod", "", name, uniqueVersion)
+            Identifier(PACKAGE_TYPE, "", name, uniqueVersion)
         }
 
     override fun dependenciesFor(dependency: Lockfile.Pod): List<Lockfile.Pod> =

--- a/plugins/package-managers/composer/src/main/kotlin/Composer.kt
+++ b/plugins/package-managers/composer/src/main/kotlin/Composer.kt
@@ -56,6 +56,9 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Composer"
+private const val PACKAGE_TYPE = "Composer"
+
 private const val COMPOSER_PHAR_BINARY = "composer.phar"
 private const val SCOPE_NAME_REQUIRE = "require"
 private const val SCOPE_NAME_REQUIRE_DEV = "require-dev"
@@ -90,7 +93,7 @@ internal object ComposerCommand : CommandLineTool {
     description = "The Composer package manager for PHP.",
     factory = PackageManagerFactory::class
 )
-class Composer(override val descriptor: PluginDescriptor = ComposerFactory.descriptor) : PackageManager("Composer") {
+class Composer(override val descriptor: PluginDescriptor = ComposerFactory.descriptor) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("composer.json")
 
     override fun beforeResolution(
@@ -317,7 +320,7 @@ private fun PackageInfo.toPackage(): Package {
 
     return Package(
         id = Identifier(
-            type = "Composer",
+            type = PACKAGE_TYPE,
             namespace = rawName.substringBefore('/'),
             name = rawName.substringAfter('/'),
             version = version

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -70,6 +70,9 @@ import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Conan"
+internal const val PACKAGE_TYPE = "Conan"
+
 internal class ConanCommand(private val useConan2: Boolean = false) : CommandLineTool {
     override fun command(workingDir: File?) = if (useConan2) "conan2" else "conan"
 
@@ -120,7 +123,7 @@ data class ConanConfig(
 class Conan(
     override val descriptor: PluginDescriptor = ConanFactory.descriptor,
     private val config: ConanConfig
-) : PackageManager("Conan") {
+) : PackageManager(PROJECT_TYPE) {
     companion object {
         internal val DUMMY_COMPILER_SETTINGS = arrayOf(
             "-s", "compiler=gcc",

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
@@ -163,7 +163,7 @@ internal class ConanV1Handler(private val conan: Conan) : ConanVersionHandler {
      */
     private fun parsePackageId(pkgInfo: PackageInfoV1, workingDir: File) =
         Identifier(
-            type = "Conan",
+            type = PACKAGE_TYPE,
             namespace = "",
             name = conan.inspectField(pkgInfo.displayName, workingDir, "name").orEmpty(),
             version = conan.inspectField(pkgInfo.displayName, workingDir, "version").orEmpty()

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
@@ -256,7 +256,7 @@ private fun findProjectPackageInfo(pkgInfos: List<PackageInfoV2>, definitionFile
  */
 private fun parsePackageId(pkgInfo: PackageInfoV2) =
     Identifier(
-        type = "Conan",
+        type = PACKAGE_TYPE,
         namespace = "",
         name = pkgInfo.name,
         version = pkgInfo.version

--- a/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
+++ b/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
@@ -39,11 +39,12 @@ import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.utils.common.div
 
+internal const val PROJECT_TYPE = "Gleam"
+internal const val PACKAGE_TYPE_HEX = "Hex"
+internal const val PACKAGE_TYPE_OTP = "OTP"
+
 private const val GLEAM_TOML = "gleam.toml"
 private const val MANIFEST_TOML = "manifest.toml"
-internal const val PACKAGE_TYPE_OTP = "OTP"
-internal const val PACKAGE_TYPE_HEX = "Hex"
-internal const val PROJECT_TYPE = "Gleam"
 
 /**
  * The [Gleam](https://gleam.run/) package manager for Gleam.

--- a/plugins/package-managers/go/src/main/kotlin/GoMod.kt
+++ b/plugins/package-managers/go/src/main/kotlin/GoMod.kt
@@ -60,6 +60,9 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "GoMod"
+private const val PACKAGE_TYPE = "Go"
+
 internal object GoCommand : CommandLineTool {
     override fun command(workingDir: File?) = "go"
 
@@ -97,7 +100,7 @@ data class GoModConfig(
 class GoMod(
     override val descriptor: PluginDescriptor = GoModFactory.descriptor,
     config: GoModConfig
-) : PackageManager("GoMod") {
+) : PackageManager(PROJECT_TYPE) {
     private val goEnvironment = buildMap {
         put("GOWORK", "off")
 
@@ -316,7 +319,7 @@ class GoMod(
         } else {
             // If the version is not blank, it is a package in ORT speak.
             Identifier(
-                type = "Go",
+                type = PACKAGE_TYPE,
                 namespace = "",
                 name = path,
                 version = normalizeModuleVersion(version)

--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
@@ -64,6 +64,8 @@ import org.ossreviewtoolkit.utils.ort.ortToolsDirectory
 
 import org.semver4j.Semver
 
+private const val PROJECT_TYPE = "Gradle"
+
 /**
  * The names of Gradle (Groovy, Kotlin script) build files for a Gradle project.
  */
@@ -116,7 +118,7 @@ data class GradleInspectorConfig(
 class GradleInspector(
     override val descriptor: PluginDescriptor = GradleInspectorFactory.descriptor,
     private val config: GradleInspectorConfig
-) : PackageManager("Gradle") {
+) : PackageManager(PROJECT_TYPE) {
     // Gradle prefers Groovy ".gradle" files over Kotlin ".gradle.kts" files, but "build" files have to come before
     // "settings" files as we should consider "settings" files only if the same directory does not also contain a
     // "build" file.

--- a/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
@@ -72,6 +72,9 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempFile
 
 import org.semver4j.Semver
 
+internal const val PROJECT_TYPE = "Gradle"
+internal const val PACKAGE_TYPE = "Maven"
+
 private val GRADLE_USER_HOME = Os.env["GRADLE_USER_HOME"]?.let { File(it) } ?: Os.userHomeDirectory.resolve(".gradle")
 
 private val GRADLE_BUILD_FILES = listOf("build.gradle", "build.gradle.kts")
@@ -112,7 +115,7 @@ data class GradleConfig(
 class Gradle(
     override val descriptor: PluginDescriptor = GradleFactory.descriptor,
     private val config: GradleConfig
-) : PackageManager("Gradle") {
+) : PackageManager(PROJECT_TYPE) {
     // Gradle prefers Groovy ".gradle" files over Kotlin ".gradle.kts" files, but "build" files have to come before
     // "settings" files as we should consider "settings" files only if the same directory does not also contain a
     // "build" file.

--- a/plugins/package-managers/gradle/src/test/kotlin/GradleDependencyHandlerTest.kt
+++ b/plugins/package-managers/gradle/src/test/kotlin/GradleDependencyHandlerTest.kt
@@ -101,7 +101,7 @@ class GradleDependencyHandlerTest : WordSpec({
 
             val scopes = graph.createScopes()
 
-            scopeDependencies(scopes, scope).single { it.id.type == "Maven" }
+            scopeDependencies(scopes, scope).single { it.id.type == PACKAGE_TYPE }
         }
 
         "collect a dependency of type Unknown" {
@@ -128,7 +128,7 @@ class GradleDependencyHandlerTest : WordSpec({
 
             val scopes = graph.createScopes()
 
-            scopeDependencies(scopes, scope).single { it.id.type == "Gradle" }
+            scopeDependencies(scopes, scope).single { it.id.type == PROJECT_TYPE }
         }
 
         "collect information about packages" {
@@ -307,7 +307,7 @@ class GradleDependencyHandlerTest : WordSpec({
             val issues = mutableListOf<Issue>()
 
             every { maven.parsePackage(any(), any(), useReposFromDependencies = false) } throws exception
-            val handler = GradleDependencyHandler("Gradle", maven)
+            val handler = GradleDependencyHandler(PROJECT_TYPE, maven)
 
             handler.createPackage(dep, issues) should beNull()
 
@@ -353,7 +353,7 @@ private fun createDependency(
  * this class.
  */
 private fun createGraphBuilder(): DependencyGraphBuilder<OrtDependency> {
-    val dependencyHandler = GradleDependencyHandler("Gradle", createMavenSupport())
+    val dependencyHandler = GradleDependencyHandler(PROJECT_TYPE, createMavenSupport())
     dependencyHandler.repositories = remoteRepositories
     return DependencyGraphBuilder(dependencyHandler)
 }
@@ -366,7 +366,7 @@ private fun createMavenSupport(): MavenSupport {
     val slotArtifact = slot<DefaultArtifact>()
     every { maven.parsePackage(capture(slotArtifact), remoteRepositories, useReposFromDependencies = false) } answers {
         val artifact = slotArtifact.captured
-        val id = Identifier("Maven", artifact.groupId, artifact.artifactId, artifact.version)
+        val id = Identifier(PACKAGE_TYPE, artifact.groupId, artifact.artifactId, artifact.version)
         Package(
             id,
             declaredLicenses = emptySet(),
@@ -384,7 +384,7 @@ private fun createMavenSupport(): MavenSupport {
 /**
  * Returns an [Identifier] for this [OrtDependency].
  */
-private fun OrtDependency.toId() = Identifier(getIdentifierType("Gradle"), groupId, artifactId, version)
+private fun OrtDependency.toId() = Identifier(getIdentifierType(PROJECT_TYPE), groupId, artifactId, version)
 
 /**
  * Return the package references from the given [scopes] associated with the scope with the given [scopeName].

--- a/plugins/package-managers/maven/src/main/kotlin/Maven.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/Maven.kt
@@ -46,6 +46,9 @@ import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.isTychoProject
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.toOrtProject
 import org.ossreviewtoolkit.utils.common.searchUpwardFor
 
+internal const val PROJECT_TYPE = "Maven"
+internal const val PACKAGE_TYPE = "Maven"
+
 /**
  * The [Maven](https://maven.apache.org/) package manager for Java.
  */
@@ -55,7 +58,7 @@ import org.ossreviewtoolkit.utils.common.searchUpwardFor
     factory = PackageManagerFactory::class
 )
 class Maven(override val descriptor: PluginDescriptor = MavenFactory.descriptor, private val sbtMode: Boolean) :
-    PackageManager(if (sbtMode) "SBT" else "Maven") {
+    PackageManager(if (sbtMode) "SBT" else PROJECT_TYPE) {
     constructor(descriptor: PluginDescriptor = MavenFactory.descriptor) : this(descriptor, false)
 
     override val globsForDefinitionFiles = listOf("pom.xml")

--- a/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.model.utils.isScopeIncluded
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.plugins.packagemanagers.maven.PACKAGE_TYPE
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.LocalProjectWorkspaceReader
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.MavenDependencyHandler
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.MavenSupport
@@ -439,7 +440,7 @@ internal fun createPackageFromManifest(artifact: Artifact, manifest: Manifest, r
 
         Package(
             id = Identifier(
-                type = "Maven",
+                type = PACKAGE_TYPE,
                 namespace = artifact.groupId,
                 name = artifact.artifactId,
                 version = artifact.version

--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenDependencyHandler.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenDependencyHandler.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyHandler
+import org.ossreviewtoolkit.plugins.packagemanagers.maven.PACKAGE_TYPE
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -67,7 +68,7 @@ class MavenDependencyHandler(
 
     override fun identifierFor(dependency: DependencyNode): Identifier =
         Identifier(
-            type = if (isLocalProject(dependency)) projectType else "Maven",
+            type = if (isLocalProject(dependency)) projectType else PACKAGE_TYPE,
             namespace = dependency.artifact.groupId,
             name = dependency.artifact.artifactId,
             version = dependency.artifact.version

--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -88,6 +88,7 @@ import org.ossreviewtoolkit.model.PackageProvider
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.fromYaml
 import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.plugins.packagemanagers.maven.PACKAGE_TYPE
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.gibibytes
@@ -558,7 +559,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) : Closeable {
 
         return Package(
             id = Identifier(
-                type = "Maven",
+                type = PACKAGE_TYPE,
                 namespace = mavenProject.groupId,
                 name = mavenProject.artifactId,
                 version = mavenProject.version

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
@@ -66,6 +66,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.Includes
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
+import org.ossreviewtoolkit.plugins.packagemanagers.maven.PACKAGE_TYPE
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.PackageResolverFun
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.identifier
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
@@ -627,7 +628,7 @@ private const val TEST_ARTIFACT_ID = "org.ossreviewtoolkit.test.bundle"
 private const val TEST_VERSION = "50.1.2"
 
 /** The expected package identifier generated for the test artifact. */
-private val testArtifactIdentifier = Identifier("Maven", TEST_GROUP_ID, TEST_ARTIFACT_ID, TEST_VERSION)
+private val testArtifactIdentifier = Identifier(PACKAGE_TYPE, TEST_GROUP_ID, TEST_ARTIFACT_ID, TEST_VERSION)
 
 /**
  * Create a mock [MavenProject] with default coordinates and the given [name] and optional [definitionFile].

--- a/plugins/package-managers/maven/src/test/kotlin/utils/MavenDependencyHandlerTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/utils/MavenDependencyHandlerTest.kt
@@ -46,6 +46,8 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.plugins.packagemanagers.maven.PACKAGE_TYPE
+import org.ossreviewtoolkit.plugins.packagemanagers.maven.PROJECT_TYPE
 
 class MavenDependencyHandlerTest : WordSpec({
     beforeSpec {
@@ -199,8 +201,6 @@ class MavenDependencyHandlerTest : WordSpec({
 })
 
 private const val MANAGER_NAME = "MavenTest"
-private const val PROJECT_TYPE = "MavenProject"
-private const val PACKAGE_TYPE = "Maven"
 private const val PACKAGE_ID_SUFFIX = "org.apache.commons:commons-lang2:3.12"
 
 /**

--- a/plugins/package-managers/nuget/src/main/kotlin/NuGet.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/NuGet.kt
@@ -36,6 +36,9 @@ import org.ossreviewtoolkit.plugins.packagemanagers.nuget.utils.NuGetInspector
 import org.ossreviewtoolkit.plugins.packagemanagers.nuget.utils.toOrtPackages
 import org.ossreviewtoolkit.plugins.packagemanagers.nuget.utils.toOrtProject
 
+private const val PROJECT_TYPE = "NuGet"
+internal const val PACKAGE_TYPE = "NuGet"
+
 data class NuGetConfig(
     /**
      * The path to the NuGet configuration file to use.
@@ -53,7 +56,7 @@ data class NuGetConfig(
     factory = PackageManagerFactory::class
 )
 class NuGet(override val descriptor: PluginDescriptor = NuGetFactory.descriptor, config: NuGetConfig) :
-    PackageManager("NuGet") {
+    PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("*.csproj", "*.fsproj", "*.vcxproj", "packages.config")
 
     private val nugetConfig = config.nugetConfigFile?.let { File(it) }

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
@@ -37,9 +37,8 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.fromYaml
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.plugins.packagemanagers.nuget.NuGetFactory
+import org.ossreviewtoolkit.plugins.packagemanagers.nuget.PACKAGE_TYPE
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
-
-private const val TYPE = "NuGet"
 
 private fun List<NuGetInspector.Party>.toAuthors(): Set<String> =
     filter { it.role == "author" }.mapNotNullTo(mutableSetOf()) { party ->
@@ -86,9 +85,9 @@ internal fun NuGetInspector.Result.toOrtProject(
 
 private fun NuGetInspector.PackageData.getIdentifierWithNamespace(): Identifier =
     if (namespace.isNullOrEmpty()) {
-        getIdentifierWithNamespace(TYPE, name, version.orEmpty())
+        getIdentifierWithNamespace(PACKAGE_TYPE, name, version.orEmpty())
     } else {
-        Identifier(TYPE, namespace, name, version.orEmpty())
+        Identifier(PACKAGE_TYPE, namespace, name, version.orEmpty())
     }
 
 private fun List<NuGetInspector.PackageData>.toPackageReferences(): Set<PackageReference> =

--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -82,6 +82,9 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Pub"
+private const val PACKAGE_TYPE = "Pub"
+
 private const val PUBSPEC_YAML = "pubspec.yaml"
 private const val PUB_LOCK_FILE = "pubspec.lock"
 private const val SCOPE_NAME_DEPENDENCIES = "dependencies"
@@ -168,7 +171,7 @@ data class PubConfig(
 )
 @Suppress("TooManyFunctions")
 class Pub(override val descriptor: PluginDescriptor = PubFactory.descriptor, private val config: PubConfig) :
-    PackageManager("Pub") {
+    PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf(PUBSPEC_YAML)
 
     private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: config.flutterVersion
@@ -452,7 +455,7 @@ class Pub(override val descriptor: PluginDescriptor = PubFactory.descriptor, pri
             if (pkgInfoFromLockfile == null || pkgInfoFromLockfile.source == "sdk") return@forEach
 
             val id = Identifier(
-                type = if (pkgInfoFromLockfile.isProject) projectType else "Pub",
+                type = if (pkgInfoFromLockfile.isProject) projectType else PACKAGE_TYPE,
                 namespace = "",
                 name = packageName,
                 version = pkgInfoFromLockfile.version.orEmpty()
@@ -708,7 +711,7 @@ class Pub(override val descriptor: PluginDescriptor = PubFactory.descriptor, pri
                 }
 
                 val id = Identifier(
-                    type = if (packageInfo.isProject) projectType else "Pub",
+                    type = if (packageInfo.isProject) projectType else PACKAGE_TYPE,
                     namespace = "",
                     name = rawName,
                     version = version

--- a/plugins/package-managers/python/src/main/kotlin/Pip.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Pip.kt
@@ -41,6 +41,8 @@ import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
+private const val PROJECT_TYPE = "PIP"
+
 @Suppress("EnumEntryNameCase", "EnumNaming")
 enum class OperatingSystem {
     linux,
@@ -86,7 +88,7 @@ class Pip internal constructor(
     projectType: String
 ) : PackageManager(projectType) {
     constructor(descriptor: PluginDescriptor = PipFactory.descriptor, config: PipConfig) :
-        this(descriptor, config, "PIP")
+        this(descriptor, config, PROJECT_TYPE)
 
     override val globsForDefinitionFiles = listOf("*requirements*.txt", "setup.py")
 

--- a/plugins/package-managers/python/src/main/kotlin/Pipenv.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Pipenv.kt
@@ -38,6 +38,8 @@ import org.semver4j.Semver
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Pipenv"
+
 /**
  * The version that introduced the requirements command.
  */
@@ -61,7 +63,7 @@ internal object PipenvCommand : CommandLineTool {
 )
 class Pipenv(
     override val descriptor: PluginDescriptor = PipenvFactory.descriptor, private val config: PipConfig
-) : PackageManager("Pipenv") {
+) : PackageManager(PROJECT_TYPE) {
     // Usually, definition files should not contain (only) lockfiles, to also support the case when no lockfile is
     // present. However, there currently is no way to distinguish a Pipenv project from a vanilla Pip project without
     // looking at the lockfile.

--- a/plugins/package-managers/python/src/main/kotlin/Poetry.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Poetry.kt
@@ -53,6 +53,8 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempFile
 import org.semver4j.Semver
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Poetry"
+
 internal object PoetryCommand : CommandLineTool {
     override fun command(workingDir: File?) = "poetry"
 
@@ -69,7 +71,7 @@ internal object PoetryCommand : CommandLineTool {
 )
 class Poetry(
     override val descriptor: PluginDescriptor = PoetryFactory.descriptor, private val config: PipConfig
-) : PackageManager("Poetry") {
+) : PackageManager(PROJECT_TYPE) {
     companion object {
         /**
          * The name of the build system requirements and information file used by modern Python packages.

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.toPurl
 
-private const val TYPE = "PyPI"
+private const val PACKAGE_TYPE = "PyPI"
 
 internal fun PythonInspector.Result.toOrtProject(
     projectType: String,
@@ -135,7 +135,7 @@ internal fun List<PythonInspector.Package>.toOrtPackages(): Set<Package> =
                 )
             } ?: RemoteArtifact.EMPTY
 
-        val id = Identifier(type = TYPE, namespace = "", name = pkg.name, version = pkg.version)
+        val id = Identifier(type = PACKAGE_TYPE, namespace = "", name = pkg.name, version = pkg.version)
         val declaredLicenses = pkg.declaredLicense?.getDeclaredLicenses().orEmpty()
         val declaredLicensesProcessed = processDeclaredLicenses(id, declaredLicenses)
 
@@ -179,6 +179,6 @@ internal fun List<PythonInspector.ResolvedDependency>.toPackageReferences(): Set
 
 private fun PythonInspector.ResolvedDependency.toPackageReference() =
     PackageReference(
-        id = Identifier(type = TYPE, namespace = "", name = packageName, version = installedVersion),
+        id = Identifier(type = PACKAGE_TYPE, namespace = "", name = packageName, version = installedVersion),
         dependencies = dependencies.toPackageReferences()
     )

--- a/plugins/package-managers/sbt/src/main/kotlin/Sbt.kt
+++ b/plugins/package-managers/sbt/src/main/kotlin/Sbt.kt
@@ -48,6 +48,8 @@ import org.ossreviewtoolkit.utils.ort.JavaBootstrapper
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "SBT"
+
 internal object SbtCommand : CommandLineTool {
     override fun command(workingDir: File?) = if (Os.isWindows) "sbt.bat" else "sbt"
 
@@ -97,7 +99,7 @@ data class SbtConfig(
     factory = PackageManagerFactory::class
 )
 class Sbt(override val descriptor: PluginDescriptor = SbtFactory.descriptor, private val config: SbtConfig) :
-    PackageManager("SBT") {
+    PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("build.sbt", "build.scala")
 
     override fun mapDefinitionFiles(

--- a/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
+++ b/plugins/package-managers/spdx/src/main/kotlin/SpdxDocumentFile.kt
@@ -69,6 +69,8 @@ import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxExternalReference
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxPackage
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxRelationship
 
+private const val PROJECT_TYPE = "SpdxDocumentFile"
+
 private const val DEFAULT_SCOPE_NAME = "default"
 
 private val SPDX_LINKAGE_RELATIONSHIPS = mapOf(
@@ -269,7 +271,7 @@ private fun hasDefaultScopeLinkage(
     factory = PackageManagerFactory::class
 )
 class SpdxDocumentFile(override val descriptor: PluginDescriptor = SpdxDocumentFileFactory.descriptor) :
-    PackageManager("SpdxDocumentFile") {
+    PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("*.spdx.yml", "*.spdx.yaml", "*.spdx.json")
 
     private val spdxDocumentCache = SpdxDocumentCache()

--- a/plugins/package-managers/stack/src/main/kotlin/Stack.kt
+++ b/plugins/package-managers/stack/src/main/kotlin/Stack.kt
@@ -56,6 +56,9 @@ import org.ossreviewtoolkit.utils.ort.okHttpClient
 import org.semver4j.range.RangeList
 import org.semver4j.range.RangeListFactory
 
+private const val PROJECT_TYPE = "Stack"
+private const val PACKAGE_TYPE = "Hackage"
+
 private const val EXTERNAL_SCOPE_NAME = "external"
 private const val TEST_SCOPE_NAME = "test"
 private const val BENCH_SCOPE_NAME = "bench"
@@ -85,7 +88,7 @@ internal object StackCommand : CommandLineTool {
     description = "The Stack package manager for Haskell.",
     factory = PackageManagerFactory::class
 )
-class Stack(override val descriptor: PluginDescriptor = StackFactory.descriptor) : PackageManager("Stack") {
+class Stack(override val descriptor: PluginDescriptor = StackFactory.descriptor) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf("stack.yaml")
 
     override fun beforeResolution(
@@ -167,14 +170,14 @@ class Stack(override val descriptor: PluginDescriptor = StackFactory.descriptor)
 
     private fun Dependency.toPackage(): Package {
         val id = Identifier(
-            type = "Hackage",
+            type = PACKAGE_TYPE,
             namespace = "",
             name = name,
             version = version
         )
 
         if (location == null || location.type == Location.TYPE_HACKAGE) {
-            okHttpClient.downloadCabalFile(id)?.let { return parseCabalFile(it, "Hackage") }
+            okHttpClient.downloadCabalFile(id)?.let { return parseCabalFile(it, PACKAGE_TYPE) }
         }
 
         return Package.EMPTY.copy(

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -54,11 +54,12 @@ import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 
+private const val PROJECT_TYPE = "SwiftPM"
+private const val PACKAGE_TYPE = "Swift"
+
 private const val PACKAGE_SWIFT_NAME = "Package.swift"
 private const val PACKAGE_RESOLVED_NAME = "Package.resolved"
 private const val REGISTRY_CONFIGURATION_PATH = ".swiftpm/configuration/registries.json"
-
-private const val PACKAGE_TYPE = "Swift"
 
 private const val DEPENDENCIES_SCOPE_NAME = "dependencies"
 
@@ -77,7 +78,7 @@ internal object SwiftCommand : CommandLineTool {
     description = "The Swift Package Manager for Swift.",
     factory = PackageManagerFactory::class
 )
-class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descriptor) : PackageManager("SwiftPM") {
+class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descriptor) : PackageManager(PROJECT_TYPE) {
     override val globsForDefinitionFiles = listOf(PACKAGE_SWIFT_NAME, PACKAGE_RESOLVED_NAME)
 
     override fun mapDefinitionFiles(

--- a/plugins/package-managers/unmanaged/src/main/kotlin/Unmanaged.kt
+++ b/plugins/package-managers/unmanaged/src/main/kotlin/Unmanaged.kt
@@ -38,6 +38,8 @@ import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 
+private const val PROJECT_TYPE = "Unmanaged"
+
 /**
  * A fake [PackageManager] for projects that do not use any of the known package managers, or no package manager at all.
  * It is required as in ORT's data model e.g. scan results need to be attached to projects (or packages), so files that
@@ -48,7 +50,9 @@ import org.ossreviewtoolkit.plugins.api.PluginDescriptor
     description = "The Unmanaged package manager for projects that do not use any package manager.",
     factory = PackageManagerFactory::class
 )
-class Unmanaged(override val descriptor: PluginDescriptor = UnmanagedFactory.descriptor) : PackageManager("Unmanaged") {
+class Unmanaged(
+    override val descriptor: PluginDescriptor = UnmanagedFactory.descriptor
+) : PackageManager(PROJECT_TYPE) {
     // The empty list returned here deliberately causes this special package manager to never be considered in
     // PackageManager.findManagedFiles(). Instead, it will only be explicitly instantiated as part of
     // Analyzer.findManagedFiles().


### PR DESCRIPTION
By convention, start to do this consistently to more easily search for package types, e.g. when dealing with PURL / ClearlyDefined mappings. In the code base, package types can then be found by a search like

    git grep -Eiho 'package_?type.* = "[^"]+"' -- "*.kt" | sort -u