### PR TITLE
fix(cli-helper): Fix loading package manager plugins via service loader

### DIFF
--- a/cli-helper/build.gradle.kts
+++ b/cli-helper/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.slf4j)
     implementation(libs.xz)
 
+    "pluginClasspath"(platform(projects.plugins.packageManagers))
     "pluginClasspath"(platform(projects.plugins.versionControlSystems))
 
     funTestImplementation(projects.utils.testUtils)


### PR DESCRIPTION
When calling `PackageManagerFactory.ALL` from within `cli-helper` and empty map is returned. This has the effect that `withResolvedScopes()` drops the scopes form `OrtResult`s, see also [1]. This affects several commands from the `cli-helper`, e.g. the ones using `readOrtResult()` which calls `withResolvedScopes()`.

[1]: https://github.com/oss-review-toolkit/ort/blob/f1323c721da2189f9e3a6357cca89da05ae1d785/analyzer/src/main/kotlin/Extensions.kt#L123-L126
