### PR TITLE
fix(node): Fix a mistake in `undoDeduplication()`

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -244,12 +244,13 @@ private fun ModuleInfo.undoDeduplication(): ModuleInfo {
 
     fun ModuleInfo.undoDeduplicationRec(ancestorsIds: Set<String> = emptySet()): ModuleInfo {
         val dependencyAncestorIds = ancestorsIds + setOfNotNull(id)
-        val dependencies = (replacements[id] ?: this)
-            .dependencies
-            .filter { it.value.id !in dependencyAncestorIds } // break cycles.
-            .mapValues { it.value.undoDeduplicationRec(dependencyAncestorIds) }
+        val replacement = replacements[id] ?: this
 
-        return copy(dependencies = dependencies)
+        return replacement.copy(
+            dependencies = replacement.dependencies
+                .filter { it.value.id !in dependencyAncestorIds } // break cycles.
+                .mapValues { it.value.undoDeduplicationRec(dependencyAncestorIds) }
+        )
     }
 
     return undoDeduplicationRec()


### PR DESCRIPTION
ORT runs `npm list --depth Infinity` to obtain a de-duplicated or rather truncated dependency tree. The data model for the tree nodes is the `ModuleInfo` class. Truncated nodes have the dependencies stripped, which is why `undoDeduplication()` patches up any truncated node by copying the `dependencies` from a non-truncated node corresponding to the same package.

However, the truncated node not just lacks the dependencies, but also has further properties not set. So, adjust the logic to cover all properties to ensure each truncated node is patched up completely.

This fixes an issue where a patched node accidentally had `resolved` set to `null`, which lead to `isProject` returning `false`, which in turn lead to `NpmDependencyHandler.createPackage()` returning `null`. As result the analyzer aborted with [1].

[1]: Exception in thread "main" java.lang.IllegalArgumentException:
     The following references do not actually refer to packages: '$PACKAGE'.
 	at org.ossreviewtoolkit.model.utils.DependencyGraphBuilder.checkReferences()

