### PR TITLE
docs: document package configuration provider precedence

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -51,8 +51,11 @@ ort:
     patentFilenames: ['patents']
     otherLicenseFilenames: ['readme*']
 
-  # Package configurations have to be unique by ID and provenance. Ensure that different providers do not provide
-  # configurations for the same package, see https://github.com/oss-review-toolkit/ort/issues/6972 for details.
+  # Package configuration providers are listed from highest to lowest priority. If multiple providers return
+  # configurations for the same package ID and provenance, the configuration from the higher-priority provider
+  # (listed first) takes precedence. Configurations must be unique by ID and provenance within a single provider.
+  # Ensure that different providers do not provide conflicting configurations for the same package, see
+  # https://github.com/oss-review-toolkit/ort/issues/6972 for details.
   packageConfigurationProviders:
   - type: DefaultDir
   - type: Dir


### PR DESCRIPTION
Adds precedence docs for packageConfigurationProviders.

## Why this matters

The packageCurationProviders section explains priority ordering. The packageConfigurationProviders comment only mentioned uniqueness. Now both sections follow the same documentation pattern.

## Changes

- **reference.yml**: Expanded the comment block for packageConfigurationProviders to explain priority ordering, precedence behavior, and the uniqueness constraint per provider.

Fixes #8742

This contribution was developed with AI assistance (Claude Code).