### PR TITLE
license-fact-providers: Enhance the API to support id-specific license text overrides

### DIFF
--- a/plugins/license-fact-providers/api/build.gradle.kts
+++ b/plugins/license-fact-providers/api/build.gradle.kts
@@ -23,5 +23,6 @@ plugins {
 }
 
 dependencies {
+    api(projects.model)
     api(projects.plugins.api)
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.ossreviewtoolkit.model.Identifier
+
 /**
  * A composition of multiple [LicenseFactProvider]s.
  */
@@ -29,15 +31,30 @@ class CompositeLicenseFactProvider(
      */
     private val providers: List<LicenseFactProvider>
 ) {
-    /** Return the [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
-    fun getLicenseText(licenseId: String): LicenseText? =
-        providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
+    /** Return the [LicenseText] for the given [licenseId] and [id], or `null` if no valid text is available. */
+    fun getLicenseText(licenseId: String, id: Identifier? = null): LicenseText? {
+        val idSpecificLicenseText = if (id != null) {
+            providers.firstNotNullOfOrNull { it.getIdSpecificLicenseText(licenseId, id) }
+        } else {
+            null
+        }
 
-    /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
+        return idSpecificLicenseText ?: providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
+    }
+
+    /** Return a non-blank license text for the given [licenseId] and [id], or `null` if no valid text is available. */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
+    fun getNonBlankLicenseText(licenseId: String, id: Identifier? = null): String? = getLicenseText(licenseId, id)?.text
 
-    /** Return `true´ if this provider has a license text for the given [licenseId]. */
-    fun hasLicenseText(licenseId: String): Boolean = providers.any { it.hasLicenseText(licenseId) }
+    /** Return `true´ if this provider has a license text for the given [licenseId] and [id]. */
+    fun hasLicenseText(licenseId: String, id: Identifier? = null): Boolean {
+        val hasIdSpecificLicenseText = if (id != null) {
+            providers.any { it.hasIdSpecificLicenseText(licenseId, id) }
+        } else {
+            false
+        }
+
+        return hasIdSpecificLicenseText || providers.any { it.hasLicenseText(licenseId) }
+    }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -19,10 +19,8 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
-import org.ossreviewtoolkit.plugins.api.PluginDescriptor
-
 /**
- * A [LicenseFactProvider] that aggregates multiple [LicenseFactProvider]s.
+ * A composition of multiple [LicenseFactProvider]s.
  */
 class CompositeLicenseFactProvider(
     /**
@@ -30,14 +28,16 @@ class CompositeLicenseFactProvider(
      *  providers: the first provider in the list that has a fact for a given license ID will be used.
      */
     private val providers: List<LicenseFactProvider>
-) : LicenseFactProvider() {
-    override val descriptor = PluginDescriptor(
-        id = "Composite",
-        displayName = "Composite License Fact Provider",
-        summary = "A license fact provider that aggregates multiple license fact providers."
-    )
+) {
+    /** Return the [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
+    fun getLicenseText(licenseId: String): LicenseText? =
+        providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
 
-    override fun getLicenseText(licenseId: String) = providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
+    /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
+    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
+    @JvmName("getLicenseText")
+    fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
 
-    override fun hasLicenseText(licenseId: String) = providers.any { it.hasLicenseText(licenseId) }
+    /** Return `true´ if this provider has a license text for the given [licenseId]. */
+    fun hasLicenseText(licenseId: String): Boolean = providers.any { it.hasLicenseText(licenseId) }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.plugins.api.Plugin
 
 /** A provider for license facts. */
@@ -28,4 +29,14 @@ interface LicenseFactProvider : Plugin {
 
     /** Return `true´ if this provider has a license text for the given [licenseId]. */
     fun hasLicenseText(licenseId: String): Boolean
+
+    /**
+     * Return the id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
+     * available.
+     **/
+    fun getIdSpecificLicenseText(licenseId: String, id: Identifier): LicenseText? = null
+
+    /** Return `true´ if this provider has an id-specific license text for the given [licenseId] and [id]. */
+    fun hasIdSpecificLicenseText(licenseId: String, id: Identifier): Boolean =
+        getIdSpecificLicenseText(licenseId, id) != null
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -22,15 +22,10 @@ package org.ossreviewtoolkit.plugins.licensefactproviders.api
 import org.ossreviewtoolkit.plugins.api.Plugin
 
 /** A provider for license facts. */
-abstract class LicenseFactProvider : Plugin {
+interface LicenseFactProvider : Plugin {
     /** Return the [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
-    abstract fun getLicenseText(licenseId: String): LicenseText?
-
-    /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
-    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
-    @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
+    fun getLicenseText(licenseId: String): LicenseText?
 
     /** Return `true´ if this provider has a license text for the given [licenseId]. */
-    abstract fun hasLicenseText(licenseId: String): Boolean
+    fun hasLicenseText(licenseId: String): Boolean
 }

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -67,7 +67,7 @@ class DefaultDirLicenseFactProvider(descriptor: PluginDescriptor = DefaultDirLic
 open class DirLicenseFactProvider(
     override val descriptor: PluginDescriptor = DirLicenseFactProviderFactory.descriptor,
     config: DirLicenseFactProviderConfig
-) : LicenseFactProvider() {
+) : LicenseFactProvider {
     private val licenseTextDir = File(config.licenseTextDir).also {
         if (!it.isDirectory) {
             logger.warn { "The license text directory '${it.absolutePath}' does not exist or is not a directory." }

--- a/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
@@ -56,7 +56,7 @@ data class ScanCodeLicenseFactProviderConfig(
 class ScanCodeLicenseFactProvider(
     override val descriptor: PluginDescriptor = ScanCodeLicenseFactProviderFactory.descriptor,
     private val config: ScanCodeLicenseFactProviderConfig
-) : LicenseFactProvider() {
+) : LicenseFactProvider {
     /**
      * The directory that contains the ScanCode license texts. This is located using a heuristic based on the path of
      * the ScanCode binary.

--- a/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseText
 )
 class SpdxLicenseFactProvider(
     override val descriptor: PluginDescriptor = SpdxLicenseFactProviderFactory.descriptor
-) : LicenseFactProvider() {
+) : LicenseFactProvider {
     override fun getLicenseText(licenseId: String) =
         getLicenseTextResource(licenseId)?.readText()?.let {
             // It can be safely assumed that the license text is not blank as all SPDX license texts are non-blank.

--- a/plugins/reporters/aosd/build.gradle.kts
+++ b/plugins/reporters/aosd/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
 
     funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(libs.kotest.assertions.json)
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     ksp(projects.reporter)

--- a/plugins/reporters/aosd/src/funTest/kotlin/Aosd21ReporterFunTest.kt
+++ b/plugins/reporters/aosd/src/funTest/kotlin/Aosd21ReporterFunTest.kt
@@ -29,7 +29,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.getResource
@@ -62,7 +62,7 @@ class Aosd21ReporterFunTest : WordSpec({
         val reportFiles = Aosd21Reporter().generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         )

--- a/plugins/reporters/asciidoc/build.gradle.kts
+++ b/plugins/reporters/asciidoc/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     funTestImplementation(testFixtures(projects.reporter))
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     runtimeOnly(libs.asciidoctorj.pdf)

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/DocBookTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/DocBookTemplateReporterFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldBe
 
 import java.time.LocalDate
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -38,7 +38,7 @@ class DocBookTemplateReporterFunTest : StringSpec({
         val reportContent = DocBookTemplateReporterFactory.create().generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         ).single().getOrThrow().readText()

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/HtmlTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/HtmlTemplateReporterFunTest.kt
@@ -23,7 +23,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -37,7 +37,7 @@ class HtmlTemplateReporterFunTest : StringSpec({
         val reportContent = reporter.generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         ).single().getOrThrow().readText()

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/ManPageTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/ManPageTemplateReporterFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldBe
 
 import java.time.LocalDate
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -39,7 +39,7 @@ class ManPageTemplateReporterFunTest : StringSpec({
         val reportContent = reporter.generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         ).single().getOrThrow().readText()

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
@@ -29,7 +29,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_VULNERABILITIES
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -40,7 +40,7 @@ class PdfTemplateReporterFunTest : StringSpec({
         val reportFileResults = PdfTemplateReporterFactory.create().generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         )

--- a/plugins/reporters/cyclonedx/build.gradle.kts
+++ b/plugins/reporters/cyclonedx/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
+    funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(libs.kotest.assertions.json)
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.commonUtils)
     funTestImplementation(projects.utils.testUtils)
 

--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
@@ -41,10 +41,10 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporter.Companion.REPORT_BASE_FILENAME
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_EMPTY
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.test.matchJsonSchema
@@ -60,7 +60,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.XML,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom should matchCycloneDxXmlSchema(DEFAULT_SCHEMA_VERSION_NAME)
@@ -82,7 +82,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom should matchJsonSchema(schemaJson)
@@ -109,7 +109,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = createResultWithAdditionalProject(otherProject),
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -135,7 +135,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = createResultWithAdditionalProject(otherProject),
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -148,7 +148,7 @@ class CycloneDxReporterFunTest : WordSpec({
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.JSON,
                 singleBomComponentType = Component.Type.LIBRARY,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -175,7 +175,7 @@ class CycloneDxReporterFunTest : WordSpec({
                 ortResult = createResultWithAdditionalProject(topLevelProject),
                 format = Format.JSON,
                 singleBomComponentName = "eric",
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -199,7 +199,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val (bomWithFindings, bomWithoutFindings) = generateMultiBomReport(
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ).also {
                 it shouldHaveSize 2
                 it.forAll { bom ->
@@ -259,7 +259,7 @@ private fun TestConfiguration.generateSingleBomReport(
     format: Format,
     singleBomComponentName: String = "",
     singleBomComponentType: Component.Type = Component.Type.APPLICATION,
-    licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList())
+    licenseFactProvider: LicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
 ): String {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },
@@ -279,7 +279,7 @@ private fun TestConfiguration.generateSingleBomReport(
 private fun TestConfiguration.generateMultiBomReport(
     ortResult: OrtResult,
     format: Format,
-    licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList())
+    licenseFactProvider: LicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
 ): List<String> {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },

--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
 import org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporter.Companion.REPORT_BASE_FILENAME
 import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_EMPTY
 import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
@@ -259,7 +259,7 @@ private fun TestConfiguration.generateSingleBomReport(
     format: Format,
     singleBomComponentName: String = "",
     singleBomComponentType: Component.Type = Component.Type.APPLICATION,
-    licenseFactProvider: LicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
+    licenseFactProvider: CompositeLicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
 ): String {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },
@@ -279,7 +279,7 @@ private fun TestConfiguration.generateSingleBomReport(
 private fun TestConfiguration.generateMultiBomReport(
     ortResult: OrtResult,
     format: Format,
-    licenseFactProvider: LicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
+    licenseFactProvider: CompositeLicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
 ): List<String> {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },

--- a/plugins/reporters/freemarker/build.gradle.kts
+++ b/plugins/reporters/freemarker/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     funTestImplementation(testFixtures(projects.reporter))
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     testImplementation(libs.mockk)

--- a/plugins/reporters/freemarker/src/funTest/kotlin/PlainTextTemplateReporterFunTest.kt
+++ b/plugins/reporters/freemarker/src/funTest/kotlin/PlainTextTemplateReporterFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseCategorization
 import org.ossreviewtoolkit.model.licenses.LicenseCategory
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.div
@@ -98,7 +98,7 @@ private fun TestConfiguration.generateReport(
         ortResult,
         ortConfig,
         licenseClassifications = createLicenseClassifications(),
-        licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+        licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
     )
 
     val outputDir = tempdir()

--- a/plugins/reporters/opossum/build.gradle.kts
+++ b/plugins/reporters/opossum/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
+    funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(libs.kotest.assertions.json)
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     testImplementation(projects.utils.testUtils)

--- a/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
+++ b/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.engine.spec.tempdir
 
 import java.time.LocalDateTime
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.test.patchActualResult
@@ -42,7 +42,7 @@ class OpossumReporterFunTest : WordSpec({
     "The generated report" should {
         "match the expected result" {
             val ortResult = readOrtResult("/reporter-test-input.yml")
-            val input = ReporterInput(ortResult, licenseFactProvider = SpdxLicenseFactProviderFactory.create())
+            val input = ReporterInput(ortResult, licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX)
             val outputDir = tempdir()
             val expectedResult = readResource("/reporter-test-output.json")
 

--- a/plugins/reporters/spdx/build.gradle.kts
+++ b/plugins/reporters/spdx/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     funTestImplementation(testFixtures(projects.plugins.reporters.spdxReporter))
-    funTestImplementation(projects.plugins.licenseFactProviders.scancodeLicenseFactProvider)
+    funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(projects.utils.testUtils)
 
     testFixturesImplementation(projects.utils.testUtils)

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -28,7 +28,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SCAN_CODE
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
@@ -159,7 +159,7 @@ private fun TestConfiguration.generateReport(
 
     return SpdxDocumentReporter(config = config)
         .generateReport(
-            input = ReporterInput(ortResult, licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX),
+            input = ReporterInput(ortResult, licenseFactProvider = LICENSE_FACT_PROVIDER_SCAN_CODE),
             outputDir = tempdir()
         )
         .single()

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -28,7 +28,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.plugins.licensefactproviders.scancode.ScanCodeLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
@@ -159,7 +159,7 @@ private fun TestConfiguration.generateReport(
 
     return SpdxDocumentReporter(config = config)
         .generateReport(
-            input = ReporterInput(ortResult, licenseFactProvider = ScanCodeLicenseFactProviderFactory.create()),
+            input = ReporterInput(ortResult, licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX),
             outputDir = tempdir()
         )
         .single()

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.prependedPath
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
@@ -242,7 +242,7 @@ private fun OrtResult.getPackageVerificationCode(id: Identifier, type: SpdxPacka
 /**
  * Use [licenseFactProvider] to add the license texts for all packages to the [SpdxDocument].
  */
-internal fun SpdxDocument.addExtractedLicenseInfo(licenseFactProvider: LicenseFactProvider): SpdxDocument {
+internal fun SpdxDocument.addExtractedLicenseInfo(licenseFactProvider: CompositeLicenseFactProvider): SpdxDocument {
     val allLicenses = buildSet {
         packages.forEach {
             add(it.licenseConcluded)

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.SourceCodeOrigin.ARTIFACT
 import org.ossreviewtoolkit.model.SourceCodeOrigin.VCS
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
 import org.ossreviewtoolkit.utils.ort.ORT_NAME
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
@@ -50,7 +50,7 @@ internal object SpdxDocumentModelMapper {
     fun map(
         ortResult: OrtResult,
         licenseInfoResolver: LicenseInfoResolver,
-        licenseFactProvider: LicenseFactProvider,
+        licenseFactProvider: CompositeLicenseFactProvider,
         config: SpdxDocumentReporterConfig
     ): SpdxDocument {
         val nextFileIndex = AtomicInteger(1)

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -35,7 +35,11 @@ dependencies {
 
     funTestImplementation(testFixtures(project))
 
+    testFixturesApi(projects.plugins.licenseFactProviders.licenseFactProviderApi)
+
     testFixturesImplementation(projects.utils.testUtils)
+    testFixturesImplementation(projects.plugins.licenseFactProviders.scancodeLicenseFactProvider)
+    testFixturesImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
 
     kotlinScriptDef(projects.utils.scriptUtils)
 }

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -28,7 +28,6 @@ import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 
 /**
@@ -46,9 +45,9 @@ data class ReporterInput(
     val ortConfig: OrtConfiguration = OrtConfiguration(),
 
     /**
-     * A [LicenseFactProvider], can be used to integrate licenses facts like license texts into reports.
+     * A [CompositeLicenseFactProvider], can be used to integrate licenses facts like license texts into reports.
      */
-    val licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList()),
+    val licenseFactProvider: CompositeLicenseFactProvider = CompositeLicenseFactProvider(emptyList()),
 
     /**
      * A [CopyrightGarbage] container, can be used to clean up copyrights used in reports.

--- a/reporter/src/testFixtures/kotlin/Utils.kt
+++ b/reporter/src/testFixtures/kotlin/Utils.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter
+
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.scancode.ScanCodeLicenseFactProviderFactory
+import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+
+val LICENSE_FACT_PROVIDER_EMPTY: LicenseFactProvider by lazy {
+    CompositeLicenseFactProvider(emptyList())
+}
+
+val LICENSE_FACT_PROVIDER_SCAN_CODE: LicenseFactProvider by lazy {
+    ScanCodeLicenseFactProviderFactory.create()
+}
+
+val LICENSE_FACT_PROVIDER_SPDX: LicenseFactProvider by lazy {
+    SpdxLicenseFactProviderFactory.create()
+}

--- a/reporter/src/testFixtures/kotlin/Utils.kt
+++ b/reporter/src/testFixtures/kotlin/Utils.kt
@@ -20,18 +20,17 @@
 package org.ossreviewtoolkit.reporter
 
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.scancode.ScanCodeLicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
 
-val LICENSE_FACT_PROVIDER_EMPTY: LicenseFactProvider by lazy {
+val LICENSE_FACT_PROVIDER_EMPTY: CompositeLicenseFactProvider by lazy {
     CompositeLicenseFactProvider(emptyList())
 }
 
-val LICENSE_FACT_PROVIDER_SCAN_CODE: LicenseFactProvider by lazy {
-    ScanCodeLicenseFactProviderFactory.create()
+val LICENSE_FACT_PROVIDER_SCAN_CODE: CompositeLicenseFactProvider by lazy {
+    CompositeLicenseFactProvider(listOf(ScanCodeLicenseFactProviderFactory.create()))
 }
 
-val LICENSE_FACT_PROVIDER_SPDX: LicenseFactProvider by lazy {
-    SpdxLicenseFactProviderFactory.create()
+val LICENSE_FACT_PROVIDER_SPDX: CompositeLicenseFactProvider by lazy {
+    CompositeLicenseFactProvider(listOf(SpdxLicenseFactProviderFactory.create()))
 }


### PR DESCRIPTION
At first, separate the plugin interface and the interface used by the reporters, to be able to dedicate the design to
each of the use cases separately. And then, enhance the API, so that id-specific license texts can be provided (optionally) and consumed (optionally).

Part of #11668.