### PR TITLE
fix(model): Fix the default license fact provider order

### DIFF
--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -89,9 +89,9 @@ data class OrtConfiguration(
      * [ORT_CUSTOM_LICENSE_TEXTS_DIRNAME].
      */
     val licenseFactProviders: LinkedHashMap<String, PluginConfig> = linkedMapOf(
+        "DefaultDir" to PluginConfig.EMPTY,
         "SPDX" to PluginConfig.EMPTY,
-        "ScanCode" to PluginConfig.EMPTY,
-        "DefaultDir" to PluginConfig.EMPTY
+        "ScanCode" to PluginConfig.EMPTY
     ),
 
     /**


### PR DESCRIPTION
According to `ort report --help`, the license texts in the `custom-license-texts` directory take priority over the configured license fact providers.

As the `DefaultDir` license fact provider is configured by default and uses the `custom-license-texts` directory, it should also be the first item in the list in order to take priority for consistency.

