### PR TITLE
feat(model): Add indicator nodes for cycles in the dependency graph

### DIFF
--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -367,7 +367,12 @@ data class DependencyGraphNode(
      * A list of [Issue]s that occurred handling this dependency.
      */
     val issues: List<Issue> = emptyList()
-)
+) {
+    /**
+     * Test whether this node is a special marker node to indicate a cycle in the dependency graph.
+     */
+    fun isCycleIndicator(): Boolean = isCycleIndicatorIndex(fragment)
+}
 
 /**
  * A data class representing an edge in the dependency graph.
@@ -382,6 +387,24 @@ data class DependencyGraphEdge(
     /** The index of the destination node of this edge. */
     val to: Int
 )
+
+/**
+ * Constant of a bit mask used to add information about cycles to a fragment index. A node acting as cycle indicator
+ * has a fragment index greater than this value.
+ */
+private const val CYCLE_INDICATOR_MASK = 0xFFFF
+
+/**
+ * Check whether the given [fragmentIndex] indicates a marker node for a cycle in the dependency graph.
+ */
+fun isCycleIndicatorIndex(fragmentIndex: Int): Boolean = fragmentIndex > CYCLE_INDICATOR_MASK
+
+/**
+ * Return the plain index of the fragment referenced by the given [fragmentIndex] stripping any information about
+ * cycles. If the passed in [fragmentIndex] is not an indicator index for cycles, it is returned as is; otherwise,
+ * the fragment component is extracted.
+ */
+fun extractFragment(fragmentIndex: Int): Int = fragmentIndex and CYCLE_INDICATOR_MASK
 
 /**
  * Convert this [DependencyReference] to a [DependencyGraphNode].

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.model.utils
 
 import java.util.LinkedList
 
+import org.apache.logging.log4j.kotlin.logger
+
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyGraphEdge
 import org.ossreviewtoolkit.model.DependencyGraphNode
@@ -30,6 +32,8 @@ import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.RootDependencyIndex
+import org.ossreviewtoolkit.model.extractFragment
+import org.ossreviewtoolkit.model.isCycleIndicatorIndex
 
 /**
  * Internal class to represent the result of a search in the dependency graph. The outcome of the search
@@ -139,6 +143,12 @@ class DependencyGraphBuilder<D>(
     private val references = mutableMapOf<DependencyReference, D>()
 
     /**
+     * A map for generating fragment indices for marker nodes that are added to the graph if cycles are detected. The
+     * key is a fragment index, the value is the number of cycles found in this fragment.
+     */
+    private val cycleCounts = mutableMapOf<Int, Int>()
+
+    /**
      * Add the given [dependency] for the scope with the given [scopeName] to this builder. This function needs to be
      * called for all direct dependencies of all scopes. That way the builder gets sufficient information to construct
      * the [DependencyGraph].
@@ -232,7 +242,8 @@ class DependencyGraphBuilder<D>(
         scopeName: String,
         dependency: D,
         transitive: Boolean,
-        processed: Set<D>
+        processed: Set<D>,
+        inCycle: Boolean = false
     ): DependencyReference? {
         val id = dependencyHandler.identifierFor(dependency)
         val issues = dependencyHandler.issuesFor(dependency).toMutableList()
@@ -248,13 +259,13 @@ class DependencyGraphBuilder<D>(
                     scopeName,
                     dependency,
                     issues,
-                    transitive,
-                    processed
+                    processed,
+                    inCycle
                 )
             }
 
             is DependencyGraphSearchResult.Incompatible ->
-                insertIntoNewFragment(id, index, scopeName, dependency, issues, transitive, processed)
+                insertIntoNewFragment(id, index, scopeName, dependency, issues, processed, inCycle)
         }
 
         return updateScopeMapping(scopeName, ref, transitive)
@@ -321,11 +332,10 @@ class DependencyGraphBuilder<D>(
     }
 
     /**
-     * Add a new fragment to the dependency graph for the [dependency] with the given [id] and [index], which may be
-     * [transitive] and belongs to the scope with the given [scopeName]. This function is called for dependencies that
-     * cannot be added to already existing fragments. Therefore, create a new fragment and add the [dependency] to it,
-     * together with its own dependencies. Store the given [issues] for the dependency. Use [processed] to detect
-     * cycles.
+     * Add a new fragment to the dependency graph for the [dependency] with the given [id] and [index], which belongs
+     * to the scope with the given [scopeName]. This function is called for dependencies that cannot be added to
+     * already existing fragments. Therefore, create a new fragment and add the [dependency] to it, together with its
+     * own dependencies. Store the given [issues] for the dependency. Use [processed] and [inCycle] to detect cycles.
      */
     private fun insertIntoNewFragment(
         id: Identifier,
@@ -333,22 +343,23 @@ class DependencyGraphBuilder<D>(
         scopeName: String,
         dependency: D,
         issues: List<Issue>,
-        transitive: Boolean,
-        processed: Set<D>
+        processed: Set<D>,
+        inCycle: Boolean
     ): DependencyReference? {
         val fragmentMapping = mutableMapOf<Int, DependencyReference>()
         val dependencyIndex = RootDependencyIndex(index, referenceMappings.size)
         referenceMappings += fragmentMapping
 
-        return insertIntoGraph(id, dependencyIndex, scopeName, dependency, issues, transitive, processed)
+        return insertIntoGraph(id, dependencyIndex, scopeName, dependency, issues, processed, inCycle)
     }
 
     /**
      * Insert the [dependency] with the given [id] and [RootDependencyIndex][index], which belongs to the scope with
-     * the given [scopeName] and may be [transitive] into the dependency graph. Insert the dependencies of this
-     * [dependency] recursively. Create a new [DependencyReference] for the dependency and initialize it with the list
-     * of [issues]. Use the given [processed] set to figure out cycles in the dependency graph. If such a cycle is
-     * detected, stop processing of further dependencies and return *null*.
+     * the given [scopeName] into the dependency graph. Insert the dependencies of this [dependency] recursively.
+     * Create a new [DependencyReference] for the dependency and initialize it with the list of [issues]. Use the given
+     * [processed] set and the [inCycle] flag to deal with cycles in the dependency graph. If such a cycle is detected,
+     * add a marker node for the affected package (with a special fragment index) that does not have further
+     * dependencies.
      */
     private fun insertIntoGraph(
         id: Identifier,
@@ -356,32 +367,50 @@ class DependencyGraphBuilder<D>(
         scopeName: String,
         dependency: D,
         issues: List<Issue>,
-        transitive: Boolean,
-        processed: Set<D>
+        processed: Set<D>,
+        inCycle: Boolean
     ): DependencyReference? {
         val nextProcessed = processed + dependency
-        val transitiveDependencies = dependencyHandler.dependenciesFor(dependency)
-            .mapNotNullTo(mutableSetOf()) { dep ->
-                dep.takeUnless { it in nextProcessed }?.let {
-                    addDependencyToGraph(scopeName, dep, transitive = true, nextProcessed + dep)
+        val transitiveDependencies = if (inCycle) {
+            emptySet()
+        } else {
+            dependencyHandler.dependenciesFor(dependency)
+                .mapNotNullTo(mutableSetOf()) { dep ->
+                    addDependencyToGraph(
+                        scopeName,
+                        dep,
+                        transitive = true,
+                        nextProcessed + dep,
+                        inCycle = dep in nextProcessed
+                    )
                 }
+        }
+
+        val fragmentIndex = if (inCycle) {
+            fragmentIndexForCycle(index.fragment).also {
+                logger.info { "Cycle detected in dependency graph for package '${id.toCoordinates()}'." }
+                logger.info { "Adding marker node with fragment index $it." }
             }
+        } else {
+            index.fragment
+        }
 
         val fragmentMapping = referenceMappings[index.fragment]
-        if (index.root in fragmentMapping) {
-            // If this point is reached, the package has already been inserted when processing its dependencies.
-            // This means that there is a cyclic dependency. To handle this case correctly, the insert operation has
-            // to be started anew.
-            return addDependencyToGraph(scopeName, dependency, transitive, nextProcessed)
+        if (index.root in fragmentMapping && !startOfCycle(index)) {
+            // If this point is reached, the package has already been inserted when processing its dependencies, but
+            // no cycle has been found. To handle this case correctly, the insert operation has to be restarted; this
+            // should then find the already inserted node in the graph.
+            return addDependencyToGraph(scopeName, dependency, transitive = true, processed + dependency)
         }
 
         val ref = DependencyReference(
             pkg = index.root,
-            fragment = index.fragment,
+            fragment = fragmentIndex,
             dependencies = transitiveDependencies,
             linkage = dependencyHandler.linkageFor(dependency),
             issues = issues
         )
+
         fragmentMapping[index.root] = ref
         references[ref] = dependency
 
@@ -391,6 +420,16 @@ class DependencyGraphBuilder<D>(
 
         return ref
     }
+
+    /**
+     * Check whether the given [index] refers to a node that is the starting point of a cycle. This is the case if
+     * there is a corresponding cycle indicator node.
+     */
+    private fun startOfCycle(index: RootDependencyIndex): Boolean =
+        references.keys.any {
+            it.pkg == index.root && isCycleIndicatorIndex(it.fragment) &&
+                extractFragment(it.fragment) == index.fragment
+        }
 
     /**
      * Construct a [Package] for the given [id] that corresponds to the given [dependency]. If the package is already
@@ -418,6 +457,20 @@ class DependencyGraphBuilder<D>(
         }
 
         return ref
+    }
+
+    /**
+     * Generate a special fragment index for a node that indicates a cycle in the dependency graph. The combination of
+     * package ID and fragment index must be unique for all nodes in the graph. Therefore, marker nodes to indicate
+     * cycles require some special values here. Cycle indicator nodes have a fragment index greater than 65536 where
+     * the upper bits are just a counter to generate a unique value. Use the provided original [fragmentIndex] to
+     * obtain the corresponding counter. To find the fragment index of the original node (that starts the cycle), the
+     * upper 16 bits just have to be masked out.
+     */
+    private fun fragmentIndexForCycle(fragmentIndex: Int): Int {
+        val counter = cycleCounts.getOrDefault(fragmentIndex, 0) + 1
+        cycleCounts[fragmentIndex] = counter
+        return fragmentIndex + (counter shl 16)
     }
 }
 

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model.utils
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
@@ -33,7 +34,7 @@ import io.mockk.every
 import io.mockk.spyk
 
 import org.ossreviewtoolkit.model.DependencyGraph
-import org.ossreviewtoolkit.model.DependencyGraphEdge
+import org.ossreviewtoolkit.model.DependencyGraphNode
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
@@ -222,27 +223,31 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency("root", 1)
                 .build(checkReferences = false)
 
-            graph.nodes shouldHaveSize 6
-            graph.edges should containExactly(
-                DependencyGraphEdge(from = 2, to = 1),
-                DependencyGraphEdge(from = 3, to = 0),
-                DependencyGraphEdge(from = 3, to = 2),
-                DependencyGraphEdge(from = 5, to = 3),
-                DependencyGraphEdge(from = 5, to = 4)
-            )
+            val expected = buildList {
+                add(handler.identifierFor(1).atLevel(0))
+                add(handler.identifierFor(2).atLevel(1))
+                add(handler.identifierFor(4).atLevel(2))
+                add(handler.identifierFor(5).atLevel(2))
+                add(handler.identifierFor(6).atLevel(3))
+                add(handler.identifierFor(2).atLevel(4, cycle = true))
+                add(handler.identifierFor(3).atLevel(1))
+                add(handler.identifierFor(1).atLevel(2, cycle = true))
+            }
+
+            val actual = graph.dumpScope("root")
+            assertGraph(expected, actual)
         }
 
         "deal with cyclic dependency graphs" {
             val scope = "CyclicGraph"
-            val depLang = createDependency("org.apache.commons", "commons-lang3", "3.20.0")
-            val depCyc = spyk(createDependency("org.cyclic", "cyclic", "77.7"))
-            val depIntermediate = createDependency(
-                "org.intermediate",
-                "intermediate",
-                "1.0.0",
-                dependencies = setOf(depLang, depCyc)
-            )
-            val depRoot = createDependency("org.foo", "foo", "1.2.0", dependencies = setOf(depIntermediate))
+            val idLang = createId("org.apache.commons", "commons-lang3", "3.20.0")
+            val idCyc = createId("org.cyclic", "cyclic", "77.7")
+            val idIntermediate = createId("org.intermediate", "intermediate", "1.0.0")
+            val idRoot = createId("org.foo", "foo", "1.2.0")
+            val depLang = createDependency(idLang)
+            val depCyc = spyk(createDependency(idCyc))
+            val depIntermediate = createDependency(idIntermediate, dependencies = setOf(depLang, depCyc))
+            val depRoot = createDependency(idRoot, dependencies = setOf(depIntermediate))
 
             // This causes a cycle in the dependency graph:
             every { depCyc.dependencies } returns setOf(depRoot)
@@ -250,11 +255,17 @@ class DependencyGraphBuilderTest : WordSpec({
             val graph = createGraphBuilder()
                 .addDependency(scope, depRoot)
                 .build()
-            val scopes = graph.createScopes()
 
-            scopeDependencies(scopes, scope) should containExactly(depRoot)
+            val expected = buildList {
+                add(idRoot.atLevel(0))
+                add(idIntermediate.atLevel(1))
+                add(idLang.atLevel(2))
+                add(idCyc.atLevel(2))
+                add(idRoot.atLevel(3, cycle = true))
+            }
 
-            graph.nodes shouldHaveSize 4
+            val actual = graph.dumpScope(scope)
+            assertGraph(expected, actual)
         }
 
         "check for illegal references when building the graph" {
@@ -402,6 +413,12 @@ private fun createGraphBuilder(): DependencyGraphBuilder<PackageReference> =
     DependencyGraphBuilder(PackageRefDependencyHandler)
 
 /**
+ * Create a test [Identifier] with the given [group], [artifact], and [version].
+ */
+private fun createId(group: String, artifact: String, version: String): Identifier =
+    Identifier("test", group, artifact, version)
+
+/**
  * Create a test dependency with the properties provided.
  */
 private fun createDependency(
@@ -409,13 +426,54 @@ private fun createDependency(
     artifact: String,
     version: String,
     dependencies: Set<PackageReference> = emptySet()
-) = PackageReference(
-    id = Identifier("test", group, artifact, version),
-    dependencies = dependencies
-)
+) = createDependency(createId(group, artifact, version), dependencies)
+
+/**
+ * Create a test dependency with the given [id] and [dependencies].
+ */
+private fun createDependency(id: Identifier, dependencies: Set<PackageReference> = emptySet()) =
+    PackageReference(
+        id = id,
+        dependencies = dependencies
+    )
 
 /**
  * Return the package references from the given [scopes] associated with the scope with the given [scopeName].
  */
 private fun scopeDependencies(scopes: Set<Scope>, scopeName: String): Set<PackageReference> =
     scopes.find { it.name == scopeName }?.dependencies.orEmpty()
+
+/**
+ * Assert that the [actual] representations of a dependency graph matches the [expected] one.
+ */
+private fun assertGraph(expected: List<String>, actual: List<String>) {
+    withClue("Expected:\n${expected.joinToString("\n")}\nActual:\n${actual.joinToString("\n")}") {
+        actual should containExactly(expected)
+    }
+}
+
+/**
+ * Generate a string to represent a graph node for the package with this [Identifier] at the given hierarchy
+ * [level] which may by an indicator for a [cycle].
+ */
+private fun Identifier.atLevel(level: Int, cycle: Boolean = false): String =
+    buildString {
+        append(" ".repeat(level))
+        append(toCoordinates())
+        if (cycle) append("->")
+    }
+
+/**
+ * Generate a list representation for the hierarchy of nodes in the scope with the given [scopeName].
+ */
+private fun DependencyGraph.dumpScope(scopeName: String): List<String> =
+    buildList {
+        fun dumpNode(node: DependencyGraphNode, level: Int) {
+            add(packages[node.pkg].atLevel(level, cycle = node.isCycleIndicator()))
+            dependencies[node].orEmpty().forEach { dumpNode(it, level + 1) }
+        }
+
+        scopes[scopeName].orEmpty().mapNotNull { root ->
+            nodes.find { it.pkg == root.root && it.fragment == root.fragment }
+        }.forEach { root -> dumpNode(root, 0) }
+    }


### PR DESCRIPTION
When during construction of the dependency graph a cycle in the dependencies is detected, add a special marker node for the package that closes the cycle that does not have any dependencies. That way, the referenced package is still visible in the graph, but the graph remains free of cycles.
