### PR TITLE
fix(ort-project-file): Properly set the projet's `vcs` / `vcsProcessed`

### DIFF
--- a/plugins/package-managers/ort-project-file/src/funTest/kotlin/OrtProjectFileFunTest.kt
+++ b/plugins/package-managers/ort-project-file/src/funTest/kotlin/OrtProjectFileFunTest.kt
@@ -68,7 +68,7 @@ class OrtProjectFileFunTest : WordSpec({
 
                 // VCS values may be different depending on the test environment,
                 // so just check for basic validity.
-                with(project.vcs) {
+                with(project.vcsProcessed) {
                     type shouldNotBe VcsType.UNKNOWN
                     url shouldNot beEmpty()
                     revision shouldNot beEmpty()
@@ -97,7 +97,7 @@ class OrtProjectFileFunTest : WordSpec({
 
                 // VCS values may be different depending on the test environment,
                 // so just check for basic validity.
-                with(project.vcs) {
+                with(project.vcsProcessed) {
                     type shouldNotBe VcsType.UNKNOWN
                     url shouldNot beEmpty()
                     revision shouldNot beEmpty()
@@ -218,7 +218,7 @@ private fun verifyBasicProject(result: ProjectAnalyzerResult) {
 
         project.authors should containExactlyInAnyOrder("John Doe", "Foo Bar")
 
-        project.vcs shouldNotBeNull {
+        project.vcsProcessed shouldNotBeNull {
             type shouldNotBe VcsType.UNKNOWN
             url shouldNot beEmpty()
             revision shouldNot beEmpty()
@@ -247,9 +247,9 @@ private fun verifyBasicProject(result: ProjectAnalyzerResult) {
                 containExactlyInAnyOrder(setOf("Apache-2.0", "MIT"))
             }
 
-            vcs shouldNotBeNull {
+            vcsProcessed shouldNotBeNull {
                 type shouldBe VcsType.MERCURIAL
-                url shouldBe "https://git.example.com/full/"
+                url shouldBe "https://git.example.com/full"
                 revision shouldBe "master"
                 path shouldBe "/"
             }

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
@@ -54,7 +54,8 @@ internal fun OrtProject.mapToProject(definitionFile: File, analysisRoot: File) =
             },
             version = ""
         ),
-        vcs = processProjectVcs(definitionFile.parentFile),
+        vcs = VcsInfo.EMPTY,
+        vcsProcessed = processProjectVcs(definitionFile.parentFile, VcsInfo.EMPTY, homepageUrl.orEmpty()),
         description = description.orEmpty(),
         authors = authors,
         homepageUrl = homepageUrl.orEmpty(),


### PR DESCRIPTION
Make the implementation consistent with other package managers in the code base. Note that the model does not have a property for the VCS info of the project, so `Project.vcs` should remain empty.
