### PR TITLE
helper-cli: Stop resolving scopes when only converting ORT files between JSON and YAML

### DIFF
--- a/cli-helper/src/main/kotlin/commands/ConvertOrtFileCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ConvertOrtFileCommand.kt
@@ -49,7 +49,7 @@ internal class ConvertOrtFileCommand : OrtHelperCommand(
         .required()
 
     override fun run() {
-        val ortResult = readOrtResult(inputOrtFile)
+        val ortResult = readOrtResult(inputOrtFile, resolveScopes = false)
 
         writeOrtResult(ortResult, outputOrtFile)
     }

--- a/cli-helper/src/main/kotlin/utils/Utils.kt
+++ b/cli-helper/src/main/kotlin/utils/Utils.kt
@@ -264,9 +264,12 @@ internal fun importLicenseFindingCurations(
 
 /**
  * Read [ortFile] into an [OrtResult] and return it. Make sure that information about project scopes is available
- * (by calling [OrtResult.withResolvedScopes]), so that it can be processed.
+ * (by calling [OrtResult.withResolvedScopes]), if [resolveScopes] is true, so that it can be processed.
  */
-internal fun readOrtResult(ortFile: File): OrtResult = ortFile.readValue<OrtResult>().withResolvedScopes()
+internal fun readOrtResult(ortFile: File, resolveScopes: Boolean = true): OrtResult {
+    val ortResult = ortFile.readValue<OrtResult>()
+    return ortResult.takeUnless { resolveScopes } ?: ortResult.withResolvedScopes()
+}
 
 /**
  * Write the [ortResult] to [file].


### PR DESCRIPTION
See individual commits.

