### PR TITLE
Allow multiple matches for `SimplePackageConfigurationProvider`

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -52,10 +52,9 @@ ort:
     otherLicenseFilenames: ['readme*']
 
   # Package configuration providers are listed from highest to lowest priority. If multiple providers return
-  # configurations for the same package ID and provenance, the configuration from the higher-priority provider
-  # (listed first) takes precedence. Configurations must be unique by ID and provenance within a single provider.
-  # Ensure that different providers do not provide conflicting configurations for the same package, see
-  # https://github.com/oss-review-toolkit/ort/issues/6972 for details.
+  # configurations for the same package ID and provenance, the configuration from the higher-priority provider (listed
+  # first) takes precedence. Ensure that different providers do not provide conflicting configurations for the same
+  # package, see https://github.com/oss-review-toolkit/ort/issues/6972 for details.
   packageConfigurationProviders:
   - type: DefaultDir
   - type: Dir

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -61,10 +61,9 @@ ort:
     otherLicenseFilenames: ['README*']
 
   # Package configuration providers are listed from highest to lowest priority. If multiple providers return
-  # configurations for the same package ID and provenance, the configuration from the higher-priority provider
-  # (listed first) takes precedence. Configurations must be unique by ID and provenance within a single provider.
-  # Ensure that different providers do not provide conflicting configurations for the same package, see
-  # https://github.com/oss-review-toolkit/ort/issues/6972 for details.
+  # configurations for the same package ID and provenance, the configuration from the higher-priority provider (listed
+  # first) takes precedence. Ensure that different providers do not provide conflicting configurations for the same
+  # package, see https://github.com/oss-review-toolkit/ort/issues/6972 for details.
   packageConfigurationProviders:
   - type: DefaultDir
   - type: Dir

--- a/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.PackageConfiguration
-import org.ossreviewtoolkit.model.config.VcsMatcher
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 
 /**
@@ -50,24 +49,9 @@ open class SimplePackageConfigurationProvider(
     private val configurationsById: Map<Identifier, List<PackageConfiguration>>
 
     init {
-        configurations.checkAtMostOneConfigurationPerIdAndProvenance()
-
         configurationsById = configurations.groupBy { it.id.copy(version = "") }
     }
 
     override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
         configurationsById[packageId.copy(version = "")]?.filter { it.matches(packageId, provenance) }.orEmpty()
-}
-
-private fun Collection<PackageConfiguration>.checkAtMostOneConfigurationPerIdAndProvenance() {
-    data class Key(val id: Identifier, val sourceArtifactUrl: String?, val vcsMatcher: VcsMatcher?)
-
-    fun PackageConfiguration.key() = Key(id, sourceArtifactUrl, vcs)
-
-    val configurationsWithSameMatcher = groupBy { it.key() }.filter { it.value.size > 1 }
-
-    require(configurationsWithSameMatcher.isEmpty()) {
-        "There must be at most one package configuration per Id and provenance, but found multiple for:\n" +
-            "${configurationsWithSameMatcher.keys.joinToString(prefix = "  ", separator = "\n  ")}."
-    }
 }

--- a/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/api/src/main/kotlin/SimplePackageConfigurationProvider.kt
@@ -46,11 +46,7 @@ open class SimplePackageConfigurationProvider(
      * A map that stores all package configurations by their [Identifier] for fast lookup. The version of the
      * [Identifier]s must be ignored because it could be a version range.
      */
-    private val configurationsById: Map<Identifier, List<PackageConfiguration>>
-
-    init {
-        configurationsById = configurations.groupBy { it.id.copy(version = "") }
-    }
+    private val configurationsById = configurations.groupBy { it.id.copy(version = "") }
 
     override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
         configurationsById[packageId.copy(version = "")]?.filter { it.matches(packageId, provenance) }.orEmpty()

--- a/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
+++ b/plugins/package-configuration-providers/api/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.plugins.packageconfigurationproviders.api
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
@@ -29,41 +28,9 @@ import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.SourceCodeOrigin
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.PackageConfiguration
-import org.ossreviewtoolkit.model.config.VcsMatcher
 
 class SimplePackageConfigurationProviderTest : WordSpec({
-    "constructor" should {
-        "throw an exception provided multiple package configurations for same Id and source artifact provenance" {
-            val packageConfig = PackageConfiguration(
-                id = Identifier("type:group:name:version"),
-                sourceArtifactUrl = "https://some-host/some/path"
-            )
-            val configurations = listOf(packageConfig, packageConfig.copy())
-
-            shouldThrow<IllegalArgumentException> {
-                SimplePackageConfigurationProvider(configurations = configurations)
-            }
-        }
-
-        "throw an exception provided multiple package configurations for same Id and VCS provenance" {
-            val packageConfig = PackageConfiguration(
-                id = Identifier("type:group:name:version"),
-                vcs = VcsMatcher(
-                    type = VcsType.GIT,
-                    url = "https://some-host/some/path.git",
-                    revision = "0c1b2aec2812e4833bdca1028b5cb4b6"
-                )
-            )
-            val configurations = listOf(packageConfig, packageConfig.copy())
-
-            shouldThrow<IllegalArgumentException> {
-                SimplePackageConfigurationProvider(configurations = configurations)
-            }
-        }
-    }
-
     "getPackageConfigurations" should {
         val id = Identifier("Maven:org.ossreviewtoolkit:model:1.0.0")
         val provenance = ArtifactProvenance(


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 

Part of #12232.