### PR TITLE
build(gradle): Disable publication of functional tests

### DIFF
--- a/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-kotlin-conventions.gradle.kts
@@ -113,6 +113,7 @@ java {
     // https://docs.gradle.org/current/userguide/how_to_create_feature_variants_of_a_library.html.
     registerFeature("funTest") {
         usingSourceSet(sourceSets["funTest"])
+        disablePublication()
     }
 
     toolchain {

--- a/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-publication-conventions.gradle.kts
@@ -22,13 +22,6 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-runCatching {
-    components["java"] as AdhocComponentWithVariants
-}.onSuccess {
-    it.withVariantsFromConfiguration(configurations["funTestApiElements"]) { skip() }
-    it.withVariantsFromConfiguration(configurations["funTestRuntimeElements"]) { skip() }
-}
-
 fun getGroupId(parent: Project?): String =
     parent?.let { "${getGroupId(it.parent)}.${it.name.replace("-", "")}" }.orEmpty()
 


### PR DESCRIPTION
The feature is only meant for ORT development use.