### PR TITLE
fix(spdx): Align on one way of traversing the dependency graph

### DIFF
--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -57,31 +57,6 @@ internal object SpdxDocumentModelMapper {
         val packages = mutableListOf<SpdxPackage>()
         val relationships = mutableListOf<SpdxRelationship>()
         val files = mutableListOf<SpdxFile>()
-        val linkageTypesForDependencyRelationships = ortResult.getLinkageTypesForDependencyRelationships()
-
-        /**
-         * Add relationships representing a directed relationship from the package or project denoted by [fromOrtId] to
-         * the one denoted by [toOrtId]. The [fromSpdxId] must correspond to the SPDX package corresponding to
-         * [fromOrtId].
-         */
-        fun addDependencyRelationships(fromOrtId: Identifier, fromSpdxId: String, toOrtId: Identifier) {
-            relationships += SpdxRelationship(
-                spdxElementId = fromSpdxId,
-                relationshipType = SpdxRelationship.Type.DEPENDS_ON,
-                relatedSpdxElement = toOrtId.toSpdxId()
-            )
-
-            linkageTypesForDependencyRelationships.getValue(fromOrtId to toOrtId)
-                .mapTo(mutableSetOf()) { it.toSpdxRelationshipType() }
-                .sorted()
-                .forEach { relationshipType ->
-                    relationships += SpdxRelationship(
-                        spdxElementId = fromSpdxId,
-                        relationshipType = relationshipType,
-                        relatedSpdxElement = toOrtId.toSpdxId()
-                    )
-                }
-        }
 
         val projects = ortResult.getProjects(omitExcluded = true, includeSubProjects = false).sortedBy { it.id }
         val projectPackages = projects.map { project ->
@@ -97,14 +72,6 @@ internal object SpdxDocumentModelMapper {
                 ortResult
             ).copy(hasFiles = filesForProject.map { it.spdxId })
 
-            ortResult.getDependencies(
-                id = project.id,
-                maxLevel = 1,
-                omitExcluded = true
-            ).forEach { dependency ->
-                addDependencyRelationships(project.id, spdxProjectPackage.spdxId, dependency)
-            }
-
             files += filesForProject
             spdxProjectPackage
         }
@@ -116,14 +83,6 @@ internal object SpdxDocumentModelMapper {
                 licenseInfoResolver,
                 ortResult
             )
-
-            ortResult.getDependencies(
-                id = pkg.id,
-                maxLevel = 1,
-                omitExcluded = true
-            ).forEach { dependency ->
-                addDependencyRelationships(pkg.id, binaryPackage.spdxId, dependency)
-            }
 
             packages += binaryPackage
 
@@ -176,6 +135,38 @@ internal object SpdxDocumentModelMapper {
                 packages += sourceArtifactPackage
                 relationships += sourceArtifactPackageRelationship
             }
+        }
+
+        // Add the dependency tree:
+        ortResult.getLinkageTypesForDependencyRelationships().forEach { (fromId, toId), linkages ->
+            fun Identifier.toSpdxId(): String {
+                val type = if (ortResult.isProject(this)) {
+                    SpdxPackageType.PROJECT
+                } else {
+                    SpdxPackageType.BINARY_PACKAGE
+                }
+
+                return toSpdxId(type)
+            }
+
+            val fromSpdxId = fromId.toSpdxId()
+            val toSpdxId = toId.toSpdxId()
+
+            relationships += SpdxRelationship(
+                spdxElementId = fromSpdxId,
+                relationshipType = SpdxRelationship.Type.DEPENDS_ON,
+                relatedSpdxElement = toSpdxId
+            )
+
+            linkages.mapTo(mutableSetOf()) { it.toSpdxRelationshipType() }
+                .sorted()
+                .forEach { relationshipType ->
+                    relationships += SpdxRelationship(
+                        spdxElementId = fromSpdxId,
+                        relationshipType = relationshipType,
+                        relatedSpdxElement = toSpdxId
+                    )
+                }
         }
 
         val creators = listOfNotNull(


### PR DESCRIPTION
The heuristic for mapping the dependency tree to SPDX is to include a relationship `id_a -> id_b`  with linkage type `l`, if a corresponding non-excluded edge `id_a -> `id_b` with linkage type `l` exists in the dependency graph contained in the ORT file. That heuristic is implemented entirely in `getLinkageTypesForDependencyRelationships()`.

In order to create the desired relationships, each entry in the map returned by `getLinkageTypesForDependencyRelationships()` has to be trivially mapped to one or multiple SPDX relationships.

However, the way this is done is more complex than necessary: there is another traversal which creates the relationships and performs look-ups on the map returned by `getLinkageTypesForDependencyRelationships()`. In order for the look-ups to not fail, the two traversals have to match (roughly speaking). But they don't, because the call to `projectDependencies()` traverses also excluded scopes, which may lead to a crash caused by the look-up via `getValue()`.

Fix that by turning the return value from
`getLinkageTypesForDependencyRelationships()` into SPDX relationships in a simpler way.

[1]: https://github.com/oss-review-toolkit/ort/blob/2adf5e45432464af89f89e3a6107cbbb1c083113/model/src/main/kotlin/OrtResult.kt#L248
[2]: NoSuchElementException

Fixes #11794.
Fixes #11823.
