### PR TITLE
fix(conan): Correctly set non-interactive mode for Conan2

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/ConanV2Handler.kt
@@ -79,6 +79,8 @@ internal class ConanV2Handler(private val conan: Conan) : ConanVersionHandler {
             workingDir,
             "graph",
             "info",
+            "-cc",
+            "core:non_interactive=True",
             "-f",
             "json",
             "--out-file",


### PR DESCRIPTION
The `CONAN_NON_INTERACTIVE` environment variable is not recognized by Conan2. Therefore, if there are missing or invalid credentials for a remote, the Conan process prompts for credentials, causing CI tasks to hang. Fix this by passing a corresponding configuration option to the command line of the affected `graph` command.
