### PR TITLE
chore(model)!: Also move `SnippetChoices` under `snippet`

### DIFF
--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.model.utils.CurationsFilter
 import org.ossreviewtoolkit.model.utils.ExcludesFilter
 import org.ossreviewtoolkit.model.utils.IncludesFilter

--- a/model/src/main/kotlin/config/snippet/SnippetChoices.kt
+++ b/model/src/main/kotlin/config/snippet/SnippetChoices.kt
@@ -17,10 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.model.config
-
-import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
-import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
+package org.ossreviewtoolkit.model.config.snippet
 
 /**
  * A collection of snippet choices for a given provenance.

--- a/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/FossIdSnippetChoiceTest.kt
@@ -62,11 +62,11 @@ import org.ossreviewtoolkit.clients.fossid.uploadFile
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.Choice
 import org.ossreviewtoolkit.model.config.snippet.Given
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
+import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.utils.ort.ORT_NAME

--- a/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/fossid/src/test/kotlin/TestUtils.kt
@@ -87,7 +87,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.Excludes
-import org.ossreviewtoolkit.model.config.SnippetChoices
+import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.plugins.api.Secret
 import org.ossreviewtoolkit.plugins.scanners.fossid.events.CloneRepositoryHandler
 import org.ossreviewtoolkit.plugins.scanners.fossid.events.UploadArchiveHandler

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -35,9 +35,9 @@ import java.time.Instant
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.config.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
+import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.scanner.PathScannerWrapper

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssTest.kt
@@ -26,11 +26,11 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.config.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.Choice
 import org.ossreviewtoolkit.model.config.snippet.Given
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
+import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
 
 // Sample files in the results.

--- a/scanner/src/main/kotlin/ScanContext.kt
+++ b/scanner/src/main/kotlin/ScanContext.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.Includes
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.SnippetChoices
+import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 /**


### PR DESCRIPTION
This is a follow-up to cbd4851 and concludes the grouping of all snippet config classes.