### PR TITLE
feat(scanoss): Expose SCANOSS snippet tuning parameters in ORT configuration

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -282,6 +282,16 @@ ort:
       SCANOSS:
         options:
           apiUrl: 'https://api.osskb.org/'
+          writeToStorage: true
+          enablePathObfuscation: false
+          # Snippet tuning parameters (all optional, these are the defaults):
+          minSnippetHits: 5
+          minSnippetLines: 3
+          honourFileExts: true
+          rankingEnabled: false
+          rankingThreshold: 0
+          skipHeaders: false
+          skipHeadersLimit: 0
         secrets:
           apiKey: 'your API key'
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -257,7 +257,18 @@ class OrtConfigurationTest : WordSpec({
                     }
 
                     get("SCANOSS") shouldNotBeNull {
-                        options should containExactlyEntries("apiUrl" to "https://api.osskb.org/")
+                        options should containExactlyEntries(
+                            "apiUrl" to "https://api.osskb.org/",
+                            "writeToStorage" to "true",
+                            "enablePathObfuscation" to "false",
+                            "minSnippetHits" to "5",
+                            "minSnippetLines" to "3",
+                            "honourFileExts" to "true",
+                            "rankingEnabled" to "false",
+                            "rankingThreshold" to "0",
+                            "skipHeaders" to "false",
+                            "skipHeadersLimit" to "0"
+                        )
                         secrets should containExactlyEntries("apiKey" to "your API key")
                     }
                 }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.scanners.scanoss
 import com.scanoss.Scanner
 import com.scanoss.filters.FilterConfig
 import com.scanoss.settings.Bom
+import com.scanoss.settings.FileSnippet
 import com.scanoss.settings.RemoveRule
 import com.scanoss.settings.ReplaceRule
 import com.scanoss.settings.Rule
@@ -55,7 +56,7 @@ import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 )
 class ScanOss(
     override val descriptor: PluginDescriptor = ScanOssFactory.descriptor,
-    config: ScanOssConfig
+    private val config: ScanOssConfig
 ) : PathScannerWrapper {
     private val scanossBuilder = Scanner.builder()
         // As there is only a single endpoint, the SCANOSS API client expects the path to be part of the API URL.
@@ -124,7 +125,7 @@ class ScanOss(
         val removeRules: List<RemoveRule>
     )
 
-    private fun buildSettingsFromORTContext(context: ScanContext): ScanossSettings {
+    internal fun buildSettingsFromORTContext(context: ScanContext): ScanossSettings {
         val rules = processSnippetChoices(context.snippetChoices)
         val bom = Bom.builder()
             .ignore(rules.ignoreRules)
@@ -132,7 +133,17 @@ class ScanOss(
             .replace(rules.replaceRules)
             .remove(rules.removeRules)
             .build()
-        return ScanossSettings.builder().bom(bom).build()
+        val fileSnippet = FileSnippet.builder()
+            .minSnippetHits(config.minSnippetHits)
+            .minSnippetLines(config.minSnippetLines)
+            .honourFileExts(config.honourFileExts)
+            .rankingEnabled(config.rankingEnabled)
+            .rankingThreshold(config.rankingThreshold)
+            .skipHeaders(config.skipHeaders)
+            .skipHeadersLimit(config.skipHeadersLimit)
+            .build()
+        val settings = ScanossSettings.Settings.builder().fileSnippet(fileSnippet).build()
+        return ScanossSettings.builder().bom(bom).settings(settings).build()
     }
 
     fun processSnippetChoices(snippetChoices: List<SnippetChoices>): ProcessedRules {

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -44,5 +44,61 @@ data class ScanOssConfig(
      * When enabled, the actual file paths will be obfuscated in the requests to protect sensitive information.
      */
     @OrtPluginOption(defaultValue = "false")
-    val enablePathObfuscation: Boolean
+    val enablePathObfuscation: Boolean,
+
+    /**
+     * The minimum number of snippet matches required to report a snippet finding.
+     * This parameter controls the quality filter for snippet detection results.
+     * A higher value reduces false positives but may miss some legitimate matches.
+     */
+    @OrtPluginOption(defaultValue = "5")
+    val minSnippetHits: Int,
+
+    /**
+     * The minimum number of lines required in a snippet match to report a finding.
+     * This parameter controls the minimum length threshold for snippet detections.
+     * Snippets shorter than this will be filtered out.
+     */
+    @OrtPluginOption(defaultValue = "3")
+    val minSnippetLines: Int,
+
+    /**
+     * Whether to honour file extension matching when detecting snippets.
+     * If enabled, snippet matches must be within files with matching extension to the source file.
+     * Set to false to allow matches across different file types.
+     */
+    @OrtPluginOption(defaultValue = "true")
+    val honourFileExts: Boolean,
+
+    /**
+     * Whether to enable ranking-based filtering for snippet results.
+     * When enabled, snippets are filtered based on the ranking threshold value.
+     * Set to false to disable ranking-based filtering.
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val rankingEnabled: Boolean,
+
+    /**
+     * The ranking threshold used to filter snippet results when ranking is enabled.
+     * Snippets with a ranking score below this threshold will be filtered out.
+     * This value is typically between 0 and 100. Only used when rankingEnabled is true.
+     */
+    @OrtPluginOption(defaultValue = "0")
+    val rankingThreshold: Int,
+
+    /**
+     * Whether to skip header files (files with common header extensions) when detecting snippets.
+     * When enabled, files matching standard header patterns will be excluded from snippet matching.
+     * Set to false to include header files in snippet detection.
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val skipHeaders: Boolean,
+
+    /**
+     * The maximum number of lines to skip in header files when skipHeaders is enabled.
+     * This limits how many lines at the beginning of a file are considered "headers" for skipping.
+     * Set to 0 to skip the entire header file if skipHeaders is enabled.
+     */
+    @OrtPluginOption(defaultValue = "0")
+    val skipHeadersLimit: Int
 )

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssTest.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
+import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.snippet.Choice
 import org.ossreviewtoolkit.model.config.snippet.Given
@@ -32,6 +33,7 @@ import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
 import org.ossreviewtoolkit.model.config.snippet.SnippetProvenance
+import org.ossreviewtoolkit.scanner.ScanContext
 
 // Sample files in the results.
 private const val FILE_1 = "a.java"
@@ -173,6 +175,32 @@ class ScanOssTest : WordSpec({
             rules.includeRules should beEmpty()
             rules.ignoreRules should beEmpty()
             rules.replaceRules should beEmpty()
+        }
+    }
+
+    "buildSettingsFromORTContext()" should {
+        "forward snippet tuning config values to FileSnippet" {
+            val config = createScanOssConfig(
+                minSnippetHits = 8,
+                minSnippetLines = 4,
+                honourFileExts = false,
+                rankingEnabled = true,
+                rankingThreshold = 60,
+                skipHeaders = true,
+                skipHeadersLimit = 100
+            )
+            val scanoss = createScanOss(config)
+            val context = ScanContext(labels = emptyMap(), packageType = PackageType.PACKAGE)
+
+            val fileSnippet = scanoss.buildSettingsFromORTContext(context).settings.fileSnippet
+
+            fileSnippet.minSnippetHits shouldBe 8
+            fileSnippet.minSnippetLines shouldBe 4
+            fileSnippet.honourFileExts shouldBe false
+            fileSnippet.rankingEnabled shouldBe true
+            fileSnippet.rankingThreshold shouldBe 60
+            fileSnippet.skipHeaders shouldBe true
+            fileSnippet.skipHeadersLimit shouldBe 100
         }
     }
 })

--- a/plugins/scanners/scanoss/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/TestUtils.kt
@@ -39,17 +39,32 @@ internal fun createScanOss(config: ScanOssConfig): ScanOss = ScanOss(config = co
 /**
  * Create a standard [ScanOssConfig] whose properties can be partly specified.
  */
+@Suppress("LongParameterList")
 internal fun createScanOssConfig(
     apiUrl: String = ScanApi.DEFAULT_BASE_URL,
     apiKey: Secret = Secret(""),
     writeToStorage: Boolean = true,
-    enablePathObfuscation: Boolean = false
+    enablePathObfuscation: Boolean = false,
+    minSnippetHits: Int = 5,
+    minSnippetLines: Int = 3,
+    honourFileExts: Boolean = true,
+    rankingEnabled: Boolean = false,
+    rankingThreshold: Int = 0,
+    skipHeaders: Boolean = false,
+    skipHeadersLimit: Int = 0
 ): ScanOssConfig =
     ScanOssConfig(
         apiUrl = apiUrl,
         apiKey = apiKey,
         writeToStorage = writeToStorage,
-        enablePathObfuscation = enablePathObfuscation
+        enablePathObfuscation = enablePathObfuscation,
+        minSnippetHits = minSnippetHits,
+        minSnippetLines = minSnippetLines,
+        honourFileExts = honourFileExts,
+        rankingEnabled = rankingEnabled,
+        rankingThreshold = rankingThreshold,
+        skipHeaders = skipHeaders,
+        skipHeadersLimit = skipHeadersLimit
     )
 
 /**


### PR DESCRIPTION
## Problem

ORT’s SCANOSS integration does not expose important snippet tuning options (e.g. `minSnippetHits`, `minSnippetLines`, `rankingThreshold`). This limits users’ ability to control scan sensitivity and reduce noise, especially in header‑heavy or generated codebases.

## Solution

*   Add optional snippet tuning parameters to `ScanOssConfig`
*   Forward them via `ScanossSettings` to the SCANOSS API
*   Keep all parameters optional with defaults to preserve current behavior

## Benefits

*   Reduces false positives by enabling stricter filtering
*   Improves scan result quality
*   No breaking changes; fully backward compatible

