### PR TITLE
fix(tycho): Use correct identifiers for mapped packages

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.kotlin.logger
 import org.apache.maven.AbstractMavenLifecycleParticipant
 import org.apache.maven.cli.MavenCli
 import org.apache.maven.execution.MavenSession
+import org.apache.maven.model.Dependency
 import org.apache.maven.model.Scm
 import org.apache.maven.project.MavenProject
 
@@ -428,7 +429,7 @@ private fun resolveMavenArtifacts(
                     repositories = dependency.repositories
                 }
 
-                resolver(mappedDependency)
+                resolver(mappedDependency).withOriginalId(dependency.artifact)
             }.onFailure { exception ->
                 logger.debug(exception) { "Failed to resolve Maven artifact candidate." }
             }.getOrNull()
@@ -437,6 +438,22 @@ private fun resolveMavenArtifacts(
         "Failed to resolve ${candidates.size} candidates for dependency " +
             "'${dependency.artifact.identifier()}'."
     }
+
+/**
+ * Return a [Package] with the same properties as this [Package], but with an [Identifier] derived from the given
+ * [Dependency]. This is necessary for artifacts referenced by Tycho under alternative IDs. Here it must be ensured
+ * that this alternative ID is set for the package, even if it has been resolved using Maven's standard mechanism.
+ * Otherwise, there could be conflicts if the standard Maven packages are listed in the dependencies as well.
+ */
+private fun Package.withOriginalId(dependency: Artifact): Package =
+    copy(
+        id = Identifier(
+            type = id.type,
+            namespace = dependency.groupId,
+            name = dependency.artifactId,
+            version = dependency.version
+        )
+    )
 
 /**
  * Create a [Package] for the given [artifact] obtaining metadata from the given [manifest] and [resolver]. This

--- a/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.kotlin.logger
 import org.apache.maven.AbstractMavenLifecycleParticipant
 import org.apache.maven.cli.MavenCli
 import org.apache.maven.execution.MavenSession
-import org.apache.maven.model.Dependency
 import org.apache.maven.model.Scm
 import org.apache.maven.project.MavenProject
 
@@ -441,7 +440,7 @@ private fun resolveMavenArtifacts(
 
 /**
  * Return a [Package] with the same properties as this [Package], but with an [Identifier] derived from the given
- * [Dependency]. This is necessary for artifacts referenced by Tycho under alternative IDs. Here it must be ensured
+ * [Artifact]. This is necessary for artifacts referenced by Tycho under alternative IDs. Here it must be ensured
  * that this alternative ID is set for the package, even if it has been resolved using Maven's standard mechanism.
  * Otherwise, there could be conflicts if the standard Maven packages are listed in the dependencies as well.
  */

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
@@ -384,15 +384,17 @@ class TychoTest : WordSpec({
         }
 
         "handle Tycho identifiers that need to be mapped to Maven dependencies" {
-            val originalArtifact = mockk<Artifact>()
-            val mappedArtifact = mockk<Artifact>()
+            val wrappedId = Identifier(PACKAGE_TYPE, "wrapped", "test", "23")
+            val originalArtifact = createArtifactMock(wrappedId)
+            val mappedArtifact = createArtifactMock(testArtifactIdentifier)
             val repo1 = mockk<RemoteRepository>()
             val repo2 = mockk<RemoteRepository>()
             val dependency = DefaultDependencyNode(originalArtifact).apply {
                 repositories = listOf(repo1, repo2)
             }
 
-            val pkg = mockk<Package>()
+            val pkg = Package.EMPTY.copy(id = testArtifactIdentifier, homepageUrl = "https://example.com/package")
+            val expectedPkg = pkg.copy(id = wrappedId)
             val delegate: PackageResolverFun = { node ->
                 if (node == dependency) {
                     throw IOException("Test exception: Unresolvable dependency.")
@@ -410,11 +412,12 @@ class TychoTest : WordSpec({
 
             val resolver = tychoPackageResolverFun(delegate, mockk(), mockk(), targetHandler, mockk(relaxed = true))
 
-            resolver(dependency) shouldBe pkg
+            resolver(dependency) shouldBe expectedPkg
         }
 
         "test all candidates for a wrapped artifact" {
-            val originalArtifact = mockk<Artifact>()
+            val wrappedId = Identifier(PACKAGE_TYPE, "wrapped", "multitest", "11")
+            val originalArtifact = createArtifactMock(wrappedId)
             val mappedArtifact1 = mockk<Artifact>()
             val mappedArtifact2 = mockk<Artifact>()
             val mappedArtifact3 = mockk<Artifact>()
@@ -422,7 +425,8 @@ class TychoTest : WordSpec({
             val dependency = DefaultDependencyNode(originalArtifact)
 
             var delegateCount = 0
-            val pkg = mockk<Package>()
+            val pkg = Package.EMPTY.copy(id = testArtifactIdentifier, homepageUrl = "https://example.com/org-package")
+            val expectedPkg = pkg.copy(id = wrappedId)
             val delegate: PackageResolverFun = { node ->
                 delegateCount++
                 if (node.artifact != mappedArtifact3) {
@@ -443,7 +447,7 @@ class TychoTest : WordSpec({
 
             val resolver = tychoPackageResolverFun(delegate, mockk(), mockk(), targetHandler, mockk(relaxed = true))
 
-            resolver(dependency) shouldBe pkg
+            resolver(dependency) shouldBe expectedPkg
             delegateCount shouldBe 4
         }
 
@@ -748,3 +752,13 @@ private fun createResolverMock(
         every { isBinary(any()) } returns false
     }
 }
+
+/**
+ * Create a mock for an [Artifact] that returns coordinates from the given [id].
+ */
+private fun createArtifactMock(id: Identifier): Artifact =
+    mockk {
+        every { groupId } returns id.namespace
+        every { artifactId } returns id.name
+        every { version } returns id.version
+    }


### PR DESCRIPTION
In some cases, Tycho references Maven packages under different identifiers. When resolving such packages, make sure that the original identifier from Tycho is kept. This fixes errors when constructing the Analyzer result due to duplicate packages, if packages with the Maven coordinates are contained in the result, too.
