### PR TITLE
fix(flox): Maintain the `CI` environment variable

### DIFF
--- a/flox/run_isolated.sh
+++ b/flox/run_isolated.sh
@@ -27,4 +27,4 @@ fi
 ENV_DIR="$(dirname "$SELF")/$1"
 shift
 
-env -i "$(which flox)" activate -d "$ENV_DIR" -- "$@"
+env -i CI=$CI "$(which flox)" activate -d "$ENV_DIR" -- "$@"


### PR DESCRIPTION
Basically, isolated environments should be empty, but the build and some tests rely on the `CI` environment variable to be properly set, so maintain it.