### PR TITLE
docs(model): Further clarify the term provenance in two cases

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfo.kt
@@ -112,7 +112,7 @@ data class DetectedLicenseInfo(
  */
 data class Findings(
     /**
-     * The [Provenance] of the scanned source code.
+     * The root [Provenance] of the scanned source code.
      */
     val provenance: Provenance,
 

--- a/model/src/main/kotlin/licenses/ResolvedLicenseLocation.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseLocation.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.config.PathExclude
  */
 data class ResolvedLicenseLocation(
     /**
-     * The provenance of the file.
+     * The root provenance of the file.
      */
     val provenance: Provenance,
 


### PR DESCRIPTION
In these cases, the provenance is always the root provenance, never a nested one, because it originates from
`OrtResult.getScanResultsForId()`.

Part of: #11869.
