### PR TITLE
docs(examples): Correct Apache-2.0 license spelling

### DIFF
--- a/examples/example.rules.kts
+++ b/examples/example.rules.kts
@@ -337,7 +337,7 @@ fun RuleSet.wrongLicenseInLicenseFileRule() = projectSourceRule("WRONG_LICENSE_I
         +projectSourceHasFile("LICENSE")
     }
 
-    val allowedRootLicenses = setOf("Apackage-2.0", "MIT")
+    val allowedRootLicenses = setOf("Apache-2.0", "MIT")
     val detectedRootLicenses = projectSourceGetDetectedLicensesByFilePath("LICENSE").values.flatten().toSet()
     val wrongLicenses = detectedRootLicenses - allowedRootLicenses
 


### PR DESCRIPTION
Corrects a misprint in the documentation where "APackage-2.0" was incorrectly listed as the license. I believe it is now correctly referenced as "Apache-2.0"