### PR TITLE
chore(oss-index): Update OSS Index links to Sonatype Guide

### DIFF
--- a/cli/src/funTest/resources/semver4j-ort-result.yml
+++ b/cli/src/funTest/resources/semver4j-ort-result.yml
@@ -376,7 +376,7 @@ advisor:
     config:
       OssIndex:
         options:
-          serverUrl: "https://ossindex.sonatype.org"
+          serverUrl: "https://api.guide.sonatype.com/"
         secrets:
           username: "username"
           password: "password"
@@ -410,7 +410,7 @@ advisor:
           \ will fix this vulnerability. For more information, including an example\
           \ of vulnerable code, see the referenced GitHub Security Advisory."
         references:
-        - url: "https://ossindex.sonatype.org/vulnerability/CVE-2020-15250?component-type=maven&component-name=junit%2Fjunit&utm_source=okhttp&utm_medium=integration&utm_content=4.12.0"
+        - url: "https://guide.sonatype.com/vulnerability/CVE-2020-15250?component-type=maven&component-name=junit%2Fjunit&utm_source=okhttp&utm_medium=integration&utm_content=5.3.2"
           scoring_system: "CVSS:3.1"
           severity: "MEDIUM"
           score: 5.5

--- a/clients/oss-index/src/main/kotlin/OssIndexService.kt
+++ b/clients/oss-index/src/main/kotlin/OssIndexService.kt
@@ -48,21 +48,28 @@ interface OssIndexService {
         val JSON = Json.Default
 
         /**
-         * Create an OSS Index service instance for communicating with a server running at the given [url], optionally
-         * using [username] and [password] for basic authentication, and / or a pre-built OkHttp [client].
+         * Create an OSS Index service instance for communicating with a server running at the given [url].
+         * Authentication happens either via a Sonatype Guide personal access [token], or OSS Index [username] and
+         * [password][token]. Optionally, a custom HTTP [client] can be used.
          */
         fun create(
             url: String? = null,
             username: String? = null,
-            password: String? = null,
+            token: String,
             client: OkHttpClient? = null
         ): OssIndexService {
             val ossIndexClient = (client?.newBuilder() ?: OkHttpClient.Builder()).addInterceptor { chain ->
                 val request = chain.request()
                 val requestBuilder = request.newBuilder()
 
-                if (username != null && password != null) {
-                    requestBuilder.header("Authorization", Credentials.basic(username, password))
+                if (username == null) {
+                    require(token.startsWith("sonatype_pat_")) {
+                        "The token is not a valid Sonatype Guide PAT."
+                    }
+
+                    requestBuilder.header("Authorization", "Bearer $token")
+                } else {
+                    requestBuilder.header("Authorization", Credentials.basic(username, token))
                 }
 
                 chain.proceed(requestBuilder.build())

--- a/clients/oss-index/src/main/kotlin/OssIndexService.kt
+++ b/clients/oss-index/src/main/kotlin/OssIndexService.kt
@@ -32,14 +32,15 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 /**
- * Interface for the OSS Index REST API, based on the documentation from https://ossindex.sonatype.org/rest.
+ * Interface for the OSS Index REST API, based on the documentation from
+ * https://guide.sonatype.com/api#/OSS%20Index%20Compatibility.
  */
 interface OssIndexService {
     companion object {
         /**
          * The default base URL for the REST API of the public OSS Index service.
          */
-        const val DEFAULT_BASE_URL = "https://ossindex.sonatype.org/"
+        const val DEFAULT_BASE_URL = "https://api.guide.sonatype.com/"
 
         /**
          * The JSON (de-)serialization object used by this service.
@@ -78,13 +79,11 @@ interface OssIndexService {
         }
     }
 
-    // See https://ossindex.sonatype.org/rest#model-ComponentReportRequest.
     @Serializable
     data class ComponentReportRequest(
         val coordinates: List<String>
     )
 
-    // See https://ossindex.sonatype.org/rest#model-ComponentReport.
     @Serializable
     data class ComponentReport(
         /** The Package URL coordinates. */
@@ -100,7 +99,6 @@ interface OssIndexService {
         val vulnerabilities: List<Vulnerability>
     )
 
-    // See https://ossindex.sonatype.org/rest#model-ComponentReportVulnerability.
     @Serializable
     data class Vulnerability(
         /** A UUID */
@@ -139,6 +137,7 @@ interface OssIndexService {
 
     /**
      * Request vulnerability reports for [components] (requires basic authentication; rate limits are relaxed).
+     * See https://guide.sonatype.com/api#/OSS%20Index%20Compatibility/getComponentReports_1.
      */
     @POST("api/v3/authorized/component-report")
     suspend fun getAuthorizedComponentReport(@Body components: ComponentReportRequest): List<ComponentReport>

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -145,7 +145,7 @@ ort:
 
       OssIndex:
         options:
-          serverUrl: 'https://ossindex.sonatype.org/'
+          serverUrl: 'https://api.guide.sonatype.com/'
         secrets:
           username: username
           password: password

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -125,7 +125,7 @@ class OrtConfigurationTest : WordSpec({
                 advisors shouldNotBeNull {
                     get("OssIndex") shouldNotBeNull {
                         options should containExactlyEntries(
-                            "serverUrl" to "https://ossindex.sonatype.org/"
+                            "serverUrl" to "https://api.guide.sonatype.com/"
                         )
 
                         secrets should containExactlyEntries(

--- a/plugins/advisors/oss-index/src/funTest/kotlin/OssIndexFunTest.kt
+++ b/plugins/advisors/oss-index/src/funTest/kotlin/OssIndexFunTest.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.plugins.api.Secret
 @EnabledIf(OssIndexCredentials::class)
 class OssIndexFunTest : WordSpec({
     val oi = OssIndexFactory.create(
-        username = checkNotNull(OssIndexCredentials.getUsername()),
+        username = OssIndexCredentials.getUsername(),
         token = Secret(checkNotNull(OssIndexCredentials.getToken()))
     )
 
@@ -131,7 +131,9 @@ class OssIndexFunTest : WordSpec({
 
 internal object OssIndexCredentials : Condition {
     fun getUsername(): String? = System.getenv("OSS_INDEX_USERNAME")
-    fun getToken(): String? = System.getenv("OSS_INDEX_PASSWORD")
+    fun getToken(): String? = System.getenv("OSS_INDEX_PASSWORD") ?: System.getenv("SONATYPE_PAT")
 
-    override fun evaluate(kclass: KClass<out Spec>): Boolean = getUsername() != null && getToken() != null
+    override fun evaluate(kclass: KClass<out Spec>): Boolean =
+        // Authentication can either happen via OSS Index username and password or Sonatype Guide personal access token.
+        getToken()?.let { it.startsWith("sonatype_pat_") || getUsername() != null } == true
 }

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
@@ -53,7 +53,8 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 private const val BULK_REQUEST_SIZE = 128
 
 /**
- * A wrapper for Sonatype's [OSS Index](https://ossindex.sonatype.org/) security vulnerability data.
+ * A wrapper for Sonatype's [OSS Index](https://www.sonatype.com/products/sonatype-guide/oss-index-users/) security
+ * vulnerability data.
  */
 @OrtPlugin(
     id = "OSSIndex",

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndexConfiguration.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndexConfiguration.kt
@@ -24,7 +24,8 @@ import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.Secret
 
 /**
- * The configuration for the OSS Index provider.
+ * The configuration for the OSS Index provider. Authentication can either happen via OSS Index username and password or
+ * Sonatype Guide personal access token.
  */
 data class OssIndexConfiguration(
     /**
@@ -34,12 +35,14 @@ data class OssIndexConfiguration(
     val serverUrl: String,
 
     /**
-     * The username to use for authentication towards the API.
+     * The optional username is null when using Sonatype Guide authentication, or the username when using OSS Index
+     * authentication.
      */
-    val username: String,
+    val username: String?,
 
     /**
-     * The token to use for authentication towards the API.
+     * The personal access token when using Sonatype Guide authentication, or the password when using OSS Index
+     * authentication.
      */
     val token: Secret
 )

--- a/plugins/advisors/oss-index/src/test/kotlin/OssIndexTest.kt
+++ b/plugins/advisors/oss-index/src/test/kotlin/OssIndexTest.kt
@@ -31,17 +31,19 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 
 import java.net.URI
 
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.plugins.api.Secret
 import org.ossreviewtoolkit.utils.test.identifierToPackage
@@ -83,34 +85,38 @@ class OssIndexTest : WordSpec({
             result.keys should containExactly(PKG_JUNIT.id)
             result[PKG_JUNIT.id] shouldNotBeNull {
                 advisor shouldBe ossIndex.details
-                vulnerabilities should containExactly(
-                    Vulnerability(
-                        id = "CVE-2020-15250",
-                        summary = "In JUnit4 from version 4.7 and before 4.13.1,...",
-                        description = "In JUnit4 from version 4.7 and before 4.13.1, the test...",
-                        references = listOf(
-                            VulnerabilityReference(
-                                url = URI(
-                                    "https://ossindex.sonatype.org/vulnerability/" +
-                                        "7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1?component-type=maven" +
-                                        "&component-name=junit.junit&utm_source=mozilla&utm_medium=integration" +
-                                        "&utm_content=5.0"
-                                ),
-                                scoringSystem = "CVSS:3.0",
-                                severity = "MEDIUM",
-                                score = 5.5f,
-                                vector = "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+                vulnerabilities.shouldBeSingleton {
+                    it.id shouldBe "CVE-2020-15250"
+                    it.summary shouldBe "Information Exposure"
+                    it.description shouldStartWith "In JUnit4 from version 4.7 and before 4.13.1, the test rule "
+                    it.references should containExactlyInAnyOrder(
+                        VulnerabilityReference(
+                            url = URI(
+                                "https://guide.sonatype.com/vulnerability/CVE-2020-15250?component-type=maven" +
+                                    "&component-name=junit%2Fjunit&utm_source=intellij&utm_medium=integration" +
+                                    "&utm_content=HTTP"
                             ),
-                            VulnerabilityReference(
-                                url = URI("https://nvd.nist.gov/vuln/detail/CVE-2020-15250"),
-                                scoringSystem = "CVSS:3.0",
-                                severity = "MEDIUM",
-                                score = 5.5f,
-                                vector = "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
-                            )
+                            scoringSystem = "CVSS:3.1",
+                            severity = "MEDIUM",
+                            score = 5.5f,
+                            vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+                        ),
+                        VulnerabilityReference(
+                            url = URI("http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-15250"),
+                            scoringSystem = "CVSS:3.1",
+                            severity = "MEDIUM",
+                            score = 5.5f,
+                            vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
+                        ),
+                        VulnerabilityReference(
+                            url = URI("https://github.com/advisories/GHSA-269g-pwp5-87pp"),
+                            scoringSystem = "CVSS:3.1",
+                            severity = "MEDIUM",
+                            score = 5.5f,
+                            vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
                         )
                     )
-                )
+                }
             }
         }
 

--- a/plugins/advisors/oss-index/src/test/resources/__files/component-report.http
+++ b/plugins/advisors/oss-index/src/test/resources/__files/component-report.http
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+POST https://api.guide.sonatype.com/api/v3/authorized/component-report
+Content-Type: application/json
+Authorization: Bearer {{$env.SONATYPE_PAT}}
+
+{
+  "coordinates": [
+    "pkg:maven/org.hamcrest/hamcrest-core@1.3",
+    "pkg:maven/junit/junit@4.12"
+  ]
+}

--- a/plugins/advisors/oss-index/src/test/resources/__files/response_components.json
+++ b/plugins/advisors/oss-index/src/test/resources/__files/response_components.json
@@ -1,26 +1,28 @@
 [
   {
     "coordinates": "pkg:maven/org.hamcrest/hamcrest-core@1.3",
-    "description": "This is the core API of hamcrest matcher framework \n\t\tto be used by third-party framework providers. \n\t\tThis includes the a foundation set of matcher\n\t\timplementations for common operations.",
-    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.hamcrest/hamcrest-core@1.3?utm_source=mozilla&utm_medium=integration&utm_content=5.0",
+    "description": "",
+    "reference": "https://guide.sonatype.com/component/maven/org.hamcrest%3Ahamcrest-core/1.3?utm_source=intellij&utm_medium=integration&utm_content=HTTP",
     "vulnerabilities": []
   },
   {
     "coordinates": "pkg:maven/junit/junit@4.12",
-    "description": "JUnit is a regression testing framework written by Erich Gamma and Kent Beck.\n        It is used by the developer who implements unit tests in Java.",
-    "reference": "https://ossindex.sonatype.org/component/pkg:maven/junit/junit@4.12?utm_source=mozilla&utm_medium=integration&utm_content=5.0",
+    "description": "",
+    "reference": "https://guide.sonatype.com/component/maven/junit%3Ajunit/4.12?utm_source=intellij&utm_medium=integration&utm_content=HTTP",
     "vulnerabilities": [
       {
-        "id": "7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1",
+        "id": "CVE-2020-15250",
         "displayName": "CVE-2020-15250",
-        "title": "[CVE-2020-15250] In JUnit4 from version 4.7 and before 4.13.1,...",
-        "description": "In JUnit4 from version 4.7 and before 4.13.1, the test...",
+        "title": "[CVE-2020-15250] CWE-200: Information Exposure",
+        "description": "In JUnit4 from version 4.7 and before 4.13.1, the test rule TemporaryFolder contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system. This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability. This vulnerability impacts you if the JUnit tests write sensitive information, like API keys or passwords, into the temporary folder, and the JUnit tests execute in an environment where the OS has other untrusted users. Because certain JDK file system APIs were only added in JDK 1.7, this this fix is dependent upon the version of the JDK you are using. For Java 1.7 and higher users: this vulnerability is fixed in 4.13.1. For Java 1.6 and lower users: no patch is available, you must use the workaround below. If you are unable to patch, or are stuck running on Java 1.6, specifying the `java.io.tmpdir` system environment variable to a directory that is exclusively owned by the executing user will fix this vulnerability. For more information, including an example of vulnerable code, see the referenced GitHub Security Advisory.",
         "cvssScore": 5.5,
-        "cvssVector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+        "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+        "cwe": "CWE-200",
         "cve": "CVE-2020-15250",
-        "reference": "https://ossindex.sonatype.org/vulnerability/7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1?component-type=maven&component-name=junit.junit&utm_source=mozilla&utm_medium=integration&utm_content=5.0",
+        "reference": "https://guide.sonatype.com/vulnerability/CVE-2020-15250?component-type=maven&component-name=junit%2Fjunit&utm_source=intellij&utm_medium=integration&utm_content=HTTP",
         "externalReferences": [
-          "https://nvd.nist.gov/vuln/detail/CVE-2020-15250"
+          "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-15250",
+          "https://github.com/advisories/GHSA-269g-pwp5-87pp"
         ]
       }
     ]

--- a/plugins/reporters/static-html/src/funTest/resources/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/resources/reporter-test-input.yml
@@ -772,7 +772,7 @@ advisor:
     config:
       OssIndex:
         options:
-          serverUrl: "https://ossindex.sonatype.org"
+          serverUrl: "https://api.guide.sonatype.com/"
         secrets:
           username: "username"
           password: "password"

--- a/website/docs/tools/advisor.md
+++ b/website/docs/tools/advisor.md
@@ -40,8 +40,8 @@ To enable this provider, pass `-a BlackDuck` on the command line.
 
 ## OSS Index
 
-This vulnerability provider does not require any further configuration as it uses the public service at https://ossindex.sonatype.org/.
-Before using this provider, please ensure to comply with its [Terms of Service](https://ossindex.sonatype.org/tos).
+The OSS Index vulnerability provider by now is part of [Sonatype Guide](https://guide.sonatype.com/) and requires free registration to obtain an API token.
+Before using this provider, please ensure to comply with its [Terms of Service](https://www.sonatype.com/terms-of-service).
 
 To enable this provider, pass `-a OssIndex` on the command line.
 


### PR DESCRIPTION
As of today, "The OSS Index API has migrated to Sonatype Guide, and credit limits are now being enforced". Also see [1].

[1]: https://help.sonatype.com/en/oss-index-migration-steps.html