### PR TITLE
refactor(Maven): Replace usage of `RepositorySystem`

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/tycho/LocalRepositoryHelper.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/LocalRepositoryHelper.kt
@@ -26,7 +26,6 @@ import java.util.jar.Manifest
 import kotlin.io.resolve
 
 import org.apache.logging.log4j.kotlin.logger
-import org.apache.maven.repository.RepositorySystem
 
 import org.eclipse.aether.artifact.Artifact
 
@@ -37,7 +36,7 @@ import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.identifier
  */
 internal class LocalRepositoryHelper(
     /** The root directory of the local Maven repository. */
-    private val localRepositoryRoot: File = RepositorySystem.defaultUserLocalRepository
+    private val localRepositoryRoot: File
 ) {
     companion object {
         /** The name of the root folder that stores artifacts downloaded from P2 repositories. */

--- a/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
@@ -120,7 +120,6 @@ class Tycho(override val descriptor: PluginDescriptor = TychoFactory.descriptor)
     ): List<ProjectAnalyzerResult> {
         logger.info { "Resolving Tycho dependencies for $definitionFile." }
 
-        val repositoryHelper = LocalRepositoryHelper()
         val collector = TychoProjectsCollector()
         val (exitCode, buildLog) = runBuild(collector, definitionFile.parentFile)
 
@@ -133,7 +132,7 @@ class Tycho(override val descriptor: PluginDescriptor = TychoFactory.descriptor)
                 collector.mavenProjects,
                 resolver,
                 targetHandler,
-                repositoryHelper
+                LocalRepositoryHelper(mavenSupport.localRepositoryPath())
             )
 
             buildLog.inputStream().use { stream ->

--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -159,9 +159,10 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) : Closeable {
 
         repositorySystemSession.mirrorSelector = HttpsMirrorSelector(repositorySystemSession.mirrorSelector)
 
+        val executionRequest = createMavenExecutionRequest()
         val localRepository = mavenRepositorySystem.createLocalRepository(
-            createMavenExecutionRequest(),
-            org.apache.maven.repository.RepositorySystem.defaultUserLocalRepository
+            executionRequest,
+            executionRequest.localRepositoryPath
         )
 
         val session = LegacyLocalRepositoryManager.overlay(
@@ -198,6 +199,11 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) : Closeable {
      * Looks up an instance of the class provided from the Maven Plexus container.
      */
     private inline fun <reified T> containerLookup(hint: String = "default"): T = container.lookup(T::class.java, hint)
+
+    /**
+     * Obtain the path to the local Maven repository as configured in the current Maven environment.
+     */
+    fun localRepositoryPath(): File = createMavenExecutionRequest().localRepositoryPath
 
     /**
      * Build the Maven projects defined in the provided [pomFiles] without resolving dependencies. The result can later


### PR DESCRIPTION
From version 3.9.12 on, this interface is deprecated; therefore, a replacement is required. The existing code used it to determine the location of a local Maven repository. This is now done via a Maven execution request, which is probably a better solution anyway, since the setup of the execution request takes the Maven configuration into account. The `RepositorySystem` interface only provided a constant for the default path of the local repository.
