### PR TITLE
fix(static-html): escape bare '&' in markdown-rendered HTML to prevent SAXParseException

### DIFF
--- a/plugins/reporters/static-html/src/funTest/resources/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/resources/reporter-test-input.yml
@@ -849,6 +849,14 @@ evaluator:
     message: "BSD-3-Clause warning"
     how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
       \ that overflow:scroll is working as expected.\n```"
+  - rule: "rule 4"
+    pkg: "Maven:com.example:example:1.0"
+    license: "MIT"
+    license_sources: ["DETECTED"]
+    severity: "WARNING"
+    message: "URL with multiple query parameters"
+    how_to_fix: "See the <a href=\"https://example.com/api?foo=1&bar=2&baz=3\">API\
+      \ documentation</a> for details."
 resolved_configuration:
   package_curations:
   - provider:

--- a/plugins/reporters/static-html/src/funTest/resources/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/resources/static-html-reporter-test-expected-output.html
@@ -482,7 +482,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
          </table>
          <h2>Index</h2>
          <ul>
-            <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a></li>
+            <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 2 warnings, 0 hints to resolve)</a></li>
             <li><a href="#analyzer-issue-summary">Analyzer Issue Summary (1 errors, 2 warnings, 1 hints to resolve)</a></li>
             <li><a href="#scanner-issue-summary">Scanner Issue Summary (3 errors, 1 warnings, 1 hints to resolve)</a></li>
             <li><a href="#advisor-issue-summary">Advisor Issue Summary (2 errors, 1 warnings, 1 hints to resolve)</a></li>
@@ -491,7 +491,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
             <li><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a></li>
             <li><a href="#repository-configuration">Repository Configuration</a></li>
          </ul>
-         <h2 id="rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</h2>
+         <h2 id="rule-violation-summary">Rule Violation Summary (1 errors, 2 warnings, 0 hints to resolve)</h2>
          <table class="report-table report-rule-violation-table">
             <thead>
                <tr>
@@ -549,8 +549,21 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                         </details>
                   </td>
                </tr>
-               <tr class="resolved" id="violation-3">
+               <tr class="warning" id="violation-3">
                   <td><a href="#violation-3">3</a></td>
+                  <td>rule 4</td>
+                  <td>Maven:com.example:example:1.0</td>
+                  <td>DETECTED: MIT</td>
+                  <td>
+                     <p>URL with multiple query parameters</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <p>See the <a href="https://example.com/api?foo=1&amp;bar=2&amp;baz=3">API documentation</a> for details.</p>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="resolved" id="violation-4">
+                  <td><a href="#violation-4">4</a></td>
                   <td>rule 2</td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>DECLARED: Apache-2.0</td>

--- a/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/StaticHtmlReporter.kt
@@ -632,7 +632,17 @@ class StaticHtmlReporter(override val descriptor: PluginDescriptor = StaticHtmlR
         val markdownParser = Parser.builder().build()
         val document = markdownParser.parse(markdown)
         val renderer = HtmlRenderer.builder().build()
-        unsafe { +renderer.render(document) }
+
+        // Escape bare '&' in URLs (e.g. <a href="example.com?foo=1&bar=2">) to prevent SAXParseException.
+        // Only matches URLs to avoid false positives; negative lookahead prevents double-escaping entities.
+        // Loop handles multiple bare '&' in a single URL (e.g. query params: ?foo=1&bar=2&baz=3).
+        var html = renderer.render(document)
+        val regex = Regex("((?:https?://|href=\"|src=\")[^\"]*?)&(?![a-zA-Z][a-zA-Z0-9]*;|#\\d+;|#[xX][0-9a-fA-F]+;)")
+        while (regex.containsMatchIn(html)) {
+            html = html.replace(regex, "$1&amp;")
+        }
+
+        unsafe { +html }
     }
 
     private fun DIV.licenseLink(license: String) {


### PR DESCRIPTION
URLs in `howToFix` / `message` text that contain query parameters (e.g. `?foo=1&bar=2`) were causing the StaticHTML reporter to crash:

```
SAXParseException: The reference to entity "bar" must end with the ';' delimiter.
```

`StaticHtmlReporter` builds its output as an XML DOM via `DocumentBuilderFactory`, so any raw `&` inserted through `unsafe { +html }` is treated as the start of an XML entity reference. Flexmark renders Markdown to HTML without escaping `&` in URLs (correct for HTML, invalid for XML).

**Fix:** after flexmark renders the Markdown, replace any `&` that is not already part of a valid entity reference (`&amp;`, `&#123;`, `&#x1F;`, etc.) with `&amp;` before inserting into the DOM.