### PR TITLE
License text curations PoC

### DIFF
--- a/model/src/main/kotlin/LicenseTextCuration.kt
+++ b/model/src/main/kotlin/LicenseTextCuration.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxSingleLicenseExpression
+
+data class LicenseTextCuration(
+    /**
+     * The license identifier to which to add the license.
+     */
+    val licenseId: SpdxSingleLicenseExpression,
+
+    /**
+     * A plain-text comment about this license text curation. Should contain information about how and why this
+     * license text curation was created.
+     */
+    val comment: String? = null,
+
+    /**
+     * The license text (variant) to associate with the corresponding [licenseId] and [identifier][PackageCuration.id].
+     */
+    val licenseText: String
+) {
+    init {
+        require(licenseText.isNotBlank()) {
+            "The license text must not be blank."
+        }
+    }
+}

--- a/model/src/main/kotlin/LicenseTextCurations.kt
+++ b/model/src/main/kotlin/LicenseTextCurations.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+data class LicenseTextCurations(
+    /**
+     * The identifier of the package, analog to [PackageCuration.id].
+     */
+    val id: Identifier,
+
+    /**
+     * The curations for [id].
+     */
+    val curations: List<LicenseTextCuration>
+) {
+    init {
+        require(curations.isNotEmpty()) {
+            "The curations must not be empty."
+        }
+    }
+}

--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -21,9 +21,7 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.ossreviewtoolkit.model.utils.idMatchesDisregardingVersion
-import org.ossreviewtoolkit.model.utils.isApplicableIvyVersion
-import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
+import org.ossreviewtoolkit.model.utils.idMatches
 
 /**
  * This class assigns a [PackageCurationData] object to a [Package] identified by the [id].
@@ -45,9 +43,7 @@ data class PackageCuration(
      * curation's version may be an
      * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
      */
-    fun isApplicable(pkgId: Identifier): Boolean =
-        idMatchesDisregardingVersion(id, pkgId)
-            && (id.version.equalsOrIsBlank(pkgId.version) || id.isApplicableIvyVersion(pkgId))
+    fun isApplicable(pkgId: Identifier): Boolean = idMatches(id, pkgId)
 
     /**
      * Apply the curation [data] to the provided [basePackage] by calling [PackageCurationData.apply], if applicable.

--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import org.ossreviewtoolkit.model.utils.idMatchesDisregardingVersion
 import org.ossreviewtoolkit.model.utils.isApplicableIvyVersion
 import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
 
@@ -40,21 +41,12 @@ data class PackageCuration(
     val data: PackageCurationData
 ) {
     /**
-     * Return true if this [PackageCuration] is applicable to the package with the given [identifier][pkgId],
-     * disregarding the version.
-     */
-    private fun isApplicableDisregardingVersion(pkgId: Identifier) =
-        id.type.equals(pkgId.type, ignoreCase = true)
-            && id.namespace == pkgId.namespace
-            && id.name.equalsOrIsBlank(pkgId.name)
-
-    /**
      * Return true if this [PackageCuration] is applicable to the package with the given [identifier][pkgId]. The
      * curation's version may be an
      * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
      */
     fun isApplicable(pkgId: Identifier): Boolean =
-        isApplicableDisregardingVersion(pkgId)
+        idMatchesDisregardingVersion(id, pkgId)
             && (id.version.equalsOrIsBlank(pkgId.version) || id.isApplicableIvyVersion(pkgId))
 
     /**

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -34,7 +34,6 @@ import java.io.File
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.ort.ORT_CUSTOM_LICENSE_TEXTS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_FAILURE_STATUS_CODE
@@ -88,10 +87,10 @@ data class OrtConfiguration(
      * license facts, license facts from a local ScanCode installation, and license facts from the default
      * [ORT_CUSTOM_LICENSE_TEXTS_DIRNAME].
      */
-    val licenseFactProviders: LinkedHashMap<String, PluginConfig> = linkedMapOf(
-        "DefaultDir" to PluginConfig.EMPTY,
-        "SPDX" to PluginConfig.EMPTY,
-        "ScanCode" to PluginConfig.EMPTY
+    val licenseFactProviders: List<ProviderPluginConfiguration> = listOf(
+        ProviderPluginConfiguration(type = "DefaultDir"),
+        ProviderPluginConfiguration(type = "SPDX"),
+        ProviderPluginConfiguration(type = "ScanCode")
     ),
 
     /**

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.utils
 import java.net.URI
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
@@ -29,6 +30,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
 import org.ossreviewtoolkit.utils.common.getDuplicates
 
 fun String.prependPath(prefix: String): String = if (prefix.isBlank()) this else "${prefix.removeSuffix("/")}/$this"
@@ -95,3 +97,11 @@ internal fun List<SourceCodeOrigin>.requireNoDuplicates() {
         "'sourceCodeOrigins' must not contain duplicates. Duplicates: $duplicates"
     }
 }
+
+/**
+ * Return true if the [matcher] is matches the given [identifier][id], disregarding the version.
+ */
+internal fun idMatchesDisregardingVersion(matcher: Identifier, id: Identifier) =
+    matcher.type.equals(id.type, ignoreCase = true)
+        && matcher.namespace == id.namespace
+        && matcher.name.equalsOrIsBlank(id.name)

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -105,3 +105,11 @@ internal fun idMatchesDisregardingVersion(matcher: Identifier, id: Identifier) =
     matcher.type.equals(id.type, ignoreCase = true)
         && matcher.namespace == id.namespace
         && matcher.name.equalsOrIsBlank(id.name)
+
+/**
+ * Return true if the [matcher] matches  the given [identifier][id]. The [matcher]s version may be an
+ * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
+ */
+internal fun idMatches(matcher: Identifier, id: Identifier): Boolean =
+    idMatchesDisregardingVersion(matcher, id)
+        && (matcher.version.equalsOrIsBlank(id.version) || matcher.isApplicableIvyVersion(id))

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -110,6 +110,6 @@ internal fun idMatchesDisregardingVersion(matcher: Identifier, id: Identifier) =
  * Return true if the [matcher] matches  the given [identifier][id]. The [matcher]s version may be an
  * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
  */
-internal fun idMatches(matcher: Identifier, id: Identifier): Boolean =
+fun idMatches(matcher: Identifier, id: Identifier): Boolean =
     idMatchesDisregardingVersion(matcher, id)
         && (matcher.version.equalsOrIsBlank(id.version) || matcher.isApplicableIvyVersion(id))

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -36,14 +36,14 @@ ort:
 
   # License fact providers, ordered from highest to lowest priority.
   licenseFactProviders:
-    SPDX: {}
-    ScanCode:
-      options:
-        scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
-    DefaultDir: {}
-    Dir:
-      options:
-        licenseTextDir: '/path/to/license/text/dir'
+  - type: "SPDX"
+  - type: "ScanCode"
+    options:
+      scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
+  - type: "DefaultDir"
+  - type: "Dir"
+    options:
+      licenseTextDir: '/path/to/license/text/dir'
 
   licenseFilePatterns:
     licenseFilenames: ['license*']

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -40,7 +40,6 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.SourceCodeOrigin
-import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.ort.ORT_REFERENCE_CONFIG_FILENAME
 
@@ -60,11 +59,17 @@ class OrtConfigurationTest : WordSpec({
 
             ortConfig.forceOverwrite shouldBe true
 
-            ortConfig.licenseFactProviders should containExactlyEntries(
-                "spdx" to PluginConfig.EMPTY,
-                "scancode" to PluginConfig(mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")),
-                "defaultdir" to PluginConfig.EMPTY,
-                "dir" to PluginConfig(mapOf("licenseTextDir" to "/path/to/license/text/dir"))
+            ortConfig.licenseFactProviders should containExactly(
+                ProviderPluginConfiguration(type = "SPDX"),
+                ProviderPluginConfiguration(
+                    type = "ScanCode",
+                    options = mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")
+                ),
+                ProviderPluginConfiguration(type = "DefaultDir"),
+                ProviderPluginConfiguration(
+                    type = "Dir",
+                    options = mapOf("licenseTextDir" to "/path/to/license/text/dir")
+                )
             )
 
             with(ortConfig.licenseFilePatterns) {

--- a/plugins/commands/reporter/src/main/kotlin/ReportCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReportCommand.kt
@@ -263,16 +263,12 @@ class ReportCommand(descriptor: PluginDescriptor = ReportCommandFactory.descript
             HowToFixTextProvider.fromKotlinScript(it.readText(), ortResult)
         } ?: HowToFixTextProvider.NONE
 
-        val licenseFactProviders = mutableListOf<LicenseFactProvider>()
+        val licenseFactProviders = buildList<LicenseFactProvider> {
+            customLicenseTextsDir?.let {
+                this += DirLicenseFactProviderFactory.create(it.absolutePath)
+            }
 
-        customLicenseTextsDir?.let {
-            licenseFactProviders += DirLicenseFactProviderFactory.create(it.absolutePath)
-        }
-
-        ortConfig.licenseFactProviders.mapTo(licenseFactProviders) { (id, config) ->
-            requireNotNull(LicenseFactProviderFactory.ALL[id]) {
-                "License fact provider '$id' is not available in the classpath."
-            }.create(config)
+            this += LicenseFactProviderFactory.create2(ortConfig.licenseFactProviders).map { it.second }
         }
 
         val licenseFactProvider = CompositeLicenseFactProvider(licenseFactProviders)

--- a/plugins/license-fact-providers/api/build.gradle.kts
+++ b/plugins/license-fact-providers/api/build.gradle.kts
@@ -25,4 +25,6 @@ plugins {
 dependencies {
     api(projects.model)
     api(projects.plugins.api)
+
+    implementation(projects.utils.commonUtils)
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -44,9 +44,9 @@ class CompositeLicenseFactProvider(
     override fun getLicenseText(licenseOrExceptionId: String) =
         providers.firstNotNullOfOrNull { it.getLicenseText(licenseOrExceptionId) }
 
-    override fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
-        providers.any { it.hasLicenseTextForId(singleLicenseExpression, id) }
+    override fun hasLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        providers.any { it.hasLicenseTextsForId(singleLicenseExpression, id) }
 
-    override fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? =
-        providers.firstNotNullOfOrNull { it.getLicenseTextForId(singleLicenseExpression, id) }
+    override fun getLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<LicenseText> =
+        providers.flatMapTo(mutableSetOf()) { it.getLicenseTextsForId(singleLicenseExpression, id) }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/CompositeLicenseFactProvider.kt
@@ -38,13 +38,15 @@ class CompositeLicenseFactProvider(
         summary = "A license fact provider that aggregates multiple license fact providers."
     )
 
-    override fun hasLicenseText(licenseId: String) = providers.any { it.hasLicenseText(licenseId) }
+    override fun hasLicenseText(licenseOrExceptionId: String) =
+        providers.any { it.hasLicenseText(licenseOrExceptionId) }
 
-    override fun getLicenseText(licenseId: String) = providers.firstNotNullOfOrNull { it.getLicenseText(licenseId) }
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        providers.firstNotNullOfOrNull { it.getLicenseText(licenseOrExceptionId) }
 
-    override fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
-        providers.any { it.hasLicenseTextForId(licenseId, id) }
+    override fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        providers.any { it.hasLicenseTextForId(singleLicenseExpression, id) }
 
-    override fun getLicenseTextForId(licenseId: String, id: Identifier): LicenseText? =
-        providers.firstNotNullOfOrNull { it.getLicenseTextForId(licenseId, id) }
+    override fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? =
+        providers.firstNotNullOfOrNull { it.getLicenseTextForId(singleLicenseExpression, id) }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -21,58 +21,82 @@ package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.plugins.api.Plugin
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxSingleLicenseExpression
 
 /** A provider for license facts. */
 abstract class LicenseFactProvider : Plugin {
-    /** Return `true´ if this provider has a license text for the given [licenseId]. */
-    abstract fun hasLicenseText(licenseId: String): Boolean
+    /** Return `true´ if this provider has a license text for the given [licenseOrExceptionId]. */
+    abstract fun hasLicenseText(licenseOrExceptionId: String): Boolean
 
-    /** Return a [LicenseText] for the given [licenseId], or `null` if no valid text is available. */
-    abstract fun getLicenseText(licenseId: String): LicenseText?
-
-    /** Return `true´ if this provider has an id-specific license text for the given [licenseId] and [id]. */
-    open fun hasLicenseTextForId(licenseId: String, id: Identifier): Boolean =
-        getLicenseTextForId(licenseId, id) != null
+    /** Return a [LicenseText] for the given [licenseOrExceptionId], or `null` if no valid text is available. */
+    abstract fun getLicenseText(licenseOrExceptionId: String): LicenseText?
 
     /**
-     * Return an id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
-     * available.
-     */
-    open fun getLicenseTextForId(licenseId: String, id: Identifier): LicenseText? = null
+     * Return `true´ if this provider has an id-specific license text for the given [singleLicenseExpression] and [id].
+     **/
+    open fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        getLicenseTextForId(singleLicenseExpression, id) != null
 
     /**
-     * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific
-     * license text for [licenseId], or `null` if no such text is available.
+     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no such text
+     * is available.
      */
-    fun hasLicenseText(licenseId: String, id: Identifier): Boolean =
-        hasLicenseText(licenseId, id) || hasLicenseText(licenseId)
+    open fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? = null
 
     /**
-     * Return an id-specific [LicenseText] for the given [licenseId] and [id] if available, or the non-id-specific
-     * license text for [licenseId], or `null` if no such text is available.
+     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
+     * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
-    fun getLicenseText(licenseId: String, id: Identifier): LicenseText? =
-        getLicenseTextForId(licenseId, id) ?: getLicenseText(licenseId)
+    fun hasLicenseText(singleLicenseExpression: String, id: Identifier): Boolean {
+        if (hasLicenseText(singleLicenseExpression, id)) return true
 
-    /** Return a non-blank license text for the given [licenseId], or `null` if no valid text is available. */
+        val spdxExpression = SpdxSingleLicenseExpression.parse(singleLicenseExpression)
+        if (!hasLicenseText(spdxExpression.simpleLicense())) return false
+
+        return spdxExpression.exception()?.let { hasLicenseText(it) } == true
+    }
+
+    /**
+     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
+     * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
+     */
+    fun getLicenseText(singleLicenseExpression: String, id: Identifier): LicenseText? =
+        getLicenseTextForId(singleLicenseExpression, id) ?: LicenseText(
+            buildString {
+                val spdxExpression = SpdxSingleLicenseExpression.parse(singleLicenseExpression)
+                val licenseText = getLicenseText(spdxExpression.simpleLicense()) ?: return null
+                val exceptionText = spdxExpression.exception()?.let { getLicenseText(it) ?: return null }
+
+                append(licenseText.text)
+                if (exceptionText != null) {
+                    appendLine()
+                    append(exceptionText.text)
+                }
+            }.trim()
+        )
+
+    /**
+     * Return a non-blank license text for the given [licenseOrExceptionId], or `null` if no valid text is available.
+     */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String): String? = getLicenseText(licenseId)?.text
+    fun getNonBlankLicenseText(licenseOrExceptionId: String): String? = getLicenseText(licenseOrExceptionId)?.text
 
     /**
-     * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id], or `null` if no such text is
-     * available.
+     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no
+     * such text is available.
      */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseTextForId")
-    fun getNonBlankLicenseTextForId(licenseId: String, id: Identifier): String? =
-        getLicenseTextForId(licenseId, id)?.text
+    fun getNonBlankLicenseTextForId(singleLicenseExpression: String, id: Identifier): String? =
+        getLicenseTextForId(singleLicenseExpression, id)?.text
 
     /**
-     * Return a non-blank id-specific [LicenseText] for the given [licenseId] and [id] if available, or the
-     * non-id-specific license text for [licenseId], or `null` if no such text is available.
+     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or
+     * the non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
     @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(licenseId: String, id: Identifier): String? = getLicenseText(licenseId, id)?.text
+    fun getNonBlankLicenseText(singleLicenseExpression: String, id: Identifier): String? =
+        getLicenseText(singleLicenseExpression, id)?.text
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProvider.kt
@@ -33,22 +33,22 @@ abstract class LicenseFactProvider : Plugin {
 
     /**
      * Return `true´ if this provider has an id-specific license text for the given [singleLicenseExpression] and [id].
-     **/
-    open fun hasLicenseTextForId(singleLicenseExpression: String, id: Identifier): Boolean =
-        getLicenseTextForId(singleLicenseExpression, id) != null
+     */
+    open fun hasLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        getLicenseTextsForId(singleLicenseExpression, id).isNotEmpty()
 
     /**
-     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no such text
-     * is available.
+     * Return all id-specific [LicenseText]s for the given [singleLicenseExpression] and [id], or an empty set if no
+     * such text is available.
      */
-    open fun getLicenseTextForId(singleLicenseExpression: String, id: Identifier): LicenseText? = null
+    open fun getLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<LicenseText> = emptySet()
 
     /**
-     * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
-     * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
+     * Return `true` if any id-specific [LicenseText]s for the given [singleLicenseExpression] and [id], or if a
+     * non-id-specific license text for [singleLicenseExpression] is available, or `false` otherwise.
      */
-    fun hasLicenseText(singleLicenseExpression: String, id: Identifier): Boolean {
-        if (hasLicenseText(singleLicenseExpression, id)) return true
+    fun hasLicenseTexts(singleLicenseExpression: String, id: Identifier): Boolean {
+        if (hasLicenseTextsForId(singleLicenseExpression, id)) return true
 
         val spdxExpression = SpdxSingleLicenseExpression.parse(singleLicenseExpression)
         if (!hasLicenseText(spdxExpression.simpleLicense())) return false
@@ -60,20 +60,22 @@ abstract class LicenseFactProvider : Plugin {
      * Return an id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or the
      * non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
      */
-    fun getLicenseText(singleLicenseExpression: String, id: Identifier): LicenseText? =
-        getLicenseTextForId(singleLicenseExpression, id) ?: LicenseText(
-            buildString {
+    fun getLicenseTexts(singleLicenseExpression: String, id: Identifier): Set<LicenseText> =
+        getLicenseTextsForId(singleLicenseExpression, id).takeIf { it.isNotEmpty() }
+            ?: buildString {
                 val spdxExpression = SpdxSingleLicenseExpression.parse(singleLicenseExpression)
-                val licenseText = getLicenseText(spdxExpression.simpleLicense()) ?: return null
-                val exceptionText = spdxExpression.exception()?.let { getLicenseText(it) ?: return null }
+                val licenseText = getLicenseText(spdxExpression.simpleLicense()) ?: return emptySet()
+                val exceptionText = spdxExpression.exception()?.let {
+                    getLicenseText(it) ?: return emptySet()
+                }
 
                 append(licenseText.text)
                 if (exceptionText != null) {
                     appendLine()
                     append(exceptionText.text)
                 }
-            }.trim()
-        )
+
+            }.trim().let { setOf(LicenseText(it)) }
 
     /**
      * Return a non-blank license text for the given [licenseOrExceptionId], or `null` if no valid text is available.
@@ -82,21 +84,16 @@ abstract class LicenseFactProvider : Plugin {
     @JvmName("getLicenseText")
     fun getNonBlankLicenseText(licenseOrExceptionId: String): String? = getLicenseText(licenseOrExceptionId)?.text
 
-    /**
-     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id], or `null` if no
-     * such text is available.
-     */
-    @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
-    @JvmName("getLicenseTextForId")
-    fun getNonBlankLicenseTextForId(singleLicenseExpression: String, id: Identifier): String? =
-        getLicenseTextForId(singleLicenseExpression, id)?.text
+    @JvmName("getLicenseTextsStringForId")
+    fun getNonBlankLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<String> =
+        getLicenseTextsForId(singleLicenseExpression, id).mapTo(mutableSetOf()) { it.text }
 
     /**
-     * Return a non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or
-     * the non-id-specific license text for [singleLicenseExpression], or `null` if no such text is available.
+     * Return all non-blank id-specific [LicenseText] for the given [singleLicenseExpression] and [id] if available, or
+     * the non-id-specific license text for [singleLicenseExpression], or an empty set if no such text is available.
      */
     @Deprecated("Java-only API", level = DeprecationLevel.HIDDEN)
-    @JvmName("getLicenseText")
-    fun getNonBlankLicenseText(singleLicenseExpression: String, id: Identifier): String? =
-        getLicenseText(singleLicenseExpression, id)?.text
+    @JvmName("getLicenseTextsString")
+    fun getNonBlankLicenseTexts(singleLicenseExpression: String, id: Identifier): Set<String> =
+        getLicenseTexts(singleLicenseExpression, id).mapTo(mutableSetOf()) { it.text }
 }

--- a/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProviderFactory.kt
+++ b/plugins/license-fact-providers/api/src/main/kotlin/LicenseFactProviderFactory.kt
@@ -19,7 +19,12 @@
 
 package org.ossreviewtoolkit.plugins.licensefactproviders.api
 
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
+import org.ossreviewtoolkit.plugins.api.PluginConfig
 import org.ossreviewtoolkit.plugins.api.PluginFactory
+import org.ossreviewtoolkit.utils.common.getDuplicates
 
 /** A factory for [LicenseFactProvider]s. */
 interface LicenseFactProviderFactory : PluginFactory<LicenseFactProvider> {
@@ -29,5 +34,34 @@ interface LicenseFactProviderFactory : PluginFactory<LicenseFactProvider> {
          * their IDs.
          */
         val ALL by lazy { PluginFactory.getAll<LicenseFactProviderFactory, LicenseFactProvider>() }
+
+        /**
+         * Create a new (identifier, provider instance) tuple for each
+         * [enabled][ProviderPluginConfiguration.enabled] provider configuration in [configurations] ordered
+         * highest priority first. The given [configurations] must be ordered highest-priority first as well.
+         */
+        fun create2(configurations: List<ProviderPluginConfiguration>): List<Pair<String, LicenseFactProvider>> =
+            configurations.filter {
+                it.enabled
+            }.mapNotNull {
+                ALL[it.type]?.let { factory ->
+                    it.id to factory.create(PluginConfig(it.options))
+                }.also { factory ->
+                    factory ?: logger.error {
+                        "Configuration provider of type '${it.type}' is enabled in configuration but not available " +
+                            "in the classpath."
+                    }
+                }
+            }.apply {
+                require(none { (id, _) -> id.isBlank() }) {
+                    "The configuration contains a license fact provider with a blank ID which is not allowed."
+                }
+
+                val duplicateIds = getDuplicates { (id, _) -> id }.keys
+                require(duplicateIds.isEmpty()) {
+                    "Found multiple license fact providers for the IDs ${duplicateIds.joinToString()}, " +
+                        "which is not allowed. Please configure a unique ID for each package configuration provider."
+                }
+            }
     }
 }

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -20,9 +20,15 @@
 package org.ossreviewtoolkit.plugins.licensefactproviders.dir
 
 import java.io.File
+import java.io.IOException
 
 import org.apache.logging.log4j.kotlin.logger
 
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseTextCuration
+import org.ossreviewtoolkit.model.LicenseTextCurations
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.idMatches
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
@@ -74,13 +80,42 @@ open class DirLicenseFactProvider(
         }
     }
 
-    override fun getLicenseText(licenseOrExceptionId: String) =
-        getLicenseTextFile(licenseOrExceptionId)?.readText()?.let { LicenseText(it) }
+    /** A cache with entries for license text curation files to read each file at most once. */
+    private val licenseTextCurationsForIdWithoutVersion = mutableMapOf<Identifier, List<LicenseTextCurations>>()
 
-    override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextFile(licenseOrExceptionId) != null
+    private fun getCurationsForId(id: Identifier): List<LicenseTextCuration> =
+        licenseTextCurationsForIdWithoutVersion.getOrPut(id.copy(version = "")) {
+            val relativeCurationFilePath = "${id.toPath(emptyValue = "_").substringBeforeLast("/")}.yml"
+            val curationFile = licenseTextDir.resolve(relativeCurationFilePath).takeIf { it.isFile }
+
+            curationFile?.let { file ->
+                runCatching {
+                    file.readValue<List<LicenseTextCurations>>()
+                }.getOrElse {
+                    throw IOException("Failed reading license text curations from '${file.absolutePath}'.", it)
+                }.also {
+                    logger.info {
+                        "Read ${it.size} license text curations for ${id.toCoordinates()} from ${file.absolutePath}."
+                    }
+                }
+            }.orEmpty()
+        }.filter { idMatches(it.id, id) }.flatMap { it.curations }
 
     private fun getLicenseTextFile(licenseOrExceptionId: String) =
         licenseTextDir.resolve(licenseOrExceptionId).takeIf { it.isFile && it.isNotBlank }
+
+    override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextFile(licenseOrExceptionId) != null
+
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextFile(licenseOrExceptionId)?.readText()?.let { LicenseText(it) }
+
+    override fun hasLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        getCurationsForId(id).any { curation -> curation.licenseId.toString() == singleLicenseExpression }
+
+    override fun getLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<LicenseText> =
+        getCurationsForId(id).mapNotNullTo(mutableSetOf()) { curation ->
+            curation.licenseText.takeIf { curation.licenseId.toString() == singleLicenseExpression }?.let { LicenseText(it) }
+        }
 }
 
 private val File.isNotBlank: Boolean

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -74,12 +74,13 @@ open class DirLicenseFactProvider(
         }
     }
 
-    override fun getLicenseText(licenseId: String) = getLicenseTextFile(licenseId)?.readText()?.let { LicenseText(it) }
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextFile(licenseOrExceptionId)?.readText()?.let { LicenseText(it) }
 
-    override fun hasLicenseText(licenseId: String) = getLicenseTextFile(licenseId) != null
+    override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextFile(licenseOrExceptionId) != null
 
-    private fun getLicenseTextFile(licenseId: String) =
-        licenseTextDir.resolve(licenseId).takeIf { it.isFile && it.isNotBlank }
+    private fun getLicenseTextFile(licenseOrExceptionId: String) =
+        licenseTextDir.resolve(licenseOrExceptionId).takeIf { it.isFile && it.isNotBlank }
 }
 
 private val File.isNotBlank: Boolean

--- a/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
@@ -106,14 +106,15 @@ class ScanCodeLicenseFactProvider(
         return scanCodeLicenseTextDir?.resolve(filename)?.takeIf { it.isFile && it.isNotBlank }
     }
 
-    override fun getLicenseText(licenseId: String) =
-        getLicenseTextFile(licenseId)?.useLines { lines ->
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextFile(licenseOrExceptionId)?.useLines { lines ->
             lines.skipYamlFrontMatter().joinToString("\n").trimEnd()
         }?.let {
             LicenseText(it)
         }
 
-    override fun hasLicenseText(licenseId: String): Boolean = getLicenseTextFile(licenseId) != null
+    override fun hasLicenseText(licenseOrExceptionId: String): Boolean =
+        getLicenseTextFile(licenseOrExceptionId) != null
 }
 
 private val logger = loggerOf(MethodHandles.lookup().lookupClass())

--- a/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/spdx/src/main/kotlin/SpdxLicenseFactProvider.kt
@@ -36,13 +36,13 @@ import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseText
 class SpdxLicenseFactProvider(
     override val descriptor: PluginDescriptor = SpdxLicenseFactProviderFactory.descriptor
 ) : LicenseFactProvider() {
-    override fun getLicenseText(licenseId: String) =
-        getLicenseTextResource(licenseId)?.readText()?.let {
+    override fun getLicenseText(licenseOrExceptionId: String) =
+        getLicenseTextResource(licenseOrExceptionId)?.readText()?.let {
             // It can be safely assumed that the license text is not blank as all SPDX license texts are non-blank.
             LicenseText(it)
         }
 
-    override fun hasLicenseText(licenseId: String) = getLicenseTextResource(licenseId) != null
+    override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextResource(licenseOrExceptionId) != null
 
     private fun getLicenseTextResource(licenseId: String): URL? =
         if (licenseId.isNotEmpty()) {

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -197,10 +197,14 @@ class FreemarkerTemplateProcessor(
         @Suppress("unused") // This function is used in the templates.
         @JvmOverloads
         fun licensesNotInLicenseFiles(
-            resolvedLicenses: List<ResolvedLicense> = license.licenses
+            resolvedLicenses: List<ResolvedLicense> = license.licenses,
+            keepLicensesWithLicenseTextCurations: Boolean = false
         ): List<ResolvedLicense> {
             val outputFileLicenses = licenseFiles.files.flatMap { it.licenses }
-            return resolvedLicenses.filter { it !in outputFileLicenses }
+            return resolvedLicenses.filter { resolvedLicense ->
+                val hasCurations = input.licenseFactProvider.hasLicenseTextsForId(resolvedLicense.license.toString(), id)
+                resolvedLicense !in outputFileLicenses || (keepLicensesWithLicenseTextCurations && hasCurations)
+            }
         }
     }
 


### PR DESCRIPTION
Initial PoC implementation, to be used as a basis for moving to a consensus on how the 
final implementation should look like.

It should include all needed functionality wrt the output notice file.
It does not yet cover how the license fact provider is injected / configured.

See also the ort-config part: https://github.com/oss-review-toolkit/ort-config/pull/446
 