### PR TITLE
fix(docker): Make nodejs toolchain and curl trust system certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,9 @@ RUN chgrp $USERNAME /opt \
 RUN echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Make curl trust system certificates both at container build timeand run time.
+RUN echo "ca-native" > /etc/curlrc
+
 # Copy certificates scripts only.
 COPY scripts/*_certificates.sh /etc/scripts/
 


### PR DESCRIPTION
Using the https://oss-review-toolkit.org/ort/docs/guides/docker#setting-custom-certificates-to-docker-image-keystore feature doesn't properly work as of now, because the nvm download (and some other build steps) use curl, which does not honor the system certificate store by default.

Also, the npm install step in nodejsbuild fails because the appropriate environment variable to the certificate bundle is not set.

Fix curl by providing a /etc/curlrc file (that also has effect at container run time) and nodejs at build time by setting the appropriate ENV.