### PR TITLE
chore(models): Make snippet class names consistent

### DIFF
--- a/model/src/main/kotlin/config/SnippetChoices.kt
+++ b/model/src/main/kotlin/config/SnippetChoices.kt
@@ -19,8 +19,8 @@
 
 package org.ossreviewtoolkit.model.config
 
-import org.ossreviewtoolkit.model.config.snippet.Provenance
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
+import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
 
 /**
  * A collection of snippet choices for a given provenance.
@@ -29,7 +29,7 @@ data class SnippetChoices(
     /**
      * The provenance this snippet choice applies to.
      */
-    val provenance: Provenance,
+    val provenance: SnippetProvenance,
 
     /**
      * The snippet choices for this package.

--- a/model/src/main/kotlin/config/snippet/SnippetProvenance.kt
+++ b/model/src/main/kotlin/config/snippet/SnippetProvenance.kt
@@ -24,4 +24,4 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 /**
  * The URL of the [RepositoryProvenance] the snippet choice applies to.
  */
-data class Provenance(val url: String)
+data class SnippetProvenance(val url: String)

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
@@ -65,9 +65,9 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.Choice
 import org.ossreviewtoolkit.model.config.snippet.Given
-import org.ossreviewtoolkit.model.config.snippet.Provenance
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
+import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.utils.ort.ORT_NAME
 import org.ossreviewtoolkit.utils.spdx.toSpdx
@@ -1122,7 +1122,7 @@ class FossIdSnippetChoiceTest : WordSpec({
 })
 
 private fun createSnippetChoices(provenanceUrl: String, vararg snippetChoices: SnippetChoice) =
-    listOf(SnippetChoices(Provenance(provenanceUrl), snippetChoices.toList()))
+    listOf(SnippetChoices(SnippetProvenance(provenanceUrl), snippetChoices.toList()))
 
 private fun createSnippetChoice(location: TextLocation, purl: String? = null, comment: String) =
     SnippetChoice(

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssTest.kt
@@ -29,9 +29,9 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.Choice
 import org.ossreviewtoolkit.model.config.snippet.Given
-import org.ossreviewtoolkit.model.config.snippet.Provenance
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
+import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
 
 // Sample files in the results.
 private const val FILE_1 = "a.java"
@@ -178,7 +178,7 @@ class ScanOssTest : WordSpec({
 })
 
 private fun createSnippetChoices(provenanceUrl: String, vararg snippetChoices: SnippetChoice) =
-    listOf(SnippetChoices(Provenance(provenanceUrl), snippetChoices.asList()))
+    listOf(SnippetChoices(SnippetProvenance(provenanceUrl), snippetChoices.asList()))
 
 private fun createSnippetChoice(location: TextLocation, purl: String? = null, comment: String) =
     SnippetChoice(


### PR DESCRIPTION
Apply same Snippet name pattern to previous Provenance class name.

During development of python-ort model bindings, a model error in tests was detected due usage of invalid Provenance class, which was misinterpreted with main Provenance class.

After adding proper Provenance class in snippet models, then linters become confused as two classes with same name are present in resolution mode.
