### PR TITLE
fix(model): Stop using notice files as resolved license files

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -51,7 +51,10 @@ class LicenseInfoResolver(
     private val resolvedLicenseInfo = ConcurrentHashMap<Identifier, ResolvedLicenseInfo>()
     private val resolvedLicenseFiles = ConcurrentHashMap<Identifier, ResolvedLicenseFileInfo>()
     private val pathLicenseMatcher = PathLicenseMatcher(
-        licenseFilePatterns = licenseFilePatterns.copy(otherLicenseFilenames = emptySet())
+        licenseFilePatterns = licenseFilePatterns.copy(
+            noticeFilenames = emptySet(),
+            otherLicenseFilenames = emptySet()
+        )
     )
     private val findingsMatcher = FindingsMatcher(PathLicenseMatcher(licenseFilePatterns))
 


### PR DESCRIPTION
The introduction of the concept of notice files by 426e73a intended to include notice files in the file archives, but not use them yet by default.

However, in order to not use the notice files, that commit should have updated [1]. Fix-up that commit to not treat notice files as license files.

[1] https://github.com/oss-review-toolkit/ort/blob/426e73ab9251e9d23152c5ad5454b1175c65c5bd/model/src/main/kotlin/licenses/LicenseInfoResolver.kt#L53-L55

Found in context of #11869.