### PR TITLE
build(gradle): Avoid rebuilds due to version changes only

### DIFF
--- a/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-base-conventions.gradle.kts
@@ -86,4 +86,12 @@ tasks.withType<Jar>().configureEach {
     }
 }
 
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Implementation-Version")
+        }
+    }
+}
+
 if (project != rootProject) version = rootProject.version


### PR DESCRIPTION
In ORT's setup, a Gradle project's version property is calculated based on Git history. The version is used as a suffix for JARs, which means that the JAR name changes with each commit. This is being handled by Gradle's default input normalization [1]. However, ORT also writes the version to the "Implementation-Version" attribute of the JAR's manifest. Ignore such changes as well, so that version-only changes in a project do not trigger rebuilds for dependent projects.

This fixes that after the steps

    $ ./gradlew detekt
    $ git commit --allow-empty -m "Dummy"
    $ ./gradlew detekt

the last line would rerun the `detekt` task for all project.

[1]: https://docs.gradle.org/current/userguide/incremental_build.html#sec:configure_input_normalization