### PR TITLE
chore(model): Introduce a helper function to delete files on exit

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -37,6 +37,8 @@ import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 import org.ossreviewtoolkit.model.utils.getSubdirectoryForProvenance
 import org.ossreviewtoolkit.model.utils.prependedPath
+import org.ossreviewtoolkit.utils.common.DeleteOnExitHook
+import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
@@ -259,8 +261,7 @@ class LicenseInfoResolver(
                 return@forEach
             }
 
-            // Register the (empty) `archiveDir` for deletion on JVM exit.
-            archiveDir.deleteOnExit()
+            DeleteOnExitHook.scheduleDeletion(archiveDir)
 
             val directory = getSubdirectoryForProvenance(provenance, id)
             val rootLicenseFiles = pathLicenseMatcher.getApplicableLicenseFilesForDirectories(
@@ -271,9 +272,7 @@ class LicenseInfoResolver(
             ).getValue(directory)
 
             licenseFiles += rootLicenseFiles.map { relativePath ->
-                // Register files in `archiveDir` for deletion. Because files are deleted in reverse order than
-                // registered, this will leave `archiveDir` empty to get properly deleted by the registration above.
-                val file = archiveDir.resolve(relativePath).apply { deleteOnExit() }
+                val file = archiveDir / relativePath
 
                 ResolvedLicenseFile(
                     provenance = provenance,

--- a/utils/common/src/main/kotlin/DeleteOnExitHook.kt
+++ b/utils/common/src/main/kotlin/DeleteOnExitHook.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.common
+
+import java.io.File
+
+object DeleteOnExitHook {
+    private val files = mutableSetOf<File>()
+
+    init {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                executeDeletion()
+            }
+        )
+    }
+
+    fun scheduleDeletion(file: File) {
+        synchronized(this) {
+            files += file.canonicalFile
+        }
+    }
+
+    private fun executeDeletion() {
+        synchronized(this) {
+            files.forEach(File::safeDeleteRecursively)
+            files.clear()
+        }
+    }
+}

--- a/utils/common/src/main/kotlin/ProcessCapture.kt
+++ b/utils/common/src/main/kotlin/ProcessCapture.kt
@@ -62,13 +62,12 @@ class ProcessCapture(
         }
     }
 
-    // Note that the `tempDir` must be empty for `deleteOnExit()` to succeed, but that should be the case as the below
-    // `stdoutFile` and `stderrFile` are deleted earlier because files / directories are deleted in the reverse order
-    // that they are registered via `deleteOnExit()`.
-    private val tempDir = createTempDirectory(javaClass.simpleName).toFile().apply { deleteOnExit() }
+    private val tempDir = createTempDirectory(javaClass.simpleName).toFile()
+        .also { DeleteOnExitHook.scheduleDeletion(it) }
+
     private val commandName = command.first().toString().substringAfterLast(File.separatorChar)
-    private val stdoutFile = tempDir.resolve("$commandName.stdout").apply { deleteOnExit() }
-    private val stderrFile = tempDir.resolve("$commandName.stderr").apply { deleteOnExit() }
+    private val stdoutFile = tempDir / "$commandName.stdout"
+    private val stderrFile = tempDir / "$commandName.stderr"
 
     /**
      * Get the standard output stream of the terminated process as a string.


### PR DESCRIPTION
Use the JVM shutdown hook together with `safeDeleteRecursively()`. This removes the need to register all files within a directory and to use a specific ordering.

This simplifies an upcoming change.

Part of: #11869.