### PR TITLE
fix(conan): Allow patch field in conandata to be both list or map

### DIFF
--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -351,8 +351,11 @@ class Conan(
 internal fun parseConanDataYaml(yaml: String, version: String): ConanData {
     val root = Yaml.default.parseToYamlNode(yaml).yamlMap
 
-    val patchesForVersion = root.get<YamlMap>("patches")?.get<YamlList>(version)
-    val hasPatches = !patchesForVersion?.items.isNullOrEmpty()
+    val hasPatches = when (val patchesNode = root.get<YamlNode>("patches")) {
+        is YamlMap -> !patchesNode.get<YamlList>(version)?.items.isNullOrEmpty()
+        is YamlList -> patchesNode.items.isNotEmpty()
+        else -> false
+    }
 
     val sources = when (val sourcesForVersion = root.get<YamlMap>("sources")?.get<YamlNode>(version)) {
         is YamlMap -> listOf(sourcesForVersion.toConanSourceEntry())


### PR DESCRIPTION
according to https://docs.conan.io/2/reference/tools/files/patches.html#conan.tools.files.patches.apply_conandata_patches  patch field in conandata can be defined in two formats