### PR TITLE
build(gradle): Make XZ a runtime dependency only

### DIFF
--- a/cli-helper/build.gradle.kts
+++ b/cli-helper/build.gradle.kts
@@ -48,7 +48,8 @@ dependencies {
     implementation(libs.jslt)
     implementation(libs.log4j.api)
     implementation(libs.slf4j)
-    implementation(libs.xz)
+
+    runtimeOnly(libs.xz)
 
     "pluginClasspath"(platform(projects.plugins.packageManagers))
     "pluginClasspath"(platform(projects.plugins.versionControlSystems))

--- a/utils/ort/build.gradle.kts
+++ b/utils/ort/build.gradle.kts
@@ -42,7 +42,8 @@ dependencies {
 
     implementation(libs.awsS3)
     implementation(libs.commonsCompress)
-    implementation(libs.xz)
+
+    runtimeOnly(libs.xz)
 
     funTestImplementation(libs.mockk)
 


### PR DESCRIPTION
This serves as a plugin to Common-Compress and it only needed at runtime.