### PR TITLE
chore: Prefer `enumEntries` over `enumValues`

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -20,6 +20,8 @@
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.report.ReportMergeTask
 
+import kotlin.enums.enumEntries
+
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.kotlin.dsl.dependencies
@@ -154,7 +156,7 @@ tasks.withType<Jar>().configureEach {
 }
 
 val maxKotlinJvmTarget = runCatching { JvmTarget.fromTarget(javaLanguageVersion) }
-    .getOrDefault(enumValues<JvmTarget>().max())
+    .getOrDefault(enumEntries<JvmTarget>().max())
 
 val mergeDetektReportsTaskName = "mergeDetektReports"
 val mergeDetektReports = if (rootProject.tasks.findByName(mergeDetektReportsTaskName) != null) {

--- a/plugins/license-fact-providers/spdx/src/test/kotlin/SpdxLicenseFactProviderTest.kt
+++ b/plugins/license-fact-providers/spdx/src/test/kotlin/SpdxLicenseFactProviderTest.kt
@@ -29,6 +29,8 @@ import io.kotest.matchers.string.beEmpty
 import io.kotest.matchers.string.contain
 import io.kotest.matchers.string.haveLength
 
+import kotlin.enums.enumEntries
+
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseException
 
@@ -43,13 +45,13 @@ class SpdxLicenseFactProviderTest : WordSpec({
         }
 
         "return the license text for all SPDX licenses" {
-            enumValues<SpdxLicense>().forAll {
+            enumEntries<SpdxLicense>().forAll {
                 provider.getLicenseText(it.id)?.text shouldNot beEmpty()
             }
         }
 
         "return the license text for all SPDX exceptions" {
-            enumValues<SpdxLicenseException>().forAll {
+            enumEntries<SpdxLicenseException>().forAll {
                 provider.getLicenseText(it.id)?.text shouldNot beEmpty()
             }
         }
@@ -61,13 +63,13 @@ class SpdxLicenseFactProviderTest : WordSpec({
 
     "hasLicenseText()" should {
         "return true for all SPDX licenses" {
-            enumValues<SpdxLicense>().forAll {
+            enumEntries<SpdxLicense>().forAll {
                 provider.hasLicenseText(it.id) shouldBe true
             }
         }
 
         "return true for all SPDX exceptions" {
-            enumValues<SpdxLicenseException>().forAll {
+            enumEntries<SpdxLicenseException>().forAll {
                 provider.hasLicenseText(it.id) shouldBe true
             }
         }


### PR DESCRIPTION
This fixes an inspection hint.