### PR TITLE
chore: Factor out `Hash?.orNone()`

### DIFF
--- a/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -51,6 +51,7 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.utils.common.expandTilde
@@ -203,7 +204,7 @@ private fun Dependency.toPackage(): Package {
         id = id,
         purl = purl ?: id.toPurl(),
         authors = authors,
-        sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash ?: Hash.NONE) }.orEmpty(),
+        sourceArtifact = sourceArtifact?.let { RemoteArtifact(url = it.url, it.hash.orNone()) }.orEmpty(),
         vcs = vcsInfo,
         declaredLicenses = declaredLicenses,
         concludedLicense = concludedLicense,

--- a/model/src/main/kotlin/Hash.kt
+++ b/model/src/main/kotlin/Hash.kt
@@ -105,6 +105,11 @@ data class Hash(
         }
 }
 
+/**
+ * Return this [Hash] if not null or else [Hash.NONE].
+ */
+fun Hash?.orNone(): Hash = this ?: Hash.NONE
+
 private class StringLowercaseConverter : StdConverter<String, String>() {
     override fun convert(value: String): String = value.lowercase()
 }

--- a/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
+++ b/plugins/package-managers/bazel/src/main/kotlin/Bazel.kt
@@ -62,6 +62,7 @@ import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.Includes
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginConfig
@@ -453,7 +454,7 @@ class Bazel(
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact(
                     url = archiveOverride.urls.first().toString(),
-                    hash = hash ?: Hash.NONE
+                    hash = hash.orNone()
                 ),
                 vcs = VcsInfo.EMPTY,
                 isModified = archiveOverride.patches?.isNotEmpty() == true

--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleDependencyHandler.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleDependencyHandler.kt
@@ -39,6 +39,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
 import org.ossreviewtoolkit.plugins.packagemanagers.gradlemodel.getIdentifierType
@@ -309,4 +310,4 @@ private fun createRemoteArtifact(
 private fun parseChecksum(checksum: String, algorithm: String) =
     checksum.splitOnWhitespace().firstNotNullOfOrNull {
         runCatching { Hash(it, algorithm) }.getOrNull()
-    } ?: Hash.NONE
+    }.orNone()

--- a/plugins/package-managers/maven/src/main/kotlin/tycho/P2RepositoryContentLoader.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/P2RepositoryContentLoader.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.common.withoutPrefix
@@ -179,7 +180,7 @@ internal class P2RepositoryContentLoader : AutoCloseable {
                 key.withoutPrefix(CHECKSUM_PROPERTY_PREFIX)?.let { algorithm ->
                     Hash(value, algorithm)
                 }
-            }.maxByOrNull { it.value.length } ?: Hash.NONE
+            }.maxByOrNull { it.value.length }.orNone()
 
         /**
          * Generate an identifier for an OSGi bundle artifact based on the given [artifactId] and [version].

--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenParsers.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenParsers.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
 import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.withoutPrefix
@@ -150,7 +151,7 @@ internal fun parseAuthors(mavenProject: MavenProject): Set<String> =
 internal fun parseChecksum(checksum: String, algorithm: String) =
     checksum.splitOnWhitespace().firstNotNullOfOrNull {
         runCatching { Hash(it, algorithm) }.getOrNull()
-    } ?: Hash.NONE
+    }.orNone()
 
 internal fun parseLicenses(mavenProject: MavenProject): Set<String> =
     mavenProject.licenses.mapNotNullTo(mutableSetOf()) { license ->

--- a/utils/cyclonedx/src/main/kotlin/ComponentExtensions.kt
+++ b/utils/cyclonedx/src/main/kotlin/ComponentExtensions.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.model.utils.toIdentifier
 import org.ossreviewtoolkit.model.utils.toPackageUrl
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -178,7 +179,7 @@ internal fun Component.extractSourceArtifact(): RemoteArtifact {
     }
 
     // Use size as a heuristic to pick the strongest hash (larger size = lower collision likelihood).
-    val hash = hashes?.maxByOrNull { it.algorithm.size } ?: Hash.NONE
+    val hash = hashes?.maxByOrNull { it.algorithm.size }.orNone()
 
     return RemoteArtifact(url = url, hash = hash)
 }


### PR DESCRIPTION
This is analog to other `orEmpty()` functions in ORT's model.
