### PR TITLE
fix(spdx): Handle missing linkage map keys for package dependencies

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -71,7 +71,7 @@ internal object SpdxDocumentModelMapper {
                 relatedSpdxElement = toOrtId.toSpdxId()
             )
 
-            linkageTypesForDependencyRelationships.getValue(fromOrtId to toOrtId)
+            linkageTypesForDependencyRelationships.getOrElse(fromOrtId to toOrtId) { emptySet() }
                 .mapTo(mutableSetOf()) { it.toSpdxRelationshipType() }
                 .sorted()
                 .forEach { relationshipType ->


### PR DESCRIPTION
Identified this issue while analyzing multi-module Gradle projects:

```
java.util.NoSuchElementException: Key (Identifier(type=Maven, namespace=com.google.guava, name=guava, version=32.1.3-jre), Identifier(type=Maven, namespace=com.google.guava, name=failureaccess, version=1.0.1)) is missing in the map.
    at SpdxDocumentModelMapper.map$addDependencyRelationships(SpdxDocumentModelMapper.kt:74)
```

Reproducible with [this dummy project](https://github.com/voidpetal/test-ort-spdx-gradle-submodules):

```bash
git clone https://github.com/voidpetal/test-ort-spdx-gradle-submodules
ort analyze -i . -o /tmp/out
ort report -i /tmp/out/analyzer-result.yml -o /tmp/out -f SpdxDocument
```

After analysis, bug seems to be introduced in [90cf722c72](https://github.com/voidpetal/ort/commit/90cf722c72). The linkage map traverses only from root projects, but `addDependencyRelationships()` also processes packages via `getPackages()`, causing `getValue()` to crash for package-to-package edges.


Proposing to use `getOrElse()` to handle missing keys gracefully. 
Dummy project works with this change.