### PR TITLE
fix(fossid-webapp): Return empty PURL when artifact name is empty

### DIFF
--- a/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
+++ b/plugins/scanners/fossid/src/main/kotlin/FossIdScanResults.kt
@@ -313,13 +313,19 @@ private fun Set<Snippet>.mapSnippetFindingsForFile(
         }
 
         val snippetProvenance = ArtifactProvenance(RemoteArtifact(url, Hash.NONE))
-        val purl = snippet.purl ?: PackageURLBuilder.aPackageURL()
-            .withType(urlToPackageType(url))
-            .withNamespace(snippet.author)
-            .withName(snippet.artifact)
-            .withVersion(snippet.version)
-            .build()
-            .canonicalize()
+        val purl = when {
+            snippet.purl != null -> checkNotNull(snippet.purl)
+
+            snippet.artifact.isNullOrEmpty() -> ""
+
+            else -> PackageURLBuilder.aPackageURL()
+                .withType(urlToPackageType(url))
+                .withNamespace(snippet.author)
+                .withName(snippet.artifact)
+                .withVersion(snippet.version)
+                .build()
+                .canonicalize()
+        }
 
         val additionalSnippetData = mutableMapOf(
             FossId.SNIPPET_DATA_ID to snippet.id.toString(),

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetMappingTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.scanners.fossid
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -110,6 +111,67 @@ class FossIdSnippetMappingTest : WordSpec({
             mappedSnippets.elementAtOrNull(2) shouldNotBeNull {
                 sourceLocation shouldBe TextLocation("src/main/java/com/vdurmont/semver4j/Requirement.java", 45, 675)
                 snippets.map { it.purl } should containExactly("pkg:github/vdurmont/semver4j@3.1.0")
+            }
+        }
+
+        "accept snippets without any artifact or purl" {
+            val issues = mutableListOf<Issue>()
+            val listSnippets = flowOf(
+                "src/main/java/Tokenizer.java" to
+                    setOf(
+                        createSnippet(
+                            1,
+                            MatchType.FULL,
+                            "",
+                            "MIT",
+                            "src/main/java/com/vdurmont/semver4j/Tokenizer.java"
+                        ).copy(
+                            author = "com/vdurmont",
+                            artifact = "semver4j",
+                            version = "3.1.0",
+                            url = "https://repo1.maven.org/maven2/com/vdurmont/semver4j/3.1.0/",
+                            purl = null
+                        ),
+                        createSnippet(
+                            2,
+                            MatchType.FULL,
+                            "pkg:maven/com.vdurmont/semver4j@3.1.0",
+                            "MIT",
+                            "com/vdurmont/semver4j/Tokenizer.java"
+                        ).copy(
+                            author = "com/vdurmont",
+                            artifact = null,
+                            version = "3.1.0",
+                            url = "https://repo1.maven.org/maven2/com/vdurmont/semver4j/3.1.0/",
+                            purl = null
+                        )
+                    )
+            )
+            val rawResults = RawResults(
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                listSnippets,
+                emptyMap()
+            )
+
+            val mappedSnippets = mapSnippetFindings(
+                rawResults,
+                500,
+                issues,
+                emptyMap(),
+                emptyList(),
+                mutableSetOf()
+            )
+
+            issues should beEmpty()
+            mappedSnippets.shouldBeSingleton { finding ->
+                with(finding.snippets) {
+                    this shouldHaveSize 2
+                    first().purl shouldBe "pkg:maven/com/vdurmont/semver4j@3.1.0"
+                    last().purl shouldBe ""
+                }
             }
         }
     }


### PR DESCRIPTION
The packageurl-jvm library throws MalformedPackageURLException when the name component is empty. This can happen for snippets with empty artifact names.
Return an empty string early when the name is blank.

This is a fixup for f1eadd8259847396555cd9ee3b98cc810e2b0ad8.

