### PR TITLE
build(gradle): Update Eclipse Maven Repository URLs

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -28,7 +28,7 @@ repositories {
 
     exclusiveContent {
         forRepository {
-            maven("https://repo.eclipse.org/content/groups/releases")
+            maven("https://repo.eclipse.org/content/repositories/releases")
         }
 
         filter {

--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -32,7 +32,7 @@ repositories {
 
     exclusiveContent {
         forRepository {
-            maven("https://repo.eclipse.org/content/groups/releases")
+            maven("https://repo.eclipse.org/content/repositories/releases")
         }
 
         filter {


### PR DESCRIPTION
This is due to the Nexus 2 to 3 migration, see [1].

[1]: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7168