### PR TITLE
build: Make the UP-TO-DATE work-around function with IntelliJ 2026.1

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -145,7 +145,7 @@ tasks.withType<JavaExec>().configureEach {
 
     // Work around https://youtrack.jetbrains.com/issue/KTIJ-34755.
     if (normalizedName.endsWith("main") || normalizedName.endsWith("run")) {
-        doNotTrackState("Interactive Java execution tasks are never supposed to be UP-TO-DATE.")
+        outputs.upToDateWhen { false }
     }
 }
 


### PR DESCRIPTION
For some reason using `doNotTrackState` stopped working, so explicitly never allow the task to be UP-TO-DATE.