### PR TITLE
feat(spdx-utils): Map "Eclipse Distribution License v1.0" to BSD-3-Clause

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -232,6 +232,7 @@
 "Eclipse Distribution License - Version 1.0": BSD-3-Clause
 "Eclipse Distribution License - v 1.0": BSD-3-Clause
 "Eclipse Distribution License v. 1.0": BSD-3-Clause
+"Eclipse Distribution License v1.0": BSD-3-Clause
 "Eclipse Public License (EPL) 1.0": EPL-1.0
 "Eclipse Public License (EPL) 2.0": EPL-2.0
 "Eclipse Public License (EPL), Version 1.0": EPL-1.0


### PR DESCRIPTION
As seen at [1].

[1]: https://github.com/eclipse-rdf4j/rdf4j/blob/5.1.6/pom.xml#L34
