### PR TITLE
feat(scanner): Store failed artifact provenance resolution results

### DIFF
--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -145,22 +145,30 @@ class DefaultPackageProvenanceResolver(
             }
         }
 
-        // Try a cheap HEAD request to probe for the artifact first, and fall back to a GET request only if necessary,
-        // like for servers that do not properly implement HEAD requests for redirected URLs.
-        val responseCode = requestSourceArtifact(pkg, "HEAD")
-            .takeUnless { it == HttpURLConnection.HTTP_BAD_METHOD || it == HttpURLConnection.HTTP_NOT_FOUND }
-            ?: requestSourceArtifact(pkg, "GET")
+        return runCatching {
+            // Try a cheap HEAD request to probe for the artifact first, and fall back to a GET request only if
+            // necessary, like for servers that do not properly implement HEAD requests for redirected URLs.
+            val responseCode = requestSourceArtifact(pkg, "HEAD")
+                .takeUnless { it == HttpURLConnection.HTTP_BAD_METHOD || it == HttpURLConnection.HTTP_NOT_FOUND }
+                ?: requestSourceArtifact(pkg, "GET")
 
-        if (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
-            val artifactProvenance = ArtifactProvenance(pkg.sourceArtifact)
-            storage.writeProvenance(pkg.id, pkg.sourceArtifact, ResolvedArtifactProvenance(artifactProvenance))
-            return artifactProvenance
-        }
-
-        throw IOException(
-            "Could not verify existence of source artifact at ${pkg.sourceArtifact.url}. " +
-                "HTTP request got response $responseCode."
-        )
+            if (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
+                val artifactProvenance = ArtifactProvenance(pkg.sourceArtifact)
+                storage.writeProvenance(pkg.id, pkg.sourceArtifact, ResolvedArtifactProvenance(artifactProvenance))
+                artifactProvenance
+            } else {
+                throw IOException(
+                    "Could not verify existence of source artifact at ${pkg.sourceArtifact.url}. " +
+                        "HTTP request got response $responseCode."
+                )
+            }
+        }.onFailure { exception ->
+            storage.writeProvenance(
+                pkg.id,
+                pkg.sourceArtifact,
+                UnresolvedPackageProvenance(exception.collectMessages())
+            )
+        }.getOrThrow()
     }
 
     /**


### PR DESCRIPTION
So far, `PackageProvenanceResolver` stores only failed attempts to resolve a repository provenance in the package provenance storage. Handle failed artifact resolutions analogously to be consistent. This is also useful in the context of ORT Server, so that all issues for a run can be displayed.
