### PR TITLE
fix(conan): Include dependencies marked with `visible=False`

### DIFF
--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan2-expected-output-py.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan2-expected-output-py.yml
@@ -22,7 +22,7 @@ project:
     dependencies: []
   - name: "requires"
     dependencies:
-    - id: "Conan::expat:2.8.0"
+    - id: "Conan::expat:2.8.1"
     - id: "Conan::libmysqlclient:8.1.0"
       dependencies:
       - id: "Conan::lz4:1.9.4"
@@ -71,8 +71,8 @@ packages:
     url: ""
     revision: ""
     path: ""
-- id: "Conan::expat:2.8.0"
-  purl: "pkg:conan/expat@2.8.0"
+- id: "Conan::expat:2.8.1"
+  purl: "pkg:conan/expat@2.8.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -85,9 +85,9 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_0/expat-2.8.0.tar.xz"
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_1/expat-2.8.1.tar.xz"
     hash:
-      value: "a37bfae0aa9775bd8521ebd85dc456d486f0ff31138f6c91fd902ea732624542"
+      value: "10b195ee78160a908388180a8fe3603d4e9a12f4755fbf5f3816b23a9d750da0"
       algorithm: "SHA-256"
   vcs:
     type: "Git"

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -60,7 +60,7 @@ import org.ossreviewtoolkit.utils.common.alsoIfNull
 import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.masked
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
-import org.ossreviewtoolkit.utils.common.stashDirectories
+import org.ossreviewtoolkit.utils.common.stashFiles
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -208,7 +208,7 @@ class Conan(
 
         val directoryToStash = conanConfig?.let { handler.getConanHome() } ?: handler.getConanPackageStoragePath()
 
-        stashDirectories(directoryToStash, handler.getConanCacheDatabasePath()).use {
+        stashFiles(directoryToStash, handler.getConanCacheDatabasePath()).use {
             configureRemoteAuthentication(conanConfig)
 
             // TODO: Support lockfiles which are located in a different directory than the definition file.

--- a/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
@@ -101,6 +101,7 @@ private data class PackageInfoV2Raw(
 ) {
     fun toPackageInfoV2() =
         graph.nodes.values.map {
+            val directDependencies = it.dependencies.values.filter { dep -> dep.direct }
             PackageInfoV2(
                 author = it.author,
                 revision = it.rrev,
@@ -109,15 +110,9 @@ private data class PackageInfoV2Raw(
                 license = it.license,
                 homepage = it.homepage,
                 label = it.label,
-                requires = it.dependencies.values.filter { dep ->
-                    dep.direct && dep.visible
-                }.map { dep2 -> dep2.ref },
-                buildRequires = it.dependencies.values.filter { dep ->
-                    dep.build && dep.direct
-                }.map { dep2 -> dep2.ref },
-                testRequires = it.dependencies.values.filter { dep ->
-                    dep.test && dep.direct
-                }.map { dep2 -> dep2.ref },
+                requires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.visible } },
+                buildRequires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.build } },
+                testRequires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.test } },
                 recipeFolder = it.recipeFolder,
                 description = it.description,
                 name = it.name.orEmpty(),

--- a/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
@@ -212,7 +212,7 @@ internal data class DependencyReference(
      * not directly violating ODR or causing linking errors. It can be set to false in advanced scenarios, when we want
      * to use different versions of the same package during the build.
      */
-    val visible: Boolean = false
+    val visible: Boolean = true
 )
 
 /**

--- a/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
@@ -110,6 +110,7 @@ private data class PackageInfoV2Raw(
                 license = it.license,
                 homepage = it.homepage,
                 label = it.label,
+                // See https://docs.conan.io/2/reference/conanfile/methods/requirements.html#default-traits-for-each-kind-of-requires.
                 requires = directDependencies.mapNotNull { dep -> dep.ref.takeUnless { dep.build || dep.test } },
                 buildRequires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.build } },
                 testRequires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.test } },
@@ -163,14 +164,54 @@ internal enum class PackageType {
     @SerialName("unknown") UNKNOWN
 }
 
+/**
+ * See https://docs.conan.io/2/reference/conanfile/methods/requirements.html#requirement-traits.
+ */
 @Serializable
 internal data class DependencyReference(
-    val build: Boolean = false,
-    val direct: Boolean = false,
-    val libs: Boolean = false,
     val ref: String,
+
+    /**
+     * This dependency is a build tool, an application or executable, like cmake, that is used exclusively at build
+     * time. It is not linked/embedded into binaries, and will be in the build context.
+     */
+    val build: Boolean = false,
+
+    /**
+     * If the dependency is a direct one, that is, it has explicitly been declared by the current recipe, or if it is a
+     * transitive one.
+     */
+    val direct: Boolean = false,
+
+    /**
+     * The dependency contains some library or artifact that will be used at link time of the consumer. This trait will
+     * typically be true for direct shared and static libraries, but could be false for indirect static libraries that
+     * are consumed via a shared library. The dependency will be in the host context.
+     */
+    val libs: Boolean = false,
+
+    /**
+     * This dependency contains some executables, either apps or shared libraries that need to be available to execute
+     * (typically in the path, or other system env-vars). This trait can be true if [build] is false. In that case, the
+     * package will contain some executables that can run in the host system when installing it, typically like an
+     * end-user application. This trait can be true if [build] is true, then the package will contain executables that
+     * will run in the build context, typically while being used to build other packages.
+     */
     val run: Boolean = false,
+
+    /**
+     * This requirement is a test library or framework, like Catch2 or gtest. It is mostly a library that needs to be
+     * included and linked, but that will not be propagated downstream.
+     */
     val test: Boolean = false,
+
+    /**
+     * This require will be propagated downstream, even if it does not propagate headers, libs or run traits.
+     * Requirements that propagate downstream can cause version conflicts. This is typically true, because in most
+     * cases, having two different versions of the same library in the same dependency graph is at least complicated, if
+     * not directly violating ODR or causing linking errors. It can be set to false in advanced scenarios, when we want
+     * to use different versions of the same package during the build.
+     */
     val visible: Boolean = false
 )
 

--- a/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
@@ -184,11 +184,31 @@ internal data class DependencyReference(
     val direct: Boolean = false,
 
     /**
+     * This requires will force its version in the dependency graph upstream, overriding other existing versions even of
+     * transitive dependencies, and also solving potential existing conflicts. The downstream consumer's force traits
+     * always have higher priority.
+     */
+    val force: Boolean = false,
+
+    /**
+     * Indicates that there are headers that are going to be included from this package at compile time. The dependency
+     * will be in the host context.
+     */
+    val headers: Boolean = false,
+
+    /**
      * The dependency contains some library or artifact that will be used at link time of the consumer. This trait will
      * typically be true for direct shared and static libraries, but could be false for indirect static libraries that
      * are consumed via a shared library. The dependency will be in the host context.
      */
     val libs: Boolean = false,
+
+    /**
+     * The same as the force trait, but not adding a direct dependency. If there is no transitive dependency to
+     * override, this "requires" will be discarded. This trait only exists at the time of defining a "requires", but it
+     * will not exist as an actual "requires" once the graph is fully evaluated.
+     */
+    val override: Boolean = false,
 
     /**
      * This dependency contains some executables, either apps or shared libraries that need to be available to execute

--- a/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/PackageInfo.kt
@@ -110,7 +110,7 @@ private data class PackageInfoV2Raw(
                 license = it.license,
                 homepage = it.homepage,
                 label = it.label,
-                requires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.visible } },
+                requires = directDependencies.mapNotNull { dep -> dep.ref.takeUnless { dep.build || dep.test } },
                 buildRequires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.build } },
                 testRequires = directDependencies.mapNotNull { dep -> dep.ref.takeIf { dep.test } },
                 recipeFolder = it.recipeFolder,


### PR DESCRIPTION
"Invisible" dependencies in Conan are still included into the deliverable; they are just not exposed to downstream consumers of the package, similar to implementation (as opposed to API) dependencies in a Gradle project. Also see [1].

Fixes https://github.com/oss-review-toolkit/ort/issues/11820.

[1]: https://docs.conan.io/2/reference/conanfile/methods/requirements.html#visible