### PR TITLE
fix(maven): Call `injectMirror` before `injectProxy`

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/utils/MavenSupport.kt
@@ -189,8 +189,8 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) : Closeable {
      */
     private fun RepositorySystemSession.initializeRequest(request: MavenExecutionRequest) {
         with(containerLookup<MavenRepositorySystem>()) {
-            injectProxy(this@initializeRequest, request.remoteRepositories)
             injectMirror(this@initializeRequest, request.remoteRepositories)
+            injectProxy(this@initializeRequest, request.remoteRepositories)
             injectAuthentication(this@initializeRequest, request.remoteRepositories)
         }
     }


### PR DESCRIPTION
According to the documentation [1], `injectProxy` must be called after `injectMirror` or the repositories might end up with the wrong proxy configuration.

This also aligns the order of the `injectMirror`, `injectProxy`, and `injectAuthentication` calls with the order they are used by the `DefaultRepositorySystemSessionFactory` [2].

[1]: https://github.com/apache/maven/blob/maven-3.9.16/maven-core/src/main/java/org/apache/maven/repository/RepositorySystem.java#L120-L129
[2]: https://github.com/apache/maven/blob/maven-3.9.16/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java#L361-L363