### PR TITLE
chore: Use the canonical URL to the ORT Slack workspace

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,4 +4,4 @@ contact_links:
   url: https://github.com/oss-review-toolkit/ort/discussions
 - name: Ask a Question 🤔
   about: Ask a quick question or just chat with the ORT community.
-  url: http://slack.oss-review-toolkit.org/
+  url: https://oss-review-toolkit.slack.com

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![REUSE status][9]][10] [![OpenSSF Best Practices][11]][12] [![OpenSSF Scorecard][13]][14]
 
 [1]: https://img.shields.io/badge/Join_us_on_Slack!-ort--talk-blue.svg?longCache=true&logo=slack
-[2]: http://slack.oss-review-toolkit.org
+[2]: https://oss-review-toolkit.slack.com
 [3]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml/badge.svg
 [4]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml
 [5]: https://github.com/oss-review-toolkit/ort/actions/workflows/build-and-test.yml/badge.svg

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -122,4 +122,4 @@ npx markdownlint-cli2
 
 All contributions are welcome.
 If you are interested in contributing, please read our [contributing guide](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md).
-To get quick answers to your questions, [join our Slack community](http://slack.oss-review-toolkit.org) or [start a GitHub discussion](https://github.com/oss-review-toolkit/ort/discussions).
+To get quick answers to your questions, [join our Slack community](https://oss-review-toolkit.slack.com) or [start a GitHub discussion](https://github.com/oss-review-toolkit/ort/discussions).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -131,7 +131,7 @@ const config = {
               },
               {
                 label: 'Slack',
-                href: 'http://slack.oss-review-toolkit.org',
+                href: 'https://oss-review-toolkit.slack.com',
               },
               {
                 label: 'Team',


### PR DESCRIPTION
There continue to be `markdown-links` check errors [1] for [2], so just use the canonical URL [3] instead.

[1]: https://github.com/oss-review-toolkit/ort/actions/runs/25654641649/job/75300101174#step:3:307
[2]: http://slack.oss-review-toolkit.org
[3]: https://oss-review-toolkit.slack.com