### PR TITLE
feat(ort-project-file): Make the source artifact hash optional

### DIFF
--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProject.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProject.kt
@@ -92,7 +92,7 @@ internal data class OrtProject(
     @Serializable
     data class SourceArtifact(
         val url: String,
-        val hash: Hash
+        val hash: Hash?
     )
 
     @Serializable

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.model.utils.toIdentifier
 import org.ossreviewtoolkit.model.utils.toPackageUrl
 import org.ossreviewtoolkit.model.utils.toPurl
@@ -93,7 +94,7 @@ private fun Vcs.toVcsInfo(): VcsInfo =
 private fun SourceArtifact.toRemoteArtifact(): RemoteArtifact =
     RemoteArtifact(
         url = url,
-        hash = Hash(hash.value.lowercase(), hash.algorithm)
+        hash = hash?.let { Hash(it.value.lowercase(), it.algorithm) }.orNone()
     )
 
 private fun Dependency.toId(): Identifier = id ?: checkNotNull(purl?.toPackageUrl()?.toIdentifier())


### PR DESCRIPTION
Leave it up to the user to decide whether to specify a hash. This increases flexibility and allows for more lightweight definitions.
