### PR TITLE
docs(gradle): Update the comment about disabled Detekt reports

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -184,11 +184,8 @@ tasks.withType<Detekt>().configureEach detekt@{
     }
 
     reports {
+        // Disable these as they have issues with Gradle task output caching due to contained timestamps.
         html.required = false
-
-        // TODO: Enable this once https://github.com/detekt/detekt/issues/5034 is resolved and use the merged
-        //       Markdown file as a GitHub Action job summary, see
-        //       https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/.
         markdown.required = false
 
         sarif.required = true


### PR DESCRIPTION
Detekt issue #5034 was closed as "not planned" meanwhile [1]. However, the HTML and Markdown report formats anyway have issues with Gradle's UP-TO-DATE check for task outputs as the files contain timestamps that are updated even if no findings change.

[1]: https://github.com/detekt/detekt/issues/5034