### PR TITLE
chore(cli-test-launcher): Conveniently run all tests

### DIFF
--- a/cli-test-launcher/build.gradle.kts
+++ b/cli-test-launcher/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
 application {
     applicationName = "ort-test-launcher"
-    mainClass = "io.kotest.engine.launcher.MainKt"
+    mainClass = "org.ossreviewtoolkit.clitestlauncher.TestMainKt"
 }
 
 val Project.hasFunTests
@@ -34,6 +34,9 @@ val Project.hasFunTests
 
 gradle.projectsEvaluated {
     dependencies {
+        implementation(libs.kotest.framework.engine)
+        implementation(projects.utils.commonUtils)
+
         rootProject.subprojects.filter { it.hasFunTests }.forEach {
             runtimeOnly(project(it.path)) {
                 capabilities {

--- a/cli-test-launcher/src/main/kotlin/TestMain.kt
+++ b/cli-test-launcher/src/main/kotlin/TestMain.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clitestlauncher
+
+import org.ossreviewtoolkit.utils.common.Os
+
+fun main(args: Array<String>) {
+    Os.fixupUserHomeProperty()
+
+    if (args.isEmpty()) {
+        io.kotest.engine.launcher.main(arrayOf("--specs", "scan"))
+    } else {
+        io.kotest.engine.launcher.main(args)
+    }
+}


### PR DESCRIPTION
As of Kotest 6.2.0, the test launcher CLI supports a special `--specs` argument called "scan" to run all tests on the classpath [1]. Add a convenience wrapper, so that's the default when running

    ./gradlew :cli-test-launcher:run

[1]: https://github.com/kotest/kotest/pull/6034