### PR TITLE
Bugfix: Handle list-format sources in conandata.yml

### DIFF
--- a/plugins/package-managers/conan/build.gradle.kts
+++ b/plugins/package-managers/conan/build.gradle.kts
@@ -43,4 +43,6 @@ dependencies {
 
     funTestImplementation(projects.utils.testUtils)
     funTestImplementation(testFixtures(projects.analyzer))
+
+    testImplementation(projects.utils.testUtils)
 }

--- a/plugins/package-managers/conan/src/funTest/assets/conandata-libselinux-3.6.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/conandata-libselinux-3.6.yml
@@ -1,0 +1,13 @@
+# Example conandata.yml with multiple source archives listed under the version key as a YAML list.
+# libselinux depends on libsepol at the same version, so the recipe bundles both tarballs.
+sources:
+  "3.6":
+    - url: "https://github.com/SELinuxProject/selinux/releases/download/3.6/libselinux-3.6.tar.gz"
+      sha256: "ba4e0ef34b270e7672a5e5f1b523fe2beab3a40bb33d9389f4ad3a8728f21b52"
+    - url: "https://github.com/SELinuxProject/selinux/releases/download/3.6/libsepol-3.6.tar.gz"
+      sha256: "c9dc585ea94903d784d597c861cd5dce6459168f95e22b31a0eab1cdd800975a"
+patches:
+  "3.6":
+    - patch_file: "patches/3.6/0001-remove-rpath.patch"
+      patch_description: "Remove RPATH from the build"
+      patch_type: "conan"

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -384,7 +384,7 @@ internal data class ConanData(
     }
 
     /**
-     * Return the [VcsInfo] for this [ConanData], or null if no VCS information is available.
+     * Return the [VcsInfo] for this [ConanData], or [VcsInfo.EMPTY] if no VCS information is available.
      */
     fun toVcsInfo(): VcsInfo {
         val url = scmUrl ?: return VcsInfo.EMPTY

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -24,7 +24,6 @@ import com.charleskorn.kaml.YamlList
 import com.charleskorn.kaml.YamlMap
 import com.charleskorn.kaml.YamlNode
 import com.charleskorn.kaml.YamlScalar
-import com.charleskorn.kaml.yamlList
 import com.charleskorn.kaml.yamlMap
 import com.charleskorn.kaml.yamlScalar
 
@@ -319,16 +318,14 @@ class Conan(
     }
 
     /**
-     * Return the source artifact contained in [conanData], or [RemoteArtifact.EMPTY] if no source artifact is
-     * available.
+     * Return the source artifacts contained in [conanData].
      */
-    internal fun parseSourceArtifact(conanData: ConanData): RemoteArtifact {
-        val url = conanData.url ?: return RemoteArtifact.EMPTY
-        val hashValue = conanData.sha256.orEmpty()
-        val hash = Hash.NONE.takeIf { hashValue.isEmpty() } ?: Hash(hashValue, HashAlgorithm.SHA256)
-
-        return RemoteArtifact(url, hash)
-    }
+    internal fun parseSourceArtifacts(conanData: ConanData): List<RemoteArtifact> =
+        conanData.sources.map { entry ->
+            val hashValue = entry.sha256.orEmpty()
+            val hash = Hash.NONE.takeIf { hashValue.isEmpty() } ?: Hash(hashValue, HashAlgorithm.SHA256)
+            RemoteArtifact(entry.url.orEmpty(), hash)
+        }
 
     /**
      * Parse information about the package author from the given [package info][pkgInfo]. If present, return a set
@@ -349,38 +346,70 @@ class Conan(
             return ConanData.EMPTY
         }
 
-        val root = Yaml.default.parseToYamlNode(conanDataFile.readText()).yamlMap
-
-        val patchesForVersion = root.get<YamlMap>("patches")?.get<YamlList>(id.version)
-        val hasPatches = !patchesForVersion?.items.isNullOrEmpty()
-
-        val sourceForVersion = root.get<YamlMap>("sources")?.get<YamlMap>(id.version)
-        val sha256 = sourceForVersion?.get<YamlScalar>("sha256")?.content
-
-        val url = sourceForVersion?.get<YamlNode>("url")?.let {
-            when {
-                it is YamlList -> it.yamlList.items.firstOrNull()?.yamlScalar?.content
-                else -> it.yamlScalar.content
-            }
-        }
-
-        val scm = root.get<YamlMap>("scm")
-        val scmUrl = scm?.get<YamlScalar>("url")?.content
-        val scmCommit = scm?.get<YamlScalar>("commit")?.content
-
-        return ConanData(url, sha256, scmUrl, scmCommit, hasPatches)
+        return parseConanDataYaml(conanDataFile.readText(), id.version)
     }
 }
 
-internal data class ConanData(
+/**
+ * Parse a [conandata.yml][yaml] file for the given [version] and return a [ConanData] object.
+ *
+ * The YAML format has two variants for the `sources` section:
+ * - Single source: the version maps directly to a `{url, sha256}` map.
+ * - Multiple sources: the version maps to a list of `{url, sha256}` maps.
+ */
+internal fun parseConanDataYaml(yaml: String, version: String): ConanData {
+    val root = Yaml.default.parseToYamlNode(yaml).yamlMap
+
+    val patchesForVersion = root.get<YamlMap>("patches")?.get<YamlList>(version)
+    val hasPatches = !patchesForVersion?.items.isNullOrEmpty()
+
+    val sources = when (val sourcesForVersion = root.get<YamlMap>("sources")?.get<YamlNode>(version)) {
+        is YamlMap -> listOf(sourcesForVersion.toConanSourceEntry())
+        is YamlList -> sourcesForVersion.items.mapNotNull { (it as? YamlMap)?.toConanSourceEntry() }
+        else -> emptyList()
+    }
+
+    val scm = root.get<YamlMap>("scm")
+    val scmUrl = scm?.get<YamlScalar>("url")?.content
+    val scmCommit = scm?.get<YamlScalar>("commit")?.content
+
+    return ConanData(sources, scmUrl, scmCommit, hasPatches)
+}
+
+private fun YamlMap.toConanSourceEntry(): ConanSourceEntry {
+    val url = get<YamlNode>("url")?.let {
+        when (it) {
+            is YamlList -> it.items.firstOrNull()?.yamlScalar?.content
+            else -> it.yamlScalar.content
+        }
+    }
+
+    val sha256 = get<YamlScalar>("sha256")?.content
+    return ConanSourceEntry(url, sha256)
+}
+
+/**
+ * A single source entry from a `conandata.yml` file.
+ */
+internal data class ConanSourceEntry(
     val url: String?,
-    val sha256: String?,
+    val sha256: String?
+)
+
+/**
+ * Parsed content from a `conandata.yml` file for a specific package version.
+ *
+ * [sources] holds one entry per source archive. Most packages have exactly one entry. Packages built from
+ * multiple co-equal archives (e.g. conan-center-index packages with multiple assets) have more than one.
+ */
+internal data class ConanData(
+    val sources: List<ConanSourceEntry>,
     val scmUrl: String?,
     val scmCommit: String?,
     val hasPatches: Boolean
 ) {
     companion object {
-        val EMPTY = ConanData(url = null, sha256 = null, scmUrl = null, scmCommit = null, hasPatches = false)
+        val EMPTY = ConanData(sources = emptyList(), scmUrl = null, scmCommit = null, hasPatches = false)
     }
 
     /**

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV1Handler.kt
@@ -151,7 +151,14 @@ internal class ConanV1Handler(private val conan: Conan) : ConanVersionHandler {
             description = conan.inspectField(pkgInfo.displayName, workingDir, "description").orEmpty(),
             homepageUrl = homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
-            sourceArtifact = conan.parseSourceArtifact(conanData),
+            sourceArtifact = conan.parseSourceArtifacts(conanData).also {
+                if (it.size > 1) {
+                    logger.warn {
+                        "Package '${id.toCoordinates()}' has ${it.size} source archives. " +
+                            "Only the first one will be used as the source artifact."
+                    }
+                }
+            }.firstOrNull() ?: RemoteArtifact.EMPTY,
             vcs = processPackageVcs(
                 conanData.toVcsInfo(),
                 homepageUrl

--- a/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
@@ -196,7 +196,14 @@ internal class ConanV2Handler(private val conan: Conan) : ConanVersionHandler {
             description = pkgInfo.description.orEmpty(),
             homepageUrl = homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY, // TODO: implement me!
-            sourceArtifact = conan.parseSourceArtifact(conanData),
+            sourceArtifact = conan.parseSourceArtifacts(conanData).also {
+                if (it.size > 1) {
+                    logger.warn {
+                        "Package '${id.toCoordinates()}' has ${it.size} source archives. " +
+                            "Only the first one will be used as the source artifact."
+                    }
+                }
+            }.firstOrNull() ?: RemoteArtifact.EMPTY,
             vcs = processPackageVcs(
                 conanData.toVcsInfo(),
                 homepageUrl

--- a/plugins/package-managers/conan/src/test/kotlin/ConanTest.kt
+++ b/plugins/package-managers/conan/src/test/kotlin/ConanTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.conan
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.utils.test.getAssetFile
+
+class ConanTest : WordSpec({
+    "parseConanDataYaml()" should {
+        "parse a single-source map" {
+            val yaml = """
+                sources:
+                  3.6.1:
+                    sha256: b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e
+                    url: https://github.com/openssl/openssl/releases/download/openssl-3.6.1/openssl-3.6.1.tar.gz
+            """.trimIndent()
+
+            val conanData = parseConanDataYaml(yaml, "3.6.1")
+
+            conanData.sources.shouldBeSingleton {
+                it.url shouldBe
+                    "https://github.com/openssl/openssl/releases/download/openssl-3.6.1/openssl-3.6.1.tar.gz"
+                it.sha256 shouldBe "b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
+            }
+
+            conanData.hasPatches shouldBe false
+        }
+
+        "parse a multi-source list" {
+            val conanDataFile = getAssetFile("conandata-libselinux-3.6.yml")
+
+            val conanData = parseConanDataYaml(conanDataFile.readText(), "3.6")
+
+            conanData.sources should containExactly(
+                ConanSourceEntry(
+                    url = "https://github.com/SELinuxProject/selinux/releases/download/3.6/libselinux-3.6.tar.gz",
+                    sha256 = "ba4e0ef34b270e7672a5e5f1b523fe2beab3a40bb33d9389f4ad3a8728f21b52"
+                ),
+                ConanSourceEntry(
+                    url = "https://github.com/SELinuxProject/selinux/releases/download/3.6/libsepol-3.6.tar.gz",
+                    sha256 = "c9dc585ea94903d784d597c861cd5dce6459168f95e22b31a0eab1cdd800975a"
+                )
+            )
+            conanData.hasPatches shouldBe true
+        }
+
+        "return an empty sources list for an unknown version" {
+            val yaml = """
+                sources:
+                  3.6.1:
+                    sha256: abc
+                    url: https://example.com/pkg-3.6.1.tar.gz
+            """.trimIndent()
+
+            val conanData = parseConanDataYaml(yaml, "9.9.9")
+
+            conanData.sources should beEmpty()
+            conanData.hasPatches shouldBe false
+        }
+    }
+
+    "parseSourceArtifacts()" should {
+        val conan = ConanFactory.create()
+
+        "return all source artifacts for a multi-source package" {
+            val conanDataFile = getAssetFile("conandata-libselinux-3.6.yml")
+            val conanData = parseConanDataYaml(conanDataFile.readText(), "3.6")
+
+            val artifacts = conan.parseSourceArtifacts(conanData)
+
+            artifacts shouldHaveSize 2
+            with(artifacts.first()) {
+                url shouldBe
+                    "https://github.com/SELinuxProject/selinux/releases/download/3.6/libselinux-3.6.tar.gz"
+                hash.algorithm shouldBe HashAlgorithm.SHA256
+                hash.value shouldBe "ba4e0ef34b270e7672a5e5f1b523fe2beab3a40bb33d9389f4ad3a8728f21b52"
+            }
+        }
+
+        "return an empty list when there are no sources" {
+            val artifacts = conan.parseSourceArtifacts(ConanData.EMPTY)
+
+            artifacts should beEmpty()
+        }
+    }
+})


### PR DESCRIPTION
Closes #11685 

Some Conan recipes bundle multiple tarballs and list them under the version key. The previous code threw an `IncorrectTypeException` in that case. Fix this by dispatching on the YAML node type and log a warning when multiple archives are present, since ORT supports only a single source artifact per package.
