### PR TITLE
fix(spdx): Avoid running into cycles when computing linkage types

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -218,6 +218,7 @@ private fun SpdxPackage.filterChecksums(wantSpdx23: Boolean): SpdxPackage =
 private fun OrtResult.getLinkageTypesForDependencyRelationships():
     Map<Pair<Identifier, Identifier>, Set<PackageLinkage>> {
     val result = mutableMapOf<Pair<Identifier, Identifier>, MutableSet<PackageLinkage>>()
+    val visitedNodeReferenceKeys = mutableSetOf<Any>()
 
     // Traverse all non-excluded edges and collect the linkage types used in between any pair of ids.
     getProjects(omitExcluded = true, includeSubProjects = true).forEach { project ->
@@ -234,6 +235,11 @@ private fun OrtResult.getLinkageTypesForDependencyRelationships():
 
             while (queue.isNotEmpty()) {
                 val parent = queue.removeFirst()
+
+                when (val key = parent.getInternalId()) {
+                    in visitedNodeReferenceKeys -> continue
+                    else -> visitedNodeReferenceKeys += key
+                }
 
                 val children = parent.visitDependencies { children ->
                     // Map to a list instead of to a sequence, so that the conversion to the stable reference is done


### PR DESCRIPTION
Previously, the function could run into an infinite loop. This has been spotted from reading the code, but has not been observed when ORT executes (yet).

