### PR TITLE
chore(advisors): Move `details` initialization to the constructor

### DIFF
--- a/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
+++ b/plugins/advisors/black-duck/src/main/kotlin/BlackDuck.kt
@@ -62,6 +62,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 )
 class BlackDuck(
     override val descriptor: PluginDescriptor = BlackDuckFactory.descriptor,
+    override val details: AdvisorDetails = AdvisorDetails(descriptor.id),
     private val blackDuckApi: ComponentServiceClient
 ) : AdviceProvider {
     companion object {
@@ -71,8 +72,6 @@ class BlackDuck(
          */
         const val PACKAGE_LABEL_BLACK_DUCK_ORIGIN_ID = "black-duck:origin-id"
     }
-
-    override val details = AdvisorDetails(descriptor.id)
 
     constructor(descriptor: PluginDescriptor = BlackDuckFactory.descriptor, config: BlackDuckConfiguration) : this(
         descriptor, ExtendedComponentService.create(config.serverUrl, config.apiToken.value)

--- a/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
+++ b/plugins/advisors/oss-index/src/main/kotlin/OssIndex.kt
@@ -64,10 +64,9 @@ private const val BULK_REQUEST_SIZE = 128
 )
 class OssIndex(
     override val descriptor: PluginDescriptor = OssIndexFactory.descriptor,
+    override val details: AdvisorDetails = AdvisorDetails(descriptor.id),
     config: OssIndexConfiguration
 ) : AdviceProvider {
-    override val details = AdvisorDetails(descriptor.id)
-
     private val service by lazy {
         OssIndexService.create(
             config.serverUrl,

--- a/plugins/advisors/osv/src/main/kotlin/Osv.kt
+++ b/plugins/advisors/osv/src/main/kotlin/Osv.kt
@@ -54,10 +54,9 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 )
 class Osv(
     override val descriptor: PluginDescriptor = OsvFactory.descriptor,
+    override val details: AdvisorDetails = AdvisorDetails(descriptor.id),
     config: OsvConfiguration
 ) : AdviceProvider {
-    override val details = AdvisorDetails(descriptor.id)
-
     private val service = OsvServiceWrapper(
         serverUrl = config.serverUrl,
         httpClient = OkHttpClientHelper.buildClient()

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -71,14 +71,9 @@ private const val MAX_SUMMARY_LENGTH = 64
 )
 class VulnerableCode(
     override val descriptor: PluginDescriptor = VulnerableCodeFactory.descriptor,
+    override val details: AdvisorDetails = AdvisorDetails(descriptor.id),
     config: VulnerableCodeConfiguration
 ) : AdviceProvider {
-    /**
-     * The details returned with each [AdvisorResult] produced by this instance. As this is constant, it can be
-     * created once beforehand.
-     */
-    override val details = AdvisorDetails(descriptor.id)
-
     private val service by lazy {
         val client = OkHttpClientHelper.buildClient {
             if (config.readTimeout != null) readTimeout(config.readTimeout, TimeUnit.SECONDS)


### PR DESCRIPTION
Create a bit more compact class bodies, and this way `details` goes next to the dependent `descriptor`.