### PR TITLE
feat(model): Enable setting package source code origins to empty list

### DIFF
--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
-import org.ossreviewtoolkit.model.utils.requireNotEmptyNoDuplicates
+import org.ossreviewtoolkit.model.utils.requireNoDuplicates
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
@@ -137,7 +137,7 @@ data class Package(
 
     /**
      * The considered source code origins and their priority order to use for this package. If null, the configured
-     * default is used. If not null, this must not be empty and not contain any duplicates.
+     * default is used. The list must not contain any duplicates.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val sourceCodeOrigins: List<SourceCodeOrigin>? = null,
@@ -172,7 +172,7 @@ data class Package(
     }
 
     init {
-        sourceCodeOrigins?.requireNotEmptyNoDuplicates()
+        sourceCodeOrigins?.requireNoDuplicates()
     }
 
     /**

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.licenses.LicenseCategory
-import org.ossreviewtoolkit.model.utils.requireNotEmptyNoDuplicates
+import org.ossreviewtoolkit.model.utils.requireNoDuplicates
 
 /**
  * The configuration model of the downloader. This class is (de-)serialized in the following places:
@@ -45,8 +45,8 @@ data class DownloaderConfiguration(
     val skipExcluded: Boolean = false,
 
     /**
-     * Configuration of the considered source code origins and their priority order. This must not be empty and not
-     * contain any duplicates.
+     * Configuration of the considered source code origins and their priority order. This must not contain any
+     * duplicates.
      */
     val sourceCodeOrigins: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT),
 
@@ -58,6 +58,6 @@ data class DownloaderConfiguration(
     val enablePreemptiveAuthentication: Boolean = false
 ) {
     init {
-        sourceCodeOrigins.requireNotEmptyNoDuplicates()
+        sourceCodeOrigins.requireNoDuplicates()
     }
 }

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -89,11 +89,7 @@ fun String.parseRepoManifestPath() =
             ?.takeUnless { it.isEmpty() }
     }.getOrNull()
 
-internal fun List<SourceCodeOrigin>.requireNotEmptyNoDuplicates() {
-    require(isNotEmpty()) {
-        "'sourceCodeOrigins' must not be empty."
-    }
-
+internal fun List<SourceCodeOrigin>.requireNoDuplicates() {
     val duplicates = getDuplicates()
     require(duplicates.isEmpty()) {
         "'sourceCodeOrigins' must not contain duplicates. Duplicates: $duplicates"

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -119,8 +119,13 @@ class Scanner(
             )
         )
 
-        val packages = ortResult.getPackages(skipExcluded).map { it.metadata }.filterNotConcluded()
-            .filterNotMetadataOnly().toSet()
+        val packages = ortResult.getPackages(skipExcluded)
+            .map { it.metadata }
+            .filterNotConcluded()
+            .filterNotEmptySourceCodeOrigins()
+            .filterNotMetadataOnly()
+            .toSet()
+
         val packageResults = scan(
             packages,
             ScanContext(
@@ -491,6 +496,17 @@ class Scanner(
 
                 keep
             }
+
+    private fun Collection<Package>.filterNotEmptySourceCodeOrigins(): List<Package> =
+        partition { it.sourceCodeOrigins?.isEmpty() == true }.let { (skip, keep) ->
+            if (skip.isNotEmpty()) {
+                logger.debug {
+                    "Not scanning the following package(s) with empty source code origins: $skip"
+                }
+            }
+
+            keep
+        }
 
     private fun Collection<Package>.filterNotMetadataOnly(): List<Package> =
         partition { it.isMetadataOnly }.let { (skip, keep) ->


### PR DESCRIPTION
The scanner already has a mechanism for skipping packages which have `Package.metadataOnly` set, or which have a concluded license. For skipped packages no technical issue is ever reported, because the scanner does not attempt to execute neither of the steps provenance resolution, file list resolution or scanning the provenance.

In case of metadata-only, the source code is not available because no source code corresponds to the package, e.g. the package content is empty. But there is further type of packages for which the source code is not available for other valid reasons, for examples closed source / proprietary packages.

Allow setting `Package.sourceCodeOrigins = []` to enable a way to skip scanning such packages, analog to the already existing skip mechanisms. This enables fixing provenance resolution issues with a dedicated package curation instead of with an issue resolution, which is clearner, easier to maintain and more powerful with regard to matching the identifier.

Fixes #11686.
