### PR TITLE
feat(evaluator): Allow getting the effective license in a package rule

### DIFF
--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -59,6 +59,7 @@ open class PackageRule(
     val resolvedLicenseInfo: ResolvedLicenseInfo
 ) : Rule(ruleSet, name) {
     private val licenseRules = mutableListOf<LicenseRule>()
+    private val effectiveLicenseForLicenseView = mutableMapOf<LicenseView, SpdxExpression?>()
 
     @Suppress("unused") // This is intended to be used by rule implementations.
     val uncuratedPkg: Package by lazy {
@@ -73,6 +74,18 @@ open class PackageRule(
     override fun runInternal() {
         licenseRules.forEach { it.evaluate() }
     }
+
+    /**
+     * Return the effective license of [pkg] for the given [licenseView].
+     */
+    fun getEffectiveLicense(licenseView: LicenseView): SpdxExpression? =
+        effectiveLicenseForLicenseView.getOrPut(licenseView) {
+            resolvedLicenseInfo.filterExcluded().effectiveLicense(
+                licenseView,
+                ruleSet.ortResult.getPackageLicenseChoices(pkg.metadata.id),
+                ruleSet.ortResult.getRepositoryLicenseChoices()
+            )?.sorted()
+        }
 
     /**
      * A [RuleMatcher] that checks whether any vulnerability was found for the [package][pkg].

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -27,9 +27,11 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicense
 import org.ossreviewtoolkit.model.licenses.ResolvedOriginalExpression
 import org.ossreviewtoolkit.utils.common.enumSetOf
+import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression.Strictness
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
@@ -61,6 +63,23 @@ class PackageRuleTest : WordSpec() {
         )
 
     init {
+        "getEffectiveLicense()" should {
+            "return the effective license corresponding to the given license view" {
+                val declaredLicenses = setOf("Apache-2.0")
+                val rule = createPackageRule(
+                    pkg = Package.EMPTY.copy(
+                        id = Identifier("Maven:some:package:0.0.1"),
+                        concludedLicense = "MIT".toSpdx(Strictness.ALLOW_ANY),
+                        declaredLicenses = declaredLicenses,
+                        declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
+                    )
+                )
+
+                rule.getEffectiveLicense(LicenseView.ONLY_DECLARED) shouldBe "Apache-2.0".toSpdx()
+                rule.getEffectiveLicense(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) shouldBe "MIT".toSpdx()
+            }
+        }
+
         "hasLicense()" should {
             "return true if the package has concluded licenses" {
                 val rule = createPackageRule(packageWithOnlyConcludedLicense)


### PR DESCRIPTION
Allow to write a rule which which executes only once per package and operates on the entire license expression. This can be useful for package which does not have a license, e.g. `hasLicense() == false`, to distinguish whether it has NOASSERTION findings.
