### PR TITLE
chore: Consistently do not log when using `getFallbackProjectName()`

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/NodePackageManager.kt
+++ b/plugins/package-managers/node/src/main/kotlin/NodePackageManager.kt
@@ -53,9 +53,7 @@ abstract class NodePackageManager(val managerType: NodePackageManagerType) : Pac
         val (namespace, name) = splitNamespaceAndName(packageJson.name.orEmpty())
 
         val projectName = name.ifBlank {
-            getFallbackProjectName(analysisRoot, packageJsonFile).also {
-                logger.warn { "'$packageJsonFile' does not define a name, falling back to '$it'." }
-            }
+            getFallbackProjectName(analysisRoot, packageJsonFile)
         }
 
         val vcs = parseVcsInfo(packageJson)

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
@@ -21,8 +21,6 @@ package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
 
 import java.io.File
 
-import org.apache.logging.log4j.kotlin.logger
-
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManager.Companion.processProjectVcs
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -52,9 +50,7 @@ internal fun OrtProject.mapToProject(definitionFile: File, analysisRoot: File) =
             type = PROJECT_TYPE,
             namespace = "",
             name = projectName.orEmpty().ifBlank {
-                PackageManager.getFallbackProjectName(analysisRoot, definitionFile).also {
-                    logger.info { "'$definitionFile' does not define a project name, falling back to '$it'." }
-                }
+                PackageManager.getFallbackProjectName(analysisRoot, definitionFile)
             },
             version = ""
         ),


### PR DESCRIPTION
Make the code of all callers consistent in terms of logging.

