### PR TITLE
chore(website): Replace deprecated `onBrokenMarkdownLinks`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -25,7 +25,6 @@ const config = {
 
   onBrokenAnchors: 'throw',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
@@ -33,6 +32,13 @@ const config = {
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
+  },
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownImages: 'throw',
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
 
   presets: [


### PR DESCRIPTION
The option is now configured in the `markdown.hooks` section [1].

[1]: https://docusaurus.io/docs/api/docusaurus-config#markdown