### PR TITLE
fix(evaluator): Fix cycle detection

### DIFF
--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -95,12 +95,13 @@ class RuleSet(
             project: Project,
             visitedPackages: MutableSet<DependencyNode>
         ) {
-            if (node in visitedPackages) {
+            val stableNode = node.getStableReference()
+            if (stableNode in visitedPackages) {
                 logger.debug { "Skipping rule $name for already visited dependency ${node.id.toCoordinates()}." }
                 return
             }
 
-            visitedPackages += node
+            visitedPackages += stableNode
 
             val curatedPackage = ortResult.getPackage(node.id)
                 ?: ortResult.getProject(node.id)?.toPackage()?.toCuratedPackage()


### PR DESCRIPTION
The check whether packages have already been visited in dependency rules was ineffective. It was based on dependency nodes processed during graph traversal, which cannot be compared or stored in collections. Fix this by
using the stable references to the nodes instead.

_Note_: The issue was found by the evaluator entering an infinite loop due to a cycle in the dependency graph.