### PR TITLE
ort-project-file: Introduce a default scope

### DIFF
--- a/plugins/package-managers/ort-project-file/src/funTest/kotlin/OrtProjectFileFunTest.kt
+++ b/plugins/package-managers/ort-project-file/src/funTest/kotlin/OrtProjectFileFunTest.kt
@@ -33,6 +33,8 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.beEmpty
 import io.kotest.matchers.string.shouldContain
 
+import kotlin.collections.find
+
 import org.ossreviewtoolkit.analyzer.analyze
 import org.ossreviewtoolkit.analyzer.getAnalyzerResult
 import org.ossreviewtoolkit.analyzer.resolveSingleProject
@@ -78,7 +80,9 @@ class OrtProjectFileFunTest : WordSpec({
                 }
 
                 project.authors should beEmptyCollection()
-                project.scopeDependencies.shouldNotBeNull() should beEmptyCollection()
+                project.scopeDependencies?.find { it.name == "unnamed" } shouldNotBeNull {
+                    dependencies.map { dep -> dep.id.name } should containExactly("minimal")
+                }
 
                 packages.shouldBeSingleton {
                     it.purl shouldBe "pkg:maven/com.example/minimal@0.1.0"
@@ -114,7 +118,9 @@ class OrtProjectFileFunTest : WordSpec({
                 }
 
                 project.authors should beEmptyCollection()
-                project.scopeDependencies.shouldNotBeNull() should beEmptyCollection()
+                project.scopeDependencies?.find { it.name == "unnamed" } shouldNotBeNull {
+                    dependencies.map { dep -> dep.id.name } should containExactly("minimal")
+                }
 
                 packages.shouldBeSingleton {
                     it.purl shouldBe "pkg:maven/com.example/minimal@0.1.0"
@@ -278,7 +284,7 @@ private fun verifyBasicProject(result: ProjectAnalyzerResult) {
         project.homepageUrl shouldBe "https://project_x.example.com"
 
         project.scopeDependencies shouldNotBeNull {
-            map { it.name } should containExactlyInAnyOrder("main", "some_scope")
+            map { it.name } should containExactlyInAnyOrder("main", "some_scope", "unnamed")
 
             find { it.name == "main" } shouldNotBeNull {
                 dependencies.map { dep -> dep.id.name } should containExactly("full")
@@ -286,6 +292,11 @@ private fun verifyBasicProject(result: ProjectAnalyzerResult) {
 
             find { it.name == "some_scope" } shouldNotBeNull {
                 dependencies.map { dep -> dep.id.name } should containExactly("full")
+            }
+
+            find { it.name == "unnamed" } shouldNotBeNull {
+                dependencies.shouldBeSingleton()
+                dependencies.map { dep -> dep.id.name } should containExactly("minimal")
             }
         }
 

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.plugins.packagemanagers.ortproject.OrtProject.Source
 import org.ossreviewtoolkit.plugins.packagemanagers.ortproject.OrtProject.Vcs
 
 private const val DEFAULT_PROJECT_NAME = "unknown"
+private const val DEFAULT_SCOPE_NAME = "unnamed"
 private const val PROJECT_TYPE = "OrtProjectFile"
 
 internal fun OrtProject.mapToProject(definitionFile: File) =
@@ -99,7 +100,10 @@ private fun Dependency.toPurl(): String = purl ?: checkNotNull(id).toPurl()
 private fun Collection<Dependency>.toScopes(): Set<Scope> {
     val idsForScopeName = buildMap {
         this@toScopes.forEach { dependency ->
-            dependency.scopes.orEmpty().forEach { scopeName ->
+            val scopeNames = dependency.scopes?.takeUnless { it.isEmpty() }
+                ?: setOf(DEFAULT_SCOPE_NAME)
+
+            scopeNames.forEach { scopeName ->
                 getOrPut(scopeName) { mutableSetOf() } += dependency.toId()
             }
         }


### PR DESCRIPTION
Stop allowing to create "dangling" packages, which are not assigned to any scope, by
assigning all packages which are not assigned to a scope explicitly to a default scope.