### PR TITLE
fix(gradle-inspector): Stop failing on component look-ups

### DIFF
--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleDependencyHandler.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleDependencyHandler.kt
@@ -67,10 +67,7 @@ internal class GradleDependencyHandler(
     private fun OrtComponentReference.component(): OrtComponent = componentForId.getValue(componentId)
 
     fun setTreeModel(treeModel: OrtDependencyTreeModel) {
-        componentForId.apply {
-            clear()
-            treeModel.components.associateByTo(this) { it.componentId }
-        }
+        treeModel.components.associateByTo(componentForId) { it.componentId }
     }
 
     override fun identifierFor(dependency: OrtComponentReference): Identifier =


### PR DESCRIPTION
The dependency graph API may call `areDependenciesEqual()` with
`OrtComponentReference` instances as parameters that originate from a
previously processed definition file. However,
`areDependenciesEqual()` calls `identifierFor()` which assumes
`componentForId` always conains the corresponding component.

But as `componentForId` only contains entries for components from the
current definition file, that assumption can fail and cause
`java.util.NoSuchElementException: Key OrtComponentIdentifierImpl(..)`.

Keep component entries from previous definition files to avoid this
exception.

Fixes https://github.com/oss-review-toolkit/ort/issues/12016.