### PR TITLE
fix(vcs): Checkout `.ort.env.yml` when doing sparse checkouts

### DIFF
--- a/cli-helper/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/cli-helper/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -31,6 +31,7 @@ import org.ossreviewtoolkit.utils.common.getAllAncestorDirectories
 import org.ossreviewtoolkit.utils.common.getCommonParentFile
 import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_SERVER_ENV_FILENAME
 
 /**
  * This class generates path excludes based on the set of file paths present in the source tree.
@@ -216,6 +217,7 @@ private val PATH_EXCLUDE_REASON_FOR_FILENAME = listOf(
     ".gitlab-ci.yml" to BUILD_TOOL_OF,
     ".jitpack.yml" to BUILD_TOOL_OF,
     ".mailmap" to PathExcludeReason.OTHER,
+    ORT_SERVER_ENV_FILENAME to BUILD_TOOL_OF,
     ORT_REPO_CONFIG_FILENAME to BUILD_TOOL_OF,
     ".travis.yml" to BUILD_TOOL_OF,
     ".zuul.yml" to BUILD_TOOL_OF,

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.titlecase
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_SERVER_ENV_FILENAME
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 import org.semver4j.Semver
@@ -148,7 +149,7 @@ abstract class VersionControlSystem : Plugin {
          * Return glob patterns for files that should be checkout out in addition to explicit sparse checkout paths.
          */
         fun getSparseCheckoutGlobPatterns(): List<String> {
-            val globPatterns = mutableListOf("*$ORT_REPO_CONFIG_FILENAME")
+            val globPatterns = mutableListOf("*$ORT_REPO_CONFIG_FILENAME", "*$ORT_SERVER_ENV_FILENAME")
             val licensePatterns = LicenseFilePatterns.getInstance()
             return licensePatterns.allLicenseFilenames.generateCapitalizationVariants().mapTo(globPatterns) { "**/$it" }
         }

--- a/utils/ort/src/main/kotlin/Constants.kt
+++ b/utils/ort/src/main/kotlin/Constants.kt
@@ -110,6 +110,11 @@ const val ORT_PACKAGE_CONFIGURATION_FILENAME = "package-configuration.yml"
 const val ORT_REPO_CONFIG_FILENAME = ".ort.yml"
 
 /**
+ * The name of the ORT Server environment configuration file.
+ */
+const val ORT_SERVER_ENV_FILENAME = ".ort.env.yml"
+
+/**
  * The name of the ORT resolutions configuration file.
  */
 const val ORT_RESOLUTIONS_FILENAME = "resolutions.yml"


### PR DESCRIPTION
This file is a configuration file for the ORT Server. When ORT is doing a sparse checkout, it should always be cloned if present in the repository. See [1].

[1]: https://github.com/eclipse-apoapsis/ort-server/issues/4051
