### PR TITLE
scanner: Add a note about the Provenant integration being experimental

### DIFF
--- a/plugins/scanners/scancode/src/main/kotlin/Provenant.kt
+++ b/plugins/scanners/scancode/src/main/kotlin/Provenant.kt
@@ -50,7 +50,8 @@ internal object ProvenantCommand : CommandLineTool {
 }
 
 /**
- * A wrapper for [Provenant](https://github.com/mstykow/provenant).
+ * A wrapper for [Provenant](https://github.com/mstykow/provenant). This is experimental currently while Provenant is
+ * still in the inital development phase and the quality of results needs to be verified.
  */
 @OrtPlugin(
     displayName = "Provenant",


### PR DESCRIPTION
The KDoc of classes with the `@OrtPlugin` annotation is rendered as official documentation, in this case at [1].

[1]: https://oss-review-toolkit.org/ort/docs/plugins/scanners/Provenant