### PR TITLE
test(reporter): Factor out constants for license fact providers

### DIFF
--- a/plugins/reporters/aosd/build.gradle.kts
+++ b/plugins/reporters/aosd/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
 
     funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(libs.kotest.assertions.json)
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     ksp(projects.reporter)

--- a/plugins/reporters/aosd/src/funTest/kotlin/Aosd21ReporterFunTest.kt
+++ b/plugins/reporters/aosd/src/funTest/kotlin/Aosd21ReporterFunTest.kt
@@ -29,7 +29,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.getResource
@@ -62,7 +62,7 @@ class Aosd21ReporterFunTest : WordSpec({
         val reportFiles = Aosd21Reporter().generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         )

--- a/plugins/reporters/asciidoc/build.gradle.kts
+++ b/plugins/reporters/asciidoc/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     funTestImplementation(testFixtures(projects.reporter))
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     runtimeOnly(libs.asciidoctorj.pdf)

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/DocBookTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/DocBookTemplateReporterFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldBe
 
 import java.time.LocalDate
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -38,7 +38,7 @@ class DocBookTemplateReporterFunTest : StringSpec({
         val reportContent = DocBookTemplateReporterFactory.create().generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         ).single().getOrThrow().readText()

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/HtmlTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/HtmlTemplateReporterFunTest.kt
@@ -23,7 +23,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -37,7 +37,7 @@ class HtmlTemplateReporterFunTest : StringSpec({
         val reportContent = reporter.generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         ).single().getOrThrow().readText()

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/ManPageTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/ManPageTemplateReporterFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldBe
 
 import java.time.LocalDate
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -39,7 +39,7 @@ class ManPageTemplateReporterFunTest : StringSpec({
         val reportContent = reporter.generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         ).single().getOrThrow().readText()

--- a/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
+++ b/plugins/reporters/asciidoc/src/funTest/kotlin/PdfTemplateReporterFunTest.kt
@@ -29,7 +29,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_VULNERABILITIES
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -40,7 +40,7 @@ class PdfTemplateReporterFunTest : StringSpec({
         val reportFileResults = PdfTemplateReporterFactory.create().generateReport(
             ReporterInput(
                 ORT_RESULT,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ),
             tempdir()
         )

--- a/plugins/reporters/cyclonedx/build.gradle.kts
+++ b/plugins/reporters/cyclonedx/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
+    funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(libs.kotest.assertions.json)
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.commonUtils)
     funTestImplementation(projects.utils.testUtils)
 

--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
@@ -41,10 +41,10 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.reporters.cyclonedx.CycloneDxReporter.Companion.REPORT_BASE_FILENAME
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_EMPTY
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.test.matchJsonSchema
@@ -60,7 +60,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.XML,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom should matchCycloneDxXmlSchema(DEFAULT_SCHEMA_VERSION_NAME)
@@ -82,7 +82,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom should matchJsonSchema(schemaJson)
@@ -109,7 +109,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = createResultWithAdditionalProject(otherProject),
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -135,7 +135,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val bom = generateSingleBomReport(
                 ortResult = createResultWithAdditionalProject(otherProject),
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -148,7 +148,7 @@ class CycloneDxReporterFunTest : WordSpec({
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.JSON,
                 singleBomComponentType = Component.Type.LIBRARY,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -175,7 +175,7 @@ class CycloneDxReporterFunTest : WordSpec({
                 ortResult = createResultWithAdditionalProject(topLevelProject),
                 format = Format.JSON,
                 singleBomComponentName = "eric",
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             )
 
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
@@ -199,7 +199,7 @@ class CycloneDxReporterFunTest : WordSpec({
             val (bomWithFindings, bomWithoutFindings) = generateMultiBomReport(
                 ortResult = ORT_RESULT_WITH_VULNERABILITIES,
                 format = Format.JSON,
-                licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+                licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
             ).also {
                 it shouldHaveSize 2
                 it.forAll { bom ->
@@ -259,7 +259,7 @@ private fun TestConfiguration.generateSingleBomReport(
     format: Format,
     singleBomComponentName: String = "",
     singleBomComponentType: Component.Type = Component.Type.APPLICATION,
-    licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList())
+    licenseFactProvider: LicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
 ): String {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },
@@ -279,7 +279,7 @@ private fun TestConfiguration.generateSingleBomReport(
 private fun TestConfiguration.generateMultiBomReport(
     ortResult: OrtResult,
     format: Format,
-    licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList())
+    licenseFactProvider: LicenseFactProvider = LICENSE_FACT_PROVIDER_EMPTY
 ): List<String> {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },

--- a/plugins/reporters/freemarker/build.gradle.kts
+++ b/plugins/reporters/freemarker/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     funTestImplementation(testFixtures(projects.reporter))
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     testImplementation(libs.mockk)

--- a/plugins/reporters/freemarker/src/funTest/kotlin/PlainTextTemplateReporterFunTest.kt
+++ b/plugins/reporters/freemarker/src/funTest/kotlin/PlainTextTemplateReporterFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseCategorization
 import org.ossreviewtoolkit.model.licenses.LicenseCategory
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.div
@@ -98,7 +98,7 @@ private fun TestConfiguration.generateReport(
         ortResult,
         ortConfig,
         licenseClassifications = createLicenseClassifications(),
-        licenseFactProvider = SpdxLicenseFactProviderFactory.create()
+        licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX
     )
 
     val outputDir = tempdir()

--- a/plugins/reporters/opossum/build.gradle.kts
+++ b/plugins/reporters/opossum/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxUtils)
 
+    funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(libs.kotest.assertions.json)
-    funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
     testImplementation(projects.utils.testUtils)

--- a/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
+++ b/plugins/reporters/opossum/src/funTest/kotlin/OpossumReporterFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.engine.spec.tempdir
 
 import java.time.LocalDateTime
 
-import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SPDX
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.test.patchActualResult
@@ -42,7 +42,7 @@ class OpossumReporterFunTest : WordSpec({
     "The generated report" should {
         "match the expected result" {
             val ortResult = readOrtResult("/reporter-test-input.yml")
-            val input = ReporterInput(ortResult, licenseFactProvider = SpdxLicenseFactProviderFactory.create())
+            val input = ReporterInput(ortResult, licenseFactProvider = LICENSE_FACT_PROVIDER_SPDX)
             val outputDir = tempdir()
             val expectedResult = readResource("/reporter-test-output.json")
 

--- a/plugins/reporters/spdx/build.gradle.kts
+++ b/plugins/reporters/spdx/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(projects.utils.spdxUtils)
 
     funTestImplementation(testFixtures(projects.plugins.reporters.spdxReporter))
-    funTestImplementation(projects.plugins.licenseFactProviders.scancodeLicenseFactProvider)
+    funTestImplementation(testFixtures(projects.reporter))
     funTestImplementation(projects.utils.testUtils)
 
     testFixturesImplementation(projects.utils.testUtils)

--- a/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
+++ b/plugins/reporters/spdx/src/funTest/kotlin/SpdxDocumentReporterFunTest.kt
@@ -28,7 +28,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.plugins.licensefactproviders.scancode.ScanCodeLicenseFactProviderFactory
+import org.ossreviewtoolkit.reporter.LICENSE_FACT_PROVIDER_SCAN_CODE
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
@@ -159,7 +159,7 @@ private fun TestConfiguration.generateReport(
 
     return SpdxDocumentReporter(config = config)
         .generateReport(
-            input = ReporterInput(ortResult, licenseFactProvider = ScanCodeLicenseFactProviderFactory.create()),
+            input = ReporterInput(ortResult, licenseFactProvider = LICENSE_FACT_PROVIDER_SCAN_CODE),
             outputDir = tempdir()
         )
         .single()

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -35,7 +35,11 @@ dependencies {
 
     funTestImplementation(testFixtures(project))
 
+    testFixturesApi(projects.plugins.licenseFactProviders.licenseFactProviderApi)
+
     testFixturesImplementation(projects.utils.testUtils)
+    testFixturesImplementation(projects.plugins.licenseFactProviders.scancodeLicenseFactProvider)
+    testFixturesImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
 
     kotlinScriptDef(projects.utils.scriptUtils)
 }

--- a/reporter/src/testFixtures/kotlin/Utils.kt
+++ b/reporter/src/testFixtures/kotlin/Utils.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter
+
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.scancode.ScanCodeLicenseFactProviderFactory
+import org.ossreviewtoolkit.plugins.licensefactproviders.spdx.SpdxLicenseFactProviderFactory
+
+val LICENSE_FACT_PROVIDER_EMPTY: LicenseFactProvider by lazy {
+    CompositeLicenseFactProvider(emptyList())
+}
+
+val LICENSE_FACT_PROVIDER_SCAN_CODE: LicenseFactProvider by lazy {
+    ScanCodeLicenseFactProviderFactory.create()
+}
+
+val LICENSE_FACT_PROVIDER_SPDX: LicenseFactProvider by lazy {
+    SpdxLicenseFactProviderFactory.create()
+}


### PR DESCRIPTION
Slightly simplify the creation of the providers in tests.

Part of https://github.com/oss-review-toolkit/ort/issues/11668.
