### PR TITLE
feat(commands): Print a docs link when outputting rule violations

### DIFF
--- a/plugins/commands/evaluator/src/main/kotlin/EvaluateCommand.kt
+++ b/plugins/commands/evaluator/src/main/kotlin/EvaluateCommand.kt
@@ -340,6 +340,8 @@ class EvaluateCommand(descriptor: PluginDescriptor = EvaluateCommandFactory.desc
             evaluatorRun.violations.forEach { violation ->
                 echo(violation.format())
             }
+
+            echo(Theme.Default.info(RULE_VIOLATION_RESOLUTION_HINT))
         } else {
             echo("No rule violations have been found.")
         }
@@ -361,6 +363,12 @@ class EvaluateCommand(descriptor: PluginDescriptor = EvaluateCommandFactory.desc
             .print().conclude(ortConfig.severeRuleViolationThreshold, 2)
     }
 }
+
+private const val RULE_VIOLATION_RESOLUTION_HINT =
+    "See https://oss-review-toolkit.org/ort/docs/configuration/resolutions for how to resolve rule violations. " +
+        "The WebApp and Static-HTML reports also show context-aware how-to-fix texts when the global ORT " +
+        "configuration from the ort-config repository is used " +
+        "(see https://oss-review-toolkit.org/ort/docs/configuration/how-to-fix-text-provider)."
 
 private fun RuleViolation.format() =
     buildString {

--- a/plugins/commands/evaluator/src/test/kotlin/EvaluateCommandTest.kt
+++ b/plugins/commands/evaluator/src/test/kotlin/EvaluateCommandTest.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.plugins.commands.evaluator
 
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.obj
 import com.github.ajalt.clikt.testing.test
 
 import io.kotest.assertions.throwables.shouldNotThrow
@@ -27,9 +29,12 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.file.exist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.shouldContain
 
+import java.io.File
 import java.io.FileNotFoundException
 
+import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.utils.common.div
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ort.ORT_EVALUATOR_RULES_FILENAME
@@ -50,5 +55,16 @@ class EvaluateCommandTest : StringSpec({
         shouldNotThrow<FileNotFoundException> {
             EvaluateCommand().test(args, envvars = mapOf(ORT_CONFIG_DIR_ENV_NAME to tempdir().path))
         }
+    }
+
+    "A docs link to resolve rule violations is printed when violations are found" {
+        val ortFile = File("src/test/resources/test-ort-result.yml")
+        val rulesFile = File("src/test/resources/test-rules.kts")
+        val args = listOf("--ort-file", ortFile.path, "--rules-file", rulesFile.path)
+
+        val result = EvaluateCommand().context { obj = OrtConfiguration() }
+            .test(args, envvars = mapOf(ORT_CONFIG_DIR_ENV_NAME to tempdir().path))
+
+        result.output shouldContain "oss-review-toolkit.org/ort/docs/configuration/resolutions"
     }
 })

--- a/plugins/commands/evaluator/src/test/resources/test-ort-result.yml
+++ b/plugins/commands/evaluator/src/test/resources/test-ort-result.yml
@@ -1,0 +1,13 @@
+---
+repository:
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  config: {}

--- a/plugins/commands/evaluator/src/test/resources/test-rules.kts
+++ b/plugins/commands/evaluator/src/test/resources/test-rules.kts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+val ruleSet = ruleSet(ortResult) {
+    ortResultRule("ALWAYS_FAIL") {
+        error("Test rule violation", "Synthetic violation used by EvaluateCommandTest.")
+    }
+}
+
+ruleViolations += ruleSet.violations


### PR DESCRIPTION
## Summary

When the evaluate command lists rule violations on the console, it now appends a short guidance line pointing users to the ORT documentation on resolving rule violations, and noting that the WebApp and Static-HTML reports include context-aware how-to-fix texts when the global ort-config is used. The line is only printed when violations are found (the "No rule violations have been found." path is unchanged) and uses the existing `Theme.Default.info` hint styling so it reads as guidance rather than another violation.

## Motivation

New users to ORT typically do not know where to look for guidance on how to resolve flagged rule violations. The WebApp and Static-HTML reports already surface context-aware how-to-fix texts when the global config from the ort-config repository is used, but the console output of `ort evaluate` gives no such pointer. This adds that pointer directly where the violations are printed.

## Changes

- `EvaluateCommand`: after the rule-violation list, print a hint line linking to the resolutions docs and the how-to-fix-text-provider docs.
- Added a test that runs the evaluate command against a rules file producing a violation and asserts the docs link appears in the output, plus minimal `test-rules.kts` / `test-ort-result.yml` fixtures.

Resolves #10930.
