### PR TITLE
fix(helper-cli): Do not resolve scopes when merging scanner runs

### DIFF
--- a/cli-helper/src/main/kotlin/commands/MergeScannerRunsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/MergeScannerRunsCommand.kt
@@ -70,8 +70,8 @@ internal class MergeScannerRunsCommand : OrtHelperCommand(
 
     override fun run() {
         val result = mergeScannerRuns(
-            result = readOrtResult(ortFile),
-            otherResult = readOrtResult(otherOrtFile)
+            result = readOrtResult(ortFile, resolveScopes = false),
+            otherResult = readOrtResult(otherOrtFile, resolveScopes = false)
         )
 
         writeOrtResult(result, outputOrtFile)


### PR DESCRIPTION
It is better to keep the graph representation as-is, because the command is only supposed to merge a scanner run into a given ORT file.

It was observed once, that this merge command ran out memory after executing a couple of minutes, for two ORT files sized just about 30MB. While the root cause is unknown, it could be due to `withResolvedScopes()` running into a cycle in the graph. This change fixes that issue.

