### PR TITLE
Avoid model name classpath clashes with `GradleInspector`

### DIFF
--- a/plugins/package-managers/gradle-model/src/main/kotlin/GradleModel.kt
+++ b/plugins/package-managers/gradle-model/src/main/kotlin/GradleModel.kt
@@ -19,9 +19,6 @@
 
 // As it is not possible to declare a package in "init.gradle" also no package is declared here.
 
-// The following interfaces have to match those in "plugins/package-managers/gradle/src/main/resources/init.gradle"
-// because they are used to deserialize the model produced there.
-
 interface OrtDependencyTreeModel {
     val group: String
     val name: String

--- a/plugins/package-managers/gradle/src/main/kotlin/Extensions.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/Extensions.kt
@@ -19,13 +19,13 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.gradle
 
-import OrtComponent
+import LegacyOrtComponent
 
 /**
  * The type of this Gradle dependency. In case of a project, it is [projectType]. Otherwise it is "Maven" unless there
  * is no POM, then it is "Unknown".
  */
-internal fun OrtComponent.getIdentifierType(projectType: String) =
+internal fun LegacyOrtComponent.getIdentifierType(projectType: String) =
     when {
         isProjectDependency -> projectType
         pomFile != null -> "Maven"
@@ -35,5 +35,5 @@ internal fun OrtComponent.getIdentifierType(projectType: String) =
 /**
  * A flag to indicate whether this Gradle dependency refers to a project, or to a package.
  */
-internal val OrtComponent.isProjectDependency: Boolean
+internal val LegacyOrtComponent.isProjectDependency: Boolean
     get() = localPath != null

--- a/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/Gradle.kt
@@ -19,8 +19,8 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.gradle
 
-import OrtDependencyTreeModel
-import OrtRepository
+import LegacyOrtDependencyTreeModel
+import LegacyOrtRepository
 
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -228,7 +228,7 @@ class Gradle(
 
                 val issues = mutableListOf<Issue>()
 
-                val dependencyTreeModel = connection.model(OrtDependencyTreeModel::class.java)
+                val dependencyTreeModel = connection.model(LegacyOrtDependencyTreeModel::class.java)
                     .apply {
                         // Work around https://github.com/gradle/gradle/issues/28464.
                         if (logger.delegate.isDebugEnabled && buildGradleVersion?.isEqualTo("8.5.0") != true) {
@@ -333,10 +333,10 @@ private fun getGradleProperties(): Map<String, String> =
         .orEmpty()
 
 /**
- * Convert this [OrtRepository] to a [RemoteRepository] taking the known properties into account.
+ * Convert this [LegacyOrtRepository] to a [RemoteRepository] taking the known properties into account.
  * TODO: Also handle snapshot policy.
  */
-private fun OrtRepository.toRemoteRepository(): RemoteRepository =
+private fun LegacyOrtRepository.toRemoteRepository(): RemoteRepository =
     RemoteRepository.Builder(url, "default", url).apply {
         if (headerName != null && headerValue != null) {
             setAuthentication(

--- a/plugins/package-managers/gradle/src/main/kotlin/GradleDependencyHandler.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/GradleDependencyHandler.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.gradle
 
-import OrtComponent
+import LegacyOrtComponent
 
 import org.apache.maven.project.ProjectBuildingException
 
@@ -48,7 +48,7 @@ internal class GradleDependencyHandler(
 
     /** The helper object to resolve packages via Maven. */
     private val maven: MavenSupport
-) : DependencyHandler<OrtComponent> {
+) : DependencyHandler<LegacyOrtComponent> {
     /**
      * A list with repositories to use when resolving packages. This list must be set before using this handler for
      * constructing the dependency graph of a project. As different projects may use different repositories, this
@@ -56,14 +56,14 @@ internal class GradleDependencyHandler(
      */
     var repositories = emptyList<RemoteRepository>()
 
-    override fun identifierFor(dependency: OrtComponent): Identifier =
+    override fun identifierFor(dependency: LegacyOrtComponent): Identifier =
         with(dependency.componentId) {
             Identifier(dependency.getIdentifierType(projectType), groupId, artifactId, version)
         }
 
-    override fun dependenciesFor(dependency: OrtComponent): List<OrtComponent> = dependency.dependencies
+    override fun dependenciesFor(dependency: LegacyOrtComponent): List<LegacyOrtComponent> = dependency.dependencies
 
-    override fun issuesFor(dependency: OrtComponent): List<Issue> =
+    override fun issuesFor(dependency: LegacyOrtComponent): List<Issue> =
         listOfNotNull(
             dependency.error?.let {
                 createAndLogIssue(
@@ -82,10 +82,10 @@ internal class GradleDependencyHandler(
             }
         )
 
-    override fun linkageFor(dependency: OrtComponent): PackageLinkage =
+    override fun linkageFor(dependency: LegacyOrtComponent): PackageLinkage =
         if (dependency.isProjectDependency) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
-    override fun createPackage(dependency: OrtComponent, issues: MutableCollection<Issue>): Package? {
+    override fun createPackage(dependency: LegacyOrtComponent, issues: MutableCollection<Issue>): Package? {
         // Only look for a package if there was no error resolving the dependency and it is no project dependency.
         if (dependency.error != null || dependency.isProjectDependency) return null
 

--- a/plugins/package-managers/gradle/src/main/kotlin/GradleModel.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/GradleModel.kt
@@ -19,9 +19,6 @@
 
 // As it is not possible to declare a package in "init.gradle" also no package is declared here.
 
-// The following interfaces have to match those in "plugins/package-managers/gradle/src/main/resources/init.gradle"
-// because they are used to deserialize the model produced there.
-
 internal interface OrtDependencyTreeModel {
     val group: String
     val name: String

--- a/plugins/package-managers/gradle/src/main/kotlin/GradleModel.kt
+++ b/plugins/package-managers/gradle/src/main/kotlin/GradleModel.kt
@@ -19,55 +19,55 @@
 
 // As it is not possible to declare a package in "init.gradle" also no package is declared here.
 
-internal interface OrtDependencyTreeModel {
+internal interface LegacyOrtDependencyTreeModel {
     val group: String
     val name: String
     val version: String
-    val configurations: List<OrtConfiguration>
-    val repositories: List<OrtRepository>
+    val configurations: List<LegacyOrtConfiguration>
+    val repositories: List<LegacyOrtRepository>
     val errors: List<String>
     val warnings: List<String>
 }
 
-internal interface OrtConfiguration {
+internal interface LegacyOrtConfiguration {
     val name: String
-    val dependencies: List<OrtComponent>
+    val dependencies: List<LegacyOrtComponent>
 }
 
-internal interface OrtComponentIdentifier {
+internal interface LegacyOrtComponentIdentifier {
     val groupId: String
     val artifactId: String
     val version: String
 }
 
-internal interface OrtComponent {
-    val componentId: OrtComponentIdentifier
+internal interface LegacyOrtComponent {
+    val componentId: LegacyOrtComponentIdentifier
     val classifier: String
     val extension: String
     val variants: Map<String, Map<String, String>>
-    val dependencies: List<OrtComponent>
+    val dependencies: List<LegacyOrtComponent>
     val error: String?
     val warning: String?
     val pomFile: String?
-    val mavenModel: OrtMavenModel?
+    val mavenModel: LegacyOrtMavenModel?
     val localPath: String?
 }
 
-internal interface OrtMavenModel {
+internal interface LegacyOrtMavenModel {
     val licenses: Set<String>
     val authors: Set<String>
     val description: String?
     val homepageUrl: String?
-    val vcs: OrtVcsModel?
+    val vcs: LegacyOrtVcsModel?
 }
 
-internal interface OrtVcsModel {
+internal interface LegacyOrtVcsModel {
     val connection: String
     val tag: String
     val browsableUrl: String
 }
 
-internal interface OrtRepository {
+internal interface LegacyOrtRepository {
     val url: String
     val username: String?
     val password: String?

--- a/plugins/package-managers/gradle/src/main/resources/init.gradle
+++ b/plugins/package-managers/gradle/src/main/resources/init.gradle
@@ -189,7 +189,7 @@ class AbstractOrtDependencyTreePlugin<T> implements Plugin<T> {
 
         @Override
         boolean canBuild(String modelName) {
-            return modelName == OrtDependencyTreeModel.name
+            return modelName == "LegacyOrtDependencyTreeModel"
         }
 
         @Override

--- a/plugins/package-managers/gradle/src/main/resources/init.gradle
+++ b/plugins/package-managers/gradle/src/main/resources/init.gradle
@@ -51,7 +51,7 @@ if (gradle.gradleVersion.isAtLeastVersion(2, 14)) {
     apply plugin: OrtDependencyTreeProjectPlugin
 }
 
-// The following interfaces have to match those in "plugins/package-managers/gradle-model/src/main/kotlin/GradleModel.kt"
+// The following interfaces have to match those in "plugins/package-managers/gradle/src/main/kotlin/GradleModel.kt"
 // because they are used to deserialize the model consumed there.
 
 interface OrtDependencyTreeModel {

--- a/plugins/package-managers/gradle/src/test/kotlin/GradleDependencyHandlerTest.kt
+++ b/plugins/package-managers/gradle/src/test/kotlin/GradleDependencyHandlerTest.kt
@@ -19,8 +19,8 @@
 
 package org.ossreviewtoolkit.plugins.packagemanagers.gradle
 
-import OrtComponent
-import OrtComponentIdentifier
+import LegacyOrtComponent
+import LegacyOrtComponentIdentifier
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
@@ -334,14 +334,14 @@ private fun createDependency(
     artifact: String,
     version: String,
     path: String? = null,
-    dependencies: List<OrtComponent> = emptyList()
-): OrtComponent {
-    val componentId = mockk<OrtComponentIdentifier>()
+    dependencies: List<LegacyOrtComponent> = emptyList()
+): LegacyOrtComponent {
+    val componentId = mockk<LegacyOrtComponentIdentifier>()
     every { componentId.groupId } returns group
     every { componentId.artifactId } returns artifact
     every { componentId.version } returns version
 
-    val dependency = mockk<OrtComponent>()
+    val dependency = mockk<LegacyOrtComponent>()
     every { dependency.componentId } returns componentId
     every { dependency.localPath } returns path
     every { dependency.pomFile } returns "pom.xml"
@@ -357,7 +357,7 @@ private fun createDependency(
  * Create a [DependencyGraphBuilder] equipped with a [GradleDependencyHandler] that is used by the test cases in
  * this class.
  */
-private fun createGraphBuilder(): DependencyGraphBuilder<OrtComponent> {
+private fun createGraphBuilder(): DependencyGraphBuilder<LegacyOrtComponent> {
     val dependencyHandler = GradleDependencyHandler(PROJECT_TYPE, createMavenSupport())
     dependencyHandler.repositories = remoteRepositories
     return DependencyGraphBuilder(dependencyHandler)
@@ -387,9 +387,9 @@ private fun createMavenSupport(): MavenSupport {
 }
 
 /**
- * Returns an [Identifier] for this [OrtComponent].
+ * Returns an [Identifier] for this [LegacyOrtComponent].
  */
-private fun OrtComponent.toId() =
+private fun LegacyOrtComponent.toId() =
     with(componentId) {
         Identifier(getIdentifierType(PROJECT_TYPE), groupId, artifactId, version)
     }
@@ -408,7 +408,7 @@ private fun Collection<PackageReference>.identifiers(): List<Identifier> = map {
 /**
  * Find the package corresponding to the given [dependency] in this collection.
  */
-private fun Collection<PackageReference>.findDependency(dependency: OrtComponent): PackageReference =
+private fun Collection<PackageReference>.findDependency(dependency: LegacyOrtComponent): PackageReference =
     findId(dependency.toId())
 
 /**
@@ -420,7 +420,7 @@ private fun Collection<PackageReference>.findId(id: Identifier): PackageReferenc
 /**
  * Check whether this [PackageReference] contains exactly the given [dependencies][expectedDependencies].
  */
-private fun PackageReference.checkDependencies(vararg expectedDependencies: OrtComponent): Set<PackageReference> {
+private fun PackageReference.checkDependencies(vararg expectedDependencies: LegacyOrtComponent): Set<PackageReference> {
     val ids = expectedDependencies.map { it.toId() }
     dependencies.identifiers() should containExactlyInAnyOrder(ids)
     return dependencies


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 