### PR TITLE
ci(renovate): Enable automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
       "matchManagers": ["gradle"],
       "commitMessageTopic": "{{depName}}",
       "recreateWhen": "never"


### PR DESCRIPTION
Let Renovate enable automerge for PRs that contain non-major updates to reduce the amount of clicks required to merge dependency updates. Note that these PRs still need to be approved and pass CI checks before they are merged.