### PR TITLE
build(gradle): Only auto-accept Gradle Develocity ToS on CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,10 +65,13 @@ idea {
     }
 }
 
-extensions.findByName("develocity")?.withGroovyBuilder {
-    getProperty("buildScan")?.withGroovyBuilder {
-        setProperty("termsOfUseUrl", "https://gradle.com/terms-of-service")
-        setProperty("termsOfUseAgree", "yes")
+// Automatically accept the Gradle Build Scan ToS when running in CI, to allow build scans to be published.
+if (System.getenv("CI") == "true") {
+    extensions.findByName("develocity")?.withGroovyBuilder {
+        getProperty("buildScan")?.withGroovyBuilder {
+            setProperty("termsOfUseUrl", "https://gradle.com/terms-of-service")
+            setProperty("termsOfUseAgree", "yes")
+        }
     }
 }
 


### PR DESCRIPTION
These should not be accepted on behalf of others.