### PR TITLE
Enhance license fact providers to allow for providing id-specific license texts

### DIFF
--- a/plugins/license-fact-providers/api/build.gradle.kts
+++ b/plugins/license-fact-providers/api/build.gradle.kts
@@ -23,5 +23,6 @@ plugins {
 }
 
 dependencies {
+    api(projects.model)
     api(projects.plugins.api)
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 
 /**
@@ -37,7 +38,13 @@ class CompositeLicenseFactProvider(
         summary = "A license fact provider that aggregates multiple license fact providers."
     )
 
+    override fun hasLicenseText(licenseId: String) = providers.any { it.hasLicenseText(licenseId) }
+
     override fun getLicenseText(licenseId: String) = providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
 
-    override fun hasLicenseText(licenseId: String) = providers.any { it.hasLicenseText(licenseId) }
+    override fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
+        providers.any { it.hasLicenseTextForId(licenseId, id) }
+
+    override fun getLicenseTextForId(licenseId: String, id: Identifier): LicenseText? =
+        providers.firstNotNullOfOrNull { it.getLicenseTextForId(licenseId, id) }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -23,7 +23,7 @@ import org.ossreviewtoolkit.plugins.api.Plugin
 
 /** A provider for license facts. */
 abstract class LicenseFactProvider : Plugin {
-    /** Return the [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
+    /** Return a [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
     abstract fun getLicenseText(licenseId: String): LicenseText?
 
     /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -23,6 +23,9 @@ import org.ossreviewtoolkit.plugins.api.Plugin
 
 /** A provider for license facts. */
 abstract class LicenseFactProvider : Plugin {
+    /** Return `true´ if this provider has a license text for the given [licenseId]. */
+    abstract fun hasLicenseText(licenseId: String): Boolean
+
     /** Return a [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
     abstract fun getLicenseText(licenseId: String): LicenseText?
 
@@ -30,7 +33,4 @@ abstract class LicenseFactProvider : Plugin {
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
     fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
-
-    /** Return `true´ if this provider has a license text for the given [licenseId]. */
-    abstract fun hasLicenseText(licenseId: String): Boolean
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.plugins.api.Plugin
 
 /** A provider for license facts. */
@@ -29,8 +30,49 @@ abstract class LicenseFactProvider : Plugin {
     /** Return a [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
     abstract fun getLicenseText(licenseId: String): LicenseText?
 
+    /** Return `true´ if this provider has an id-specific license text for the given [licenseId] and [id]. */
+    open fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
+        getLicenseTextForId(licenseId, id) != null
+
+    /**
+     * Return an id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
+     * available.
+     */
+    open fun getLicenseTextForId(licenseId: String, id: Identifier): LicenseText? = null
+
+    /**
+     * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific
+     * license text for [licenseId], or `null` if no such text is available.
+     */
+    fun hasLicenseText(licenseId: String, id: Identifier): Boolean =
+        hasLicenseText(licenseId, id) || hasLicenseText(licenseId)
+
+    /**
+     * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific
+     * license text for [licenseId], or `null` if no such text is available.
+     */
+    fun getLicenseText(licenseId: String, id: Identifier): LicenseText? =
+        getLicenseTextForId(licenseId, id) ?: getLicenseText(licenseId)
+
     /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
     fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
+
+    /**
+     * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
+     * available.
+     */
+    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
+    @JvmName("getLicenseTextForId")
+    fun getNonBlankLicenseTextForId(licenseId: String, id: Identifier): String? =
+        getLicenseTextForId(licenseId, id)?.text
+
+    /**
+     * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id] if available, or the
+     * non-id-specific license text for [licenseId], or `null` if no such text is available.
+     */
+    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
+    @JvmName("getLicenseText")
+    fun getNonBlankLicenseText(licenseId: String, id: Identifier): String? = getLicenseText(licenseId, id)?.text
 }


### PR DESCRIPTION
This prepares for providing id-specific texts from `DirBasedLicenseFactProvider` and to later on consume these from the reporters.

Part of #https://github.com/oss-review-toolkit/ort/issues/11668.