### PR TITLE
fix(spdx): Include subprojects when building the linkage type map

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -220,7 +220,7 @@ private fun OrtResult.getLinkageTypesForDependencyRelationships():
     val result = mutableMapOf<Pair<Identifier, Identifier>, MutableSet<PackageLinkage>>()
 
     // Traverse all non-excluded edges and collect the linkage types used in between any pair of ids.
-    getProjects(omitExcluded = true, includeSubProjects = false).forEach { project ->
+    getProjects(omitExcluded = true, includeSubProjects = true).forEach { project ->
         val scopeNames = dependencyNavigator.scopeNames(project).filterNot { isScopeExcluded(it) }
 
         scopeNames.forEach { scopeName ->


### PR DESCRIPTION
Identified this issue while analyzing multi-module Gradle projects:

```
java.util.NoSuchElementException: Key (Identifier(type=Maven, namespace=com.google.guava, name=guava, version=32.1.3-jre), Identifier(type=Maven, namespace=com.google.guava, name=failureaccess, version=1.0.1)) is missing in the map.
    at SpdxDocumentModelMapper.map$addDependencyRelationships(SpdxDocumentModelMapper.kt:74)
```

Reproducible with [this dummy project](https://github.com/voidpetal/test-ort-spdx-gradle-submodules):

```bash
git clone https://github.com/voidpetal/test-ort-spdx-gradle-submodules
ort analyze -i . -o /tmp/out
ort report -i /tmp/out/analyzer-result.yml -o /tmp/out -f SpdxDocument
```

After analysis, bug seems to be introduced in [90cf722c72](https://github.com/oss-review-toolkit/ort/commit/90cf722c72). `getLinkageTypesForDependencyRelationships()` uses `getProjects(includeSubProjects=false)`, so it only traverses from root projects. But `addDependencyRelationships()` iterates over all packages via `getPackages()`, including those only reachable from subproject scopes, causing `getValue()` to crash.

Proposing to use `includeSubProjects=true` to ensure all project scopes are traversed and all dependency edges are recorded in the linkage map. Dummy project works with this change.

