### PR TITLE
ci(native-build): Do not archive the already compressed UPX executable

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           name: ORT Analyzer-only
           path: cli/build/native/nativeCompile/ort
-          compression-level: 0
+          archive: false
           retention-days: 7


### PR DESCRIPTION
See [1].

[1]: https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/