### PR TITLE
fix(detekt-rules): Correctly determine the root project

### DIFF
--- a/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
@@ -51,7 +51,7 @@ class OrtPackageNaming(config: Config) : Rule(
 
         // TODO: Find a better way to determine the project path. Unfortunately, `KtFile.project.basePath` is null.
         projectPath = generateSequence(root.absolutePath()) { it.parent }.find {
-            it.resolve("build.gradle.kts").isRegularFile()
+            it.resolve("settings.gradle.kts").isRegularFile()
         }
     }
 

--- a/detekt-rules/src/test/kotlin/OrtPackageNamingTest.kt
+++ b/detekt-rules/src/test/kotlin/OrtPackageNamingTest.kt
@@ -151,7 +151,7 @@ class OrtPackageNamingTest : WordSpec({
 })
 
 private fun TestConfiguration.createFile(dir: String, content: String): KtFile {
-    val projectDir = tempdir().apply { resolve("build.gradle.kts").createNewFile() }
+    val projectDir = tempdir().apply { resolve("settings.gradle.kts").createNewFile() }
     val parent = projectDir.resolve(dir).safeMkdirs()
     val file = parent.resolve("Test.kt").apply { writeText(content) }
     return compileForTest(file.toPath())

--- a/plugins/package-managers/ort-project-file/src/funTest/kotlin/OrtProjectFileFunTest.kt
+++ b/plugins/package-managers/ort-project-file/src/funTest/kotlin/OrtProjectFileFunTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+package org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty as beEmptyCollection

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProject.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProject.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+package org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile
 
 import com.charleskorn.kaml.Yaml
 

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectFile.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectFile.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+package org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile
 
 import java.io.File
 

--- a/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
+++ b/plugins/package-managers/ort-project-file/src/main/kotlin/OrtProjectMapper.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.ortproject
+package org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile
 
 import java.io.File
 
@@ -39,9 +39,9 @@ import org.ossreviewtoolkit.model.orNone
 import org.ossreviewtoolkit.model.utils.toIdentifier
 import org.ossreviewtoolkit.model.utils.toPackageUrl
 import org.ossreviewtoolkit.model.utils.toPurl
-import org.ossreviewtoolkit.plugins.packagemanagers.ortproject.OrtProject.Dependency
-import org.ossreviewtoolkit.plugins.packagemanagers.ortproject.OrtProject.SourceArtifact
-import org.ossreviewtoolkit.plugins.packagemanagers.ortproject.OrtProject.Vcs
+import org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile.OrtProject.Dependency
+import org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile.OrtProject.SourceArtifact
+import org.ossreviewtoolkit.plugins.packagemanagers.ortprojectfile.OrtProject.Vcs
 
 private const val DEFAULT_SCOPE_NAME = "unnamed"
 private const val PROJECT_TYPE = "OrtProjectFile"

--- a/plugins/package-managers/spdx-document-file/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
+++ b/plugins/package-managers/spdx-document-file/src/funTest/kotlin/SpdxDocumentFileFunTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile
 
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.WordSpec

--- a/plugins/package-managers/spdx-document-file/src/main/kotlin/SpdxDocumentFile.kt
+++ b/plugins/package-managers/spdx-document-file/src/main/kotlin/SpdxDocumentFile.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile
 
 import java.io.File
 
@@ -49,17 +49,17 @@ import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.SpdxDocumentCache
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.SpdxResolvedDocument
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.extractScopeFromExternalReferences
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.isExternalDocumentReferenceId
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.locateCpe
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.locateExternalReference
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.mapNotPresentToEmpty
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.projectPackage
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.toIdentifier
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.toPackage
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.wrapPresentInSet
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.SpdxDocumentCache
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.SpdxResolvedDocument
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.extractScopeFromExternalReferences
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.isExternalDocumentReferenceId
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.locateCpe
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.locateExternalReference
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.mapNotPresentToEmpty
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.projectPackage
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.toIdentifier
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.toPackage
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.wrapPresentInSet
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxExternalReference
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxPackage
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxRelationship

--- a/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxDocumentCache.kt
+++ b/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxDocumentCache.kt
@@ -17,13 +17,13 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils
 
 import java.io.File
 
 import org.apache.logging.log4j.kotlin.logger
 
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.SpdxDocumentFile
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.SpdxDocumentFile
 import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxDocument
 

--- a/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxExtensions.kt
+++ b/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxExtensions.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils
 
 import java.io.File
 
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.utils.toIdentifier
 import org.ossreviewtoolkit.model.utils.toPackageUrl
 import org.ossreviewtoolkit.model.utils.toPurl
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.PACKAGE_TYPE_SPDX
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.PACKAGE_TYPE_SPDX
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxdocument.model.SpdxDocument

--- a/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxResolvedDocument.kt
+++ b/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxResolvedDocument.kt
@@ -19,7 +19,7 @@
 
 @file:Suppress("TooManyFunctions")
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils
 
 import java.io.File
 import java.net.URI
@@ -30,8 +30,8 @@ import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.SpdxDocumentFile
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.SpdxDocumentFileFactory
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.SpdxDocumentFile
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.SpdxDocumentFileFactory
 import org.ossreviewtoolkit.utils.authentication.requestPasswordAuthentication
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively

--- a/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/StringExtensions.kt
+++ b/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/StringExtensions.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.utils.common.collapseWhitespace

--- a/plugins/package-managers/spdx-document-file/src/test/kotlin/SpdxDocumentFileTest.kt
+++ b/plugins/package-managers/spdx-document-file/src/test/kotlin/SpdxDocumentFileTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.nulls.beNull
@@ -32,10 +32,10 @@ import java.io.File
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.SpdxResolvedDocument
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.extractScopeFromExternalReferences
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.getVcsInfo
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils.projectPackage
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.SpdxResolvedDocument
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.extractScopeFromExternalReferences
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.getVcsInfo
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils.projectPackage
 import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper

--- a/plugins/package-managers/spdx-document-file/src/test/kotlin/utils/SpdxDocumentCacheTest.kt
+++ b/plugins/package-managers/spdx-document-file/src/test/kotlin/utils/SpdxDocumentCacheTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should

--- a/plugins/package-managers/spdx-document-file/src/test/kotlin/utils/SpdxResolvedDocumentTest.kt
+++ b/plugins/package-managers/spdx-document-file/src/test/kotlin/utils/SpdxResolvedDocumentTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.plugins.packagemanagers.spdx.utils
+package org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.utils
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
@@ -48,7 +48,7 @@ import java.net.URI
 
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.plugins.packagemanagers.spdx.SpdxDocumentFileFactory
+import org.ossreviewtoolkit.plugins.packagemanagers.spdxdocumentfile.SpdxDocumentFileFactory
 import org.ossreviewtoolkit.utils.common.calculateHash
 import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.spdxdocument.SpdxModelMapper


### PR DESCRIPTION
This did not cause violations for nested projects because the rule was skipped in that case due to `pathPattern` not being matched.