### PR TITLE
test(cyclonedx): Use an own, non-shared test input asset

### DIFF
--- a/plugins/reporters/cyclonedx/build.gradle.kts
+++ b/plugins/reporters/cyclonedx/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
-    funTestImplementation(testFixtures(projects.reporter))
-
     funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 

--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
@@ -46,9 +46,6 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporter.Companion.REPORT_BASE_FILENAME
-import org.ossreviewtoolkit.reporter.ORT_RESULT
-import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_ILLEGAL_COPYRIGHTS
-import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_VULNERABILITIES
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks

--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/TestData.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/TestData.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter
+package org.ossreviewtoolkit.plugins.reporters.cyclonedx
 
 import java.net.URI
 import java.time.Instant
@@ -468,6 +468,33 @@ val ORT_RESULT_WITH_VULNERABILITIES = ORT_RESULT.copy(
                                     vector = null
                                 )
                             )
+                        )
+                    )
+                )
+            )
+        )
+    )
+)
+
+val ORT_RESULT_WITH_ILLEGAL_COPYRIGHTS = ORT_RESULT.copy(
+    scanner = scannerRunOf(
+        Identifier("NPM:@ort:no-license-file:1.0") to listOf(
+            ScanResult(
+                provenance = UnknownProvenance,
+                scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                summary = ScanSummary.EMPTY.copy(
+                    licenseFindings = setOf(
+                        LicenseFinding(
+                            license = "MIT",
+                            location = TextLocation("file", 1)
+                        )
+                    ),
+                    copyrightFindings = setOf(
+                        CopyrightFinding(
+                            statement = "Portions created by the Initial Developer are Copyright (c) 2002 the " +
+                                "Initial Developer, holder is Tim Hudson (tjh@cryptsoft.com), Objc, (c) Objv, " +
+                                "\u0002 \u0002 \u0001A\u0002\u0002\u0001o\u0002\u0012 AB, Copyright (c)",
+                            location = TextLocation("file", 1)
                         )
                     )
                 )


### PR DESCRIPTION
Previously, the functional test used `TestData` as input ORT result, which is shared with a bunch of other reporters. This slows down CycloneDx development iterations which require enhancing that test data tremendously, because all corresponding expected outputs of other reporters using that same test input need to be updated too.

Make a copy of the test data, and start using it as an isolated asset, dedicated just to CycloneDx testing.

Note: In the future, it could make sense to carefully craft a dedicated
      test input asset which can be used as shared asset between the
      just the SPDX and CycloneDx reporters. But even then, it can still
      make sense to keep also an isolated asset additionally, for
      testing the things which are specific to a single reporter.

Part of #11824.

