### PR TITLE
feat(Conan): Add support for scm field from conandata for VCS info

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -364,17 +364,33 @@ class Conan(
             }
         }
 
-        return ConanData(url, sha256, hasPatches)
+        val scm = root.get<YamlMap>("scm")
+        val scmUrl = scm?.get<YamlScalar>("url")?.content
+        val scmCommit = scm?.get<YamlScalar>("commit")?.content
+
+        return ConanData(url, sha256, scmUrl, scmCommit, hasPatches)
     }
 }
 
 internal data class ConanData(
     val url: String?,
     val sha256: String?,
+    val scmUrl: String?,
+    val scmCommit: String?,
     val hasPatches: Boolean
 ) {
     companion object {
-        val EMPTY = ConanData(url = null, sha256 = null, hasPatches = false)
+        val EMPTY = ConanData(url = null, sha256 = null, scmUrl = null, scmCommit = null, hasPatches = false)
+    }
+
+    /**
+     * Return the [VcsInfo] for this [ConanData], or null if no VCS information is available.
+     */
+    fun toVcsInfo(): VcsInfo {
+        val url = scmUrl ?: return VcsInfo.EMPTY
+        val vcsInfo = VcsHost.parseUrl(url)
+        val revision = scmCommit ?: return vcsInfo
+        return vcsInfo.copy(revision = revision)
     }
 }
 

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -319,16 +319,6 @@ class Conan(
     }
 
     /**
-     * Return the [VcsInfo] contained in [pkgInfo].
-     */
-    internal fun parseVcsInfo(pkgInfo: PackageInfo): VcsInfo {
-        val revision = pkgInfo.revision.orEmpty()
-        val url = pkgInfo.url.orEmpty()
-        val vcsInfo = VcsHost.parseUrl(url)
-        return if (revision == "0") vcsInfo else vcsInfo.copy(revision = revision)
-    }
-
-    /**
      * Return the source artifact contained in [conanData], or [RemoteArtifact.EMPTY] if no source artifact is
      * available.
      */
@@ -386,4 +376,12 @@ internal data class ConanData(
     companion object {
         val EMPTY = ConanData(url = null, sha256 = null, hasPatches = false)
     }
+}
+
+/**
+ * Return the [VcsInfo] contained in [PackageInfo].
+ */
+internal fun PackageInfo.toVcsInfo(): VcsInfo {
+    val vcsInfo = VcsHost.parseUrl(url.orEmpty())
+    return if (revision == "0") vcsInfo else vcsInfo.copy(revision = revision.orEmpty())
 }

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
@@ -29,7 +29,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
-import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.DUMMY_COMPILER_SETTINGS
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEPENDENCIES
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEV_DEPENDENCIES
@@ -153,7 +152,10 @@ internal class ConanV1Handler(private val conan: Conan) : ConanVersionHandler {
             homepageUrl = homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
             sourceArtifact = conan.parseSourceArtifact(conanData),
-            vcs = processPackageVcs(VcsInfo.EMPTY, homepageUrl),
+            vcs = processPackageVcs(
+                conanData.toVcsInfo(),
+                homepageUrl
+            ),
             isModified = conanData.hasPatches
         )
     }

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
@@ -195,7 +195,7 @@ internal class ConanV1Handler(private val conan: Conan) : ConanVersionHandler {
             homepageUrl = pkgInfo.homepage.orEmpty(),
             binaryArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
             sourceArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
-            vcs = conan.parseVcsInfo(pkgInfo)
+            vcs = pkgInfo.toVcsInfo()
         )
     }
 

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
@@ -31,7 +31,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
-import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.DUMMY_COMPILER_SETTINGS
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEPENDENCIES
 import org.ossreviewtoolkit.plugins.packagemanagers.conan.Conan.Companion.SCOPE_NAME_DEV_DEPENDENCIES
@@ -198,7 +197,10 @@ internal class ConanV2Handler(private val conan: Conan) : ConanVersionHandler {
             homepageUrl = homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
             sourceArtifact = conan.parseSourceArtifact(conanData),
-            vcs = processPackageVcs(VcsInfo.EMPTY, homepageUrl),
+            vcs = processPackageVcs(
+                conanData.toVcsInfo(),
+                homepageUrl
+            ),
             isModified = conanData.hasPatches
         )
     }

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
@@ -231,7 +231,7 @@ internal class ConanV2Handler(private val conan: Conan) : ConanVersionHandler {
             homepageUrl = pkgInfo.homepage.orEmpty(),
             binaryArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
             sourceArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
-            vcs = conan.parseVcsInfo(pkgInfo)
+            vcs = pkgInfo.toVcsInfo()
         )
     }
 }


### PR DESCRIPTION
We want to support vcs information from conandata that can be exported using https://github.com/conan-io/conan/blob/develop2/conan/tools/scm/git.py#L273
