### PR TITLE
docs(model): Document that filename patterns get prepended with `"**/"`

### DIFF
--- a/model/src/main/kotlin/config/LicenseFilePatterns.kt
+++ b/model/src/main/kotlin/config/LicenseFilePatterns.kt
@@ -23,27 +23,27 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 
 /**
  * A class that holds various filename patterns for files that typically contain license-related information. All
- * patterns are supposed to be used case-insensitively.
+ * patterns are supposed to be used case-insensitively. The prefix '*​*​/' will be prepended before usage.
  */
 data class LicenseFilePatterns(
     /**
-     * A set of globs that match typical license filenames.
+     * A set of globs that match typical license filenames. The prefix '*​*​/' will be prepended before usage.
      */
     val licenseFilenames: Set<String>,
 
     /**
-     * A set of globs that match typical notice filenames.
+     * A set of globs that match typical notice filenames. The prefix '*​*​/' will be prepended before usage.
      */
     val noticeFilenames: Set<String>,
 
     /**
-     * A set of globs that match typical patent filenames.
+     * A set of globs that match typical patent filenames. The prefix '*​*​/' will be prepended before usage.
      */
     val patentFilenames: Set<String>,
 
     /**
      * A set of globs that match files that often contain the license of a project, but that are no license files and
-     * are therefore not contained in [licenseFilenames].
+     * are therefore not contained in [licenseFilenames]. The prefix '*​*​/' will be prepended before usage.
      */
     val otherLicenseFilenames: Set<String>
 ) {

--- a/website/docs/configuration/license-texts.md
+++ b/website/docs/configuration/license-texts.md
@@ -53,6 +53,7 @@ See the [`reference.yml`](https://github.com/oss-review-toolkit/ort/blob/main/mo
 #### License File Patterns
 
 To decide which files to archive, ORT has a [predefined set of license file patterns](https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/config/LicenseFilePatterns.kt).
+The prefix '**/' will be prepended prior to their usage.
 To overwrite these patterns, you can add the `licenseFilePatterns` section to the `config.yml` file:
 
 ```yaml


### PR DESCRIPTION
Part of: #11869.