### PR TITLE
fix(spdx): Fix an issue with traversing nodes with the graph navigator

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -235,7 +235,11 @@ private fun OrtResult.getLinkageTypesForDependencyRelationships():
             while (queue.isNotEmpty()) {
                 val parent = queue.removeFirst()
 
-                val children = parent.visitDependencies { children -> children.map { it.getStableReference() } }
+                val children = parent.visitDependencies { children ->
+                    // Map to a list instead of to a sequence, so that the conversion to the stable reference is done
+                    // within this code block. After leaving the block, the node reference are not valid anymore.
+                    children.mapTo(mutableListOf()) { it.getStableReference() }
+                }
 
                 children.forEach { child ->
                     result.getOrPut(parent.id to child.id) { mutableSetOf() } += child.linkage


### PR DESCRIPTION
The node reference get invalidate after the scope passed to `visitDependencies()` is left. This results in the tree not being properly traversed, the map returned by
`getLinkageTypesForDependencyRelationships()` lacks some keys, which in turn breaks the assumption made by a `getValue()` on that map, see [^1].

Fix the traversal by simply executing the mapping to stable references within the scope of validity of the node references.

Fixes #11794.

[^1]: https://github.com/oss-review-toolkit/ort/blob/75891a2d28ea59be4808f5b41dadeaa60ebd288d/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt#L74
