### PR TITLE
rules-api: Add two functions to determine non-applicable license choices

### DIFF
--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -19,9 +19,12 @@
 
 package org.ossreviewtoolkit.evaluator
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.utils.common.enumSetOf
+import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
 
 /**
  * A [Rule] to check an [OrtResult].
@@ -75,4 +78,25 @@ open class OrtResultRule(
             message = message,
             howToFix = howToFix
         )
+
+    /**
+     * Return the set of non-applicable choices associated with the [Identifier] corresponding to the respective
+     * [org.ossreviewtoolkit.model.config.PackageLicenseChoice].
+     */
+    fun getNonApplicablePackageLicenseChoices(licenseView: LicenseView): Map<Identifier, Set<SpdxLicenseChoice>> =
+        buildMap<Identifier, MutableSet<SpdxLicenseChoice>> {
+            val existingIds = ortResult.getIdentifiers()
+
+            ortResult.repository.config.licenseChoices.packageLicenseChoices.forEach { (id, choices) ->
+                if (id !in existingIds) {
+                    getOrPut(id) { mutableSetOf() } += choices
+                    return@forEach
+                }
+
+                val appliedChoices = ruleSet.licenseInfoResolver.resolveLicenseInfo(id).filterExcluded()
+                    .effectiveLicenseAndAppliedChoices(licenseView, choices).second.toSet()
+
+                getOrPut(id) { mutableSetOf() } += (choices.toSet() - appliedChoices)
+            }
+        }
 }

--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -99,4 +99,22 @@ open class OrtResultRule(
                 getOrPut(id) { mutableSetOf() } += (choices.toSet() - appliedChoices)
             }
         }
+
+    /**
+     * Return the set of non-applicable repository license choices.
+     */
+    fun getNonApplicableRepositoryLicenseChoices(licenseView: LicenseView): Set<SpdxLicenseChoice> {
+        val repositoryLicenseChoices = ortResult.repository.config.licenseChoices.repositoryLicenseChoices
+        val appliedRepositoryLicenseChoices = mutableSetOf<SpdxLicenseChoice>()
+
+        ortResult.getIdentifiers().forEach { id ->
+            val appliedChoices = ruleSet.licenseInfoResolver.resolveLicenseInfo(id).filterExcluded()
+                .effectiveLicenseAndAppliedChoices(licenseView, repositoryLicenseChoices)
+                .second.toSet()
+
+            appliedRepositoryLicenseChoices += appliedChoices
+        }
+
+        return repositoryLicenseChoices.toSet() - appliedRepositoryLicenseChoices
+    }
 }

--- a/evaluator/src/test/kotlin/OrtResultRuleTest.kt
+++ b/evaluator/src/test/kotlin/OrtResultRuleTest.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.config.LicenseChoices
 import org.ossreviewtoolkit.model.config.PackageLicenseChoice
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -148,17 +149,22 @@ private fun OrtResult.createOrtResultRule(): OrtResultRule =
     )
 
 private fun OrtResult.setPackageLicenseChoices(vararg choices: Pair<String, List<SpdxLicenseChoice>>): OrtResult =
+    setLicenseChoices(
+        repository.config.licenseChoices.copy(
+            packageLicenseChoices = choices.map {
+                PackageLicenseChoice(
+                    packageId = Identifier(it.first),
+                    licenseChoices = it.second
+                )
+            }
+        )
+    )
+
+private fun OrtResult.setLicenseChoices(licenseChoices: LicenseChoices): OrtResult =
     copy(
         repository = repository.copy(
             config = repository.config.copy(
-                licenseChoices = repository.config.licenseChoices.copy(
-                    packageLicenseChoices = choices.map {
-                        PackageLicenseChoice(
-                            packageId = Identifier(it.first),
-                            licenseChoices = it.second
-                        )
-                    }
-                )
+                licenseChoices = licenseChoices
             )
         )
     )

--- a/evaluator/src/test/kotlin/OrtResultRuleTest.kt
+++ b/evaluator/src/test/kotlin/OrtResultRuleTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.AnalyzerRun
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.config.PackageLicenseChoice
+import org.ossreviewtoolkit.model.licenses.LicenseView
+import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
+import org.ossreviewtoolkit.utils.spdx.SpdxLicenseChoice
+import org.ossreviewtoolkit.utils.spdx.toSpdx
+
+class OrtResultRuleTest : WordSpec({
+    "getNonApplicablePackageLicenseChoices()" should {
+        "return all corresponding SPDX license choices if the packageId does not exist" {
+            val rule = createAnalyzerResult(
+                "NPM::some-package:1.0.0" to "BSD-3-Clause OR MIT"
+            ).setPackageLicenseChoices(
+                "NPM::some-other-package:1.0.0" to listOf(
+                    SpdxLicenseChoice(
+                        choice = "BSD-3-Clause".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        given = "A OR B".toSpdx(),
+                        choice = "B".toSpdx()
+                    )
+                )
+            ).createOrtResultRule()
+
+            val choices = rule.getNonApplicablePackageLicenseChoices(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
+
+            choices.mapKeys { (id, _) -> id.toCoordinates() } shouldBe mapOf(
+                "NPM::some-other-package:1.0.0" to setOf(
+                    SpdxLicenseChoice(
+                        choice = "BSD-3-Clause".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        given = "A OR B".toSpdx(),
+                        choice = "B".toSpdx()
+                    )
+                )
+            )
+        }
+
+        "return only non-applicable SPDX license choices for packageId if the package id does exist" {
+            val rule = createAnalyzerResult(
+                "NPM::some-package:1.0.0" to "MIT OR Apache-2.0"
+            ).setPackageLicenseChoices(
+                "NPM::some-package:1.0.0" to listOf(
+                    SpdxLicenseChoice(
+                        choice = "BSD-3-Clause".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        choice = "Apache-2.0".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        given = "Apache-2.0 OR BSD-3-Clause".toSpdx(),
+                        choice = "Apache-2.0".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        given = "A OR B".toSpdx(),
+                        choice = "B".toSpdx()
+                    )
+                )
+            ).createOrtResultRule()
+
+            val choices = rule.getNonApplicablePackageLicenseChoices(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
+
+            choices.mapKeys { (id, _) -> id.toCoordinates() } shouldBe mapOf(
+                "NPM::some-package:1.0.0" to setOf(
+                    SpdxLicenseChoice(
+                        choice = "BSD-3-Clause".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        given = "Apache-2.0 OR BSD-3-Clause".toSpdx(),
+                        choice = "Apache-2.0".toSpdx()
+                    ),
+                    SpdxLicenseChoice(
+                        given = "A OR B".toSpdx(),
+                        choice = "B".toSpdx()
+                    )
+                )
+            )
+        }
+    }
+})
+
+private fun createAnalyzerResult(vararg idsWithDeclaredLicenses: Pair<String, String>): OrtResult =
+    OrtResult.EMPTY.copy(
+        analyzer = AnalyzerRun.EMPTY.copy(
+            result = AnalyzerResult.EMPTY.copy(
+                projects = setOf(
+                    Project.EMPTY.copy(
+                        id = Identifier("NPM::project:0.0.1"),
+                        scopeDependencies = setOf(
+                            Scope(
+                                name = "dependencies",
+                                dependencies = idsWithDeclaredLicenses.mapTo(mutableSetOf()) { (id, _) ->
+                                    PackageReference(
+                                        id = Identifier(id)
+                                    )
+                                }
+                            )
+                        )
+                    )
+                ),
+                packages = idsWithDeclaredLicenses.mapTo(mutableSetOf()) { (id, declaredLicense) ->
+                    Package.EMPTY.copy(
+                        id = Identifier(id),
+                        declaredLicenses = setOf(declaredLicense),
+                        declaredLicensesProcessed = DeclaredLicenseProcessor.process(setOf(declaredLicense))
+                    )
+                }
+            )
+        )
+    )
+
+private fun OrtResult.createOrtResultRule(): OrtResultRule =
+    OrtResultRule(
+        ruleSet = ruleSet(this),
+        name = "rule"
+    )
+
+private fun OrtResult.setPackageLicenseChoices(vararg choices: Pair<String, List<SpdxLicenseChoice>>): OrtResult =
+    copy(
+        repository = repository.copy(
+            config = repository.config.copy(
+                licenseChoices = repository.config.licenseChoices.copy(
+                    packageLicenseChoices = choices.map {
+                        PackageLicenseChoice(
+                            packageId = Identifier(it.first),
+                            licenseChoices = it.second
+                        )
+                    }
+                )
+            )
+        )
+    )

--- a/evaluator/src/test/kotlin/OrtResultRuleTest.kt
+++ b/evaluator/src/test/kotlin/OrtResultRuleTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.evaluator
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.AnalyzerResult
@@ -110,6 +111,40 @@ class OrtResultRuleTest : WordSpec({
             )
         }
     }
+
+    "getNonApplicableRepositoryLicenseChoices()" should {
+        "return all repository SPDX license choices which are not applicable" {
+            val rule = createAnalyzerResult(
+                "NPM::some-package:1.0.0" to "BSD-3-Clause OR MIT"
+            ).setRepositoryLicenseChoices(
+                SpdxLicenseChoice(
+                    given = "BSD-3-Clause OR MIT".toSpdx(),
+                    choice = "BSD-3-Clause".toSpdx()
+                ),
+                SpdxLicenseChoice(
+                    given = "Apache-2.0 OR MIT".toSpdx(),
+                    choice = "MIT".toSpdx()
+                ),
+                SpdxLicenseChoice(
+                    given = "A OR B".toSpdx(),
+                    choice = "B".toSpdx()
+                )
+            ).createOrtResultRule()
+
+            val choices = rule.getNonApplicableRepositoryLicenseChoices(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
+
+            choices.shouldContainExactlyInAnyOrder(
+                SpdxLicenseChoice(
+                    given = "Apache-2.0 OR MIT".toSpdx(),
+                    choice = "MIT".toSpdx()
+                ),
+                SpdxLicenseChoice(
+                    given = "A OR B".toSpdx(),
+                    choice = "B".toSpdx()
+                )
+            )
+        }
+    }
 })
 
 private fun createAnalyzerResult(vararg idsWithDeclaredLicenses: Pair<String, String>): OrtResult =
@@ -157,6 +192,13 @@ private fun OrtResult.setPackageLicenseChoices(vararg choices: Pair<String, List
                     licenseChoices = it.second
                 )
             }
+        )
+    )
+
+private fun OrtResult.setRepositoryLicenseChoices(vararg choices: SpdxLicenseChoice): OrtResult =
+    setLicenseChoices(
+        repository.config.licenseChoices.copy(
+            repositoryLicenseChoices = choices.toList()
         )
     )
 

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -115,17 +115,28 @@ data class ResolvedLicenseInfo(
     }
 
     /**
-     * Return the effective [SpdxExpression] of this [ResolvedLicenseInfo] based on their [licenses] filtered by the
-     * [licenseView] and the applied [licenseChoices]. Effective, in this context, refers to an [SpdxExpression] that
-     * can be used as a final license of this [ResolvedLicenseInfo]. [licenseChoices] will be applied in the order they
-     * are given to the function.
+     * Convenience function which returns the first coordinate from [effectiveLicenseAndAppliedChoices].
      */
-    fun effectiveLicense(licenseView: LicenseView, vararg licenseChoices: List<SpdxLicenseChoice>): SpdxExpression? {
-        val resolvedLicenseInfo = filter(licenseView, filterSources = true)
-        val resolvedLicenses = resolvedLicenseInfo.toExpression() ?: return null
-        val choices = licenseChoices.asList().flatten().takeUnless { it.isEmpty() } ?: return resolvedLicenses
+    fun effectiveLicense(licenseView: LicenseView, vararg licenseChoices: List<SpdxLicenseChoice>): SpdxExpression? =
+        effectiveLicenseAndAppliedChoices(licenseView, *licenseChoices).first
 
-        return resolvedLicenses.applyChoices(choices).validChoices().toExpression(SpdxOperator.OR)
+    /**
+     * Return the effective [SpdxExpression] of this [ResolvedLicenseInfo] based on their [licenses] filtered by the
+     * [licenseView] and the applied [licenseChoices] along with applied choices in the order they have been applied.
+     * Effective, in this context, refers to an [SpdxExpression] that can be used as a final license of this
+     * [ResolvedLicenseInfo]. [licenseChoices] will be applied in the order they are given to the function.
+     */
+    fun effectiveLicenseAndAppliedChoices(
+        licenseView: LicenseView,
+        vararg licenseChoices: List<SpdxLicenseChoice>
+    ): Pair<SpdxExpression?, List<SpdxLicenseChoice>> {
+        val resolvedLicenseInfo = filter(licenseView, filterSources = true)
+        val resolvedLicenses = resolvedLicenseInfo.toExpression() ?: return null to emptyList()
+        val choices = licenseChoices.asList().flatten().takeUnless { it.isEmpty() }
+            ?: return resolvedLicenses to emptyList()
+
+        val (expression, appliedChoices) = resolvedLicenses.applyAndGetChoices(choices)
+        return expression.validChoices().toExpression(SpdxOperator.OR) to appliedChoices
     }
 
     /**

--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -186,21 +186,30 @@ sealed class SpdxExpression {
     /**
      * Apply [licenseChoices] in the given order to [this][SpdxExpression].
      */
-    fun applyChoices(licenseChoices: List<SpdxLicenseChoice>): SpdxExpression {
-        if (validChoices().size == 1) return this
+    fun applyChoices(licenseChoices: List<SpdxLicenseChoice>): SpdxExpression = applyAndGetChoices(licenseChoices).first
+
+    /**
+     * Apply [licenseChoices] in the given order to [this][SpdxExpression] and return the resulting SPDX expression
+     * along with the applied license choices in the order they were applied.
+     */
+    fun applyAndGetChoices(licenseChoices: List<SpdxLicenseChoice>): Pair<SpdxExpression, List<SpdxLicenseChoice>> {
+        if (validChoices().size == 1) return this to emptyList()
 
         var currentExpression = this
+        val appliedChoices = mutableListOf<SpdxLicenseChoice>()
 
         licenseChoices.forEach {
             if (it.given == null && currentExpression.isValidChoice(it.choice)) {
                 currentExpression = currentExpression.applyChoice(it.choice)
+                appliedChoices += it
             } else if (currentExpression.isSubExpression(it.given)) {
                 @Suppress("UnsafeCallOnNullableType")
                 currentExpression = currentExpression.applyChoice(it.choice, it.given!!)
+                appliedChoices += it
             }
         }
 
-        return currentExpression
+        return currentExpression to appliedChoices
     }
 
     /**

--- a/utils/spdx/src/main/kotlin/SpdxLicenseChoice.kt
+++ b/utils/spdx/src/main/kotlin/SpdxLicenseChoice.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.utils.spdx
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 /**
  * An individual license choice.
  *
@@ -49,7 +51,8 @@ package org.ossreviewtoolkit.utils.spdx
  * ```
  */
 data class SpdxLicenseChoice(
-    val given: SpdxExpression?,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val given: SpdxExpression? = null,
     val choice: SpdxExpression
 ) {
     init {


### PR DESCRIPTION
These can be used from the rules to flag non-matching entries.

For the use-case see: https://github.com/oss-review-toolkit/ort-config/pull/428.