### PR TITLE
ci(qodana): Pin to the previous version

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -20,4 +20,4 @@ profile:
   name: qodana.recommended
 include:
   - name: CheckDependencyLicenses
-linter: jetbrains/qodana-jvm-community
+linter: jetbrains/qodana-jvm-community:2025.3


### PR DESCRIPTION
The current version 2026.1 seems to have an issue saying

    specify sdk 'null' for module 'oss-review-toolkit.buildSrc.main'

so pin to the previous version until [1] is resolved.

[1]: https://youtrack.jetbrains.com/issue/QD-14478