### PR TITLE
feat(ort-project-file): Add a default value for project dependencies

### DIFF
--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProject.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProject.kt
@@ -44,7 +44,7 @@ internal data class OrtProject(
     val description: String? = null,
     val homepageUrl: String? = null,
     val authors: Set<String> = emptySet(),
-    val dependencies: List<Dependency>
+    val dependencies: List<Dependency> = emptyList()
 ) {
     @Serializable
     data class Dependency(

--- a/website/docs/guides/ort-project-package-manager.md
+++ b/website/docs/guides/ort-project-package-manager.md
@@ -95,7 +95,7 @@ declaredLicenses:
 # (optional) List of authors of the project.
 authors:
   - String Author name.
-# (mandatory) List of dependency packages for the project.
+# (optional) List of dependency packages for the project.
 dependencies: 
   - Dependency element schema (see below)
 ~~~


### PR DESCRIPTION
Avoid the need to explicitly specify an empty list.
