### PR TITLE
Various ScanOss fixes

### DIFF
--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -31,7 +31,6 @@ import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseException
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxCompoundExpression
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
-import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseWithExceptionExpression
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxOperator
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxSimpleExpression
@@ -334,7 +333,7 @@ fun associateLicensesWithExceptions(license: SpdxExpression): SpdxExpression {
     val orphanExceptions = standAloneExceptionIds - handledExceptions
 
     orphanExceptions.mapTo(associatedLicenses) { exceptionId ->
-        SpdxLicenseWithExceptionExpression(SpdxLicenseIdExpression(SpdxConstants.NOASSERTION), exceptionId)
+        SpdxLicenseWithExceptionExpression(SpdxExpression.NOASSERTION, exceptionId)
     }
 
     // Recreate the compound AND-expression from the associated licenses.

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -142,7 +142,7 @@ internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String)
 
     val license = details.licenseDetails.orEmpty()
         .map { license -> SpdxExpression.parse(license.name) }
-        .toExpression()?.sorted() ?: SpdxExpression.NOASSERTION
+        .toExpression() ?: SpdxExpression.NOASSERTION
 
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?
     val vcsInfo = VcsHost.parseUrl(url.takeUnless { it == "none" }.orEmpty())

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.model.SnippetFinding
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
-import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdxexpression.toExpression
 
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())
@@ -143,7 +142,7 @@ private fun getSnippetFindings(details: ScanFileDetails, localFilePath: String):
 
     val license = details.licenseDetails.orEmpty()
         .map { license -> SpdxExpression.parse(license.name) }
-        .toExpression()?.sorted() ?: SpdxLicenseIdExpression(SpdxConstants.NOASSERTION)
+        .toExpression()?.sorted() ?: SpdxExpression.NOASSERTION
 
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?
     val vcsInfo = VcsHost.parseUrl(url.takeUnless { it == "none" }.orEmpty())

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -129,7 +129,7 @@ private fun getCopyrightFindings(details: ScanFileDetails, path: String): Set<Co
  * PURLs the function extracts the first PURL as the primary identifier while storing the remaining PURLs in
  * additionalData to preserve the complete information.
  */
-private fun getSnippetFindings(details: ScanFileDetails, localFilePath: String): Set<SnippetFinding> {
+internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String): Set<SnippetFinding> {
     val matched = requireNotNull(details.matched)
     val ossFile = requireNotNull(details.file)
     val ossLines = requireNotNull(details.ossLines)

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -90,17 +90,19 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
 internal fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
 
-    return details.licenseDetails.orEmpty().mapTo(mutableSetOf()) { license ->
+    val licenses = details.licenseDetails.orEmpty().map { license ->
         val licenseExpression = runCatching { SpdxExpression.parse(license.name) }.getOrNull()
 
-        val validatedLicense = when {
+        when {
             licenseExpression == null -> SpdxConstants.NOASSERTION
             licenseExpression.isValid() -> license.name
             else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}"
         }
+    }
 
+    return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(
-            license = validatedLicense,
+            license = license,
             location = TextLocation(
                 path = path,
                 startLine = TextLocation.UNKNOWN_LINE,

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
+import com.scanoss.dto.LicenseDetails
 import com.scanoss.dto.ScanFileDetails
 import com.scanoss.dto.ScanFileResult
 import com.scanoss.dto.enums.MatchType
@@ -89,16 +90,7 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
  */
 internal fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
-
-    val licenses = details.licenseDetails.orEmpty().map { license ->
-        val licenseExpression = runCatching { SpdxExpression.parse(license.name) }.getOrNull()
-
-        when {
-            licenseExpression == null -> SpdxConstants.NOASSERTION
-            licenseExpression.isValid() -> license.name
-            else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}"
-        }
-    }
+    val licenses = details.licenseDetails.toSpdxExpressions()
 
     return licenses.mapTo(mutableSetOf()) { license ->
         LicenseFinding(
@@ -144,15 +136,7 @@ internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String)
     val score = matched.substringBeforeLast("%").toFloat()
     val primaryPurl = purls.removeFirstOrNull().orEmpty()
 
-    val license = details.licenseDetails.orEmpty().map { license ->
-        val expression = license.name.toSpdxOrNull()
-
-        when {
-            expression == null -> SpdxExpression.NOASSERTION
-            expression.isValid() -> expression
-            else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}".toSpdx()
-        }
-    }.toExpression() ?: SpdxExpression.NOASSERTION
+    val license = details.licenseDetails.toSpdxExpressions().toExpression() ?: SpdxExpression.NOASSERTION
 
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?
     val vcsInfo = VcsHost.parseUrl(url.takeUnless { it == "none" }.orEmpty())
@@ -211,5 +195,19 @@ private fun convertLines(file: String, lineRanges: String): List<TextLocation> =
             '-' in it -> TextLocation(file, it.substringBefore('-').toInt(), it.substringAfter('-').toInt())
 
             else -> TextLocation(file, it.toInt())
+        }
+    }
+
+/**
+ * Turn an array of [LicenseDetails] into a set of [SpdxExpression]s.
+ */
+private fun Array<LicenseDetails>?.toSpdxExpressions(): Set<SpdxExpression> =
+    orEmpty().mapTo(mutableSetOf()) { license ->
+        val expression = license.name.toSpdxOrNull()
+
+        when {
+            expression == null -> SpdxExpression.NOASSERTION
+            expression.isValid() -> expression
+            else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}".toSpdx()
         }
     }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
 import org.ossreviewtoolkit.utils.spdxexpression.toExpression
+import org.ossreviewtoolkit.utils.spdxexpression.toSpdx
 import org.ossreviewtoolkit.utils.spdxexpression.toSpdxOrNull
 
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())
@@ -141,9 +142,15 @@ internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String)
     val score = matched.substringBeforeLast("%").toFloat()
     val primaryPurl = purls.removeFirstOrNull().orEmpty()
 
-    val license = details.licenseDetails.orEmpty()
-        .map { license -> license.name.toSpdxOrNull() ?: SpdxExpression.NOASSERTION }
-        .toExpression() ?: SpdxExpression.NOASSERTION
+    val license = details.licenseDetails.orEmpty().map { license ->
+        val expression = license.name.toSpdxOrNull()
+
+        when {
+            expression == null -> SpdxExpression.NOASSERTION
+            expression.isValid() -> expression
+            else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}".toSpdx()
+        }
+    }.toExpression() ?: SpdxExpression.NOASSERTION
 
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?
     val vcsInfo = VcsHost.parseUrl(url.takeUnless { it == "none" }.orEmpty())

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -136,8 +136,6 @@ internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String)
     val score = matched.substringBeforeLast("%").toFloat()
     val primaryPurl = purls.removeFirstOrNull().orEmpty()
 
-    val license = details.licenseDetails.toSpdxExpressions().toExpression() ?: SpdxExpression.NOASSERTION
-
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?
     val vcsInfo = VcsHost.parseUrl(url.takeUnless { it == "none" }.orEmpty())
     val provenance = RepositoryProvenance(vcsInfo, ".")
@@ -173,6 +171,7 @@ internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String)
     }
 
     // Directly pair source locations with their corresponding OSS locations and create a SnippetFinding.
+    val license = checkNotNull(details.licenseDetails.toSpdxExpressions().toExpression())
     return sourceLocations.zip(ossLocations).mapTo(mutableSetOf()) { (sourceLocation, ossLocation) ->
         SnippetFinding(
             sourceLocation,
@@ -210,4 +209,4 @@ private fun Array<LicenseDetails>?.toSpdxExpressions(): Set<SpdxExpression> =
             expression.isValid() -> expression
             else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-${license.name}".toSpdx()
         }
-    }
+    }.ifEmpty { setOf(SpdxExpression.NOASSERTION) }

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
 import org.ossreviewtoolkit.utils.spdxexpression.toExpression
+import org.ossreviewtoolkit.utils.spdxexpression.toSpdxOrNull
 
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())
 
@@ -141,7 +142,7 @@ internal fun getSnippetFindings(details: ScanFileDetails, localFilePath: String)
     val primaryPurl = purls.removeFirstOrNull().orEmpty()
 
     val license = details.licenseDetails.orEmpty()
-        .map { license -> SpdxExpression.parse(license.name) }
+        .map { license -> license.name.toSpdxOrNull() ?: SpdxExpression.NOASSERTION }
         .toExpression() ?: SpdxExpression.NOASSERTION
 
     // TODO: No resolved revision is available. Should an ArtifactProvenance be created instead?

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssResultParser.kt
@@ -87,7 +87,7 @@ internal fun generateSummary(startTime: Instant, endTime: Instant, results: List
 /**
  * Get the license findings from the given [details].
  */
-private fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
+internal fun getLicenseFindings(details: ScanFileDetails, path: String): Set<LicenseFinding> {
     val score = details.matched?.removeSuffix("%")?.toFloatOrNull()
 
     return details.licenseDetails.orEmpty().mapTo(mutableSetOf()) { license ->

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -289,6 +289,20 @@ class ScanOssResultParserTest : WordSpec({
                 }
             }
         }
+
+        "handle licenses only SCANOSS knows about" {
+            val detailsWithUnparsableLicense = dummyDetails.toBuilder()
+                .licenseDetails(
+                    arrayOf(LicenseDetails().apply { name = "OnlyScanOssKnows" })
+                )
+                .build()
+
+            getSnippetFindings(detailsWithUnparsableLicense, "dummy").shouldBeSingleton { finding ->
+                finding.snippets.shouldBeSingleton { snippet ->
+                    snippet.license.toString() shouldBe "LicenseRef-scanoss-OnlyScanOssKnows"
+                }
+            }
+        }
     }
 })
 

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -267,6 +267,32 @@ class ScanOssResultParserTest : WordSpec({
         }
     }
 
+    "getLicenseFindings()" should {
+        "handle unparsable license names" {
+            val detailsWithUnparsableLicense = dummyDetails.toBuilder()
+                .licenseDetails(
+                    arrayOf(LicenseDetails().apply { name = "Not a license name" })
+                )
+                .build()
+
+            getLicenseFindings(detailsWithUnparsableLicense, "dummy").shouldBeSingleton { finding ->
+                finding.license shouldBe SpdxExpression.NOASSERTION
+            }
+        }
+
+        "handle licenses only SCANOSS knows about" {
+            val detailsWithUnparsableLicense = dummyDetails.toBuilder()
+                .licenseDetails(
+                    arrayOf(LicenseDetails().apply { name = "OnlyScanOssKnows" })
+                )
+                .build()
+
+            getLicenseFindings(detailsWithUnparsableLicense, "dummy").shouldBeSingleton { finding ->
+                finding.license.toString() shouldBe "LicenseRef-scanoss-OnlyScanOssKnows"
+            }
+        }
+    }
+
     "getSnippetFindings()" should {
         "use NOASSERTION for empty license findings" {
             getSnippetFindings(dummyDetails, "dummy").shouldBeSingleton { finding ->

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -275,6 +275,20 @@ class ScanOssResultParserTest : WordSpec({
                 }
             }
         }
+
+        "handle unparsable license names" {
+            val detailsWithUnparsableLicense = dummyDetails.toBuilder()
+                .licenseDetails(
+                    arrayOf(LicenseDetails().apply { name = "Not a license name" })
+                )
+                .build()
+
+            getSnippetFindings(detailsWithUnparsableLicense, "dummy").shouldBeSingleton { finding ->
+                finding.snippets.shouldBeSingleton { snippet ->
+                    snippet.license shouldBe SpdxExpression.NOASSERTION
+                }
+            }
+        }
     }
 })
 

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -19,12 +19,21 @@
 
 package org.ossreviewtoolkit.plugins.scanners.scanoss
 
+import com.scanoss.dto.CopyrightDetails
+import com.scanoss.dto.LicenseDetails
+import com.scanoss.dto.QualityDetails
+import com.scanoss.dto.ScanFileDetails
+import com.scanoss.dto.ServerDetails
+import com.scanoss.dto.VulnerabilityDetails
+import com.scanoss.dto.enums.MatchType
+import com.scanoss.dto.enums.StatusType
 import com.scanoss.utils.JsonUtils
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -257,4 +266,39 @@ class ScanOssResultParserTest : WordSpec({
             summary.snippetFindings should haveSize(1)
         }
     }
+
+    "getSnippetFindings()" should {
+        "use NOASSERTION for empty license findings" {
+            getSnippetFindings(dummyDetails, "dummy").shouldBeSingleton { finding ->
+                finding.snippets.shouldBeSingleton { snippet ->
+                    snippet.license shouldBe SpdxExpression.NOASSERTION
+                }
+            }
+        }
+    }
 })
+
+private val dummyDetails = ScanFileDetails(
+    MatchType.snippet,
+    "component",
+    "vendor",
+    "1.0.0",
+    "2.0.0",
+    "url",
+    StatusType.pending,
+    "100%",
+    "file",
+    "100-200",
+    "200-300",
+    "fileHash",
+    "fileUrl",
+    "urlHash",
+    "releaseDate",
+    "sourceHash",
+    arrayOf("purl1", "purl2"),
+    ServerDetails("version", ServerDetails.KbVersion("monthly", "daily")),
+    arrayOf<LicenseDetails>(),
+    arrayOf<QualityDetails>(),
+    arrayOf<VulnerabilityDetails>(),
+    arrayOf<CopyrightDetails>()
+)

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -68,10 +68,11 @@ class ScanOssResultParserTest : WordSpec({
                 "EPL-1.0",
                 "MIT",
                 "LicenseRef-scancode-free-unknown",
-                "LicenseRef-scanoss-SSPL"
+                "LicenseRef-scanoss-SSPL",
+                "NOASSERTION"
             )
 
-            summary.licenseFindings should haveSize(201)
+            summary.licenseFindings should haveSize(362)
             summary.licenseFindings shouldContain LicenseFinding(
                 license = "Apache-2.0",
                 location = TextLocation(
@@ -268,6 +269,12 @@ class ScanOssResultParserTest : WordSpec({
     }
 
     "getLicenseFindings()" should {
+        "use NOASSERTION for empty license findings" {
+            getLicenseFindings(dummyDetails, "dummy").shouldBeSingleton { finding ->
+                finding.license shouldBe SpdxExpression.NOASSERTION
+            }
+        }
+
         "handle unparsable license names" {
             val detailsWithUnparsableLicense = dummyDetails.toBuilder()
                 .licenseDetails(

--- a/utils/spdx-expression/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx-expression/src/main/kotlin/SpdxExpression.kt
@@ -68,6 +68,16 @@ sealed class SpdxExpression {
 
     companion object {
         /**
+         * A constant for [NONE][SpdxConstants.NONE] as an expression.
+         */
+        val NONE = SpdxLicenseIdExpression(SpdxConstants.NONE)
+
+        /**
+         * A constant for [NOASSERTION][SpdxConstants.NOASSERTION] as an expression.
+         */
+        val NOASSERTION = SpdxLicenseIdExpression(SpdxConstants.NOASSERTION)
+
+        /**
          * The "WITH" keyword, used to concatenate a license with an exception.
          */
         const val WITH = "WITH"


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 

This is an alternative to https://github.com/oss-review-toolkit/ort/pull/12056 with the goal to align the license mapping for both snippet and license findings.