### PR TITLE
feat(license-fact-provider): Return a set of texts per `id`

### DIFF
--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -38,9 +38,11 @@ class CompositeLicenseFactProvider(
         summary = "A license fact provider that aggregates multiple license fact providers."
     )
 
-    override fun hasLicenseText(licenseId: String) = providers.any { it.hasLicenseText(licenseId) }
+    override fun hasLicenseText(licenseOrExceptionId: String) =
+        providers.any { it.hasLicenseText(licenseOrExceptionId) }
 
-    override fun getLicenseText(licenseId: String) = providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        providers.firstNotNullOfOrNull { it.getLicenseText(licenseOrExceptionId) }
 
     override fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
         providers.any { it.hasLicenseTextForId(licenseId, id) }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -44,9 +44,9 @@ class CompositeLicenseFactProvider(
     override fun getLicenseText(licenseOrExceptionId: String) =
         providers.firstNotNullOfOrNull { it.getLicenseText(licenseOrExceptionId) }
 
-    override fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
-        providers.any { it.hasLicenseTextForId(licenseId, id) }
+    override fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        providers.any { it.hasLicenseTextForId(singleLicenseExpression, id) }
 
-    override fun getLicenseTextForId(licenseId: String, id: Identifier): LicenseText? =
-        providers.firstNotNullOfOrNull { it.getLicenseTextForId(licenseId, id) }
+    override fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? =
+        providers.firstNotNullOfOrNull { it.getLicenseTextForId(singleLicenseExpression, id) }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -44,9 +44,11 @@ class CompositeLicenseFactProvider(
     override fun getLicenseText(licenseOrExceptionId: String) =
         providers.firstNotNullOfOrNull { it.getLicenseText(licenseOrExceptionId) }
 
-    override fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
-        providers.any { it.hasLicenseTextForId(singleLicenseExpression, id) }
+    override fun hasLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        providers.any { it.hasLicenseTextsForId(singleLicenseExpression, id) }
 
-    override fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? =
-        providers.firstNotNullOfOrNull { it.getLicenseTextForId(singleLicenseExpression, id) }
+    override fun getLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<LicenseText> =
+        providers.firstNotNullOfOrNull { provider ->
+            provider.getLicenseTextsForId(singleLicenseExpression, id).takeUnless { it.isEmpty() }
+        }.orEmpty()
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -36,21 +36,21 @@ abstract class LicenseFactProvider : Plugin {
     /**
      * Return `true´ if this provider has an id-specific license text for the given [singleLicenseExpression] and [id].
      */
-    open fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
-        getLicenseTextForId(singleLicenseExpression, id) != null
+    open fun hasLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        getLicenseTextsForId(singleLicenseExpression, id).isNotEmpty()
 
     /**
-     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no such text
-     * is available.
+     * Return all id-specific [LicenseText]s for the given [singleLicenseExpression] and [id], or an empty set if no
+     * such text is available.
      */
-    open fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? = null
+    open fun getLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<LicenseText> = emptySet()
 
     /**
-     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
-     * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
+     * Return `true` if any id-specific [LicenseText]s for the given [singleLicenseExpression] and [id], or if a
+     * non-id-specific license text for [singleLicenseExpression] is available, or `false` otherwise.
      */
     fun hasLicenseText(singleLicenseExpression: String, id: Identifier): Boolean {
-        if (hasLicenseTextForId(singleLicenseExpression, id)) return true
+        if (hasLicenseTextsForId(singleLicenseExpression, id)) return true
 
         val spdxExpression = runCatching { SpdxSingleLicenseExpression.parse(singleLicenseExpression) }.getOrElse {
             logger.info { "Could not parse '$singleLicenseExpression' as a single license expression." }
@@ -64,19 +64,20 @@ abstract class LicenseFactProvider : Plugin {
      * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
      * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
-    fun getLicenseText(singleLicenseExpression: String, id: Identifier): LicenseText? =
-        getLicenseTextForId(singleLicenseExpression, id) ?: run {
+    fun getLicenseTexts(singleLicenseExpression: String, id: Identifier): Set<LicenseText> =
+        getLicenseTextsForId(singleLicenseExpression, id).ifEmpty {
             val spdxExpression = runCatching {
                 SpdxSingleLicenseExpression.parse(singleLicenseExpression)
             }.getOrElse {
                 logger.info { "Could not parse '$singleLicenseExpression' as a single license expression." }
-                return null
+                return emptySet()
             }
 
             listOfNotNull(spdxExpression.simpleLicense(), spdxExpression.exception())
-                .map { getLicenseText(it) ?: return null }
+                .map { getLicenseText(it) ?: return emptySet() }
                 .joinToString("\n") { it.text }
-        }.let { LicenseText(it) }
+                .let { setOf(LicenseText(it)) }
+        }
 
     /**
      * Return a non-blank license text for the given [licenseOrExceptionId], or `null` if no valid text is available.
@@ -85,21 +86,16 @@ abstract class LicenseFactProvider : Plugin {
     @JvmName("getLicenseText")
     fun getNonBlankLicenseText(licenseOrExceptionId: String): String? = getLicenseText(licenseOrExceptionId)?.text
 
-    /**
-     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no
-     * such text is available.
-     */
-    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
-    @JvmName("getLicenseTextForId")
-    fun getNonBlankLicenseTextForId(singleLicenseExpression: String, id: Identifier): String? =
-        getLicenseTextForId(singleLicenseExpression, id)?.text
+    @JvmName("getLicenseTextsStringForId")
+    fun getNonBlankLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<String> =
+        getLicenseTextsForId(singleLicenseExpression, id).mapTo(mutableSetOf()) { it.text }
 
     /**
-     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or
-     * the non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
+     * Return all non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or
+     * the non-id-specific license text for [singleLicenseExpression], or an empty set if no such text is available.
      */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
-    @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(singleLicenseExpression: String, id: Identifier): String? =
-        getLicenseText(singleLicenseExpression, id)?.text
+    @JvmName("getLicenseTextsString")
+    fun getNonBlankLicenseTexts(singleLicenseExpression: String, id: Identifier): Set<String> =
+        getLicenseTexts(singleLicenseExpression, id).mapTo(mutableSetOf()) { it.text }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -24,11 +24,11 @@ import org.ossreviewtoolkit.plugins.api.Plugin
 
 /** A provider for license facts. */
 abstract class LicenseFactProvider : Plugin {
-    /** Return `true´ if this provider has a license text for the given [licenseId]. */
-    abstract fun hasLicenseText(licenseId: String): Boolean
+    /** Return `true´ if this provider has a license text for the given [licenseOrExceptionId]. */
+    abstract fun hasLicenseText(licenseOrExceptionId: String): Boolean
 
-    /** Return a [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
-    abstract fun getLicenseText(licenseId: String): LicenseText?
+    /** Return a [LicenseText] for the given [licenseOrExceptionId], or `null` if no valid text is available. */
+    abstract fun getLicenseText(licenseOrExceptionId: String): LicenseText?
 
     /** Return `true´ if this provider has an id-specific license text for the given [licenseId] and [id]. */
     open fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
@@ -57,7 +57,7 @@ abstract class LicenseFactProvider : Plugin {
     /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
+    fun getNonBlankLicenseText(licenseOrExceptionId: String): String? = getLicenseText(licenseOrExceptionId)?.text
 
     /**
      * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -19,8 +19,11 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.apache.logging.log4j.kotlin.logger
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.plugins.api.Plugin
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxSingleLicenseExpression
 
 /** A provider for license facts. */
 abstract class LicenseFactProvider : Plugin {
@@ -30,49 +33,73 @@ abstract class LicenseFactProvider : Plugin {
     /** Return a [LicenseText] for the given [licenseOrExceptionId], or `null` if no valid text is available. */
     abstract fun getLicenseText(licenseOrExceptionId: String): LicenseText?
 
-    /** Return `true´ if this provider has an id-specific license text for the given [licenseId] and [id]. */
-    open fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
-        getLicenseTextForId(licenseId, id) != null
+    /**
+     * Return `true´ if this provider has an id-specific license text for the given [singleLicenseExpression] and [id].
+     */
+    open fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        getLicenseTextForId(singleLicenseExpression, id) != null
 
     /**
-     * Return an id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
-     * available.
+     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no such text
+     * is available.
      */
-    open fun getLicenseTextForId(licenseId: String, id: Identifier): LicenseText? = null
+    open fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? = null
 
     /**
-     * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific
-     * license text for [licenseId], or `null` if no such text is available.
+     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
+     * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
-    fun hasLicenseText(licenseId: String, id: Identifier): Boolean =
-        hasLicenseTextForId(licenseId, id) || hasLicenseText(licenseId)
+    fun hasLicenseText(singleLicenseExpression: String, id: Identifier): Boolean {
+        if (hasLicenseTextForId(singleLicenseExpression, id)) return true
+
+        val spdxExpression = runCatching { SpdxSingleLicenseExpression.parse(singleLicenseExpression) }.getOrElse {
+            logger.info { "Could not parse '$singleLicenseExpression' as a single license expression." }
+            return false
+        }
+
+        return listOfNotNull(spdxExpression.simpleLicense(), spdxExpression.exception()).all { hasLicenseText(it) }
+    }
 
     /**
-     * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific
-     * license text for [licenseId], or `null` if no such text is available.
+     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
+     * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
-    fun getLicenseText(licenseId: String, id: Identifier): LicenseText? =
-        getLicenseTextForId(licenseId, id) ?: getLicenseText(licenseId)
+    fun getLicenseText(singleLicenseExpression: String, id: Identifier): LicenseText? =
+        getLicenseTextForId(singleLicenseExpression, id) ?: run {
+            val spdxExpression = runCatching {
+                SpdxSingleLicenseExpression.parse(singleLicenseExpression)
+            }.getOrElse {
+                logger.info { "Could not parse '$singleLicenseExpression' as a single license expression." }
+                return null
+            }
 
-    /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
+            listOfNotNull(spdxExpression.simpleLicense(), spdxExpression.exception())
+                .map { getLicenseText(it) ?: return null }
+                .joinToString("\n") { it.text }
+        }.let { LicenseText(it) }
+
+    /**
+     * Return a non-blank license text for the given [licenseOrExceptionId], or `null` if no valid text is available.
+     */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
     fun getNonBlankLicenseText(licenseOrExceptionId: String): String? = getLicenseText(licenseOrExceptionId)?.text
 
     /**
-     * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
-     * available.
+     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no
+     * such text is available.
      */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseTextForId")
-    fun getNonBlankLicenseTextForId(licenseId: String, id: Identifier): String? =
-        getLicenseTextForId(licenseId, id)?.text
+    fun getNonBlankLicenseTextForId(singleLicenseExpression: String, id: Identifier): String? =
+        getLicenseTextForId(singleLicenseExpression, id)?.text
 
     /**
-     * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id] if available, or the
-     * non-id-specific license text for [licenseId], or `null` if no such text is available.
+     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or
+     * the non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String, id: Identifier): String? = getLicenseText(licenseId, id)?.text
+    fun getNonBlankLicenseText(singleLicenseExpression: String, id: Identifier): String? =
+        getLicenseText(singleLicenseExpression, id)?.text
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -45,7 +45,7 @@ abstract class LicenseFactProvider : Plugin {
      * license text for [licenseId], or `null` if no such text is available.
      */
     fun hasLicenseText(licenseId: String, id: Identifier): Boolean =
-        hasLicenseText(licenseId, id) || hasLicenseText(licenseId)
+        hasLicenseTextForId(licenseId, id) || hasLicenseText(licenseId)
 
     /**
      * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -74,12 +74,13 @@ open class DirLicenseFactProvider(
         }
     }
 
-    override fun getLicenseText(licenseId: String) = getLicenseTextFile(licenseId)?.readText()?.let { LicenseText(it) }
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextFile(licenseOrExceptionId)?.readText()?.let { LicenseText(it) }
 
-    override fun hasLicenseText(licenseId: String) = getLicenseTextFile(licenseId) != null
+    override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextFile(licenseOrExceptionId) != null
 
-    private fun getLicenseTextFile(licenseId: String) =
-        licenseTextDir.resolve(licenseId).takeIf { it.isFile && it.isNotBlank }
+    private fun getLicenseTextFile(licenseOrExceptionId: String) =
+        licenseTextDir.resolve(licenseOrExceptionId).takeIf { it.isFile && it.isNotBlank }
 }
 
 private val File.isNotBlank: Boolean

--- a/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
@@ -94,26 +94,27 @@ class ScanCodeLicenseFactProvider(
         }
     }
 
-    private fun getLicenseTextFile(licenseId: String): File? {
-        val filename = if (licenseId == "LicenseRef-scancode-x11-xconsortium-veillard") {
+    private fun getLicenseTextFile(licenseOrExceptionId: String): File? {
+        val filename = if (licenseOrExceptionId == "LicenseRef-scancode-x11-xconsortium-veillard") {
             // Work around for https://github.com/aboutcode-org/scancode-toolkit/issues/2813 which affects ScanCode
             // versions below 31.0.0.
             "x11-xconsortium_veillard.LICENSE"
         } else {
-            "${licenseId.removePrefix("LicenseRef-scancode-").lowercase()}.LICENSE"
+            "${licenseOrExceptionId.removePrefix("LicenseRef-scancode-").lowercase()}.LICENSE"
         }
 
         return scanCodeLicenseTextDir?.resolve(filename)?.takeIf { it.isFile && it.isNotBlank }
     }
 
-    override fun getLicenseText(licenseId: String) =
-        getLicenseTextFile(licenseId)?.useLines { lines ->
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextFile(licenseOrExceptionId)?.useLines { lines ->
             lines.skipYamlFrontMatter().joinToString("\n").trimEnd()
         }?.let {
             LicenseText(it)
         }
 
-    override fun hasLicenseText(licenseId: String): Boolean = getLicenseTextFile(licenseId) != null
+    override fun hasLicenseText(licenseOrExceptionId: String): Boolean =
+        getLicenseTextFile(licenseOrExceptionId) != null
 }
 
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())

--- a/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
@@ -36,17 +36,18 @@ import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseText
 class SpdxLicenseFactProvider(
     override val descriptor: PluginDescriptor = SpdxLicenseFactProviderFactory.descriptor
 ) : LicenseFactProvider() {
-    override fun getLicenseText(licenseId: String) =
-        getLicenseTextResource(licenseId)?.readText()?.let {
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextResource(licenseOrExceptionId)?.readText()?.let {
             // It can be safely assumed that the license text is not blank as all SPDX license texts are non-blank.
             LicenseText(it)
         }
 
-    override fun hasLicenseText(licenseId: String) = getLicenseTextResource(licenseId) != null
+    override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextResource(licenseOrExceptionId) != null
 
-    private fun getLicenseTextResource(licenseId: String): URL? =
-        if (licenseId.isNotEmpty()) {
-            javaClass.getResource("/licenses/$licenseId") ?: javaClass.getResource("/exceptions/$licenseId")
+    private fun getLicenseTextResource(licenseOrExceptionId: String): URL? =
+        if (licenseOrExceptionId.isNotEmpty()) {
+            javaClass.getResource("/licenses/$licenseOrExceptionId")
+                ?: javaClass.getResource("/exceptions/$licenseOrExceptionId")
         } else {
             null
         }


### PR DESCRIPTION
Allow multiple license text variants to be provided for a single `licenseId` instead of a single concatenated string.

Rationale: Some packages include more than one distinct text for the same licenseId; forcing a single text required curators to concatenate variants, which is inflexible. Returning a set enables additive curation semantics (append/merge) rather than overwrite semantics, which is more powerful for future tooling. Each text entry can carr its own metadata (e.g., comment or source), improving traceability.

The signature now returns a set of license text entries for a given `licenseId` and the helper getLicenseText(licenseId, id) is removed, since integrations (for example NOTICE template generation) need to distinguish between single and multiple texts and will need to call both functions anyway.

Note: The `JvmName` has to be changed to avoid a clash due to the now equal return type of `Set`.

Part of #11668.