### PR TITLE
feat(spdx): Derive document name from project name by default

### DIFF
--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -83,6 +83,18 @@ class SpdxDocumentReporterFunTest : WordSpec({
             jsonSpdxDocument should matchJsonSchema(schemaJson)
             document.files should beEmpty()
         }
+
+        "use the project name as document name when no document name is configured" {
+            val jsonSpdxDocument = generateReport(
+                ORT_RESULT,
+                FileFormat.JSON,
+                SpdxVersion.SPDX_2_2,
+                documentName = null
+            )
+            val document = fromJson<SpdxDocument>(jsonSpdxDocument)
+
+            document.name shouldBe "proj1"
+        }
     }
 
     "Reporting to SPDX-2.3" should {
@@ -131,7 +143,8 @@ private fun TestConfiguration.generateReport(
     ortResult: OrtResult,
     format: FileFormat,
     spdxVersion: SpdxVersion,
-    fileInformationEnabled: Boolean = true
+    fileInformationEnabled: Boolean = true,
+    documentName: String? = "some document name"
 ): String {
     val config = SpdxDocumentReporterConfig(
         spdxVersion = spdxVersion,
@@ -139,7 +152,7 @@ private fun TestConfiguration.generateReport(
         creationInfoPerson = "some creation info person",
         creationInfoOrganization = "some creation info organization",
         documentComment = "some document comment",
-        documentName = "some document name",
+        documentName = documentName,
         fileInformationEnabled = fileInformationEnabled,
         outputFileFormats = listOf(format)
     )

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -173,7 +173,9 @@ internal object SpdxDocumentModelMapper {
             ),
             documentNamespace = "spdx://${UUID.randomUUID()}",
             documentDescribes = projectPackages.map { it.spdxId },
-            name = config.documentName,
+            name = config.documentName
+                ?: projects.firstOrNull()?.id?.name?.takeIf(String::isNotBlank)
+                ?: "Unnamed document",
             packages = projectPackages + packages,
             relationships = relationships.sortedBy { it.spdxElementId },
             files = files

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentReporter.kt
@@ -81,10 +81,10 @@ data class SpdxDocumentReporterConfig(
     val documentComment: String?,
 
     /**
-     * The name of the generated [SpdxDocument].
+     * The name of the generated [SpdxDocument]. Defaults to the first project name from the ORT result if not set.
      */
-    @OrtPluginOption(defaultValue = "Unnamed document", aliases = ["document.name"])
-    val documentName: String,
+    @OrtPluginOption(aliases = ["document.name"])
+    val documentName: String?,
 
     /**
      * The list of file formats to generate.


### PR DESCRIPTION
When no document name is configured, the SPDX document name is now derived from the project name in the ORT result. This allows users with monorepos to distinguish SPDX reports per service when uploading to tools like CSI, without requiring any additional configuration.
