### PR TITLE
Add support for VulnerableCode API v3

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -151,6 +151,11 @@ SPDX-FileCopyrightText = "Copyright (c) 2022 SCANOSS"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
+path = "clients/vulnerable-code/openapi/**"
+SPDX-FileCopyrightText = "Copyright (c) nexB Inc. and others"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 path = "evaluator/src/main/resources/rules/matrixseqexpl.json"
 SPDX-FileCopyrightText = "2021 Open Source Automation Development Lab (OSADL) eG"
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/clients/osv/src/main/kotlin/OsvService.kt
+++ b/clients/osv/src/main/kotlin/OsvService.kt
@@ -41,7 +41,6 @@ import retrofit2.http.Path
 
 /**
  * An interface for the REST API of the Google Open Source Vulnerabilities (OSV) service, see https://osv.dev/.
- * The list of data sources is documented at https://google.github.io/osv.dev/data/#current-data-sources.
  */
 interface OsvService {
     companion object {

--- a/clients/vulnerable-code/build.gradle.kts
+++ b/clients/vulnerable-code/build.gradle.kts
@@ -17,20 +17,41 @@
  * License-Filename: LICENSE
  */
 
+import io.github.hfhbd.kfx.openapi.OpenApi
+
 plugins {
     // Apply precompiled plugins.
     id("ort-library-conventions")
 
     // Apply third-party plugins.
+    alias(libs.plugins.kfx)
     alias(libs.plugins.kotlinSerialization)
 }
 
+kfx {
+    register<OpenApi>("VulnerableCodeApi") {
+        files.from("openapi/vulnerablecode.openapi.json")
+
+        packageName = "org.ossreviewtoolkit.clients.vulnerablecode"
+
+        dependencies {
+            compiler(kotlinClasses())
+            compiler(kotlinxJson())
+            compiler(ktorClient())
+        }
+
+        usingKotlinSourceSet(kotlin.sourceSets.main)
+    }
+}
+
 dependencies {
+    api(ktorLibs.client.core)
     api(libs.kotlinx.serialization.core)
     api(libs.kotlinx.serialization.json)
     api(libs.okhttp)
     api(libs.retrofit)
 
+    implementation(ktorLibs.http)
     implementation(libs.retrofit.converter.kotlinxSerialization)
 }
 

--- a/clients/vulnerable-code/openapi/README.md
+++ b/clients/vulnerable-code/openapi/README.md
@@ -1,0 +1,1 @@
+The OpenAPI schema in this directory was copied from the public [VulnerableCode API schema](https://public.vulnerablecode.io/api/schema/?format=json).

--- a/clients/vulnerable-code/openapi/vulnerablecode.openapi.json
+++ b/clients/vulnerable-code/openapi/vulnerablecode.openapi.json
@@ -52,11 +52,11 @@
           {}
         ],
         "responses": {
-          "201": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PackageV3"
+                  "$ref": "#/components/schemas/PaginatedPackageV3List"
                 }
               }
             },
@@ -100,11 +100,11 @@
           {}
         ],
         "responses": {
-          "201": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AdvisoryV3"
+                  "$ref": "#/components/schemas/PaginatedAdvisoryV3List"
                 }
               }
             },
@@ -381,12 +381,7 @@
             "maxLength": 50
           },
           "scoring_system": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ScoringSystemEnum"
-              }
-            ],
-            "description": "Identifier for the scoring system used. Available choices are: cvssv2: CVSSv2 Base Score,\ncvssv3: CVSSv3 Base Score,\ncvssv3.1: CVSSv3.1 Base Score,\ncvssv4: CVSSv4 Base Score,\nrhbs: RedHat Bugzilla severity,\nrhas: RedHat Aggregate severity,\narchlinux: Archlinux Vulnerability Group Severity,\ncvssv3.1_qr: CVSSv3.1 Qualitative Severity Rating,\ngeneric_textual: Generic textual severity rating,\napache_httpd: Apache Httpd Severity,\napache_tomcat: Apache Tomcat Severity,\nepss: Exploit Prediction Scoring System,\nssvc: Stakeholder-Specific Vulnerability Categorization,\nopenssl: OpenSSL Severity,\nubuntu-priority: Ubuntu Priority "
+            "$ref": "#/components/schemas/ScoringSystemEnum"
           },
           "scoring_elements": {
             "type": "string",
@@ -402,11 +397,7 @@
           }
         },
         "required": [
-          "published_at",
-          "scoring_elements",
-          "scoring_system",
-          "url",
-          "value"
+          "scoring_system"
         ]
       },
       "AdvisoryV3": {
@@ -477,7 +468,10 @@
             "description": "Risk expressed as a number ranging from 0 to 10. Risk is calculated from weighted severity and exploitability values. It is the maximum value of (the weighted severity multiplied by its exploitability) or 10. Risk = min(weighted severity * exploitability, 10)"
           },
           "related_ssvc_trees": {
-            "type": "string",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RelatedSSVCTree"
+            },
             "readOnly": true
           }
         },
@@ -579,11 +573,17 @@
             "description": "Risk expressed as a number ranging from 0 to 10. Risk is calculated from weighted severity and exploitability values. It is the maximum value of (the weighted severity multiplied by its exploitability) or 10. Risk = min(weighted severity * exploitability, 10)"
           },
           "related_ssvc_trees": {
-            "type": "string",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RelatedSSVCTree"
+            },
             "readOnly": true
           },
           "fixed_by_packages": {
-            "type": "string",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
             "readOnly": true
           }
         },
@@ -638,44 +638,120 @@
             "type": "string"
           },
           "affected_by_vulnerabilities": {
-            "type": "string",
-            "readOnly": true
-          },
-          "affected_by_vulnerabilities_url": {
-            "type": "string",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PackageVulnerabilityV3"
+            },
             "readOnly": true
           },
           "fixing_vulnerabilities": {
-            "type": "string",
-            "readOnly": true
-          },
-          "fixing_vulnerabilities_url": {
-            "type": "string",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PackageVulnerabilityV3"
+            },
             "readOnly": true
           },
           "next_non_vulnerable_version": {
             "type": "string",
+            "nullable": true,
             "readOnly": true
           },
           "latest_non_vulnerable_version": {
             "type": "string",
+            "nullable": true,
             "readOnly": true
           },
           "risk_score": {
             "type": "number",
             "format": "double",
+            "nullable": true,
             "readOnly": true
           }
         },
         "required": [
           "affected_by_vulnerabilities",
-          "affected_by_vulnerabilities_url",
           "fixing_vulnerabilities",
-          "fixing_vulnerabilities_url",
-          "latest_non_vulnerable_version",
-          "next_non_vulnerable_version",
-          "purl",
-          "risk_score"
+          "purl"
+        ]
+      },
+      "PackageVulnerabilityV3": {
+        "type": "object",
+        "properties": {
+          "advisory_id": {
+            "type": "string",
+            "description": "An advisory is a unique vulnerability identifier in some database, such as PYSEC-2020-2233",
+            "maxLength": 200
+          },
+          "advisory_uid": {
+            "type": "string",
+            "readOnly": true
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string"
+          },
+          "exploitability": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Exploitability indicates the likelihood that a vulnerability in a software package could be used by malicious actors to compromise systems, applications, or networks. This metric is determined automatically based on the discovery of known exploits."
+          },
+          "weighted_severity": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Weighted severity is the highest value calculated by multiplying each severity by its corresponding weight, divided by 10."
+          },
+          "risk_score": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Risk expressed as a number ranging from 0 to 10. Risk is calculated from weighted severity and exploitability values. It is the maximum value of (the weighted severity multiplied by its exploitability) or 10. Risk = min(weighted severity * exploitability, 10)"
+          },
+          "fixed_by_packages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "introduced_in_patches": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "fixed_in_patches": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "ssvc_trees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RelatedSSVCTree"
+            },
+            "readOnly": true
+          },
+          "resource_url": {
+            "type": "string",
+            "format": "uri",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "advisory_id",
+          "advisory_uid",
+          "resource_url"
         ]
       },
       "PaginatedAdvisoryV3List": {
@@ -739,6 +815,63 @@
             }
           }
         }
+      },
+      "PaginatedPackageV3List": {
+        "type": "object",
+        "required": [
+          "count",
+          "results"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "example": 123
+          },
+          "next": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "example": "http://api.example.org/accounts/?page=4"
+          },
+          "previous": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "example": "http://api.example.org/accounts/?page=2"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PackageV3"
+            }
+          }
+        }
+      },
+      "RelatedSSVCTree": {
+        "type": "object",
+        "properties": {
+          "vector": {
+            "type": "string"
+          },
+          "decision": {
+            "type": "string"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "source_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision",
+          "options",
+          "source_url",
+          "vector"
+        ]
       },
       "ScoringSystemEnum": {
         "enum": [

--- a/clients/vulnerable-code/openapi/vulnerablecode.openapi.json
+++ b/clients/vulnerable-code/openapi/vulnerablecode.openapi.json
@@ -1,0 +1,778 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "VulnerableCode API",
+    "version": "40.0.0",
+    "description": "\n<div>\n    <strong>Note:</strong> All API requests must include the following\n    <code>User-Agent</code> header:\n    <pre>User-Agent: VCIO_API_AGENT </pre>\n    Requests without this exact header value will be rejected.\n    <p><strong>VulnerableCode</strong> is open data and free software by\n    <a href=\"https://github.com/nexB/vulnerablecode\"> nexB Inc. and others.</a>\n    </p>\n    <p>The VulnerableCode API exposes these endpoints:</p>\n    <ul>\n        <li>\n            <strong>packages/</strong>: main endpoint to lookup for vulnerable packages.\n        </li>\n        <li>\n            <strong>vulnerabilities/</strong>: secondary endpoint to lookup by vulnerabilities.\n        </li>\n        <li>\n            <strong>alias/</strong>: secondary endpoint to lookup vulnerabilities by aliases (e.g., CVE)\n        </li>\n        <li>\n            <strong>cpes/</strong>: secondary endpoint to lookup vulnerabilities by CPE.\n        </li>\n    </ul>\n</div>\n",
+    "termsOfService": "/tos/",
+    "contact": {
+      "name": "nexB Inc.",
+      "url": "https://public.vulnerablecode.io",
+      "email": "mailto:info@nexb.com"
+    },
+    "license": {
+      "name": "Source code: Apache-2.0 | Data: CC-BY-SA-4.0",
+      "url": "https://github.com/nexb/vulnerablecode#license"
+    }
+  },
+  "paths": {
+    "/api/v3/packages/": {
+      "post": {
+        "operationId": "v3_packages_create",
+        "tags": [
+          "v3"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PackageQuery"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/PackageQuery"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/PackageQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackageV3"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v3/advisories/": {
+      "post": {
+        "operationId": "v3_advisories_create",
+        "tags": [
+          "v3"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdvisoryQuery"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/AdvisoryQuery"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/AdvisoryQuery"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdvisoryV3"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v3/affected-by-advisories/": {
+      "get": {
+        "operationId": "v3_affected_by_advisories_list",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "v3"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAffectedByAdvisoryV3List"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v3/affected-by-advisories/{id}/": {
+      "get": {
+        "operationId": "v3_affected_by_advisories_retrieve",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "A unique integer value identifying this advisory v2.",
+            "required": true
+          }
+        ],
+        "tags": [
+          "v3"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffectedByAdvisoryV3"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v3/fixing-advisories/": {
+      "get": {
+        "operationId": "v3_fixing_advisories_list",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "A search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "v3"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAdvisoryV3List"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v3/fixing-advisories/{id}/": {
+      "get": {
+        "operationId": "v3_fixing_advisories_retrieve",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "A unique integer value identifying this advisory v2.",
+            "required": true
+          }
+        ],
+        "tags": [
+          "v3"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdvisoryV3"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v3/package-types/": {
+      "get": {
+        "operationId": "v3_package_types_retrieve",
+        "tags": [
+          "v3"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "tokenAuth": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "description": "No response body"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AdvisoryQuery": {
+        "type": "object",
+        "properties": {
+          "purls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AdvisoryReference": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "reference_type": {
+            "type": "string"
+          },
+          "reference_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "reference_id",
+          "reference_type",
+          "url"
+        ]
+      },
+      "AdvisorySeverity": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "description": "URL to the vulnerability severity",
+            "maxLength": 1024
+          },
+          "value": {
+            "type": "string",
+            "nullable": true,
+            "description": "Example: 9.0, Important, High",
+            "maxLength": 50
+          },
+          "scoring_system": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScoringSystemEnum"
+              }
+            ],
+            "description": "Identifier for the scoring system used. Available choices are: cvssv2: CVSSv2 Base Score,\ncvssv3: CVSSv3 Base Score,\ncvssv3.1: CVSSv3.1 Base Score,\ncvssv4: CVSSv4 Base Score,\nrhbs: RedHat Bugzilla severity,\nrhas: RedHat Aggregate severity,\narchlinux: Archlinux Vulnerability Group Severity,\ncvssv3.1_qr: CVSSv3.1 Qualitative Severity Rating,\ngeneric_textual: Generic textual severity rating,\napache_httpd: Apache Httpd Severity,\napache_tomcat: Apache Tomcat Severity,\nepss: Exploit Prediction Scoring System,\nssvc: Stakeholder-Specific Vulnerability Categorization,\nopenssl: OpenSSL Severity,\nubuntu-priority: Ubuntu Priority "
+          },
+          "scoring_elements": {
+            "type": "string",
+            "nullable": true,
+            "description": "Supporting scoring elements used to compute the score values. For example a CVSS vector string as used to compute a CVSS score.",
+            "maxLength": 250
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "UTC Date of publication of the vulnerability severity"
+          }
+        },
+        "required": [
+          "published_at",
+          "scoring_elements",
+          "scoring_system",
+          "url",
+          "value"
+        ]
+      },
+      "AdvisoryV3": {
+        "type": "object",
+        "properties": {
+          "advisory_id": {
+            "type": "string",
+            "description": "An advisory is a unique vulnerability identifier in some database, such as PYSEC-2020-2233",
+            "maxLength": 200
+          },
+          "advisory_uid": {
+            "type": "string",
+            "readOnly": true
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Link to the advisory on the upstream website",
+            "maxLength": 200
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string"
+          },
+          "severities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisorySeverity"
+            }
+          },
+          "weaknesses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisoryWeakness"
+            }
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisoryReference"
+            }
+          },
+          "exploitability": {
+            "type": "string",
+            "format": "decimal",
+            "pattern": "^-?\\d{0,1}(?:\\.\\d{0,1})?$",
+            "nullable": true,
+            "description": "Exploitability indicates the likelihood that a vulnerability in a software package could be used by malicious actors to compromise systems, applications, or networks. This metric is determined automatically based on the discovery of known exploits."
+          },
+          "weighted_severity": {
+            "type": "string",
+            "format": "decimal",
+            "pattern": "^-?\\d{0,2}(?:\\.\\d{0,1})?$",
+            "nullable": true,
+            "description": "Weighted severity is the highest value calculated by multiplying each severity by its corresponding weight, divided by 10."
+          },
+          "risk_score": {
+            "type": "string",
+            "format": "decimal",
+            "pattern": "^-?\\d{0,2}(?:\\.\\d{0,1})?$",
+            "nullable": true,
+            "description": "Risk expressed as a number ranging from 0 to 10. Risk is calculated from weighted severity and exploitability values. It is the maximum value of (the weighted severity multiplied by its exploitability) or 10. Risk = min(weighted severity * exploitability, 10)"
+          },
+          "related_ssvc_trees": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "advisory_id",
+          "advisory_uid",
+          "aliases",
+          "references",
+          "related_ssvc_trees",
+          "severities",
+          "url",
+          "weaknesses"
+        ]
+      },
+      "AdvisoryWeakness": {
+        "type": "object",
+        "properties": {
+          "cwe_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cwe_id",
+          "description",
+          "name"
+        ]
+      },
+      "AffectedByAdvisoryV3": {
+        "type": "object",
+        "properties": {
+          "advisory_id": {
+            "type": "string",
+            "description": "An advisory is a unique vulnerability identifier in some database, such as PYSEC-2020-2233",
+            "maxLength": 200
+          },
+          "advisory_uid": {
+            "type": "string",
+            "readOnly": true
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Link to the advisory on the upstream website",
+            "maxLength": 200
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string"
+          },
+          "severities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisorySeverity"
+            }
+          },
+          "weaknesses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisoryWeakness"
+            }
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisoryReference"
+            }
+          },
+          "exploitability": {
+            "type": "string",
+            "format": "decimal",
+            "pattern": "^-?\\d{0,1}(?:\\.\\d{0,1})?$",
+            "nullable": true,
+            "description": "Exploitability indicates the likelihood that a vulnerability in a software package could be used by malicious actors to compromise systems, applications, or networks. This metric is determined automatically based on the discovery of known exploits."
+          },
+          "weighted_severity": {
+            "type": "string",
+            "format": "decimal",
+            "pattern": "^-?\\d{0,2}(?:\\.\\d{0,1})?$",
+            "nullable": true,
+            "description": "Weighted severity is the highest value calculated by multiplying each severity by its corresponding weight, divided by 10."
+          },
+          "risk_score": {
+            "type": "string",
+            "format": "decimal",
+            "pattern": "^-?\\d{0,2}(?:\\.\\d{0,1})?$",
+            "nullable": true,
+            "description": "Risk expressed as a number ranging from 0 to 10. Risk is calculated from weighted severity and exploitability values. It is the maximum value of (the weighted severity multiplied by its exploitability) or 10. Risk = min(weighted severity * exploitability, 10)"
+          },
+          "related_ssvc_trees": {
+            "type": "string",
+            "readOnly": true
+          },
+          "fixed_by_packages": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "advisory_id",
+          "advisory_uid",
+          "aliases",
+          "fixed_by_packages",
+          "references",
+          "related_ssvc_trees",
+          "severities",
+          "url",
+          "weaknesses"
+        ]
+      },
+      "PackageQuery": {
+        "type": "object",
+        "properties": {
+          "purls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "details": {
+            "type": "boolean",
+            "default": false
+          },
+          "ignore_qualifiers_subpath": {
+            "type": "boolean",
+            "default": false
+          },
+          "max_advisories": {
+            "type": "integer",
+            "maximum": 10000,
+            "minimum": 1,
+            "default": 100
+          },
+          "reachability": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": [
+          "purls"
+        ]
+      },
+      "PackageV3": {
+        "type": "object",
+        "properties": {
+          "purl": {
+            "type": "string"
+          },
+          "affected_by_vulnerabilities": {
+            "type": "string",
+            "readOnly": true
+          },
+          "affected_by_vulnerabilities_url": {
+            "type": "string",
+            "readOnly": true
+          },
+          "fixing_vulnerabilities": {
+            "type": "string",
+            "readOnly": true
+          },
+          "fixing_vulnerabilities_url": {
+            "type": "string",
+            "readOnly": true
+          },
+          "next_non_vulnerable_version": {
+            "type": "string",
+            "readOnly": true
+          },
+          "latest_non_vulnerable_version": {
+            "type": "string",
+            "readOnly": true
+          },
+          "risk_score": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "affected_by_vulnerabilities",
+          "affected_by_vulnerabilities_url",
+          "fixing_vulnerabilities",
+          "fixing_vulnerabilities_url",
+          "latest_non_vulnerable_version",
+          "next_non_vulnerable_version",
+          "purl",
+          "risk_score"
+        ]
+      },
+      "PaginatedAdvisoryV3List": {
+        "type": "object",
+        "required": [
+          "count",
+          "results"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "example": 123
+          },
+          "next": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "example": "http://api.example.org/accounts/?page=4"
+          },
+          "previous": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "example": "http://api.example.org/accounts/?page=2"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdvisoryV3"
+            }
+          }
+        }
+      },
+      "PaginatedAffectedByAdvisoryV3List": {
+        "type": "object",
+        "required": [
+          "count",
+          "results"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "example": 123
+          },
+          "next": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "example": "http://api.example.org/accounts/?page=4"
+          },
+          "previous": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "example": "http://api.example.org/accounts/?page=2"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AffectedByAdvisoryV3"
+            }
+          }
+        }
+      },
+      "ScoringSystemEnum": {
+        "enum": [
+          "cvssv2",
+          "cvssv3",
+          "cvssv3.1",
+          "cvssv4",
+          "rhbs",
+          "rhas",
+          "archlinux",
+          "cvssv3.1_qr",
+          "generic_textual",
+          "apache_httpd",
+          "apache_tomcat",
+          "epss",
+          "ssvc",
+          "openssl",
+          "ubuntu-priority"
+        ],
+        "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "sessionid"
+      },
+      "tokenAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "Token-based authentication with required prefix \"Token\""
+      }
+    }
+  }
+}

--- a/clients/vulnerable-code/src/main/kotlin/Constants.kt
+++ b/clients/vulnerable-code/src/main/kotlin/Constants.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.vulnerablecode
+
+/** Base URL of the public VulnerableCode API. */
+const val VULNERABLE_CODE_BASE_URL = "https://public.vulnerablecode.io/api/"
+
+/** The HTTP user agent to use when making requests to VulnerableCode. */
+const val VULNERABLE_CODE_USER_AGENT = "VCIO_API_AGENT"

--- a/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
+++ b/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
@@ -41,11 +41,6 @@ import retrofit2.http.POST
 interface VulnerableCodeService {
     companion object {
         /**
-         * The URL to version 1 of the API, which by now is deprecated.
-         */
-        const val PUBLIC_SERVER_URL = "https://public.vulnerablecode.io/api/"
-
-        /**
          * The JSON (de-)serialization object used by this service.
          */
         val JSON = Json {
@@ -61,7 +56,7 @@ interface VulnerableCodeService {
                 newBuilder().addInterceptor { chain ->
                     val request = chain.request().newBuilder()
                         .apply { if (apiKey != null) header("Authorization", "Token $apiKey") }
-                        .header("User-Agent", "VCIO_API_AGENT")
+                        .header("User-Agent", VULNERABLE_CODE_USER_AGENT)
                         .build()
 
                     chain.proceed(request)
@@ -71,7 +66,7 @@ interface VulnerableCodeService {
             val contentType = "application/json".toMediaType()
             val retrofit = Retrofit.Builder()
                 .client(vulnerableCodeClient)
-                .baseUrl(url ?: PUBLIC_SERVER_URL)
+                .baseUrl(url ?: VULNERABLE_CODE_BASE_URL)
                 .addConverterFactory(JSON.asConverterFactory(contentType))
                 .build()
 

--- a/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
+++ b/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
@@ -36,7 +36,6 @@ import retrofit2.http.POST
 /**
  * Interface for a REST service that allows interaction with the VulnerableCode API to query information about
  * vulnerabilities detected for specific packages.
- * The list of data sources is documented at https://github.com/aboutcode-org/vulnerablecode/blob/main/SOURCES.rst.
  */
 interface VulnerableCodeService {
     companion object {

--- a/plugins/advisors/osv/src/main/kotlin/Osv.kt
+++ b/plugins/advisors/osv/src/main/kotlin/Osv.kt
@@ -50,6 +50,8 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 
 /**
  * An advice provider that obtains vulnerability information from [Open Source Vulnerabilities](https://osv.dev/).
+ *
+ * For the list of data sources see [here](https://google.github.io/osv.dev/data/#current-data-sources).
  */
 @OrtPlugin(
     id = "OSV",

--- a/plugins/advisors/vulnerable-code/build.gradle.kts
+++ b/plugins/advisors/vulnerable-code/build.gradle.kts
@@ -25,6 +25,9 @@ plugins {
 dependencies {
     api(projects.plugins.advisors.advisorApi)
 
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.client.okhttp)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation(projects.clients.vulnerableCodeClient)
     implementation(projects.utils.commonUtils)
     implementation(projects.utils.ortUtils)

--- a/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
+++ b/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
@@ -33,10 +33,10 @@ import org.ossreviewtoolkit.plugins.advisors.api.normalizeVulnerabilityData
 import org.ossreviewtoolkit.plugins.api.Secret
 
 class VulnerableCodeFunTest : WordSpec({
-    val vc = VulnerableCodeFactory.create(apiKey = System.getenv("VULNERABLECODE_API_KEY")?.let { Secret(it) })
+    "VulnerableCode API v1" should {
+        val vc = createVulnerableCode(VulnerableCodeApiVersion.V1)
 
-    "Vulnerable Go packages" should {
-        "return findings for QUIC" {
+        "return findings for Go package QUIC" {
             val id = Identifier("Go::github.com/quic-go/quic-go:0.40.0")
             val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
 
@@ -61,10 +61,8 @@ class VulnerableCodeFunTest : WordSpec({
                 }
             }
         }
-    }
 
-    "Vulnerable Maven packages" should {
-        "return findings for Guava" {
+        "return findings for Maven package Guava" {
             val id = Identifier("Maven:com.google.guava:guava:19.0")
             val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
 
@@ -92,7 +90,7 @@ class VulnerableCodeFunTest : WordSpec({
             }
         }
 
-        "return findings for Commons-Compress" {
+        "return findings for Maven package Commons-Compress" {
             val id = Identifier("Maven:org.apache.commons:commons-compress:1.23.0")
             val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
 
@@ -117,10 +115,8 @@ class VulnerableCodeFunTest : WordSpec({
                 }
             }
         }
-    }
 
-    "Vulnerable NPM packages" should {
-        "return findings for Elliptic" {
+        "return findings for NPM package Elliptic" {
             val id = Identifier("NPM::elliptic:6.5.7")
             val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
 
@@ -147,3 +143,9 @@ class VulnerableCodeFunTest : WordSpec({
         }
     }
 })
+
+private fun createVulnerableCode(apiVersion: VulnerableCodeApiVersion): VulnerableCode =
+    VulnerableCodeFactory.create(
+        apiKey = System.getenv("VULNERABLECODE_API_KEY")?.let { Secret(it) },
+        apiVersion = apiVersion
+    )

--- a/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
+++ b/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
@@ -142,6 +142,118 @@ class VulnerableCodeFunTest : WordSpec({
             }
         }
     }
+
+    "VulnerableCode API v3" should {
+        val vc = createVulnerableCode(VulnerableCodeApiVersion.V3)
+
+        // TODO: Add test for QUIC, Go packages are not yet supported in V3, see
+        //       https://github.com/aboutcode-org/vulnerablecode/issues/2334
+        "return findings for Go package QUIC".config(enabled = false) {
+            val id = Identifier("Go::github.com/quic-go/quic-go:0.40.0")
+            val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
+
+            val results = vc.retrievePackageFindings(setOf(pkg)).values.map { it.normalizeVulnerabilityData() }
+
+            results.flatMap { it.summary.issues } should beEmpty()
+            with(results.flatMap { it.vulnerabilities }.associateBy { it.id }) {
+                keys should containAll(
+                    "CVE-2023-49295"
+                )
+
+                val vulnerability = getValue("CVE-2023-49295")
+                vulnerability.summary shouldBe "quic-go is an implementation of the QUIC protocol (RFC 9000, RFC..."
+
+                vulnerability.references.find {
+                    it.url.toString() == "https://nvd.nist.gov/vuln/detail/CVE-2023-49295"
+                } shouldNotBeNull {
+                    scoringSystem shouldBe "cvssv3"
+                    severity shouldBe "MEDIUM"
+                    score shouldBe 6.5f
+                    vector shouldBe "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+                }
+            }
+        }
+
+        "return findings for Maven package Guava" {
+            val id = Identifier("Maven:com.google.guava:guava:19.0")
+            val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
+
+            val results = vc.retrievePackageFindings(setOf(pkg)).values.map { it.normalizeVulnerabilityData() }
+
+            results.flatMap { it.summary.issues } should beEmpty()
+            with(results.flatMap { it.vulnerabilities }.associateBy { it.id }) {
+                keys should containAll(
+                    "CVE-2018-10237",
+                    "CVE-2020-8908",
+                    "CVE-2023-2976"
+                )
+
+                val vulnerability = getValue("CVE-2023-2976")
+                vulnerability.summary shouldBe "Guava vulnerable to insecure use of temporary directory\nUse of J..."
+
+                vulnerability.references.find {
+                    it.url.toString() == "https://nvd.nist.gov/vuln/detail/CVE-2023-2976"
+                } shouldNotBeNull {
+                    scoringSystem shouldBe "cvssv3.1"
+                    severity shouldBe "MEDIUM"
+                    score shouldBe 5.5f
+                    vector shouldBe "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+                }
+            }
+        }
+
+        "return findings for Maven package Commons-Compress" {
+            val id = Identifier("Maven:org.apache.commons:commons-compress:1.23.0")
+            val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
+
+            val results = vc.retrievePackageFindings(setOf(pkg)).values.map { it.normalizeVulnerabilityData() }
+
+            results.flatMap { it.summary.issues } should beEmpty()
+            with(results.flatMap { it.vulnerabilities }.associateBy { it.id }) {
+                keys should containAll(
+                    "CVE-2023-42503"
+                )
+
+                val vulnerability = getValue("CVE-2023-42503")
+                vulnerability.summary shouldBe "Apache Commons Compress denial of service vulnerability\nImproper..."
+
+                vulnerability.references.find {
+                    it.url.toString() == "https://nvd.nist.gov/vuln/detail/CVE-2023-42503"
+                } shouldNotBeNull {
+                    scoringSystem shouldBe "cvssv3.1"
+                    severity shouldBe "MEDIUM"
+                    score shouldBe 5.5f
+                    vector shouldBe "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+                }
+            }
+        }
+
+        "return findings for NPM package Elliptic" {
+            val id = Identifier("NPM::elliptic:6.5.7")
+            val pkg = Package.EMPTY.copy(id = id, purl = id.toPurl())
+
+            val results = vc.retrievePackageFindings(setOf(pkg)).values.map { it.normalizeVulnerabilityData() }
+
+            results.flatMap { it.summary.issues } should beEmpty()
+            with(results.flatMap { it.vulnerabilities }.associateBy { it.id }) {
+                keys should containAll(
+                    "CVE-2024-48948"
+                )
+
+                val vulnerability = getValue("CVE-2024-48948")
+                vulnerability.summary shouldBe "Valid ECDSA signatures erroneously rejected in Elliptic\nThe Elli..."
+
+                vulnerability.references.find {
+                    it.url.toString() == "https://github.com/indutny/elliptic"
+                } shouldNotBeNull {
+                    scoringSystem shouldBe "cvssv3.1"
+                    severity shouldBe "MEDIUM"
+                    score shouldBe 4.8f
+                    vector shouldBe "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:L"
+                }
+            }
+        }
+    }
 })
 
 private fun createVulnerableCode(apiVersion: VulnerableCodeApiVersion): VulnerableCode =

--- a/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
+++ b/plugins/advisors/vulnerable-code/src/funTest/kotlin/VulnerableCodeFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.plugins.advisors.api.normalizeVulnerabilityData
 import org.ossreviewtoolkit.plugins.api.Secret
 
 class VulnerableCodeFunTest : WordSpec({
-    "VulnerableCode API v1" should {
+    "VulnerableCode API v1".config(enabled = false) should {
         val vc = createVulnerableCode(VulnerableCodeApiVersion.V1)
 
         "return findings for Go package QUIC" {

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -19,26 +19,13 @@
 
 package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
 
-import java.net.URI
-import java.time.Instant
-import java.util.concurrent.TimeUnit
-
-import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
-import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService.PackagesWrapper
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
-import org.ossreviewtoolkit.model.AdvisorSummary
-import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
-import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
-import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.plugins.advisors.api.AdviceProvider
 import org.ossreviewtoolkit.plugins.advisors.api.AdviceProviderFactory
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
-import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 
 /**
  * An [AdviceProvider] implementation that obtains security vulnerability information from a
@@ -59,108 +46,12 @@ class VulnerableCode(
      */
     override val details = AdvisorDetails(descriptor.id)
 
-    private val service by lazy {
-        val client = OkHttpClientHelper.buildClient {
-            if (config.readTimeout != null) readTimeout(config.readTimeout, TimeUnit.SECONDS)
+    private val api by lazy {
+        when (config.apiVersion) {
+            VulnerableCodeApiVersion.V1 -> VulnerableCodeApiV1(descriptor, details, config)
         }
-
-        VulnerableCodeService.create(config.serverUrl, config.apiKey?.value, client)
     }
 
-    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
-        val startTime = Instant.now()
-
-        val purls = packages.mapNotNull { pkg -> pkg.purl.ifEmpty { null } }
-        val chunks = purls.chunked(BULK_REQUEST_SIZE)
-
-        val allVulnerabilities = mutableMapOf<String, List<VulnerableCodeService.Vulnerability>>()
-        val issues = mutableListOf<Issue>()
-
-        chunks.forEachIndexed { index, chunk ->
-            runCatching {
-                val chunkVulnerabilities = service.getPackageVulnerabilities(PackagesWrapper(chunk)).filter {
-                    it.affectedByVulnerabilities.isNotEmpty()
-                }
-
-                allVulnerabilities += chunkVulnerabilities.associate { it.purl to it.affectedByVulnerabilities }
-            }.onFailure {
-                it.handleChunkRequestFailure(
-                    chunk,
-                    index,
-                    chunks.size,
-                    descriptor.displayName,
-                    allVulnerabilities,
-                    issues
-                )
-            }
-        }
-
-        val endTime = Instant.now()
-
-        return packages.mapNotNullTo(mutableListOf()) { pkg ->
-            allVulnerabilities[pkg.purl]?.let { packageVulnerabilities ->
-                val vulnerabilities = packageVulnerabilities.map { it.toModel(issues) }
-                val summary = AdvisorSummary(startTime, endTime, issues)
-                pkg to AdvisorResult(details, summary, vulnerabilities = vulnerabilities)
-            }
-        }.toMap()
-    }
-
-    /**
-     * Convert this vulnerability from the VulnerableCode data model to a [Vulnerability]. Populate [issues] if this
-     * fails.
-     */
-    private fun VulnerableCodeService.Vulnerability.toModel(issues: MutableList<Issue>): Vulnerability {
-        val description = description?.ifBlank { null }
-        return Vulnerability(
-            id = preferredCommonId(),
-            // VulnerableCode API v1 has no dedicated summary field (its summary actually is the description), so try to
-            // summarize the description.
-            summary = description.deriveSummary(),
-            description = description,
-            references = references.flatMap { it.toModel(issues) }
-        )
-    }
-
-    /**
-     * Convert this reference from the VulnerableCode data model to a list of [VulnerabilityReference] objects.
-     * In the VulnerableCode model, the reference can be assigned multiple scores in different scoring systems.
-     * For each of these scores, a single [VulnerabilityReference] is created. If no score is available, return a
-     * list with a single [VulnerabilityReference] with limited data. Populate [issues] in case of a failure,
-     * e.g. if the conversion to a URI fails.
-     */
-    private fun VulnerableCodeService.VulnerabilityReference.toModel(
-        issues: MutableList<Issue>
-    ): List<VulnerabilityReference> =
-        runCatching {
-            val sourceUri = URI(url.fixupUrlEscaping())
-
-            if (scores.isEmpty()) return listOf(VulnerabilityReference(sourceUri, null, null, null, null))
-
-            return scores.map {
-                // In VulnerableCode's data model, a Score class's value is either a numeric score or a severity string.
-                val score = it.value.toFloatOrNull()
-                val severity = it.value.takeUnless { score != null }
-
-                val vector = it.scoringElements?.ifEmpty { null }
-
-                VulnerabilityReference(sourceUri, it.scoringSystem, severity, score, vector)
-            }
-        }.onFailure {
-            issues += createAndLogIssue("Failed to map $this to ORT model due to $it.", Severity.HINT)
-        }.getOrElse { emptyList() }
-
-    /**
-     * Return a meaningful identifier for this vulnerability that can be used in reports. Obtain this identifier from
-     * the defined aliases if there are any. The data model of VulnerableCode supports multiple aliases while ORT's
-     * [Vulnerability] has just one identifier. To resolve this discrepancy, prefer CVEs over other identifiers. If
-     * there are no aliases referencing CVEs, use an arbitrary alias, assuming that every alias is preferable over
-     * the provider-specific ID of VulnerableCode. Only if no aliases are defined, use the latter as fallback. Note
-     * that it should still be possible via the references to find mentions of aliases that have been dropped.
-     */
-    private fun VulnerableCodeService.Vulnerability.preferredCommonId(): String {
-        if (aliases.isEmpty()) return vulnerabilityId
-
-        return aliases.firstOrNull { it.startsWith("cve", ignoreCase = true) } ?: aliases.first()
-    }
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> =
+        api.retrievePackageFindings(packages)
 }

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -49,6 +49,7 @@ class VulnerableCode(
     private val api by lazy {
         when (config.apiVersion) {
             VulnerableCodeApiVersion.V1 -> VulnerableCodeApiV1(descriptor, details, config)
+            VulnerableCodeApiVersion.V3 -> VulnerableCodeApiV3(descriptor, details, config)
         }
     }
 

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -23,13 +23,6 @@ import java.net.URI
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import kotlin.coroutines.cancellation.CancellationException
-
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
-
-import org.apache.logging.log4j.kotlin.logger
-
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService.PackagesWrapper
 import org.ossreviewtoolkit.model.AdvisorDetails
@@ -45,20 +38,7 @@ import org.ossreviewtoolkit.plugins.advisors.api.AdviceProvider
 import org.ossreviewtoolkit.plugins.advisors.api.AdviceProviderFactory
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
-import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.common.percentEncode
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-
-/**
- * The number of elements to request at once in a bulk request. This value was chosen more or less randomly to keep the
- * size of responses reasonably small.
- */
-private const val BULK_REQUEST_SIZE = 100
-
-/**
- * The maximum length for the summary as derived from the description of a vulnerability.
- */
-private const val MAX_SUMMARY_LENGTH = 64
 
 /**
  * An [AdviceProvider] implementation that obtains security vulnerability information from a
@@ -104,20 +84,14 @@ class VulnerableCode(
 
                 allVulnerabilities += chunkVulnerabilities.associate { it.purl to it.affectedByVulnerabilities }
             }.onFailure {
-                if (it is CancellationException) currentCoroutineContext().ensureActive()
-
-                // Create dummy entries for all packages in the chunk as the current data model does not allow to return
-                // issues that are not associated to any package.
-                allVulnerabilities += chunk.associateWith { emptyList() }
-
-                issues += Issue(source = descriptor.displayName, message = it.collectMessages())
-
-                logger.error {
-                    "The request of chunk ${index + 1} of ${chunks.size} failed for the following ${chunk.size} " +
-                        "PURL(s):"
-                }
-
-                chunk.forEach(logger::error)
+                it.handleChunkRequestFailure(
+                    chunk,
+                    index,
+                    chunks.size,
+                    descriptor.displayName,
+                    allVulnerabilities,
+                    issues
+                )
             }
         }
 
@@ -142,9 +116,7 @@ class VulnerableCode(
             id = preferredCommonId(),
             // VulnerableCode API v1 has no dedicated summary field (its summary actually is the description), so try to
             // summarize the description.
-            summary = description?.take(MAX_SUMMARY_LENGTH)?.let {
-                if (it.length < description.length) "$it..." else it
-            },
+            summary = description.deriveSummary(),
             description = description,
             references = references.flatMap { it.toModel(issues) }
         )
@@ -192,10 +164,3 @@ class VulnerableCode(
         return aliases.firstOrNull { it.startsWith("cve", ignoreCase = true) } ?: aliases.first()
     }
 }
-
-private val BACKSLASH_ESCAPE_REGEX = """\\\\?(.)""".toRegex()
-
-internal fun String.fixupUrlEscaping(): String =
-    replace("""\/""", "/").replace(BACKSLASH_ESCAPE_REGEX) {
-        it.groupValues[1].percentEncode()
-    }

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCode.kt
@@ -30,6 +30,8 @@ import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 /**
  * An [AdviceProvider] implementation that obtains security vulnerability information from a
  * [VulnerableCode](https://github.com/aboutcode-org/vulnerablecode) instance.
+ *
+ * For the list of data sources see [here](https://github.com/aboutcode-org/vulnerablecode/blob/main/SOURCES.rst).
  */
 @OrtPlugin(
     displayName = "VulnerableCode",

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV1.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV1.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2021 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import java.net.URI
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
+import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService.PackagesWrapper
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorSummary
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
+import org.ossreviewtoolkit.plugins.advisors.api.AdviceProvider
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
+
+/**
+ * An [AdviceProvider] implementation for VulnerableCode API v1.
+ *
+ * This provider uses the legacy [VulnerableCodeService] client and maps the API v1 vulnerability model to ORT's
+ * vulnerability model.
+ */
+internal class VulnerableCodeApiV1(
+    override val descriptor: PluginDescriptor,
+    override val details: AdvisorDetails,
+    private val config: VulnerableCodeConfiguration
+) : AdviceProvider {
+    private val service by lazy {
+        val client = OkHttpClientHelper.buildClient {
+            if (config.readTimeout != null) readTimeout(config.readTimeout, TimeUnit.SECONDS)
+        }
+
+        VulnerableCodeService.create(config.serverUrl, config.apiKey?.value, client)
+    }
+
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
+        val startTime = Instant.now()
+
+        val purls = packages.mapNotNull { pkg -> pkg.purl.ifEmpty { null } }
+        val chunks = purls.chunked(BULK_REQUEST_SIZE)
+
+        val allVulnerabilities = mutableMapOf<String, List<VulnerableCodeService.Vulnerability>>()
+        val issues = mutableListOf<Issue>()
+
+        chunks.forEachIndexed { index, chunk ->
+            runCatching {
+                val chunkVulnerabilities = service.getPackageVulnerabilities(PackagesWrapper(chunk)).filter {
+                    it.affectedByVulnerabilities.isNotEmpty()
+                }
+
+                allVulnerabilities += chunkVulnerabilities.associate { it.purl to it.affectedByVulnerabilities }
+            }.onFailure {
+                it.handleChunkRequestFailure(
+                    chunk,
+                    index,
+                    chunks.size,
+                    descriptor.displayName,
+                    allVulnerabilities,
+                    issues
+                )
+            }
+        }
+
+        val endTime = Instant.now()
+
+        return packages.mapNotNullTo(mutableListOf()) { pkg ->
+            allVulnerabilities[pkg.purl]?.let { packageVulnerabilities ->
+                val vulnerabilities = packageVulnerabilities.map { it.toModel(issues) }
+                val summary = AdvisorSummary(startTime, endTime, issues)
+                pkg to AdvisorResult(details, summary, vulnerabilities = vulnerabilities)
+            }
+        }.toMap()
+    }
+
+    /**
+     * Convert this vulnerability from the VulnerableCode data model to a [Vulnerability]. Populate [issues] if this
+     * fails.
+     */
+    private fun VulnerableCodeService.Vulnerability.toModel(issues: MutableList<Issue>): Vulnerability {
+        val description = description?.ifBlank { null }
+        return Vulnerability(
+            id = preferredCommonId(),
+            // VulnerableCode API v1 has no dedicated summary field (its summary actually is the description), so try to
+            // summarize the description.
+            summary = description.deriveSummary(),
+            description = description,
+            references = references.flatMap { it.toModel(issues) }
+        )
+    }
+
+    /**
+     * Convert this reference from the VulnerableCode data model to a list of [VulnerabilityReference] objects.
+     * In the VulnerableCode model, the reference can be assigned multiple scores in different scoring systems.
+     * For each of these scores, a single [VulnerabilityReference] is created. If no score is available, return a
+     * list with a single [VulnerabilityReference] with limited data. Populate [issues] in case of a failure,
+     * e.g. if the conversion to a URI fails.
+     */
+    private fun VulnerableCodeService.VulnerabilityReference.toModel(
+        issues: MutableList<Issue>
+    ): List<VulnerabilityReference> =
+        runCatching {
+            val sourceUri = URI(url.fixupUrlEscaping())
+
+            if (scores.isEmpty()) return listOf(VulnerabilityReference(sourceUri, null, null, null, null))
+
+            return scores.map {
+                // In VulnerableCode's data model, a Score class's value is either a numeric score or a severity string.
+                val score = it.value.toFloatOrNull()
+                val severity = it.value.takeUnless { score != null }
+
+                val vector = it.scoringElements?.ifEmpty { null }
+
+                VulnerabilityReference(sourceUri, it.scoringSystem, severity, score, vector)
+            }
+        }.onFailure {
+            issues += createAndLogIssue("Failed to map $this to ORT model due to $it.", Severity.HINT)
+        }.getOrElse { emptyList() }
+
+    /**
+     * Return a meaningful identifier for this vulnerability that can be used in reports. Obtain this identifier from
+     * the defined aliases if there are any. The data model of VulnerableCode supports multiple aliases while ORT's
+     * [Vulnerability] has just one identifier. To resolve this discrepancy, prefer CVEs over other identifiers. If
+     * there are no aliases referencing CVEs, use an arbitrary alias, assuming that every alias is preferable over
+     * the provider-specific ID of VulnerableCode. Only if no aliases are defined, use the latter as fallback. Note
+     * that it should still be possible via the references to find mentions of aliases that have been dropped.
+     */
+    private fun VulnerableCodeService.Vulnerability.preferredCommonId(): String {
+        if (aliases.isEmpty()) return vulnerabilityId
+
+        return aliases.firstOrNull { it.startsWith("cve", ignoreCase = true) } ?: aliases.first()
+    }
+}

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV3.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV3.kt
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+
+import java.net.URI
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import kotlin.collections.orEmpty
+
+import kotlinx.serialization.json.Json
+
+import org.ossreviewtoolkit.clients.vulnerablecode.AdvisoryQuery
+import org.ossreviewtoolkit.clients.vulnerablecode.AdvisoryReference
+import org.ossreviewtoolkit.clients.vulnerablecode.AdvisorySeverity
+import org.ossreviewtoolkit.clients.vulnerablecode.AdvisoryV3
+import org.ossreviewtoolkit.clients.vulnerablecode.PackageQuery
+import org.ossreviewtoolkit.clients.vulnerablecode.PackageV3
+import org.ossreviewtoolkit.clients.vulnerablecode.PaginatedAdvisoryV3List
+import org.ossreviewtoolkit.clients.vulnerablecode.PaginatedPackageV3List
+import org.ossreviewtoolkit.clients.vulnerablecode.VULNERABLE_CODE_USER_AGENT
+import org.ossreviewtoolkit.clients.vulnerablecode.client.v3AdvisoriesCreate
+import org.ossreviewtoolkit.clients.vulnerablecode.client.v3PackagesCreate
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorSummary
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
+import org.ossreviewtoolkit.plugins.advisors.api.AdviceProvider
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
+
+/**
+ * The default maximum number of advisories returned for a single package by the v3/packages endpoint.
+ */
+private const val DEFAULT_MAX_ADVISORIES = 100
+
+/**
+ * An [AdviceProvider] implementation for VulnerableCode API v3.
+ *
+ * This provider uses the kfx-generated Ktor client and maps the API v3 advisory model to ORT's vulnerability model.
+ */
+internal class VulnerableCodeApiV3(
+    override val descriptor: PluginDescriptor,
+    override val details: AdvisorDetails,
+    private val config: VulnerableCodeConfiguration
+) : AdviceProvider {
+    private val client by lazy {
+        HttpClient(OkHttp) {
+            expectSuccess = true
+
+            engine {
+                preconfigured = OkHttpClientHelper.buildClient {
+                    if (config.readTimeout != null) readTimeout(config.readTimeout, TimeUnit.SECONDS)
+                }
+            }
+
+            install(DefaultRequest) {
+                // The kfx-generated API client code contains the "/api/" part for each endpoint path already.
+                val urlWithoutApiSuffix = config.serverUrl.trimEnd('/').removeSuffix("/api")
+                url(urlWithoutApiSuffix)
+
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                header(HttpHeaders.UserAgent, VULNERABLE_CODE_USER_AGENT)
+
+                config.apiKey?.value?.also {
+                    header(HttpHeaders.Authorization, "Token $it")
+                }
+            }
+
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
+        val startTime = Instant.now()
+
+        val purls = packages.mapNotNull { pkg -> pkg.purl.ifEmpty { null } }
+        val chunks = purls.chunked(BULK_REQUEST_SIZE)
+
+        val allVulnerabilities = mutableMapOf<String, List<AdvisoryV3>>()
+        val issues = mutableListOf<Issue>()
+
+        chunks.forEachIndexed { index, chunk ->
+            runCatching {
+                allVulnerabilities += client.getAdvisoriesByPackage(chunk, issues)
+            }.onFailure {
+                it.handleChunkRequestFailure(
+                    chunk,
+                    index,
+                    chunks.size,
+                    descriptor.displayName,
+                    allVulnerabilities,
+                    issues
+                )
+            }
+        }
+
+        val endTime = Instant.now()
+
+        return packages.mapNotNullTo(mutableListOf()) { pkg ->
+            allVulnerabilities[pkg.purl]?.let { packageVulnerabilities ->
+                val vulnerabilities = packageVulnerabilities.map { it.toModel(issues) }.mergeVulnerabilities()
+                val summary = AdvisorSummary(startTime, endTime, issues)
+                pkg to AdvisorResult(details, summary, vulnerabilities = vulnerabilities)
+            }
+        }.toMap()
+    }
+
+    /**
+     * Retrieve the advisories affecting each package in [purls]. Use v3/packages as the package-to-advisory index and
+     * v3/advisories as the source for advisory details. Populate [issues] for advisory references that cannot be mapped
+     * to details.
+     */
+    private suspend fun HttpClient.getAdvisoriesByPackage(
+        purls: List<String>,
+        issues: MutableList<Issue>
+    ): Map<String, List<AdvisoryV3>> {
+        val advisoryUidsByPurl = getAllPackageDetails(purls).associate { packageDetails ->
+            if (packageDetails.affected_by_vulnerabilities.size >= DEFAULT_MAX_ADVISORIES) {
+                issues += createAndLogIssue(
+                    "The v3/packages response for '${packageDetails.purl}' contains at least " +
+                        "$DEFAULT_MAX_ADVISORIES advisories. There may be additional advisories that were not " +
+                        "retrieved.",
+                    Severity.WARNING
+                )
+            }
+
+            packageDetails.purl to packageDetails.affected_by_vulnerabilities.mapTo(mutableSetOf()) {
+                it.advisory_uid
+            }
+        }.filterValues { advisoryUids -> advisoryUids.isNotEmpty() }
+
+        if (advisoryUidsByPurl.isEmpty()) return emptyMap()
+
+        val advisoriesByUid = getAllAdvisories(purls).associateBy { it.advisory_uid }
+        val missingAdvisoryUids = advisoryUidsByPurl.values.flatten().toSet() - advisoriesByUid.keys
+
+        missingAdvisoryUids.forEach { advisoryUid ->
+            issues += createAndLogIssue(
+                "The v3/packages response referenced advisory '$advisoryUid', but the v3/advisories response did " +
+                    "not contain its details.",
+                Severity.WARNING
+            )
+        }
+
+        return advisoryUidsByPurl.mapValues { (_, advisoryUids) ->
+            advisoryUids.mapNotNull { advisoriesByUid[it] }
+        }
+    }
+
+    /**
+     * Retrieve detailed package information for the given [purls].
+     */
+    private suspend fun HttpClient.getAllPackageDetails(purls: List<String>): List<PackageV3> {
+        val request = PackageQuery(purls, details = true)
+        var page = v3PackagesCreate(request)
+
+        val packages = page.results.toMutableList()
+
+        while (true) {
+            val nextUrl = page.next ?: break
+
+            page = post(nextUrl) {
+                setBody(request)
+            }.body<PaginatedPackageV3List>()
+
+            packages += page.results
+        }
+
+        return packages
+    }
+
+    /**
+     * Retrieve detailed advisory information for the given package [purls].
+     */
+    private suspend fun HttpClient.getAllAdvisories(purls: List<String>): List<AdvisoryV3> {
+        val request = AdvisoryQuery(purls)
+        var page = v3AdvisoriesCreate(request)
+
+        val advisories = page.results.toMutableList()
+
+        while (true) {
+            val nextUrl = page.next ?: break
+
+            page = post(nextUrl) {
+                setBody(request)
+            }.body<PaginatedAdvisoryV3List>()
+
+            advisories += page.results
+        }
+
+        return advisories
+    }
+
+    /**
+     * Convert this advisory from the VulnerableCode data model to a [Vulnerability]. Populate [issues] if this
+     * fails.
+     */
+    private fun AdvisoryV3.toModel(issues: MutableList<Issue>): Vulnerability {
+        val normalizedSummary = summary?.ifBlank { null }
+
+        return Vulnerability(
+            id = preferredCommonId(),
+            // The VulnerableCode API v3 summary is actually a more detailed description of the vulnerability, so use it
+            // as description and derive a shorter summary from it.
+            summary = normalizedSummary.deriveSummary(),
+            description = normalizedSummary,
+            references = toReferences(issues)
+        )
+    }
+
+    /**
+     * Convert this advisory from the VulnerableCode data model to a list of [VulnerabilityReference] objects. The
+     * advisory contains two fields with relevant information: references and severities. If references are available,
+     * use them as source locations and enrich them with the scores from the severities. Only use severities as source
+     * locations if the advisory has no references. If there are no entries in either of these fields, create a
+     * reference from the advisory's URL. Populate [issues] if this fails.
+     */
+    private fun AdvisoryV3.toReferences(issues: MutableList<Issue>): List<VulnerabilityReference> {
+        val advisoryReferences = references.flatMap { it.toReferences(severities, issues) }
+
+        if (advisoryReferences.isNotEmpty()) return advisoryReferences
+
+        val scoredReferences = severities.mapNotNull { it.toReference(url, issues) }
+
+        return scoredReferences.ifEmpty {
+            url.toUri(issues)?.let { listOf(VulnerabilityReference(it, null, null, null, null)) }.orEmpty()
+        }
+    }
+
+    /**
+     * Convert this advisory reference from the VulnerableCode data model to [VulnerabilityReference] objects.
+     * Populate [issues] if this fails.
+     */
+    private fun AdvisoryReference.toReferences(
+        severities: List<AdvisorySeverity>,
+        issues: MutableList<Issue>
+    ): List<VulnerabilityReference> {
+        val sourceUri = url.toUri(issues) ?: return emptyList()
+
+        return severities.map { it.toReference(sourceUri) }
+            .ifEmpty { listOf(VulnerabilityReference(sourceUri, null, null, null, null)) }
+    }
+
+    /**
+     * Convert this advisory severity from the VulnerableCode data model to a [VulnerabilityReference] using the
+     * severity URL, or [fallbackUrl] if the severity URL is missing. Populate [issues] if the selected URL cannot be
+     * converted to a URI.
+     */
+    private fun AdvisorySeverity.toReference(fallbackUrl: String, issues: MutableList<Issue>): VulnerabilityReference? {
+        val sourceUrl = url?.takeUnless { it.isBlank() } ?: fallbackUrl
+
+        return sourceUrl.toUri(issues)?.let { toReference(it) }
+    }
+
+    /**
+     * Convert this advisory severity from the VulnerableCode data model to a [VulnerabilityReference] object with the
+     * given source URI.
+     */
+    private fun AdvisorySeverity.toReference(sourceUri: URI): VulnerabilityReference {
+        val score = value?.toFloatOrNull()
+        val textualSeverity = value.takeUnless { score != null }
+        val vector = scoring_elements?.ifEmpty { null }
+
+        return VulnerabilityReference(sourceUri, scoring_system.toString(), textualSeverity, score, vector)
+    }
+
+    /**
+     * Return a meaningful identifier for this vulnerability that can be used in reports. Consider the defined aliases
+     * and the advisory ID as candidate identifiers. To resolve the discrepancy between VulnerableCode's multiple
+     * identifiers and ORT's single [Vulnerability] identifier, prefer a CVE if one is available. Otherwise, use the
+     * advisory ID.
+     */
+    private fun AdvisoryV3.preferredCommonId(): String {
+        val allIds = buildList {
+            addAll(aliases)
+            add(advisory_id)
+        }
+
+        return allIds.firstOrNull { it.startsWith("cve", ignoreCase = true) }
+            ?: advisory_id
+    }
+
+    /**
+     * Merge vulnerabilities with the same ID into a single vulnerability, combining their references.
+     */
+    private fun Collection<Vulnerability>.mergeVulnerabilities(): List<Vulnerability> =
+        groupBy { it.id }.values.map { vulnerabilitiesWithSameId ->
+            val references = vulnerabilitiesWithSameId.flatMapTo(mutableSetOf()) { it.references }
+            val entry = vulnerabilitiesWithSameId.find { it.summary != null || it.description != null }
+                ?: vulnerabilitiesWithSameId.first()
+
+            entry.copy(references = references.toList())
+        }
+
+    /**
+     * Convert this string to a [URI] object. Populate [issues] if this fails.
+     */
+    private fun String.toUri(issues: MutableList<Issue>): URI? =
+        runCatching { URI(fixupUrlEscaping()) }.onFailure {
+            issues += createAndLogIssue("Failed to map $this to ORT model due to $it.", Severity.HINT)
+        }.getOrNull()
+}

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
@@ -27,7 +27,8 @@ import org.ossreviewtoolkit.plugins.api.Secret
  * The supported VulnerableCode API versions.
  */
 enum class VulnerableCodeApiVersion {
-    V1
+    V1,
+    V3
 }
 
 /**

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
 
-import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
+import org.ossreviewtoolkit.clients.vulnerablecode.VULNERABLE_CODE_BASE_URL
 import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.Secret
 
@@ -30,7 +30,7 @@ data class VulnerableCodeConfiguration(
     /**
      * The base URL of the VulnerableCode REST API. By default, the public VulnerableCode instance is used.
      */
-    @OrtPluginOption(defaultValue = VulnerableCodeService.PUBLIC_SERVER_URL)
+    @OrtPluginOption(defaultValue = VULNERABLE_CODE_BASE_URL)
     val serverUrl: String,
 
     /**

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
@@ -24,11 +24,19 @@ import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.Secret
 
 /**
+ * The supported VulnerableCode API versions.
+ */
+enum class VulnerableCodeApiVersion {
+    V1
+}
+
+/**
  * The configuration for VulnerableCode as security vulnerability provider.
  */
 data class VulnerableCodeConfiguration(
     /**
-     * The base URL of the VulnerableCode REST API. By default, the public VulnerableCode instance is used.
+     * The base URL of the VulnerableCode REST API. By default, the public VulnerableCode instance is used. The
+     * implementation will take care of normalizing the API URL to contain the "/api/" part.
      */
     @OrtPluginOption(defaultValue = VULNERABLE_CODE_BASE_URL)
     val serverUrl: String,
@@ -41,5 +49,11 @@ data class VulnerableCodeConfiguration(
     /**
      * The read timeout for the server connection in seconds. Defaults to whatever is the HTTP client's default value.
      */
-    val readTimeout: Long?
+    val readTimeout: Long?,
+
+    /**
+     * The VulnerableCode API version to use.
+     */
+    @OrtPluginOption(defaultValue = "V1")
+    val apiVersion: VulnerableCodeApiVersion
 )

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt
@@ -55,6 +55,6 @@ data class VulnerableCodeConfiguration(
     /**
      * The VulnerableCode API version to use.
      */
-    @OrtPluginOption(defaultValue = "V1")
+    @OrtPluginOption(defaultValue = "V3")
     val apiVersion: VulnerableCodeApiVersion
 )

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeUtils.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import kotlin.coroutines.cancellation.CancellationException
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.utils.common.collectMessages
+import org.ossreviewtoolkit.utils.common.percentEncode
+
+/**
+ * The number of elements to request at once in a bulk request. This value was chosen more or less randomly to keep the
+ * size of responses reasonably small.
+ */
+internal const val BULK_REQUEST_SIZE = 100
+
+/**
+ * The maximum length for the summary as derived from the description of a vulnerability.
+ */
+internal const val MAX_SUMMARY_LENGTH = 64
+
+/**
+ * Return a short summary derived from this string, or null if this string is null or blank.
+ */
+internal fun String?.deriveSummary(): String? {
+    val description = this?.ifBlank { null }
+
+    return description?.take(MAX_SUMMARY_LENGTH)?.let {
+        if (it.length < description.length) "$it..." else it
+    }
+}
+
+/**
+ * Handle a failure while requesting a chunk of PURLs. Populate [allVulnerabilities] with empty entries for all PURLs
+ * in [chunk] as the current data model does not allow returning issues that are not associated to any package.
+ */
+internal suspend fun <T> Throwable.handleChunkRequestFailure(
+    chunk: Collection<String>,
+    chunkIndex: Int,
+    chunkCount: Int,
+    issueSource: String,
+    allVulnerabilities: MutableMap<String, List<T>>,
+    issues: MutableList<Issue>
+) {
+    if (this is CancellationException) currentCoroutineContext().ensureActive()
+
+    allVulnerabilities += chunk.associateWith { emptyList<T>() }
+    issues += Issue(source = issueSource, message = collectMessages())
+
+    logger.error {
+        "The request of chunk ${chunkIndex + 1} of $chunkCount failed for the following ${chunk.size} PURL(s):"
+    }
+
+    chunk.forEach(logger::error)
+}
+
+private val BACKSLASH_ESCAPE_REGEX = """\\\\?(.)""".toRegex()
+
+internal fun String.fixupUrlEscaping(): String =
+    replace("""\/""", "/").replace(BACKSLASH_ESCAPE_REGEX) {
+        it.groupValues[1].percentEncode()
+    }

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import io.kotest.core.TestConfiguration
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.utils.toPurl
+import org.ossreviewtoolkit.utils.test.readResourceValue
+
+internal const val ADVISOR_NAME = "VulnerableCode"
+
+internal val idLang = Identifier("Maven:org.apache.commons:commons-lang3:3.5")
+internal val idText = Identifier("Maven:org.apache.commons:commons-text:1.1")
+internal val idStruts = Identifier("Maven:org.apache.struts:struts2-assembly:2.5.14.1")
+internal val idJUnit = Identifier("Maven:junit:junit:4.12")
+internal val idHamcrest = Identifier("Maven:org.hamcrest:hamcrest-core:1.3")
+internal val idLog4j = Identifier("Maven:org.apache.logging.log4j:log4j-core:2.17.0")
+
+/**
+ * The list with the identifiers of packages that are referenced in the test result file.
+ */
+internal val packageIdentifiers = setOf(idJUnit, idLang, idText, idStruts, idHamcrest)
+
+/**
+ * The list of packages referenced by the test result. These packages should be requested by the vulnerability provider.
+ */
+internal val packages = packageIdentifiers.map { it.toPurl() }
+
+/**
+ * Return a list with [Package]s from the analyzer result file that serve as input for the [VulnerableCode] advisor.
+ */
+internal fun TestConfiguration.inputPackagesFromAnalyzerResult(): Set<Package> =
+    readResourceValue<OrtResult>("/ort-analyzer-result.yml").getPackages().mapTo(mutableSetOf()) { it.metadata }
+
+/**
+ * Return a set with [Package]s to be used as input for the [VulnerableCode] advisor derived from the given
+ * [identifiers].
+ */
+internal fun inputPackagesFromIdentifiers(vararg identifiers: Identifier): Set<Package> =
+    identifiers.mapTo(mutableSetOf()) { Package.EMPTY.copy(id = it, purl = it.toPurl()) }
+
+/**
+ * Generate the JSON body of the request to query information about the packages identified by the given [purls].
+ * The request mainly consists of an array with the package URLs.
+ */
+internal fun generatePackagesRequest(purls: Collection<String> = packages): String =
+    purls.joinToString(prefix = "{ \"purls\": [", postfix = "] }") { "\"$it\"" }
+
+/**
+ * Generate the JSON body of the request to query vulnerability information about the [Package] with the given [id].
+ */
+internal fun generatePackagesRequest(id: Identifier): String = generatePackagesRequest(listOf(id.toPurl()))

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
@@ -19,8 +19,11 @@
 
 package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
 
+import com.github.tomakehurst.wiremock.WireMockServer
+
 import io.kotest.core.TestConfiguration
 
+import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
@@ -70,3 +73,21 @@ internal fun generatePackagesRequest(purls: Collection<String> = packages): Stri
  * Generate the JSON body of the request to query vulnerability information about the [Package] with the given [id].
  */
 internal fun generatePackagesRequest(id: Identifier): String = generatePackagesRequest(listOf(id.toPurl()))
+
+/**
+ * The advisor details expected in results produced by the VulnerableCode test instances.
+ */
+internal val details = AdvisorDetails(VulnerableCodeFactory.descriptor.id)
+
+/**
+ * Create a configuration for the VulnerableCode implementation with the given [apiVersion] that points to the local
+ * [server]. If [apiUrl] is true, append the legacy "/api/" suffix to the server URL.
+ */
+internal fun createConfig(
+    server: WireMockServer,
+    apiVersion: VulnerableCodeApiVersion,
+    apiUrl: Boolean = false
+): VulnerableCodeConfiguration {
+    val url = "http://localhost:${server.port()}" + if (apiUrl) "/api/" else ""
+    return VulnerableCodeConfiguration(url, null, null, apiVersion)
+}

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
@@ -75,6 +75,28 @@ internal fun generatePackagesRequest(purls: Collection<String> = packages): Stri
 internal fun generatePackagesRequest(id: Identifier): String = generatePackagesRequest(listOf(id.toPurl()))
 
 /**
+ * Generate the JSON body of the API v3 packages request for the given [purls].
+ */
+internal fun generateV3PackagesRequest(purls: Collection<String> = packages): String =
+    purls.joinToString(prefix = "{ \"purls\": [", postfix = "], \"details\": true }") { "\"$it\"" }
+
+/**
+ * Generate the JSON body of the API v3 packages request for the [Package] with the given [id].
+ */
+internal fun generateV3PackagesRequest(id: Identifier): String = generateV3PackagesRequest(listOf(id.toPurl()))
+
+/**
+ * Generate the JSON body of the API v3 advisories request for the given [purls].
+ */
+internal fun generateAdvisoriesRequest(purls: Collection<String> = packages): String =
+    purls.joinToString(prefix = "{ \"purls\": [", postfix = "] }") { "\"$it\"" }
+
+/**
+ * Generate the JSON body of the API v3 advisories request for the [Package] with the given [id].
+ */
+internal fun generateAdvisoriesRequest(id: Identifier): String = generateAdvisoriesRequest(listOf(id.toPurl()))
+
+/**
  * The advisor details expected in results produced by the VulnerableCode test instances.
  */
 internal val details = AdvisorDetails(VulnerableCodeFactory.descriptor.id)

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2021 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.maps.beEmpty as beEmptyMap
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+
+import java.net.URI
+
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
+import org.ossreviewtoolkit.plugins.advisors.api.normalizeVulnerabilityData
+
+class VulnerableCodeApiV1Test : WordSpec({
+    val server = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+    )
+
+    beforeSpec {
+        server.start()
+    }
+
+    afterSpec {
+        server.stop()
+    }
+
+    beforeEach {
+        server.resetAll()
+    }
+
+    "retrievePackageFindings()" should {
+        "return vulnerability information" {
+            server.stubPackagesRequest("response_packages.json")
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result shouldNot beEmptyMap()
+            result.keys should containExactlyInAnyOrder(idLang, idStruts)
+
+            val langResult = result.getValue(idLang)
+            langResult.advisor shouldBe details
+
+            val expLangVulnerability = Vulnerability(
+                id = "CVE-2014-8242",
+                references = listOf(
+                    VulnerabilityReference(
+                        URI("https://nvd.nist.gov/vuln/detail/CVE-2014-8242"),
+                        scoringSystem = null,
+                        severity = null,
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("https://github.com/apache/commons-lang/security/advisories/GHSA-2cxf-6567-7pp6"),
+                        scoringSystem = "cvssv3.1_qr",
+                        severity = "LOW",
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("https://github.com/advisories/GHSA-2cxf-6567-7pp6"),
+                        scoringSystem = null,
+                        severity = null,
+                        score = null,
+                        vector = null
+                    )
+                )
+            )
+            langResult.vulnerabilities.normalizeVulnerabilityData() should containExactly(expLangVulnerability)
+
+            val strutsResult = result.getValue(idStruts)
+            strutsResult.advisor shouldBe details
+
+            val expStrutsVulnerabilities = listOf(
+                Vulnerability(
+                    id = "CVE-2009-1382",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2009-1382"),
+                            scoringSystem = "cvssv2",
+                            severity = "HIGH",
+                            score = 7.0f,
+                            vector = null
+                        )
+                    )
+                ),
+                Vulnerability(
+                    id = "CVE-2019-CoV19",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19"),
+                            scoringSystem = "cvssv3",
+                            severity = "CRITICAL",
+                            score = 10.0f,
+                            vector = null
+                        ),
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19"),
+                            scoringSystem = "cvssv3.1_qr",
+                            severity = "HIGH",
+                            score = null,
+                            vector = null
+                        )
+                    )
+                )
+            )
+            strutsResult.vulnerabilities.normalizeVulnerabilityData() should
+                containExactlyInAnyOrder(expStrutsVulnerabilities)
+        }
+
+        "extract the CVE ID from an alias" {
+            server.stubPackagesRequest("response_junit.json", request = generatePackagesRequest(idJUnit))
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idJUnit)
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val expJunitVulnerability = Vulnerability(
+                id = "CVE-2020-15250",
+                references = listOf(
+                    VulnerabilityReference(
+                        URI("http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html"),
+                        scoringSystem = "generic_textual",
+                        severity = "Medium",
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json"),
+                        scoringSystem = "cvssv3",
+                        severity = "MEDIUM",
+                        score = 4.0f,
+                        vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                    )
+                )
+            )
+            result.getValue(idJUnit).vulnerabilities.normalizeVulnerabilityData() should
+                containExactly(expJunitVulnerability)
+        }
+
+        "extract other official identifiers from aliases" {
+            server.stubPackagesRequest("response_log4j.json", generatePackagesRequest(idLog4j))
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val expLog4jVulnerabilities = listOf(
+                Vulnerability(
+                    id = "GHSA-jfh8-c2jp-5v3q",
+                    summary = "Remote code injection in Log4j",
+                    description = "Remote code injection in Log4j",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("http://ref.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"),
+                            scoringSystem = null,
+                            severity = null,
+                            score = null,
+                            vector = null
+                        )
+                    )
+                ),
+                Vulnerability(
+                    id = "CVE-2021-44832",
+                    summary = "Improper Input Validation and Injection in Apache Log4j2",
+                    description = "Improper Input Validation and Injection in Apache Log4j2",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json"),
+                            scoringSystem = "cvssv3",
+                            severity = "MEDIUM",
+                            score = 6.6f,
+                            vector = "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
+                        )
+                    )
+                )
+            )
+            result.getValue(idLog4j).vulnerabilities.normalizeVulnerabilityData() should
+                containExactlyInAnyOrder(expLog4jVulnerabilities)
+        }
+
+        "handle a failure response from the server" {
+            server.stubFor(
+                post(urlPathEqualTo(PACKAGES_REQUEST_URL))
+                    .willReturn(
+                        aResponse().withStatus(500)
+                    )
+            )
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result shouldNotBeNull {
+                keys should containExactly(packageIdentifiers)
+
+                packageIdentifiers.forEach { pkg ->
+                    with(getValue(pkg)) {
+                        advisor shouldBe details
+                        vulnerabilities should beEmpty()
+                        summary.issues.shouldBeSingleton { issue ->
+                            issue.severity shouldBe Severity.ERROR
+                            issue.message shouldBe "HttpException: HTTP 500 Server Error"
+                        }
+                    }
+                }
+            }
+        }
+
+        "filter out packages without vulnerabilities" {
+            server.stubPackagesRequest("response_packages_no_vulnerabilities.json")
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.keys should containExactly(idStruts)
+        }
+
+        "handle unexpected packages in the query result" {
+            server.stubPackagesRequest("response_unexpected_packages.json")
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.keys should containExactlyInAnyOrder(idLang, idStruts)
+        }
+    }
+})
+
+private const val PACKAGES_REQUEST_URL = "/packages/bulk_search"
+
+/**
+ * The JSON request to query the test packages found in the result.
+ */
+private val packagesRequestJson = generatePackagesRequest()
+
+/**
+ * Prepare this server to expect an API v1 bulk package [request] and to answer it with the given [responseFile].
+ */
+private fun WireMockServer.stubPackagesRequest(responseFile: String, request: String = packagesRequestJson) {
+    stubFor(
+        post(urlPathEqualTo(PACKAGES_REQUEST_URL))
+            .withRequestBody(
+                equalToJson(request, /* ignoreArrayOrder = */ true, /* ignoreExtraElements = */ false)
+            )
+            .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+            .willReturn(
+                aResponse().withStatus(200)
+                    .withBodyFile(responseFile)
+            )
+    )
+}
+
+/**
+ * Create a test instance of [VulnerableCodeApiV1] that communicates with the local [server].
+ */
+private fun createApi(server: WireMockServer, apiUrl: Boolean = false): VulnerableCodeApiV1 =
+    VulnerableCodeApiV1(
+        VulnerableCodeFactory.descriptor,
+        details,
+        createConfig(server, VulnerableCodeApiVersion.V1, apiUrl)
+    )

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV3Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV3Test.kt
@@ -1,0 +1,411 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.beEmpty as beEmptyMap
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+
+import java.net.URI
+
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
+import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
+import org.ossreviewtoolkit.plugins.advisors.api.normalizeVulnerabilityData
+
+class VulnerableCodeApiV3Test : WordSpec({
+    val server = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+    )
+
+    beforeSpec {
+        server.start()
+    }
+
+    afterSpec {
+        server.stop()
+    }
+
+    beforeEach {
+        server.resetAll()
+    }
+
+    "retrievePackageFindings()" should {
+        "return vulnerability information" {
+            server.stubPackagesRequest("packages_response_packages.json")
+            server.stubAdvisoriesRequest("advisories_response_packages.json", generateAdvisoriesRequest())
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.values.flatMap { it.summary.issues } should beEmpty()
+            result shouldNot beEmptyMap()
+            result.keys should containExactlyInAnyOrder(idLang, idStruts)
+
+            val langResult = result.getValue(idLang)
+            langResult.advisor shouldBe details
+
+            val expLangVulnerability = Vulnerability(
+                id = "CVE-2014-8242",
+                references = listOf(
+                    VulnerabilityReference(
+                        URI("https://nvd.nist.gov/vuln/detail/CVE-2014-8242"),
+                        scoringSystem = "cvssv3.1_qr",
+                        severity = "LOW",
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("https://nvd.nist.gov/vuln/detail/CVE-2014-8242"),
+                        scoringSystem = null,
+                        severity = null,
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("https://github.com/advisories/GHSA-2cxf-6567-7pp6"),
+                        scoringSystem = null,
+                        severity = null,
+                        score = null,
+                        vector = null
+                    )
+                )
+            )
+            langResult.vulnerabilities.normalizeVulnerabilityData() should containExactly(expLangVulnerability)
+
+            val strutsResult = result.getValue(idStruts)
+            strutsResult.advisor shouldBe details
+
+            val expStrutsVulnerabilities = listOf(
+                Vulnerability(
+                    id = "CVE-2009-1382",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2009-1382"),
+                            scoringSystem = "cvssv2",
+                            severity = "HIGH",
+                            score = 7.0f,
+                            vector = null
+                        )
+                    )
+                ),
+                Vulnerability(
+                    id = "CVE-2019-CoV19",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19"),
+                            scoringSystem = "cvssv3",
+                            severity = "CRITICAL",
+                            score = 10.0f,
+                            vector = null
+                        ),
+                        VulnerabilityReference(
+                            URI("https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19"),
+                            scoringSystem = "cvssv3.1_qr",
+                            severity = "HIGH",
+                            score = null,
+                            vector = null
+                        )
+                    )
+                )
+            )
+            strutsResult.vulnerabilities.normalizeVulnerabilityData() should
+                containExactlyInAnyOrder(expStrutsVulnerabilities)
+        }
+
+        "extract the CVE ID from an alias" {
+            server.stubPackagesRequest("packages_response_junit.json", request = generateV3PackagesRequest(idJUnit))
+            server.stubAdvisoriesRequest("advisories_response_junit.json", generateAdvisoriesRequest(idJUnit))
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idJUnit)
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val expJunitVulnerability = Vulnerability(
+                id = "CVE-2020-15250",
+                references = listOf(
+                    VulnerabilityReference(
+                        URI("http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html"),
+                        scoringSystem = "generic_textual",
+                        severity = "Medium",
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html"),
+                        scoringSystem = "cvssv3",
+                        severity = "MEDIUM",
+                        score = 4.0f,
+                        vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                    ),
+                    VulnerabilityReference(
+                        URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json"),
+                        scoringSystem = "generic_textual",
+                        severity = "Medium",
+                        score = null,
+                        vector = null
+                    ),
+                    VulnerabilityReference(
+                        URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json"),
+                        scoringSystem = "cvssv3",
+                        severity = "MEDIUM",
+                        score = 4.0f,
+                        vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                    )
+                )
+            )
+            result.getValue(idJUnit).vulnerabilities.normalizeVulnerabilityData() should
+                containExactly(expJunitVulnerability)
+        }
+
+        "extract other official identifiers from the advisory ID" {
+            server.stubPackagesRequest("packages_response_log4j.json", generateV3PackagesRequest(idLog4j))
+            server.stubAdvisoriesRequest(
+                "advisories_response_log4j_no_aliases.json",
+                generateAdvisoriesRequest(idLog4j)
+            )
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val expLog4jVulnerabilities = listOf(
+                Vulnerability(
+                    id = "GHSA-8489-44mv-ggj8",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://github.com/advisories/GHSA-8489-44mv-ggj8.json"),
+                            scoringSystem = null,
+                            severity = null,
+                            score = null,
+                            vector = null
+                        )
+                    )
+                )
+            )
+            result.getValue(idLog4j).vulnerabilities.normalizeVulnerabilityData() should
+                containExactlyInAnyOrder(expLog4jVulnerabilities)
+        }
+
+        "prefer CVE ID from the advisory ID over aliases" {
+            server.stubPackagesRequest("packages_response_log4j_cve.json", generateV3PackagesRequest(idLog4j))
+            server.stubAdvisoriesRequest("advisories_response_log4j_cve.json", generateAdvisoriesRequest(idLog4j))
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val expLog4jVulnerabilities = listOf(
+                Vulnerability(
+                    id = "CVE-2021-44832",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://github.com/advisories/GHSA-8489-44mv-ggj8.json"),
+                            scoringSystem = "cvssv3",
+                            severity = "MEDIUM",
+                            score = 6.6f,
+                            vector = "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
+                        )
+                    )
+                )
+            )
+            result.getValue(idLog4j).vulnerabilities.normalizeVulnerabilityData() should
+                containExactlyInAnyOrder(expLog4jVulnerabilities)
+        }
+
+        "gather purls from paginated response" {
+            server.stubPackagesRequest("packages_response_page1.json")
+            server.stubFor(
+                post(urlPathEqualTo("/api/v3/packages/"))
+                    .withQueryParam("page", equalTo("2"))
+                    .withRequestBody(equalToJson(packagesRequestJson, true, false))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBodyFile("packages_response_page2.json")
+                    )
+            )
+            server.stubAdvisoriesRequest("advisories_response_packages_paginated.json", generateAdvisoriesRequest())
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.values.flatMap { it.summary.issues } should beEmpty()
+            result shouldNot beEmptyMap()
+            result.keys should containExactlyInAnyOrder(idJUnit, idLang, idStruts)
+        }
+
+        "gather vulnerabilities from paginated advisories" {
+            server.stubPackagesRequest(
+                "packages_response_log4j_page_advisories.json",
+                generateV3PackagesRequest(idLog4j)
+            )
+            server.stubAdvisoriesRequest("advisories_response_page1.json", generateAdvisoriesRequest(idLog4j))
+            server.stubFor(
+                post(urlPathEqualTo("/api/v3/advisories/"))
+                    .withQueryParam("page", equalTo("2"))
+                    .withRequestBody(equalToJson(generateAdvisoriesRequest(idLog4j), true, false))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBodyFile("advisories_response_page2.json")
+                    )
+            )
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.keys shouldBe setOf(idLog4j)
+            result.getValue(idLog4j).vulnerabilities shouldHaveSize 3
+
+            with(result.getValue(idLog4j)) {
+                vulnerabilities shouldHaveSize 3
+                vulnerabilities.map {
+                    it.id
+                } shouldContainExactlyInAnyOrder setOf("CVE-2026-34480", "CVE-2026-34477", "CVE-2021-44832")
+            }
+        }
+
+        "handle a failure response from the server" {
+            server.stubFor(
+                post(urlPathEqualTo("/api/v3/packages/"))
+                    .willReturn(
+                        aResponse().withStatus(500)
+                    )
+            )
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result shouldNotBeNull {
+                keys should containExactly(packageIdentifiers)
+
+                packageIdentifiers.forEach { pkg ->
+                    with(getValue(pkg)) {
+                        advisor shouldBe details
+                        vulnerabilities should beEmpty()
+                        summary.issues.shouldBeSingleton { issue ->
+                            issue.severity shouldBe Severity.ERROR
+                            issue.message shouldStartWith "ServerResponseException"
+                            issue.message shouldContain "500 Server Error"
+                        }
+                    }
+                }
+            }
+        }
+
+        "filter out packages without vulnerabilities" {
+            server.stubPackagesRequest("packages_response_packages_no_vulnerabilities.json")
+            server.stubAdvisoriesRequest("advisories_response_packages.json", generateAdvisoriesRequest())
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.keys should containExactly(idStruts)
+        }
+
+        "handle unexpected packages in the query result" {
+            server.stubPackagesRequest("packages_response_unexpected_packages.json")
+            server.stubAdvisoriesRequest("advisories_response_unexpected_packages.json", generateAdvisoriesRequest())
+            val api = createApi(server)
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+
+            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            result.keys should containExactlyInAnyOrder(idLang, idStruts)
+        }
+    }
+})
+
+/**
+ * The JSON request to query the test packages found in the result via the VulnerableCode API v3 packages endpoint.
+ */
+private val packagesRequestJson = generateV3PackagesRequest()
+
+/**
+ * Prepare this server to expect an API v3 packages [request] and to answer it with the given [responseFile].
+ */
+private fun WireMockServer.stubPackagesRequest(responseFile: String, request: String = packagesRequestJson) {
+    stubFor(
+        post(urlPathEqualTo("/api/v3/packages/"))
+            .withRequestBody(
+                equalToJson(request, /* ignoreArrayOrder = */ true, /* ignoreExtraElements = */ false)
+            )
+            .withHeader("Content-Type", equalTo("application/json"))
+            .willReturn(
+                aResponse().withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBodyFile(responseFile)
+            )
+    )
+}
+
+/**
+ * Prepare this server to expect an API v3 advisories [request] and to answer it with the given [responseFile].
+ */
+private fun WireMockServer.stubAdvisoriesRequest(responseFile: String, request: String) {
+    stubFor(
+        post(urlPathEqualTo("/api/v3/advisories/"))
+            .withRequestBody(
+                equalToJson(request, /* ignoreArrayOrder = */ true, /* ignoreExtraElements = */ false)
+            )
+            .withHeader("Content-Type", equalTo("application/json"))
+            .willReturn(
+                aResponse().withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBodyFile(responseFile)
+            )
+    )
+}
+
+/**
+ * Create a test instance of [VulnerableCode] that communicates with the local [server].
+ */
+private fun createApi(server: WireMockServer, apiUrl: Boolean = false): VulnerableCodeApiV3 =
+    VulnerableCodeApiV3(
+        VulnerableCodeFactory.descriptor,
+        details,
+        createConfig(server, VulnerableCodeApiVersion.V3, apiUrl)
+    )

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
@@ -59,20 +59,37 @@ class VulnerableCodeTest : WordSpec({
             vulnerableCode.details shouldBe AdvisorDetails(ADVISOR_NAME)
         }
 
-        "use the V1 API by default" {
+        "use the V3 API by default" {
             server.stubFor(
-                post(urlPathEqualTo("/api/packages/bulk_search"))
+                post(urlPathEqualTo("/api/v3/packages/"))
                     .withRequestBody(
                         equalToJson(
-                            generatePackagesRequest(idJUnit),
-                            true,
-                            false
+                            generateV3PackagesRequest(idJUnit),
+                            /* ignoreArrayOrder = */ true,
+                            /* ignoreExtraElements = */ false
                         )
                     )
-                    .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                    .withHeader("Content-Type", equalTo("application/json"))
                     .willReturn(
                         aResponse().withStatus(200)
-                            .withBodyFile("response_junit.json")
+                            .withHeader("Content-Type", "application/json")
+                            .withBodyFile("packages_response_junit.json")
+                    )
+            )
+            server.stubFor(
+                post(urlPathEqualTo("/api/v3/advisories/"))
+                    .withRequestBody(
+                        equalToJson(
+                            generateAdvisoriesRequest(idJUnit),
+                            /* ignoreArrayOrder = */ true,
+                            /* ignoreExtraElements = */ false
+                        )
+                    )
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBodyFile("advisories_response_junit.json")
                     )
             )
             val vulnerableCode = VulnerableCodeFactory.create(serverUrl = "http://localhost:${server.port()}")

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
@@ -28,23 +28,11 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
-import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldBeSingleton
-import io.kotest.matchers.maps.beEmpty as beEmptyMap
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
-
-import java.net.URI
 
 import org.ossreviewtoolkit.model.AdvisorDetails
-import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
-import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
-import org.ossreviewtoolkit.plugins.advisors.api.normalizeVulnerabilityData
 
 class VulnerableCodeTest : WordSpec({
     val server = WireMockServer(
@@ -65,245 +53,38 @@ class VulnerableCodeTest : WordSpec({
     }
 
     "VulnerableCode" should {
-        "return vulnerability information" {
-            server.stubPackagesRequest("response_packages.json")
-            val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackagesFromAnalyzerResult()
+        "provide correct AdvisorDetails" {
+            val vulnerableCode = VulnerableCodeFactory.create()
 
-            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
-
-            result shouldNot beEmptyMap()
-            result.keys should containExactlyInAnyOrder(idLang, idStruts)
-
-            val langResult = result.getValue(idLang)
-            langResult.advisor shouldBe vulnerableCode.details
-
-            val expLangVulnerability = Vulnerability(
-                id = "CVE-2014-8242",
-                references = listOf(
-                    VulnerabilityReference(
-                        URI("https://nvd.nist.gov/vuln/detail/CVE-2014-8242"),
-                        scoringSystem = null,
-                        severity = null,
-                        score = null,
-                        vector = null
-                    ),
-                    VulnerabilityReference(
-                        URI("https://github.com/apache/commons-lang/security/advisories/GHSA-2cxf-6567-7pp6"),
-                        scoringSystem = "cvssv3.1_qr",
-                        severity = "LOW",
-                        score = null,
-                        vector = null
-                    ),
-                    VulnerabilityReference(
-                        URI("https://github.com/advisories/GHSA-2cxf-6567-7pp6"),
-                        scoringSystem = null,
-                        severity = null,
-                        score = null,
-                        vector = null
-                    )
-                )
-            )
-            langResult.vulnerabilities.normalizeVulnerabilityData() should containExactly(expLangVulnerability)
-
-            val strutsResult = result.getValue(idStruts)
-            strutsResult.advisor shouldBe vulnerableCode.details
-
-            val expStrutsVulnerabilities = listOf(
-                Vulnerability(
-                    id = "CVE-2009-1382",
-                    references = listOf(
-                        VulnerabilityReference(
-                            URI("https://nvd.nist.gov/vuln/detail/CVE-2009-1382"),
-                            scoringSystem = "cvssv2",
-                            severity = "HIGH",
-                            score = 7.0f,
-                            vector = null
-                        )
-                    )
-                ),
-                Vulnerability(
-                    id = "CVE-2019-CoV19",
-                    references = listOf(
-                        VulnerabilityReference(
-                            URI("https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19"),
-                            scoringSystem = "cvssv3",
-                            severity = "CRITICAL",
-                            score = 10.0f,
-                            vector = null
-                        ),
-                        VulnerabilityReference(
-                            URI("https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19"),
-                            scoringSystem = "cvssv3.1_qr",
-                            severity = "HIGH",
-                            score = null,
-                            vector = null
-                        )
-                    )
-                )
-            )
-            strutsResult.vulnerabilities.normalizeVulnerabilityData() should
-                containExactlyInAnyOrder(expStrutsVulnerabilities)
+            vulnerableCode.details shouldBe AdvisorDetails(ADVISOR_NAME)
         }
 
-        "extract the CVE ID from an alias" {
-            server.stubPackagesRequest("response_junit.json", request = generatePackagesRequest(idJUnit))
-            val vulnerableCode = createVulnerableCode(server)
+        "use the V1 API by default" {
+            server.stubFor(
+                post(urlPathEqualTo("/api/packages/bulk_search"))
+                    .withRequestBody(
+                        equalToJson(
+                            generatePackagesRequest(idJUnit),
+                            true,
+                            false
+                        )
+                    )
+                    .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                            .withBodyFile("response_junit.json")
+                    )
+            )
+            val vulnerableCode = VulnerableCodeFactory.create(serverUrl = "http://localhost:${server.port()}")
             val packagesToAdvise = inputPackagesFromIdentifiers(idJUnit)
 
             val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
-            val expJunitVulnerability = Vulnerability(
-                id = "CVE-2020-15250",
-                references = listOf(
-                    VulnerabilityReference(
-                        URI("http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html"),
-                        scoringSystem = "generic_textual",
-                        severity = "Medium",
-                        score = null,
-                        vector = null
-                    ),
-                    VulnerabilityReference(
-                        URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json"),
-                        scoringSystem = "cvssv3",
-                        severity = "MEDIUM",
-                        score = 4.0f,
-                        vector = "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
-                    )
-                )
-            )
-            result.getValue(idJUnit).vulnerabilities.normalizeVulnerabilityData() should
-                containExactly(expJunitVulnerability)
-        }
-
-        "extract other official identifiers from aliases" {
-            server.stubPackagesRequest("response_log4j.json", generatePackagesRequest(idLog4j))
-            val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
-
-            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
-
-            val expLog4jVulnerabilities = listOf(
-                Vulnerability(
-                    id = "GHSA-jfh8-c2jp-5v3q",
-                    summary = "Remote code injection in Log4j",
-                    description = "Remote code injection in Log4j",
-                    references = listOf(
-                        VulnerabilityReference(
-                            URI("http://ref.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"),
-                            scoringSystem = null,
-                            severity = null,
-                            score = null,
-                            vector = null
-                        )
-                    )
-                ),
-                Vulnerability(
-                    id = "CVE-2021-44832",
-                    summary = "Improper Input Validation and Injection in Apache Log4j2",
-                    description = "Improper Input Validation and Injection in Apache Log4j2",
-                    references = listOf(
-                        VulnerabilityReference(
-                            URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json"),
-                            scoringSystem = "cvssv3",
-                            severity = "MEDIUM",
-                            score = 6.6f,
-                            vector = "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
-                        )
-                    )
-                )
-            )
-            result.getValue(idLog4j).vulnerabilities.normalizeVulnerabilityData() should
-                containExactlyInAnyOrder(expLog4jVulnerabilities)
-        }
-
-        "handle a failure response from the server" {
-            server.stubFor(
-                post(urlPathEqualTo("/packages/bulk_search"))
-                    .willReturn(
-                        aResponse().withStatus(500)
-                    )
-            )
-            val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackagesFromAnalyzerResult()
-
-            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
-
-            result shouldNotBeNull {
-                keys should containExactly(packageIdentifiers)
-
-                packageIdentifiers.forEach { pkg ->
-                    with(getValue(pkg)) {
-                        advisor shouldBe vulnerableCode.details
-                        vulnerabilities should beEmpty()
-                        summary.issues.shouldBeSingleton { issue ->
-                            issue.severity shouldBe Severity.ERROR
-                            issue.message shouldBe "HttpException: HTTP 500 Server Error"
-                        }
-                    }
-                }
+            result.keys should containExactly(idJUnit)
+            with(result.getValue(idJUnit)) {
+                summary.issues shouldBe emptyList()
+                vulnerabilities.map { it.id } should containExactly("CVE-2020-15250")
             }
-        }
-
-        "filter out packages without vulnerabilities" {
-            server.stubPackagesRequest("response_packages_no_vulnerabilities.json")
-            val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackagesFromAnalyzerResult()
-
-            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
-
-            result.keys should containExactly(idStruts)
-        }
-
-        "handle unexpected packages in the query result" {
-            server.stubPackagesRequest("response_unexpected_packages.json")
-            val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackagesFromAnalyzerResult()
-
-            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
-
-            result.keys should containExactlyInAnyOrder(idLang, idStruts)
-        }
-
-        "provide correct AdvisorDetails" {
-            val vulnerableCode = createVulnerableCode(server)
-
-            vulnerableCode.details shouldBe AdvisorDetails(ADVISOR_NAME)
         }
     }
 })
-
-/**
- * The JSON request to query the test packages found in the result.
- */
-private val packagesRequestJson = generatePackagesRequest()
-
-/**
- * Prepare this server to expect a bulk [request] for the test packages and to answer it with the given [responseFile].
- */
-private fun WireMockServer.stubPackagesRequest(responseFile: String, request: String = packagesRequestJson) {
-    stubFor(
-        post(urlPathEqualTo("/packages/bulk_search"))
-            .withRequestBody(
-                equalToJson(request, /* ignoreArrayOrder = */ true, /* ignoreExtraElements = */ false)
-            )
-            .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
-            .willReturn(
-                aResponse().withStatus(200)
-                    .withBodyFile(responseFile)
-            )
-    )
-}
-
-/**
- * Create a configuration for the [VulnerableCode] vulnerability provider that points to the local [server].
- */
-private fun createConfig(server: WireMockServer): VulnerableCodeConfiguration {
-    val url = "http://localhost:${server.port()}"
-    return VulnerableCodeConfiguration(url, null, null)
-}
-
-/**
- * Create a test instance of [VulnerableCode] that communicates with the local [server].
- */
-private fun createVulnerableCode(server: WireMockServer): VulnerableCode = VulnerableCode(config = createConfig(server))

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeTest.kt
@@ -27,7 +27,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
-import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
@@ -42,15 +41,10 @@ import io.kotest.matchers.shouldNot
 import java.net.URI
 
 import org.ossreviewtoolkit.model.AdvisorDetails
-import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.plugins.advisors.api.normalizeVulnerabilityData
-import org.ossreviewtoolkit.utils.test.readResourceValue
 
 class VulnerableCodeTest : WordSpec({
     val server = WireMockServer(
@@ -277,53 +271,7 @@ class VulnerableCodeTest : WordSpec({
             vulnerableCode.details shouldBe AdvisorDetails(ADVISOR_NAME)
         }
     }
-
-    @Suppress("MaxLineLength")
-    "fixupUrlEscaping()" should {
-        "fixup a wrongly escaped ampersand" {
-            val u = """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:retail_category_management_planning_\\&_optimization:16.0.3:*:*:*:*:*:*:*"""
-
-            URI(u.fixupUrlEscaping()) shouldBe URI(
-                """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:retail_category_management_planning_%26_optimization:16.0.3:*:*:*:*:*:*:*"""
-            )
-        }
-
-        "fixup a wrongly escaped slash" {
-            val u = """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:apple:swiftnio_http\/2:*:*:*:*:*:swift:*:*"""
-
-            URI(u.fixupUrlEscaping()) shouldBe URI(
-                """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:apple:swiftnio_http/2:*:*:*:*:*:swift:*:*"""
-            )
-        }
-
-        "fixup a wrongly escaped plus" {
-            val u = """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:hyperion_bi\+:*:*:*:*:*:*:*:*"""
-
-            URI(u.fixupUrlEscaping()) shouldBe URI(
-                """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:hyperion_bi%2B:*:*:*:*:*:*:*:*"""
-            )
-        }
-    }
 })
-
-private const val ADVISOR_NAME = "VulnerableCode"
-
-private val idLang = Identifier("Maven:org.apache.commons:commons-lang3:3.5")
-private val idText = Identifier("Maven:org.apache.commons:commons-text:1.1")
-private val idStruts = Identifier("Maven:org.apache.struts:struts2-assembly:2.5.14.1")
-private val idJUnit = Identifier("Maven:junit:junit:4.12")
-private val idHamcrest = Identifier("Maven:org.hamcrest:hamcrest-core:1.3")
-private val idLog4j = Identifier("Maven:org.apache.logging.log4j:log4j-core:2.17.0")
-
-/**
- * The list with the identifiers of packages that are referenced in the test result file.
- */
-private val packageIdentifiers = setOf(idJUnit, idLang, idText, idStruts, idHamcrest)
-
-/**
- * The list of packages referenced by the test result. These packages should be requested by the vulnerability provider.
- */
-private val packages = packageIdentifiers.map { it.toPurl() }
 
 /**
  * The JSON request to query the test packages found in the result.
@@ -359,28 +307,3 @@ private fun createConfig(server: WireMockServer): VulnerableCodeConfiguration {
  * Create a test instance of [VulnerableCode] that communicates with the local [server].
  */
 private fun createVulnerableCode(server: WireMockServer): VulnerableCode = VulnerableCode(config = createConfig(server))
-
-/**
- * Return a list with [Package]s from the analyzer result file that serve as input for the [VulnerableCode] advisor.
- */
-private fun TestConfiguration.inputPackagesFromAnalyzerResult(): Set<Package> =
-    readResourceValue<OrtResult>("/ort-analyzer-result.yml").getPackages().mapTo(mutableSetOf()) { it.metadata }
-
-/**
- * Return a set with [Package]s to be used as input for the [VulnerableCode] advisor derived from the given
- * [identifiers].
- */
-private fun inputPackagesFromIdentifiers(vararg identifiers: Identifier): Set<Package> =
-    identifiers.mapTo(mutableSetOf()) { Package.EMPTY.copy(id = it, purl = it.toPurl()) }
-
-/**
- * Generate the JSON body of the request to query information about the packages identified by the given [purls].
- * The request mainly consists of an array with the package URLs.
- */
-private fun generatePackagesRequest(purls: Collection<String> = packages): String =
-    purls.joinToString(prefix = "{ \"purls\": [", postfix = "] }") { "\"$it\"" }
-
-/**
- * Generate the JSON body of the request to query vulnerability information about the [Package] with the given [id].
- */
-private fun generatePackagesRequest(id: Identifier): String = generatePackagesRequest(listOf(id.toPurl()))

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeUtilsTest.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeUtilsTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2021 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.net.URI
+
+class VulnerableCodeUtilsTest : WordSpec({
+    "deriveSummary()" should {
+        "return null for a null or blank string" {
+            null.deriveSummary() shouldBe null
+            "".deriveSummary() shouldBe null
+            " ".deriveSummary() shouldBe null
+        }
+
+        "return the original string if it fits into the maximum summary length" {
+            val description = "a".repeat(MAX_SUMMARY_LENGTH)
+
+            description.deriveSummary() shouldBe description
+        }
+
+        "truncate a string that exceeds the maximum summary length" {
+            val description = "a".repeat(MAX_SUMMARY_LENGTH) + "b"
+
+            description.deriveSummary() shouldBe "${"a".repeat(MAX_SUMMARY_LENGTH)}..."
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    "fixupUrlEscaping()" should {
+        "fixup a wrongly escaped ampersand" {
+            val u = """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:retail_category_management_planning_\\&_optimization:16.0.3:*:*:*:*:*:*:*"""
+
+            URI(u.fixupUrlEscaping()) shouldBe URI(
+                """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:retail_category_management_planning_%26_optimization:16.0.3:*:*:*:*:*:*:*"""
+            )
+        }
+
+        "fixup a wrongly escaped slash" {
+            val u = """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:apple:swiftnio_http\/2:*:*:*:*:*:swift:*:*"""
+
+            URI(u.fixupUrlEscaping()) shouldBe URI(
+                """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:apple:swiftnio_http/2:*:*:*:*:*:swift:*:*"""
+            )
+        }
+
+        "fixup a wrongly escaped plus" {
+            val u = """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:hyperion_bi\+:*:*:*:*:*:*:*:*"""
+
+            URI(u.fixupUrlEscaping()) shouldBe URI(
+                """https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:hyperion_bi%2B:*:*:*:*:*:*:*:*"""
+            )
+        }
+    }
+})

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_junit.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_junit.json
@@ -1,0 +1,41 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "GHSA-269g-pwp5-87pp",
+      "advisory_uid": "github_osv/GHSA-269g-pwp5-87pp",
+      "url": "https://github.com/advisories/GHSA-269g-pwp5-87pp",
+      "aliases": [
+        "CVE-2020-15250"
+      ],
+      "summary": "",
+      "severities": [
+        {
+          "value": "Medium",
+          "scoring_system": "generic_textual"
+        },
+        {
+          "value": "4.0",
+          "scoring_system": "cvssv3",
+          "scoring_elements": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+        }
+      ],
+      "weaknesses": [],
+      "references": [
+        {
+          "url": "http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html",
+          "reference_type": "",
+          "reference_id": ""
+        },
+        {
+          "url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json",
+          "reference_type": "",
+          "reference_id": ""
+        }
+      ],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_log4j_cve.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_log4j_cve.json
@@ -1,0 +1,33 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "CVE-2021-44832",
+      "advisory_uid": "project-kb-statements_v2/CVE-2021-44832",
+      "url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json",
+      "aliases": [
+        "GHSA-jfh8-c2jp-5v3q"
+      ],
+      "summary": null,
+      "severities": [
+        {
+          "url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json",
+          "value": "6.6",
+          "scoring_system": "cvssv3",
+          "scoring_elements": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "weaknesses": [],
+      "references": [
+        {
+          "url": "https://github.com/advisories/GHSA-8489-44mv-ggj8.json",
+          "reference_type": "other",
+          "reference_id": "4077"
+        }
+      ],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_log4j_no_aliases.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_log4j_no_aliases.json
@@ -1,0 +1,18 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "GHSA-8489-44mv-ggj8",
+      "advisory_uid": "github_osv_importer_v2/GHSA-8489-44mv-ggj8",
+      "url": "https://github.com/advisories/GHSA-8489-44mv-ggj8.json",
+      "aliases": [],
+      "summary": null,
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_packages.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_packages.json
@@ -1,0 +1,96 @@
+{
+  "count": 4,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "GHSA-2cxf-6567-7pp6",
+      "advisory_uid": "github_osv_importer_v2/GHSA-2cxf-6567-7pp6",
+      "url": "https://github.com/advisories/GHSA-2cxf-6567-7pp6",
+      "aliases": [
+        "CVE-2014-8242"
+      ],
+      "severities": [
+        {
+          "url": "https://github.com/apache/commons-lang/security/advisories/GHSA-2cxf-6567-7pp6",
+          "value": "LOW",
+          "scoring_system": "cvssv3.1_qr"
+        }
+      ],
+      "weaknesses": [],
+      "references": [
+        {
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-8242",
+          "reference_type": "",
+          "reference_id": "CVE-2014-8242"
+        }
+      ],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "CVE-2014-8242",
+      "advisory_uid": "gitlab_importer_v2/maven/org.apache.commons/commons-lang3/CVE-2014-8242",
+      "url": "https://gitlab.com/advisories-community/CVE-2014-8242.yml",
+      "aliases": [
+        "CVE-2014-8242",
+        "GHSA-2cxf-6567-7pp6"
+      ],
+      "severities": [],
+      "weaknesses": [],
+      "references": [
+        {
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-8242",
+          "reference_type": "",
+          "reference_id": "CVE-2014-8242"
+        },
+        {
+          "url": "https://github.com/advisories/GHSA-2cxf-6567-7pp6",
+          "reference_type": "",
+          "reference_id": "GHSA-2cxf-6567-7pp6"
+        }
+      ],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+      "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+      "url": "https://example.org/advisories/GHSA-v7xh-cg3m-mx2g",
+      "aliases": [
+        "CVE-2009-1382"
+      ],
+      "severities": [
+        {
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2009-1382",
+          "value": "7.0",
+          "scoring_system": "cvssv2"
+        }
+      ],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "GHSA-struts-2019-cov19",
+      "advisory_uid": "github_osv_importer_v2/GHSA-struts-2019-cov19",
+      "url": "https://example.org/advisories/GHSA-struts-2019-cov19",
+      "aliases": [
+        "CVE-2019-CoV19"
+      ],
+      "severities": [
+        {
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19",
+          "value": "10.0",
+          "scoring_system": "cvssv3"
+        },
+        {
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-CoV19",
+          "value": "HIGH",
+          "scoring_system": "cvssv3.1_qr"
+        }
+      ],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_packages_paginated.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_packages_paginated.json
@@ -1,0 +1,43 @@
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "GHSA-269g-pwp5-87pp",
+      "advisory_uid": "github_osv/GHSA-269g-pwp5-87pp",
+      "url": "https://github.com/advisories/GHSA-269g-pwp5-87pp",
+      "aliases": [
+        "CVE-2020-15250"
+      ],
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "GHSA-2cxf-6567-7pp6",
+      "advisory_uid": "github_osv_importer_v2/GHSA-2cxf-6567-7pp6",
+      "url": "https://github.com/advisories/GHSA-2cxf-6567-7pp6",
+      "aliases": [
+        "CVE-2014-8242"
+      ],
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+      "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+      "url": "https://example.org/advisories/GHSA-v7xh-cg3m-mx2g",
+      "aliases": [
+        "CVE-2009-1382"
+      ],
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_page1.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_page1.json
@@ -1,0 +1,33 @@
+{
+  "count": 3,
+  "next": "/api/v3/advisories/?page=2",
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "GHSA-3pxv-7cmr-fjr4",
+      "advisory_uid": "github_osv_importer_v2/GHSA-3pxv-7cmr-fjr4",
+      "url": "https://github.com/advisories/GHSA-3pxv-7cmr-fjr4.json",
+      "aliases": [
+        "CVE-2026-34480"
+      ],
+      "summary": "Apache Log4j Core: Silent log event loss in XmlLayout due to unescaped XML 1.0 forbidden characters",
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "GHSA-6hg6-v5c8-fphq",
+      "advisory_uid": "github_osv_importer_v2/GHSA-6hg6-v5c8-fphq",
+      "url": "https://github.com/advisories/GHSA-6hg6-v5c8-fphq.json",
+      "aliases": [
+        "CVE-2026-34477"
+      ],
+      "summary": "Apache Log4j Core: verifyHostName attribute silently ignored in TLS configuration",
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_page2.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_page2.json
@@ -1,0 +1,20 @@
+{
+  "count": 3,
+  "next": null,
+  "previous": "/api/v3/advisories/?page=1",
+  "results": [
+    {
+      "advisory_id": "GHSA-8489-44mv-ggj8",
+      "advisory_uid": "github_osv_importer_v2/GHSA-8489-44mv-ggj8",
+      "url": "https://github.com/advisories/GHSA-8489-44mv-ggj8.json",
+      "aliases": [
+        "CVE-2021-44832"
+      ],
+      "summary": "Improper Input Validation and Injection in Apache Log4j2",
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_unexpected_packages.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/advisories_response_unexpected_packages.json
@@ -1,0 +1,41 @@
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "advisory_id": "GHSA-2cxf-6567-7pp6",
+      "advisory_uid": "github_osv_importer_v2/GHSA-2cxf-6567-7pp6",
+      "url": "https://github.com/advisories/GHSA-2cxf-6567-7pp6",
+      "aliases": [
+        "CVE-2014-8242"
+      ],
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "CVE-2021-9876",
+      "advisory_uid": "test/CVE-2021-9876",
+      "url": "https://example.org/advisories/CVE-2021-9876",
+      "aliases": [],
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    },
+    {
+      "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+      "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+      "url": "https://example.org/advisories/GHSA-v7xh-cg3m-mx2g",
+      "aliases": [
+        "CVE-2009-1382"
+      ],
+      "severities": [],
+      "weaknesses": [],
+      "references": [],
+      "related_ssvc_trees": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_junit.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_junit.json
@@ -1,0 +1,18 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/junit/junit@4.12",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-269g-pwp5-87pp",
+          "advisory_uid": "github_osv/GHSA-269g-pwp5-87pp",
+          "resource_url": "http://public.vulnerablecode.io/advisories/github_osv/GHSA-269g-pwp5-87pp"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_log4j.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_log4j.json
@@ -1,0 +1,18 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.17.0",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-8489-44mv-ggj8",
+          "advisory_uid": "github_osv_importer_v2/GHSA-8489-44mv-ggj8",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-8489-44mv-ggj8"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_log4j_cve.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_log4j_cve.json
@@ -1,0 +1,18 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.17.0",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "CVE-2021-44832",
+          "advisory_uid": "project-kb-statements_v2/CVE-2021-44832",
+          "resource_url": "https://example.org/advisories/project-kb-statements_v2/CVE-2021-44832"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_log4j_page_advisories.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_log4j_page_advisories.json
@@ -1,0 +1,28 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.17.0",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-3pxv-7cmr-fjr4",
+          "advisory_uid": "github_osv_importer_v2/GHSA-3pxv-7cmr-fjr4",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-3pxv-7cmr-fjr4"
+        },
+        {
+          "advisory_id": "GHSA-6hg6-v5c8-fphq",
+          "advisory_uid": "github_osv_importer_v2/GHSA-6hg6-v5c8-fphq",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-6hg6-v5c8-fphq"
+        },
+        {
+          "advisory_id": "GHSA-8489-44mv-ggj8",
+          "advisory_uid": "github_osv_importer_v2/GHSA-8489-44mv-ggj8",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-8489-44mv-ggj8"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_packages.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_packages.json
@@ -1,0 +1,39 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.5",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-2cxf-6567-7pp6",
+          "advisory_uid": "github_osv_importer_v2/GHSA-2cxf-6567-7pp6",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-2cxf-6567-7pp6"
+        },
+        {
+          "advisory_id": "CVE-2014-8242",
+          "advisory_uid": "gitlab_importer_v2/maven/org.apache.commons/commons-lang3/CVE-2014-8242",
+          "resource_url": "https://example.org/advisories/gitlab_importer_v2/maven/org.apache.commons/commons-lang3/CVE-2014-8242"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    },
+    {
+      "purl": "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+          "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g"
+        },
+        {
+          "advisory_id": "GHSA-struts-2019-cov19",
+          "advisory_uid": "github_osv_importer_v2/GHSA-struts-2019-cov19",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-struts-2019-cov19"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_packages_no_vulnerabilities.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_packages_no_vulnerabilities.json
@@ -1,0 +1,23 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.5",
+      "affected_by_vulnerabilities": [],
+      "fixing_vulnerabilities": []
+    },
+    {
+      "purl": "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+          "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_page1.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_page1.json
@@ -1,0 +1,29 @@
+{
+  "count": 3,
+  "next": "/api/v3/packages/?page=2",
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/junit/junit@4.12",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-269g-pwp5-87pp",
+          "advisory_uid": "github_osv/GHSA-269g-pwp5-87pp",
+          "resource_url": "https://example.org/advisories/github_osv/GHSA-269g-pwp5-87pp"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    },
+    {
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.5",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-2cxf-6567-7pp6",
+          "advisory_uid": "github_osv_importer_v2/GHSA-2cxf-6567-7pp6",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-2cxf-6567-7pp6"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_page2.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_page2.json
@@ -1,0 +1,18 @@
+{
+  "count": 3,
+  "next": null,
+  "previous": "/api/v3/packages/?page=1",
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+          "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}

--- a/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_unexpected_packages.json
+++ b/plugins/advisors/vulnerable-code/src/test/resources/__files/packages_response_unexpected_packages.json
@@ -1,0 +1,40 @@
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "purl": "pkg:maven/org.apache.commons/commons-lang3@3.5",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-2cxf-6567-7pp6",
+          "advisory_uid": "github_osv_importer_v2/GHSA-2cxf-6567-7pp6",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-2cxf-6567-7pp6"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    },
+    {
+      "purl": "pkg:maven/org.unknown/unexpected@4.2",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "CVE-2021-9876",
+          "advisory_uid": "test/CVE-2021-9876",
+          "resource_url": "https://example.org/advisories/test/CVE-2021-9876"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    },
+    {
+      "purl": "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1",
+      "affected_by_vulnerabilities": [
+        {
+          "advisory_id": "GHSA-v7xh-cg3m-mx2g",
+          "advisory_uid": "github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g",
+          "resource_url": "https://example.org/advisories/github_osv_importer_v2/GHSA-v7xh-cg3m-mx2g"
+        }
+      ],
+      "fixing_vulnerabilities": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for VulnerableCode v3 API, while still preserving support for v1 API. Also the default API version is set to v3, as by now the support for v1 has been removed in the public VulnerableCode instance, which is the instance that's used by default.

The API v3 implementation uses a kfx-generated client and gathers the needed data from two bulk search endpoints `v3/packages` and `v3/advisories` with a chunk of PURLs.

Please see the individual commits for details.