### PR TITLE
scanner: Broaden the  condition for including license files into file archives

### DIFF
--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -92,7 +92,7 @@ fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver? {
         )
     }
 
-    val patterns = LicenseFilePatterns.getInstance().allLicenseFilenames
+    val patterns = LicenseFilePatterns.getInstance().allLicenseFilenames.map { "**/$it" }
 
     return FileArchiver(patterns, storage)
 }

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -21,11 +21,13 @@ package org.ossreviewtoolkit.model.licenses
 
 import java.util.concurrent.ConcurrentHashMap
 
+import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
@@ -35,7 +37,6 @@ import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
-import org.ossreviewtoolkit.model.utils.getSubdirectoryForProvenance
 import org.ossreviewtoolkit.model.utils.prependedPath
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -316,3 +317,21 @@ private class ResolvedLicenseBuilder(val license: SpdxSingleLicenseExpression) {
 }
 
 private val UNDEFINED_TEXT_LOCATION = TextLocation(".", TextLocation.UNKNOWN_LINE, TextLocation.UNKNOWN_LINE)
+
+/**
+ * Get the (potentially [id]-type specific) nested path directory for the given [provenance].
+ */
+private fun getSubdirectoryForProvenance(provenance: KnownProvenance, id: Identifier): String =
+    when (provenance) {
+        // In case of a repository, match paths relative to the VCS path.
+        is RepositoryProvenance -> provenance.vcsInfo.path
+
+        // In case of a source artifact, match paths relative to the archive root or a type-specific directory.
+        is ArtifactProvenance -> {
+            // Java Archives (JARs) by convention (see e.g. the Apache Release Policy) often contain licensing
+            // information as part of the "META-INF" directory.
+            if (id.type == "Maven") "META-INF" else ""
+
+            // TODO: Check if more types need special handling.
+        }
+    }

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -71,40 +71,35 @@ class FileArchiver(
     fun hasArchive(provenance: KnownProvenance): Boolean = storage.hasData(provenance)
 
     /**
-     * Archive the files matching [patterns] inside [rootDirectory] and put them to the [storage]. The archive is
-     * associated with the given [provenance] and [id].
+     * Archive all files in [directory] matching any of the configured patterns in the [storage].
      */
-    fun archive(rootDirectory: File, provenance: KnownProvenance, id: Identifier) {
-        val subdirectory = getSubdirectoryForProvenance(provenance, id)
-        val directories = setOf(rootDirectory, rootDirectory / subdirectory)
-
-        logger.info { "Archiving files matching ${matcher.patterns} from '$rootDirectory'..." }
+    fun archive(directory: File, provenance: KnownProvenance) {
+        logger.info { "Archiving files matching ${matcher.patterns} from '$directory'..." }
 
         val zipFile = createOrtTempFile(suffix = ".zip")
         val tika = Tika()
 
         val zipDuration = measureTime {
-            rootDirectory.packZip(zipFile, overwrite = true) { file ->
-                val matchingFile = directories.find {
-                    val relativePath = file.relativeTo(it).invariantSeparatorsPath
-                    matcher.matches(relativePath)
-                } ?: return@packZip false
+            directory.packZip(zipFile, overwrite = true) { file ->
+                val relativePath = file.relativeTo(directory).invariantSeparatorsPath
+
+                if (!matcher.matches(relativePath)) return@packZip false
 
                 if (!tika.detect(file).startsWith("text/")) {
-                    logger.info { "Not adding file '$matchingFile' to archive because it is not a text file." }
+                    logger.info { "Not adding file '$relativePath' to archive because it is not a text file." }
                     return@packZip false
                 }
 
-                logger.debug { "Adding '$matchingFile' to archive." }
+                logger.debug { "Adding '$relativePath' to archive." }
                 true
             }
         }
 
-        logger.info { "Archived directory '$rootDirectory' in $zipDuration." }
+        logger.info { "Archived directory '$directory' in $zipDuration." }
 
         val writeDuration = measureTime { storage.putData(provenance, zipFile.inputStream(), zipFile.length()) }
 
-        logger.info { "Wrote archive of directory '$rootDirectory' to storage in $writeDuration." }
+        logger.info { "Wrote archive of directory '$directory' to storage in $writeDuration." }
 
         zipFile.parentFile.safeDeleteRecursively()
     }

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -27,10 +27,7 @@ import kotlin.time.measureTimedValue
 import org.apache.logging.log4j.kotlin.logger
 import org.apache.tika.Tika
 
-import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
-import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.div
@@ -132,21 +129,3 @@ class FileArchiver(
         }.isSuccess
     }
 }
-
-/**
- * Get the (potentially [id]-type specific) nested path directory for the given [provenance].
- */
-fun getSubdirectoryForProvenance(provenance: KnownProvenance, id: Identifier): String =
-    when (provenance) {
-        // In case of a repository, match paths relative to the VCS path.
-        is RepositoryProvenance -> provenance.vcsInfo.path
-
-        // In case of a source artifact, match paths relative to the archive root or a type-specific directory.
-        is ArtifactProvenance -> {
-            // Java Archives (JARs) by convention (see e.g. the Apache Release Policy) often contain licensing
-            // information as part of the "META-INF" directory.
-            if (id.type == "Maven") "META-INF" else ""
-
-            // TODO: Check if more types need special handling.
-        }
-    }

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -33,7 +33,6 @@ import io.kotest.matchers.shouldNot
 import java.io.File
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsInfo
@@ -93,7 +92,7 @@ class FileArchiverTest : StringSpec() {
             createFile("path/LICENSE")
 
             val archiver = FileArchiver(setOf("**/LICENSE"), storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -110,7 +109,7 @@ class FileArchiverTest : StringSpec() {
             createFile("d/LiCeNsE")
 
             val archiver = FileArchiver(setOf("**/LICENSE"), storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -130,7 +129,7 @@ class FileArchiverTest : StringSpec() {
 
             val archiver = FileArchiver(setOf("a", "**/a"), storage)
 
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -153,7 +152,7 @@ class FileArchiverTest : StringSpec() {
             createFile("c/b")
 
             val archiver = FileArchiver(setOf("**"), storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
 
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
@@ -169,7 +168,7 @@ class FileArchiverTest : StringSpec() {
         "Empty archives can be handled" {
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
 
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
 
             archiver.unarchive(targetDir, REPOSITORY_PROVENANCE) shouldBe true
             targetDir shouldContainNFiles 0
@@ -179,7 +178,7 @@ class FileArchiverTest : StringSpec() {
             createFile("License") { writeBytes(byteArrayOf(0xFF.toByte(), 0xD8.toByte())) }
 
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -190,7 +189,7 @@ class FileArchiverTest : StringSpec() {
             createFile("build.gradle")
 
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -201,7 +200,7 @@ class FileArchiverTest : StringSpec() {
             createFile("License") { writeText("ぁあぃいぅうぇえぉおかが") }
 
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -212,7 +211,7 @@ class FileArchiverTest : StringSpec() {
             createFile("License.md") { writeText("# Heading level 1") }
 
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
-            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
             result shouldBe true
@@ -223,7 +222,8 @@ class FileArchiverTest : StringSpec() {
             createFile("LICENSE")
 
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
-            archiver.archive(workingDir, ARTIFACT_PROVENANCE, Identifier.EMPTY)
+            archiver.archive(workingDir, ARTIFACT_PROVENANCE)
+
             val result = archiver.unarchive(targetDir, ARTIFACT_PROVENANCE)
 
             result shouldBe true
@@ -234,7 +234,7 @@ class FileArchiverTest : StringSpec() {
             createFile("META-INF/LICENSE")
 
             val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
-            archiver.archive(workingDir, ARTIFACT_PROVENANCE, Identifier("Maven:::"))
+            archiver.archive(workingDir, ARTIFACT_PROVENANCE)
             val result = archiver.unarchive(targetDir, ARTIFACT_PROVENANCE)
 
             result shouldBe true

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -184,6 +184,17 @@ class FileArchiverTest : StringSpec() {
             targetDir shouldNot containFile("License")
         }
 
+        "exclude a file which does not match the default patterns" {
+            createFile("build.gradle")
+
+            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
+            val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
+
+            result shouldBe true
+            targetDir shouldNot containFile("build.gradle")
+        }
+
         "include utf8 file with japanese chars" {
             createFile("License") { writeText("ぁあぃいぅうぇえぉおかが") }
 

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
 
-private val DEFAULT_PATTERNS = LicenseFilePatterns.DEFAULT.allLicenseFilenames
+private val DEFAULT_PATTERNS = LicenseFilePatterns.DEFAULT.allLicenseFilenames.map { "**/$it" }
 
 private val REPOSITORY_PROVENANCE = RepositoryProvenance(
     vcsInfo = VcsInfo(

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -214,9 +214,7 @@ class FileArchiverTest : StringSpec() {
             val result = archiver.unarchive(targetDir, ARTIFACT_PROVENANCE)
 
             result shouldBe true
-            with(targetDir) {
-                shouldContainFileWithContent("LICENSE")
-            }
+            targetDir.shouldContainFileWithContent("LICENSE")
         }
 
         "LICENSE files from Maven artifacts with META-INF are archived" {
@@ -227,9 +225,7 @@ class FileArchiverTest : StringSpec() {
             val result = archiver.unarchive(targetDir, ARTIFACT_PROVENANCE)
 
             result shouldBe true
-            with(targetDir) {
-                shouldContainFileWithContent("META-INF/LICENSE")
-            }
+            targetDir.shouldContainFileWithContent("META-INF/LICENSE")
         }
     }
 }

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -44,6 +44,8 @@ import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
 
+private val DEFAULT_PATTERNS = LicenseFilePatterns.DEFAULT.allLicenseFilenames
+
 private val REPOSITORY_PROVENANCE = RepositoryProvenance(
     vcsInfo = VcsInfo(
         type = VcsType.GIT,
@@ -165,7 +167,7 @@ class FileArchiverTest : StringSpec() {
         }
 
         "Empty archives can be handled" {
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
 
             archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
 
@@ -176,7 +178,7 @@ class FileArchiverTest : StringSpec() {
         "exclude basic binary license file" {
             createFile("License") { writeBytes(byteArrayOf(0xFF.toByte(), 0xD8.toByte())) }
 
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
             archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
@@ -187,7 +189,7 @@ class FileArchiverTest : StringSpec() {
         "exclude a file which does not match the default patterns" {
             createFile("build.gradle")
 
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
             archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
@@ -198,7 +200,7 @@ class FileArchiverTest : StringSpec() {
         "include utf8 file with japanese chars" {
             createFile("License") { writeText("ぁあぃいぅうぇえぉおかが") }
 
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
             archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
@@ -209,7 +211,7 @@ class FileArchiverTest : StringSpec() {
         "include files with mime type text/x-web-markdown" {
             createFile("License.md") { writeText("# Heading level 1") }
 
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
             archiver.archive(workingDir, REPOSITORY_PROVENANCE, Identifier.EMPTY)
             val result = archiver.unarchive(targetDir, REPOSITORY_PROVENANCE)
 
@@ -220,7 +222,7 @@ class FileArchiverTest : StringSpec() {
         "LICENSE files from source artifacts are archived" {
             createFile("LICENSE")
 
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
             archiver.archive(workingDir, ARTIFACT_PROVENANCE, Identifier.EMPTY)
             val result = archiver.unarchive(targetDir, ARTIFACT_PROVENANCE)
 
@@ -231,7 +233,7 @@ class FileArchiverTest : StringSpec() {
         "LICENSE files from Maven artifacts with META-INF are archived" {
             createFile("META-INF/LICENSE")
 
-            val archiver = FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, storage)
+            val archiver = FileArchiver(DEFAULT_PATTERNS, storage)
             archiver.archive(workingDir, ARTIFACT_PROVENANCE, Identifier("Maven:::"))
             val result = archiver.unarchive(targetDir, ARTIFACT_PROVENANCE)
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -763,7 +763,7 @@ class Scanner(
                 // runCatching has a bug with smart-cast, see https://youtrack.jetbrains.com/issue/KT-27748.
                 try {
                     dir = provenanceDownloader.downloadRecursively(nestedProvenance)
-                    archiver.archive(dir, nestedProvenance.root, pkg.id)
+                    archiver.archive(dir, nestedProvenance.root)
                 } catch (e: DownloadException) {
                     controller.addIssue(
                         pkg.id,


### PR DESCRIPTION
The file archives creation had two issues:

1. Not all needed files were included.
2. It was package-specific (aka using the VCS path)

The problem #1 happens very frequently for source artifact scans,
in which the root directory contains just a single directory, which in turn contains the LICENSE file.

Part of #11869.