### PR TITLE
fix(model): Skip excluded projects in getDependencies when omitExcluded is true

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -243,7 +243,7 @@ data class OrtResult(
         val dependencies = mutableSetOf<Identifier>()
         val matcher = DependencyNavigator.MATCH_ALL.takeUnless { omitExcluded } ?: { !isExcluded(it.id) }
 
-        getProjects().forEach { project ->
+        getProjects(omitExcluded).forEach { project ->
             if (project.id == id) {
                 dependencies += dependencyNavigator.projectDependencies(project, maxLevel, matcher)
             }


### PR DESCRIPTION
Previously, getDependencies(omitExcluded=true) only filtered excluded packages
from results but still traversed all projects. This caused inconsistencies when
dependency edges only exist in excluded projects (e.g., test-only submodules).

Now excluded projects are also skipped during traversal, ensuring dependencies
only reachable through excluded projects are not discovered.