### PR TITLE
Various ScanOss fixes

### DIFF
--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
+import com.scanoss.dto.LicenseDetails
 import com.scanoss.dto.ScanFileDetails
 import com.scanoss.dto.ScanFileResult
 import com.scanoss.dto.enums.MatchType
@@ -89,15 +90,10 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
 private fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
 
-    val licenses = details.licenseDetails.orEmpty().mapNotNull { license ->
-        val licenseExpression = runCatching { SpdxExpression.parse(license.name) }.getOrNull()
-            ?: return@mapNotNull null
-
-        when {
-            licenseExpression.isValid() -> license.name
-            else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}"
-        }
-    }.ifEmpty { listOf(SpdxConstants.NOASSERTION) }
+    val licenses = details.licenseDetails
+        .orEmpty()
+        .mapNotNull { it.toSpdxExpression() }
+        .ifEmpty { listOf(SpdxConstants.NOASSERTION) }
 
     return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(
@@ -206,3 +202,12 @@ private fun convertLines(file: String, lineRanges: String): List<TextLocation> =
             else -> TextLocation(file, it.toInt())
         }
     }
+
+private fun LicenseDetails.toSpdxExpression(): String? {
+    val licenseExpression = runCatching { SpdxExpression.parse(name) }.getOrNull() ?: return null
+
+    return when {
+        licenseExpression.isValid() -> name
+        else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-$name"
+    }
+}

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -93,7 +93,7 @@ private fun getLicenseFindings(details: ScanFileDetails, path: String): Set<Lice
     val licenses = details.licenseDetails
         .orEmpty()
         .mapNotNull { it.toSpdxExpression() }
-        .ifEmpty { listOf(SpdxConstants.NOASSERTION) }
+        .ifEmpty { listOf(SpdxExpression.parse(SpdxConstants.NOASSERTION)) }
 
     return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(
@@ -203,11 +203,11 @@ private fun convertLines(file: String, lineRanges: String): List<TextLocation> =
         }
     }
 
-private fun LicenseDetails.toSpdxExpression(): String? {
+private fun LicenseDetails.toSpdxExpression(): SpdxExpression? {
     val licenseExpression = runCatching { SpdxExpression.parse(name) }.getOrNull() ?: return null
 
     return when {
-        licenseExpression.isValid() -> name
-        else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-$name"
+        licenseExpression.isValid() -> licenseExpression
+        else -> SpdxExpression.parse("${SpdxConstants.LICENSE_REF_PREFIX}scanoss-$name")
     }
 }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -210,7 +210,7 @@ private fun LicenseDetails.toSpdxExpression(): SpdxExpression? {
     }
 }
 
-private fun Array<LicenseDetails>?.toSpdxExpressions(): List<SpdxExpression> =
+private fun Array<LicenseDetails>?.toSpdxExpressions(): Set<SpdxExpression> =
     orEmpty()
-        .mapNotNull { it.toSpdxExpression() }
-        .ifEmpty { listOf(SpdxExpression.parse(SpdxConstants.NOASSERTION)) }
+        .mapNotNullTo(mutableSetOf()) { it.toSpdxExpression() }
+        .ifEmpty { setOf(SpdxExpression.parse(SpdxConstants.NOASSERTION)) }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -90,10 +90,7 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
 private fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
 
-    val licenses = details.licenseDetails
-        .orEmpty()
-        .mapNotNull { it.toSpdxExpression() }
-        .ifEmpty { listOf(SpdxExpression.parse(SpdxConstants.NOASSERTION)) }
+    val licenses = details.licenseDetails.toSpdxExpressions()
 
     return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(
@@ -211,3 +208,8 @@ private fun LicenseDetails.toSpdxExpression(): SpdxExpression? {
         else -> SpdxExpression.parse("${SpdxConstants.LICENSE_REF_PREFIX}scanoss-$name")
     }
 }
+
+private fun Array<LicenseDetails>?.toSpdxExpressions(): List<SpdxExpression> =
+    orEmpty()
+        .mapNotNull { it.toSpdxExpression() }
+        .ifEmpty { listOf(SpdxExpression.parse(SpdxConstants.NOASSERTION)) }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -89,17 +89,19 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
 private fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
 
-    return details.licenseDetails.orEmpty().mapTo(mutableSetOf()) { license ->
+    val licenses = details.licenseDetails.orEmpty().map { license ->
         val licenseExpression = runCatching { SpdxExpression.parse(license.name) }.getOrNull()
 
-        val validatedLicense = when {
+        when {
             licenseExpression == null -> SpdxConstants.NOASSERTION
             licenseExpression.isValid() -> license.name
             else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}"
         }
+    }
 
+    return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(
-            license = validatedLicense,
+            license = license,
             location = TextLocation(
                 path = path,
                 startLine = TextLocation.UNKNOWN_LINE,

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -89,15 +89,15 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
 private fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
 
-    val licenses = details.licenseDetails.orEmpty().map { license ->
+    val licenses = details.licenseDetails.orEmpty().mapNotNull { license ->
         val licenseExpression = runCatching { SpdxExpression.parse(license.name) }.getOrNull()
+            ?: return@mapNotNull null
 
         when {
-            licenseExpression == null -> SpdxConstants.NOASSERTION
             licenseExpression.isValid() -> license.name
             else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}"
         }
-    }
+    }.ifEmpty { listOf(SpdxConstants.NOASSERTION) }
 
     return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -40,7 +40,6 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
-import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdxexpression.toExpression
 
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())
@@ -136,9 +135,11 @@ private fun getSnippetFindings(details: ScanFileDetails, localFilePath: String):
     val score = matched.substringBeforeLast("%").toFloat()
     val primaryPurl = purls.removeFirstOrNull().orEmpty()
 
-    val license = details.licenseDetails.orEmpty()
-        .map { license -> SpdxExpression.parse(license.name) }
-        .toExpression()?.sorted() ?: SpdxLicenseIdExpression(SpdxConstants.NOASSERTION)
+    val license = details.licenseDetails
+        .toSpdxExpressions()
+        .toExpression()
+        .let { checkNotNull(it) }
+        .sorted()
 
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?
     val vcsInfo = VcsHost.parseUrl(url.takeUnless { it == "none" }.orEmpty())

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -59,10 +59,11 @@ class ScanOssResultParserTest : WordSpec({
                 "EPL-1.0",
                 "MIT",
                 "LicenseRef-scancode-free-unknown",
-                "LicenseRef-scanoss-SSPL"
+                "LicenseRef-scanoss-SSPL",
+                "NOASSERTION"
             )
 
-            summary.licenseFindings should haveSize(201)
+            summary.licenseFindings should haveSize(362)
             summary.licenseFindings shouldContain LicenseFinding(
                 license = "Apache-2.0",
                 location = TextLocation(


### PR DESCRIPTION
When identifying (choosing with reason `ORIGINAL_FINDING`) a `NOASSERTION` snippet finding, 
that `NOASSERTION` finding will disappear from the next scan result, without any corresponding `licenseFinding`.
Fix that by including also `NOASSERTION` license findings into the result.

Furthermore, remove the code redundancy and inconsistency of the license parsing, between snippet licenses and license finding licenses.

Context: #12057.