### PR TITLE
build(detekt-rules): Do not add Detekt to the runtime classpath

### DIFF
--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -31,10 +31,11 @@ dependencies {
     compileOnly(libs.detekt.api)
     compileOnly(libs.detekt.psiUtils)
 
-    runtimeOnly(libs.detekt.core)
+    testRuntimeOnly(libs.detekt.psiUtils)
 
     testImplementation(projects.utils.testUtils)
 
+    testImplementation(libs.detekt.api)
     testImplementation(libs.detekt.test)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,7 +104,6 @@ clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 cyclonedx = { module = "org.cyclonedx:cyclonedx-core-java", version.ref = "cyclonedx" }
 detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detektPlugin" }
-detekt-core = { module = "dev.detekt:detekt-core", version.ref = "detektPlugin" }
 detekt-psiUtils = { module = "dev.detekt:detekt-psi-utils", version.ref = "detektPlugin" }
 detekt-test = { module = "dev.detekt:detekt-test", version.ref = "detektPlugin" }
 diffUtils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "diffUtils" }


### PR DESCRIPTION
Detekt rules should not have Detekt libraries on the runtime classpath to ensure the rules to work more independently of the exact Detekt version. The dependency on `libs.detekt.core` was to broad anyway; depending on `api` and `psiUtils` is sufficient.