### PR TITLE
chore(scanner): Drop storing failed repository provenance resolutions

### DIFF
--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -276,8 +276,6 @@ class DefaultPackageProvenanceResolver(
             val message = "Could not resolve revision for package '${pkg.id.toCoordinates()}' with " +
                 "${pkg.vcsProcessed}:\n${messages.joinToString("\n") { "\t$it" }}"
 
-            storage.writeProvenance(pkg.id, pkg.vcsProcessed, UnresolvedPackageProvenance(message))
-
             throw IOException(message)
         }
     }


### PR DESCRIPTION
`PackageProvenanceResolver` used to write an
`UnresolvedPackageProvenance` to the provenance store when a repository provenance could not be resolved. Drop this, since there is currently no clear reason why this is needed or for which purpose this information could be used. The Scanner anyway creates an issue for a failed provenance resolution.
