### PR TITLE
fix(spdx): Check for the presence of files

### DIFF
--- a/plugins/reporters/spdx/build.gradle.kts
+++ b/plugins/reporters/spdx/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
     implementation(jacksonLibs.jacksonDatabind)
 
+    testImplementation(libs.mockk)
+
     funTestImplementation(projects.utils.testUtils)
     funTestImplementation(projects.plugins.licenseFactProviders.scancodeLicenseFactProvider)
     funTestImplementation(testFixtures(projects.plugins.reporters.spdxReporter))

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -143,15 +143,23 @@ internal enum class SpdxPackageType(val infix: String, val suffix: String = "") 
 /**
  * Convert this ORT package to an SPDX package. As an ORT package can hold more metadata about its associated artifacts
  * and origin than an SPDX package, the [type] is used to specify which kind of SPDX package should be created from the
- * respective ORT package metadata.
+ * respective ORT package metadata. Also, the list of [files] contained in the package can be provided which has an
+ * impact on some properties.
  */
 internal fun Package.toSpdxPackage(
     type: SpdxPackageType,
     licenseInfoResolver: LicenseInfoResolver,
-    ortResult: OrtResult
+    ortResult: OrtResult,
+    files: List<SpdxFile> = emptyList()
 ): SpdxPackage {
-    val packageVerificationCode = ortResult.getPackageVerificationCode(id, type)?.let {
-        SpdxPackageVerificationCode(packageVerificationCodeValue = it)
+    val packageVerificationCode = if (files.isNotEmpty()) {
+        ortResult.getPackageVerificationCode(id, type)?.let {
+            SpdxPackageVerificationCode(packageVerificationCodeValue = it)
+        }
+    } else {
+        // A package verification code is only allowed if files are present. Some other properties are derived from
+        // this as well.
+        null
     }
 
     val resolvedLicenseInfo = licenseInfoResolver.resolveLicenseInfo(id).filterExcluded()
@@ -181,6 +189,7 @@ internal fun Package.toSpdxPackage(
         },
         externalRefs = if (type == SpdxPackageType.PROJECT) emptyList() else toSpdxExternalReferences(),
         filesAnalyzed = packageVerificationCode != null,
+        hasFiles = files.map { it.spdxId },
         homepage = homepageUrl.nullOrBlankToSpdxNone(),
         licenseComments = "effectiveLicense: ${effectiveLicense?.toString().nullOrBlankToSpdxNone()}",
         licenseConcluded = when (type) {

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -94,8 +94,9 @@ internal object SpdxDocumentModelMapper {
             val spdxProjectPackage = project.toPackage().toSpdxPackage(
                 SpdxPackageType.PROJECT,
                 licenseInfoResolver,
-                ortResult
-            ).copy(hasFiles = filesForProject.map { it.spdxId })
+                ortResult,
+                filesForProject
+            )
 
             ortResult.getDependencies(
                 id = project.id,
@@ -138,8 +139,9 @@ internal object SpdxDocumentModelMapper {
                 val vcsPackage = pkg.toSpdxPackage(
                     SpdxPackageType.VCS_PACKAGE,
                     licenseInfoResolver,
-                    ortResult
-                ).copy(hasFiles = filesForPackage.map { it.spdxId })
+                    ortResult,
+                    filesForPackage
+                )
 
                 val vcsPackageRelationShip = SpdxRelationship(
                     spdxElementId = binaryPackage.spdxId,
@@ -163,8 +165,9 @@ internal object SpdxDocumentModelMapper {
                 val sourceArtifactPackage = pkg.toSpdxPackage(
                     SpdxPackageType.SOURCE_PACKAGE,
                     licenseInfoResolver,
-                    ortResult
-                ).copy(hasFiles = filesForPackage.map { it.spdxId })
+                    ortResult,
+                    filesForPackage
+                )
 
                 val sourceArtifactPackageRelationship = SpdxRelationship(
                     spdxElementId = binaryPackage.spdxId,

--- a/plugins/reporters/spdx/src/test/kotlin/ExtensionsTest.kt
+++ b/plugins/reporters/spdx/src/test/kotlin/ExtensionsTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.reporters.spdx
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+
+import io.mockk.mockk
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxFile
+
+class ExtensionsTest : WordSpec({
+    "toSpdxPackage" should {
+        "set filesAnalyzed to true if there is a package verification code and files are available" {
+            val id = Identifier("Maven:pkg1-grp:pkg1:0.0.1")
+            val pkg = requireNotNull(ORT_RESULT.getPackage(id)?.metadata)
+            val spdxFile = SpdxFile(
+                spdxId = "SPDXRef-Pkg1-testFile",
+                filename = "testFile",
+                checksums = emptyList(),
+                licenseConcluded = "MIT"
+            )
+            val files = listOf(spdxFile)
+
+            val spdxPkg = pkg.toSpdxPackage(
+                type = SpdxPackageType.VCS_PACKAGE,
+                licenseInfoResolver = mockk(relaxed = true),
+                ortResult = ORT_RESULT,
+                files = files
+            )
+
+            spdxPkg.filesAnalyzed shouldBe true
+            spdxPkg.hasFiles shouldContainExactly listOf(spdxFile.spdxId)
+            spdxPkg.packageVerificationCode shouldNot beNull()
+        }
+
+        "set filesAnalyzed to false and no verification code if there are no files available" {
+            val id = Identifier("Maven:pkg1-grp:pkg1:0.0.1")
+            val pkg = requireNotNull(ORT_RESULT.getPackage(id)?.metadata)
+
+            val spdxPkg = pkg.toSpdxPackage(
+                type = SpdxPackageType.VCS_PACKAGE,
+                licenseInfoResolver = mockk(relaxed = true),
+                ortResult = ORT_RESULT
+            )
+
+            spdxPkg.filesAnalyzed shouldBe false
+            spdxPkg.hasFiles should beEmpty()
+            spdxPkg.packageVerificationCode should beNull()
+        }
+    }
+})


### PR DESCRIPTION
The SPDX specification allows certain property values for packages only if actually files are present for this package. The SPDX reporter used to derive such properties from the presence of a package verification code. However, there could be cases in which such a verification code exists, but there are no files with relevant findings for the package. In such cases, the generated SPDX documents were invalid according to the specification.

To prevent this, pass the list of files to the `toSpdxPackage()` function and evaluate it when computing the value for related properties. The new parameter also slightly simplifies the code on caller side.
