### PR TITLE
docs(model): Update the KDoc for `Project.vcsProcessed`

### DIFF
--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -82,6 +82,7 @@ data class Project(
 
     /**
      * Processed VCS-related information about the [Project] that has e.g. common mistakes corrected.
+     * The information originates from [vcs], and optionally also from the code repository of the project.
      */
     val vcsProcessed: VcsInfo = vcs.normalize(),
 


### PR DESCRIPTION
While `Project.vcs` only contains information from the metadata of the project, `Project.vcsProcessed`, according to various package manager implementations, may additionally contain information derived from the version control system.

So, update the documentation to reflect the implementation.

