### PR TITLE
Support multiple license fact providers of the same type

### DIFF
--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -34,7 +34,6 @@ import java.io.File
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.ort.ORT_CUSTOM_LICENSE_TEXTS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_FAILURE_STATUS_CODE
@@ -88,10 +87,10 @@ data class OrtConfiguration(
      * license facts, license facts from a local ScanCode installation, and license facts from the default
      * [ORT_CUSTOM_LICENSE_TEXTS_DIRNAME].
      */
-    val licenseFactProviders: LinkedHashMap<String, PluginConfig> = linkedMapOf(
-        "DefaultDir" to PluginConfig.EMPTY,
-        "SPDX" to PluginConfig.EMPTY,
-        "ScanCode" to PluginConfig.EMPTY
+    val licenseFactProviders: List<ProviderPluginConfiguration> = listOf(
+        ProviderPluginConfiguration(type = "DefaultDir"),
+        ProviderPluginConfiguration(type = "SPDX"),
+        ProviderPluginConfiguration(type = "ScanCode")
     ),
 
     /**

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -38,8 +38,13 @@ ort:
   licenseFactProviders:
   - type: "DefaultDir"
   - type: "Dir"
+    id: "local-custom-license-texts"
     options:
-      licenseTextDir: '/path/to/license/text/dir'
+      licenseTextDir: '/project-sources/.ort/custom-license-texts'
+  - type: "Dir"
+    id: "global-custom-license-texts"
+    options:
+      licenseTextDir: '/ort-config/custom-license-texts'
   - type: "SPDX"
   - type: "ScanCode"
     options:

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -36,14 +36,14 @@ ort:
 
   # License fact providers, ordered from highest to lowest priority.
   licenseFactProviders:
-    SPDX: {}
-    ScanCode:
-      options:
-        scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
-    DefaultDir: {}
-    Dir:
-      options:
-        licenseTextDir: '/path/to/license/text/dir'
+  - type: "SPDX"
+  - type: "ScanCode"
+    options:
+      scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
+  - type: "DefaultDir"
+  - type: "Dir"
+    options:
+      licenseTextDir: '/path/to/license/text/dir'
 
   licenseFilePatterns:
     licenseFilenames: ['license*']

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -36,14 +36,14 @@ ort:
 
   # License fact providers, ordered from highest to lowest priority.
   licenseFactProviders:
-  - type: "SPDX"
-  - type: "ScanCode"
-    options:
-      scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
   - type: "DefaultDir"
   - type: "Dir"
     options:
       licenseTextDir: '/path/to/license/text/dir'
+  - type: "SPDX"
+  - type: "ScanCode"
+    options:
+      scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
 
   licenseFilePatterns:
     licenseFilenames: ['license*']

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -63,7 +63,13 @@ class OrtConfigurationTest : WordSpec({
                 ProviderPluginConfiguration(type = "DefaultDir"),
                 ProviderPluginConfiguration(
                     type = "Dir",
-                    options = mapOf("licenseTextDir" to "/path/to/license/text/dir")
+                    id = "local-custom-license-texts",
+                    options = mapOf("licenseTextDir" to "/project-sources/.ort/custom-license-texts")
+                ),
+                ProviderPluginConfiguration(
+                    type = "Dir",
+                    id = "global-custom-license-texts",
+                    options = mapOf("licenseTextDir" to "/ort-config/custom-license-texts")
                 ),
                 ProviderPluginConfiguration(type = "SPDX"),
                 ProviderPluginConfiguration(

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -40,7 +40,6 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.SourceCodeOrigin
-import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.ort.ORT_REFERENCE_CONFIG_FILENAME
 
@@ -60,11 +59,17 @@ class OrtConfigurationTest : WordSpec({
 
             ortConfig.forceOverwrite shouldBe true
 
-            ortConfig.licenseFactProviders should containExactlyEntries(
-                "spdx" to PluginConfig.EMPTY,
-                "scancode" to PluginConfig(mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")),
-                "defaultdir" to PluginConfig.EMPTY,
-                "dir" to PluginConfig(mapOf("licenseTextDir" to "/path/to/license/text/dir"))
+            ortConfig.licenseFactProviders should containExactly(
+                ProviderPluginConfiguration(type = "SPDX"),
+                ProviderPluginConfiguration(
+                    type = "ScanCode",
+                    options = mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")
+                ),
+                ProviderPluginConfiguration(type = "DefaultDir"),
+                ProviderPluginConfiguration(
+                    type = "Dir",
+                    options = mapOf("licenseTextDir" to "/path/to/license/text/dir")
+                )
             )
 
             with(ortConfig.licenseFilePatterns) {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -60,15 +60,15 @@ class OrtConfigurationTest : WordSpec({
             ortConfig.forceOverwrite shouldBe true
 
             ortConfig.licenseFactProviders should containExactly(
-                ProviderPluginConfiguration(type = "SPDX"),
-                ProviderPluginConfiguration(
-                    type = "ScanCode",
-                    options = mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")
-                ),
                 ProviderPluginConfiguration(type = "DefaultDir"),
                 ProviderPluginConfiguration(
                     type = "Dir",
                     options = mapOf("licenseTextDir" to "/path/to/license/text/dir")
+                ),
+                ProviderPluginConfiguration(type = "SPDX"),
+                ProviderPluginConfiguration(
+                    type = "ScanCode",
+                    options = mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")
                 )
             )
 

--- a/plugins/commands/reporter/src/main/kotlin/ReportCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReportCommand.kt
@@ -64,7 +64,6 @@ import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
-import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.licensefactproviders.dir.DirLicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.CompositePackageConfigurationProvider
@@ -263,16 +262,12 @@ class ReportCommand(descriptor: PluginDescriptor = ReportCommandFactory.descript
             HowToFixTextProvider.fromKotlinScript(it.readText(), ortResult)
         } ?: HowToFixTextProvider.NONE
 
-        val licenseFactProviders = mutableListOf<LicenseFactProvider>()
+        val licenseFactProviders = buildList {
+            customLicenseTextsDir?.also {
+                add(DirLicenseFactProviderFactory.create(it.absolutePath))
+            }
 
-        customLicenseTextsDir?.let {
-            licenseFactProviders += DirLicenseFactProviderFactory.create(it.absolutePath)
-        }
-
-        ortConfig.licenseFactProviders.mapTo(licenseFactProviders) { (id, config) ->
-            requireNotNull(LicenseFactProviderFactory.ALL[id]) {
-                "License fact provider '$id' is not available in the classpath."
-            }.create(config)
+            addAll(LicenseFactProviderFactory.create(ortConfig.licenseFactProviders).map { it.second })
         }
 
         val licenseFactProvider = CompositeLicenseFactProvider(licenseFactProviders)

--- a/plugins/license-fact-providers/api/build.gradle.kts
+++ b/plugins/license-fact-providers/api/build.gradle.kts
@@ -25,4 +25,6 @@ plugins {
 dependencies {
     api(projects.model)
     api(projects.plugins.api)
+
+    implementation(projects.utils.commonUtils)
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProviderFactory.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProviderFactory.kt
@@ -19,7 +19,12 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
+import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.plugins.api.PluginFactory
+import org.ossreviewtoolkit.utils.common.getDuplicates
 
 /** A factory for [LicenseFactProvider]s. */
 interface LicenseFactProviderFactory : PluginFactory<LicenseFactProvider> {
@@ -29,5 +34,34 @@ interface LicenseFactProviderFactory : PluginFactory<LicenseFactProvider> {
          * their IDs.
          */
         val ALL by lazy { PluginFactory.getAll<LicenseFactProviderFactory, LicenseFactProvider>() }
+
+        /**
+         * Create a new (identifier, provider instance) tuple for each
+         * [enabled][ProviderPluginConfiguration.enabled] provider configuration in [configurations] ordered
+         * highest priority first. The given [configurations] must be ordered highest-priority first as well.
+         */
+        fun create(configurations: List<ProviderPluginConfiguration>): List<Pair<String, LicenseFactProvider>> =
+            configurations.filter {
+                it.enabled
+            }.mapNotNull {
+                ALL[it.type]?.let { factory ->
+                    it.id to factory.create(PluginConfig(it.options))
+                }.also { factory ->
+                    factory ?: logger.error {
+                        "License fact provider of type '${it.type}' is enabled in configuration but not available " +
+                            "in the classpath."
+                    }
+                }
+            }.apply {
+                require(none { (id, _) -> id.isBlank() }) {
+                    "The configuration contains a license fact provider with a blank ID which is not allowed."
+                }
+
+                val duplicateIds = getDuplicates { (id, _) -> id }.keys
+                require(duplicateIds.isEmpty()) {
+                    "Found multiple license fact providers for the IDs ${duplicateIds.joinToString()}, " +
+                        "which is not allowed. Please configure a unique ID for each license fact provider."
+                }
+            }
     }
 }


### PR DESCRIPTION
Allow to configure multiple instances of the same provider type. This flexibility can be used to organize the upcoming identifier-specific license text in a directory separate from the identifier-agnostic custom license texts.

**Breaking change:** This change is not backwards compatible with regards to
                 deserializing ORT's `config.yml`. The changes in
                 `reference.yml` illustrate the needed alignments.

Part of #11668.