### PR TITLE
feat(package-configurations): Allow blank version

### DIFF
--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -22,11 +22,7 @@ package org.ossreviewtoolkit.model
 import com.fasterxml.jackson.annotation.JsonProperty
 
 import org.ossreviewtoolkit.model.utils.isApplicableIvyVersion
-
-/**
- * Return true if this string equals the [other] string, or if either string is blank.
- */
-private fun String.equalsOrIsBlank(other: String) = equals(other) || isBlank() || other.isBlank()
+import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
 
 /**
  * This class assigns a [PackageCurationData] object to a [Package] identified by the [id].

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.hasIvyVersionRange
 import org.ossreviewtoolkit.model.utils.isApplicableIvyVersion
+import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 
 /**
@@ -43,8 +44,11 @@ import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 data class PackageConfiguration(
     /**
      * The [Identifier] which must match with the identifier of the package in order for this package curation to apply.
-     * The [version][Identifier.version] can be either a plain version string matched for equality, or an
-     * [Ivy-style version matchers](https://ant.apache.org/ivy/history/2.5.0/settings/version-matchers.html).
+     * The [version][Identifier.version] can be either:
+     * - blank, to match any version,
+     * - a plain version string matched for equality,
+     * - an [Ivy-style version matcher](https://ant.apache.org/ivy/history/2.5.0/settings/version-matchers.html).
+     * If the package's version is blank, it matches regardless of the version set here.
      * The other components of the [identifier][id] are matched by equality.
      */
     val id: Identifier,
@@ -98,7 +102,7 @@ data class PackageConfiguration(
         if (!id.type.equals(otherId.type, ignoreCase = true) ||
             id.namespace != otherId.namespace ||
             id.name != otherId.name ||
-            !id.isApplicableIvyVersion(otherId)
+            !(id.version.equalsOrIsBlank(otherId.version) || id.isApplicableIvyVersion(otherId))
         ) {
             return false
         }

--- a/model/src/test/kotlin/config/PackageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/PackageConfigurationTest.kt
@@ -184,6 +184,22 @@ class PackageConfigurationTest : WordSpec({
 
             config.matches(config.id.copy(version = "6"), ARTIFACT_PROVENANCE) shouldBe false
         }
+
+        "return true for any version if the id version is blank" {
+            val config = PackageConfiguration(id = Identifier.EMPTY.copy(name = "some-name"))
+
+            config.matches(config.id.copy(version = "1.0.0"), ARTIFACT_PROVENANCE) shouldBe true
+            config.matches(config.id.copy(version = "2.0.0-alpha1"), REPOSITORY_PROVENANCE) shouldBe true
+        }
+
+        "return true if the package version is blank regardless of the configured version" {
+            val config = PackageConfiguration(
+                id = Identifier.EMPTY.copy(name = "some-name", version = "1.0.0")
+            )
+
+            config.matches(config.id.copy(version = ""), ARTIFACT_PROVENANCE) shouldBe true
+            config.matches(config.id.copy(version = ""), REPOSITORY_PROVENANCE) shouldBe true
+        }
     }
 
     "init()" should {

--- a/utils/common/src/main/kotlin/StringUtils.kt
+++ b/utils/common/src/main/kotlin/StringUtils.kt
@@ -42,6 +42,11 @@ fun String.encodeOr(emptyValue: String): String {
 fun String.encodeOrUnknown(): String = encodeOr("unknown")
 
 /**
+ * Return true if this string equals the [other] string, or if either string is blank.
+ */
+fun String.equalsOrIsBlank(other: String) = equals(other) || isBlank() || other.isBlank()
+
+/**
  * Return the string encoded for safe use as a file name. Also limit the length to 255 characters which is the maximum
  * length in most modern filesystems, see
  * [comparison of file system limits](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits).

--- a/utils/common/src/test/kotlin/StringUtilsTest.kt
+++ b/utils/common/src/test/kotlin/StringUtilsTest.kt
@@ -143,6 +143,36 @@ class StringUtilsTest : WordSpec({
         }
     }
 
+    "equalsOrIsBlank()" should {
+        "return true if both strings are equal" {
+            "foo".equalsOrIsBlank("foo") shouldBe true
+        }
+
+        "return true if the receiver is empty" {
+            "".equalsOrIsBlank("foo") shouldBe true
+        }
+
+        "return true if the receiver is blank" {
+            "   ".equalsOrIsBlank("foo") shouldBe true
+        }
+
+        "return true if the other string is empty" {
+            "foo".equalsOrIsBlank("") shouldBe true
+        }
+
+        "return true if the other string is blank" {
+            "foo".equalsOrIsBlank("   ") shouldBe true
+        }
+
+        "return true if both strings are blank" {
+            "   ".equalsOrIsBlank("") shouldBe true
+        }
+
+        "return false if the strings differ and neither is blank" {
+            "foo".equalsOrIsBlank("bar") shouldBe false
+        }
+    }
+
     "unquote()" should {
         "remove surrounding quotes" {
             "'single'".unquote() shouldBe "single"

--- a/website/docs/configuration/package-configurations.md
+++ b/website/docs/configuration/package-configurations.md
@@ -42,6 +42,10 @@ source_code_origin: VCS
 id: "NPM::ansi-styles:[4.0,4.2.1]"
 source_code_origin: ARTIFACT
 
+# Apply to all versions.
+id: "NPM::ansi-styles:"
+source_code_origin: VCS
+
 # Apply only to version 4.2.1, regardless whether
 # code repository or source artifact was scanned.
 id: "NPM::ansi-styles:4.2.1"


### PR DESCRIPTION
Allow not setting any version for package-configurations. This aligns the version matching to package-curations and allows matching any version of a package.