### PR TITLE
Add the feature of license text curations to support setting id-specific license texts

### DIFF
--- a/model/src/main/kotlin/LicenseTextCuration.kt
+++ b/model/src/main/kotlin/LicenseTextCuration.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxSingleLicenseExpression
+
+data class LicenseTextCuration(
+    /**
+     * The SPDX license identifier to which to add license text(s) e.g., BSD-3-Clause or
+     * GPL-2.0-or-later WITH SANE-exception. Accepts SPDX expressions using WITH, but not AND/OR.
+     */
+    val licenseId: SpdxSingleLicenseExpression,
+
+    /**
+     * A plain-text comment about this license text curation. Should contain information about how and why this
+     * license text curation was created.
+     */
+    val comment: String? = null,
+
+    /**
+     * The license text (variant) to associate with the corresponding [licenseId] and [identifier][PackageCuration.id].
+     */
+    val licenseText: String
+) {
+    init {
+        require(licenseText.isNotBlank()) {
+            "The license text must not be blank."
+        }
+    }
+}

--- a/model/src/main/kotlin/LicenseTextCurations.kt
+++ b/model/src/main/kotlin/LicenseTextCurations.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import org.ossreviewtoolkit.model.utils.isMatchedBy
+
+data class LicenseTextCurations(
+    /**
+     * The identifier of the project or package, where the version can be a version range, analog to
+     * [PackageCuration.id].
+     */
+    val id: Identifier,
+
+    /**
+     * The curations for [id].
+     */
+    val curations: List<LicenseTextCuration>
+) {
+    init {
+        require(curations.isNotEmpty()) {
+            "The curations must not be empty."
+        }
+    }
+
+    /**
+     * Return true the enclosed [curations] are applicable to the given [id].
+     */
+    fun isApplicable(id: Identifier): Boolean = id.isMatchedBy(this.id)
+}

--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -21,9 +21,7 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.ossreviewtoolkit.model.utils.isApplicableIvyVersion
-import org.ossreviewtoolkit.model.utils.matchesDisregardingVersion
-import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
+import org.ossreviewtoolkit.model.utils.isMatchedBy
 
 /**
  * This class assigns a [PackageCurationData] object to a [Package] identified by the [id].
@@ -45,9 +43,7 @@ data class PackageCuration(
      * curation's version may be an
      * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
      */
-    fun isApplicable(pkgId: Identifier): Boolean =
-        id.matchesDisregardingVersion(pkgId)
-            && (id.version.equalsOrIsBlank(pkgId.version) || id.isApplicableIvyVersion(pkgId))
+    fun isApplicable(pkgId: Identifier): Boolean = pkgId.isMatchedBy(id)
 
     /**
      * Apply the curation [data] to the provided [basePackage] by calling [PackageCurationData.apply], if applicable.

--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model
 import com.fasterxml.jackson.annotation.JsonProperty
 
 import org.ossreviewtoolkit.model.utils.isApplicableIvyVersion
+import org.ossreviewtoolkit.model.utils.matchesDisregardingVersion
 import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
 
 /**
@@ -40,21 +41,12 @@ data class PackageCuration(
     val data: PackageCurationData
 ) {
     /**
-     * Return true if this [PackageCuration] is applicable to the package with the given [identifier][pkgId],
-     * disregarding the version.
-     */
-    private fun isApplicableDisregardingVersion(pkgId: Identifier) =
-        id.type.equals(pkgId.type, ignoreCase = true)
-            && id.namespace == pkgId.namespace
-            && id.name.equalsOrIsBlank(pkgId.name)
-
-    /**
      * Return true if this [PackageCuration] is applicable to the package with the given [identifier][pkgId]. The
      * curation's version may be an
      * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
      */
     fun isApplicable(pkgId: Identifier): Boolean =
-        isApplicableDisregardingVersion(pkgId)
+        id.matchesDisregardingVersion(pkgId)
             && (id.version.equalsOrIsBlank(pkgId.version) || id.isApplicableIvyVersion(pkgId))
 
     /**

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -86,7 +86,7 @@ data class OrtConfiguration(
      * directory, the bundled SPDX license text, and license texts from a local ScanCode installation.
      */
     val licenseFactProviders: List<ProviderPluginConfiguration> = listOf(
-        ProviderPluginConfiguration(type = "DefaultDir"),
+        ProviderPluginConfiguration(type = "DefaultCustomLicenseTexts"),
         ProviderPluginConfiguration(type = "SPDX"),
         ProviderPluginConfiguration(type = "ScanCode")
     ),

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -87,6 +87,7 @@ data class OrtConfiguration(
      */
     val licenseFactProviders: List<ProviderPluginConfiguration> = listOf(
         ProviderPluginConfiguration(type = "DefaultCustomLicenseTexts"),
+        ProviderPluginConfiguration(type = "DefaultLicenseTextCurationProvider"),
         ProviderPluginConfiguration(type = "SPDX"),
         ProviderPluginConfiguration(type = "ScanCode")
     ),

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -105,3 +105,11 @@ internal fun Identifier.matchesDisregardingVersion(other: Identifier) =
     type.equals(other.type, ignoreCase = true)
         && namespace == other.namespace
         && name.equalsOrIsBlank(other.name)
+
+/**
+ * Return true if this [Identifier] is matched by the given [matcher]. The [matcher]s version may be an
+ * [Ivy version matcher](http://ant.apache.org/ivy/history/2.4.0/settings/version-matchers.html).
+ */
+internal fun Identifier.isMatchedBy(matcher: Identifier): Boolean =
+    matchesDisregardingVersion(matcher)
+        && (matcher.version.equalsOrIsBlank(version) || matcher.isApplicableIvyVersion(this))

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.utils
 import java.net.URI
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
@@ -29,6 +30,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.utils.common.equalsOrIsBlank
 import org.ossreviewtoolkit.utils.common.getDuplicates
 
 fun String.prependPath(prefix: String): String = if (prefix.isBlank()) this else "${prefix.removeSuffix("/")}/$this"
@@ -95,3 +97,11 @@ internal fun List<SourceCodeOrigin>.requireNoDuplicates() {
         "'sourceCodeOrigins' must not contain duplicates. Duplicates: $duplicates"
     }
 }
+
+/**
+ * Return true if this [Identifier] matches the given [other] identifier, disregarding the version.
+ */
+internal fun Identifier.matchesDisregardingVersion(other: Identifier) =
+    type.equals(other.type, ignoreCase = true)
+        && namespace == other.namespace
+        && name.equalsOrIsBlank(other.name)

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -52,7 +52,7 @@ ort:
   - type: "SPDX"
   - type: "ScanCode"
     options:
-      scanCodeLicenseTextDir: '/path/to/scancode/license/text/dir'
+      licenseTextDir: '/path/to/scancode/license/text/dir'
 
   licenseFilePatterns:
     licenseFilenames: ['license*']

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -45,6 +45,10 @@ ort:
     id: "global-custom-license-texts"
     options:
       dir: '/ort-config/custom-license-texts'
+  - type: "DefaultLicenseTextCuration"
+  - type: "LicenseTextCuration"
+    options:
+      dir: '/ort-config/license-text-curations'
   - type: "SPDX"
   - type: "ScanCode"
     options:

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -36,15 +36,15 @@ ort:
 
   # License fact providers, ordered from highest to lowest priority.
   licenseFactProviders:
-  - type: "DefaultDir"
-  - type: "Dir"
+  - type: "DefaultCustomLicenseTexts"
+  - type: "CustomLicenseTexts"
     id: "local-custom-license-texts"
     options:
-      licenseTextDir: '/project-sources/.ort/custom-license-texts'
-  - type: "Dir"
+      dir: '/project-sources/.ort/custom-license-texts'
+  - type: "CustomLicenseTexts"
     id: "global-custom-license-texts"
     options:
-      licenseTextDir: '/ort-config/custom-license-texts'
+      dir: '/ort-config/custom-license-texts'
   - type: "SPDX"
   - type: "ScanCode"
     options:

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -79,7 +79,7 @@ class OrtConfigurationTest : WordSpec({
                 ProviderPluginConfiguration(type = "SPDX"),
                 ProviderPluginConfiguration(
                     type = "ScanCode",
-                    options = mapOf("scanCodeLicenseTextDir" to "/path/to/scancode/license/text/dir")
+                    options = mapOf("licenseTextDir" to "/path/to/scancode/license/text/dir")
                 )
             )
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -71,6 +71,11 @@ class OrtConfigurationTest : WordSpec({
                     id = "global-custom-license-texts",
                     options = mapOf("dir" to "/ort-config/custom-license-texts")
                 ),
+                ProviderPluginConfiguration(type = "DefaultLicenseTextCuration"),
+                ProviderPluginConfiguration(
+                    type = "LicenseTextCuration",
+                    options = mapOf("dir" to "/ort-config/license-text-curations")
+                ),
                 ProviderPluginConfiguration(type = "SPDX"),
                 ProviderPluginConfiguration(
                     type = "ScanCode",

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -60,16 +60,16 @@ class OrtConfigurationTest : WordSpec({
             ortConfig.forceOverwrite shouldBe true
 
             ortConfig.licenseFactProviders should containExactly(
-                ProviderPluginConfiguration(type = "DefaultDir"),
+                ProviderPluginConfiguration(type = "DefaultCustomLicenseTexts"),
                 ProviderPluginConfiguration(
-                    type = "Dir",
+                    type = "CustomLicenseTexts",
                     id = "local-custom-license-texts",
-                    options = mapOf("licenseTextDir" to "/project-sources/.ort/custom-license-texts")
+                    options = mapOf("dir" to "/project-sources/.ort/custom-license-texts")
                 ),
                 ProviderPluginConfiguration(
-                    type = "Dir",
+                    type = "CustomLicenseTexts",
                     id = "global-custom-license-texts",
-                    options = mapOf("licenseTextDir" to "/ort-config/custom-license-texts")
+                    options = mapOf("dir" to "/ort-config/custom-license-texts")
                 ),
                 ProviderPluginConfiguration(type = "SPDX"),
                 ProviderPluginConfiguration(

--- a/plugins/commands/reporter/src/main/kotlin/ReportCommand.kt
+++ b/plugins/commands/reporter/src/main/kotlin/ReportCommand.kt
@@ -65,7 +65,7 @@ import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.CompositeLicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProviderFactory
-import org.ossreviewtoolkit.plugins.licensefactproviders.dir.DirLicenseFactProviderFactory
+import org.ossreviewtoolkit.plugins.licensefactproviders.dir.CustomLicenseTextsProviderFactory
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.CompositePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.api.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.packageconfigurationproviders.dir.DirPackageConfigurationProvider
@@ -264,7 +264,7 @@ class ReportCommand(descriptor: PluginDescriptor = ReportCommandFactory.descript
 
         val licenseFactProviders = buildList {
             customLicenseTextsDir?.also {
-                add(DirLicenseFactProviderFactory.create(it.absolutePath))
+                add(CustomLicenseTextsProviderFactory.create(it.absolutePath))
             }
 
             addAll(LicenseFactProviderFactory.create(ortConfig.licenseFactProviders).map { it.second })

--- a/plugins/license-fact-providers/dir/src/main/kotlin/CustomLicenseTextsProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/CustomLicenseTextsProvider.kt
@@ -34,43 +34,44 @@ import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 const val ORT_CUSTOM_LICENSE_TEXTS_DIRNAME = "custom-license-texts"
 
 /** The configuration for the directory-based license fact provider. */
-data class DirLicenseFactProviderConfig(
+data class CustomLicenseTextsProviderConfig(
     /** The directory that contains the license texts. */
-    val licenseTextDir: String
+    val dir: String
 )
 
 /**
- * A license fact provider that reads license information from the default directory. The files must be named after the
- * SPDX-conform license IDs, e.g., 'Apache-2.0' or 'LicenseRef-custom-license'.
+ * A license fact provider that reads license information from the default custom license texts directory. The files
+ * must be named after the SPDX-conform license IDs, e.g., 'Apache-2.0' or 'LicenseRef-custom-license'.
  */
 @OrtPlugin(
-    displayName = "Default Directory License Fact Provider",
-    summary = "A license fact provider that reads license information from the default directory.",
+    displayName = "Default Directory License Texts Provider",
+    summary = "A license fact provider that reads license texts from the default custom license texts directory.",
     factory = LicenseFactProviderFactory::class
 )
-class DefaultDirLicenseFactProvider(descriptor: PluginDescriptor = DefaultDirLicenseFactProviderFactory.descriptor) :
-    DirLicenseFactProvider(
-        descriptor,
-        DirLicenseFactProviderConfig(
-            licenseTextDir = ortConfigDirectory.resolve(ORT_CUSTOM_LICENSE_TEXTS_DIRNAME).absolutePath
-        )
+class DefaultCustomLicenseTextsProvider(
+    descriptor: PluginDescriptor = DefaultCustomLicenseTextsProviderFactory.descriptor
+) : CustomLicenseTextsProvider(
+    descriptor,
+    CustomLicenseTextsProviderConfig(
+        dir = ortConfigDirectory.resolve(ORT_CUSTOM_LICENSE_TEXTS_DIRNAME).absolutePath
     )
+)
 
 /**
  * A license fact provider that reads license information from a local directory. The files must be named after the
  * SPDX-conform license IDs, e.g., 'Apache-2.0' or 'LicenseRef-custom-license'.
  */
 @OrtPlugin(
-    id = "Dir",
-    displayName = "Directory License Fact Provider",
-    summary = "A license fact provider that reads license information from a local directory.",
+    id = "CustomLicenseTexts",
+    displayName = "Custom License Texts Provider",
+    summary = "A license fact provider that reads license texts from a local directory.",
     factory = LicenseFactProviderFactory::class
 )
-open class DirLicenseFactProvider(
-    override val descriptor: PluginDescriptor = DirLicenseFactProviderFactory.descriptor,
-    config: DirLicenseFactProviderConfig
+open class CustomLicenseTextsProvider(
+    override val descriptor: PluginDescriptor = DefaultCustomLicenseTextsProviderFactory.descriptor,
+    config: CustomLicenseTextsProviderConfig
 ) : LicenseFactProvider() {
-    private val licenseTextDir = File(config.licenseTextDir).also {
+    private val licenseTextsDir = File(config.dir).also {
         if (!it.isDirectory) {
             logger.warn { "The license text directory '${it.absolutePath}' does not exist or is not a directory." }
         }
@@ -82,7 +83,7 @@ open class DirLicenseFactProvider(
     override fun hasLicenseText(licenseOrExceptionId: String) = getLicenseTextFile(licenseOrExceptionId) != null
 
     private fun getLicenseTextFile(licenseOrExceptionId: String) =
-        licenseTextDir.resolve(licenseOrExceptionId).takeIf { it.isFile && it.isNotBlank }
+        licenseTextsDir.resolve(licenseOrExceptionId).takeIf { it.isFile && it.isNotBlank }
 }
 
 private val File.isNotBlank: Boolean

--- a/plugins/license-fact-providers/dir/src/main/kotlin/LicenseTextCurationProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/LicenseTextCurationProvider.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.licensefactproviders.dir
+
+import java.io.File
+import java.io.IOException
+
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseTextCuration
+import org.ossreviewtoolkit.model.LicenseTextCurations
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProviderFactory
+import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseText
+import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
+
+/**
+ * The name of the ORT license text curations configuration directory.
+ */
+const val ORT_LICENSE_TEXT_CURATIONS_DIRNAME = "license-text-curations"
+
+/** The configuration for the license text-curations-directory-based license fact provider. */
+data class LicenseTextCurationProviderConfig(
+    /** The directory that contains the license text curations. */
+    val dir: String
+)
+
+/**
+ * A license fact provider that reads license text curations from the default license texts curations directory. It only
+ * returns id-specific license texts.
+ */
+@OrtPlugin(
+    displayName = "Default License Text Curation Provider",
+    summary = "A license fact provider that reads license information from the default directory.",
+    factory = LicenseFactProviderFactory::class
+)
+class DefaultLicenseTextCurationProvider(
+    descriptor: PluginDescriptor = DefaultLicenseTextCurationProviderFactory.descriptor
+) : LicenseTextCurationProvider(
+    descriptor,
+    LicenseTextCurationProviderConfig(
+        dir = ortConfigDirectory.resolve(ORT_LICENSE_TEXT_CURATIONS_DIRNAME).absolutePath
+    )
+)
+
+/**
+ * A license fact provider that reads license text curations from a local directory. It only returns id-specific license
+ * texts.
+ */
+@OrtPlugin(
+    id = "LicenseTextCurationProvider",
+    displayName = "License Text Curation Provider",
+    summary = "A license fact provider that reads license text curations from a local directory.",
+    factory = LicenseFactProviderFactory::class
+)
+open class LicenseTextCurationProvider(
+    override val descriptor: PluginDescriptor = LicenseTextCurationProviderFactory.descriptor,
+    config: LicenseTextCurationProviderConfig
+) : LicenseFactProvider() {
+    private val licenseTextCurationsDir = File(config.dir).also {
+        if (!it.isDirectory) {
+            logger.warn {
+                "The license text curations directory '${it.absolutePath}' does not exist or is not a directory."
+            }
+        }
+    }
+
+    /** A cache with entries for license text curation files to read each file at most once. */
+    private val licenseTextCurationsForIdWithoutVersion = mutableMapOf<Identifier, List<LicenseTextCurations>>()
+
+    private fun getCurationsForId(id: Identifier): List<LicenseTextCuration> =
+        licenseTextCurationsForIdWithoutVersion.getOrPut(id.copy(version = "")) {
+            val relativeCurationFilePath = "${id.toPath(emptyValue = "_").substringBeforeLast("/")}.yml"
+            val curationFile = licenseTextCurationsDir.resolve(relativeCurationFilePath).takeIf { it.isFile }
+
+            curationFile?.let { file ->
+                runCatching {
+                    file.readValue<List<LicenseTextCurations>>()
+                }.getOrElse {
+                    throw IOException("Failed reading license text curations from '${file.absolutePath}'.", it)
+                }.also {
+                    logger.info {
+                        "Read ${it.size} license text curations for ${id.toCoordinates()} from ${file.absolutePath}."
+                    }
+                }
+            }.orEmpty()
+        }.filter { it.isApplicable(id) }.flatMap { it.curations }
+
+    override fun hasLicenseText(licenseOrExceptionId: String) = false
+
+    override fun getLicenseText(licenseOrExceptionId: String) = null
+
+    override fun hasLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Boolean =
+        getCurationsForId(id).any { curation -> curation.licenseId.toString() == singleLicenseExpression }
+
+    override fun getLicenseTextsForId(singleLicenseExpression: String, id: Identifier): Set<LicenseText> =
+        getCurationsForId(id).mapNotNullTo(mutableSetOf()) { curation ->
+            curation.licenseText.takeIf {
+                curation.licenseId.toString() == singleLicenseExpression
+            }?.let { LicenseText(it) }
+        }
+}

--- a/plugins/license-fact-providers/dir/src/test/kotlin/CustomLicenseTextsProviderTest.kt
+++ b/plugins/license-fact-providers/dir/src/test/kotlin/CustomLicenseTextsProviderTest.kt
@@ -28,10 +28,10 @@ import io.kotest.matchers.shouldBe
 class CustomLicenseTextsProviderTest : WordSpec({
     "getLicenseText()" should {
         "return the license text from the configured directory" {
-            val licenseDir = tempdir()
-            licenseDir.resolve("LicenseRef-custom-license").writeText("custom license text")
+            val licenseTextsDir = tempdir()
+            licenseTextsDir.resolve("LicenseRef-custom-license").writeText("custom license text")
 
-            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseTextsDir.absolutePath)
 
             provider.getLicenseText("LicenseRef-custom-license")?.text shouldBe "custom license text"
         }
@@ -43,10 +43,10 @@ class CustomLicenseTextsProviderTest : WordSpec({
         }
 
         "return null if the license text file is blank" {
-            val licenseDir = tempdir()
-            licenseDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
+            val licenseTextsDir = tempdir()
+            licenseTextsDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
 
-            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseTextsDir.absolutePath)
 
             provider.getLicenseText("LicenseRef-blank-license") should beNull()
         }
@@ -54,10 +54,10 @@ class CustomLicenseTextsProviderTest : WordSpec({
 
     "hasLicenseText()" should {
         "return true if the license text exists" {
-            val licenseDir = tempdir()
-            licenseDir.resolve("LicenseRef-custom-license").writeText("custom license text")
+            val licenseTextsDir = tempdir()
+            licenseTextsDir.resolve("LicenseRef-custom-license").writeText("custom license text")
 
-            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseTextsDir.absolutePath)
 
             provider.hasLicenseText("LicenseRef-custom-license") shouldBe true
         }
@@ -69,10 +69,10 @@ class CustomLicenseTextsProviderTest : WordSpec({
         }
 
         "return false if the license text file is blank" {
-            val licenseDir = tempdir()
-            licenseDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
+            val licenseTextsDir = tempdir()
+            licenseTextsDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
 
-            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseTextsDir.absolutePath)
 
             provider.hasLicenseText("LicenseRef-blank-license") shouldBe false
         }

--- a/plugins/license-fact-providers/dir/src/test/kotlin/CustomLicenseTextsProviderTest.kt
+++ b/plugins/license-fact-providers/dir/src/test/kotlin/CustomLicenseTextsProviderTest.kt
@@ -25,19 +25,19 @@ import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-class DirLicenseFactProviderTest : WordSpec({
+class CustomLicenseTextsProviderTest : WordSpec({
     "getLicenseText()" should {
         "return the license text from the configured directory" {
             val licenseDir = tempdir()
             licenseDir.resolve("LicenseRef-custom-license").writeText("custom license text")
 
-            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
 
             provider.getLicenseText("LicenseRef-custom-license")?.text shouldBe "custom license text"
         }
 
         "return null if no license text is found" {
-            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = tempdir().absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = tempdir().absolutePath)
 
             provider.getLicenseText("LicenseRef-non-existing-license") should beNull()
         }
@@ -46,7 +46,7 @@ class DirLicenseFactProviderTest : WordSpec({
             val licenseDir = tempdir()
             licenseDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
 
-            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
 
             provider.getLicenseText("LicenseRef-blank-license") should beNull()
         }
@@ -57,13 +57,13 @@ class DirLicenseFactProviderTest : WordSpec({
             val licenseDir = tempdir()
             licenseDir.resolve("LicenseRef-custom-license").writeText("custom license text")
 
-            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
 
             provider.hasLicenseText("LicenseRef-custom-license") shouldBe true
         }
 
         "return false if the license text does not exist" {
-            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = tempdir().absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = tempdir().absolutePath)
 
             provider.hasLicenseText("LicenseRef-non-existing-license") shouldBe false
         }
@@ -72,7 +72,7 @@ class DirLicenseFactProviderTest : WordSpec({
             val licenseDir = tempdir()
             licenseDir.resolve("LicenseRef-blank-license").writeText("   \n   ")
 
-            val provider = DirLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
+            val provider = CustomLicenseTextsProviderFactory.create(dir = licenseDir.absolutePath)
 
             provider.hasLicenseText("LicenseRef-blank-license") shouldBe false
         }

--- a/plugins/license-fact-providers/dir/src/test/kotlin/LicenseTextCurationProviderTest.kt
+++ b/plugins/license-fact-providers/dir/src/test/kotlin/LicenseTextCurationProviderTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.licensefactproviders.dir
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.model.Identifier
+
+class LicenseTextCurationProviderTest : WordSpec({
+    "getLicenseTextForId()" should {
+        val dir = tempdir().apply {
+            resolve("Npm/_/mime-types.yml").apply {
+                parentFile.mkdirs()
+                writeText(CURATIONS_FILE_CONTENT)
+            }
+        }
+
+        val provider = LicenseTextCurationProviderFactory.create(dir = dir.absolutePath)
+
+        "return the expected texts if version matches the exact version and the version range" {
+            provider.getLicenseTextsForId(
+                "MIT",
+                Identifier("Npm::mime-types:2.2.1")
+            ).map { it.text } should containExactlyInAnyOrder(
+                "Text for mime-types 2.2.1",
+                "Text for mime-types from 2.0.0 up to 3.0.0."
+            )
+        }
+
+        "return the expected texts if version only matches the version range" {
+            provider.getLicenseTextsForId(
+                "MIT",
+                Identifier("Npm::mime-types:2.0.1")
+            ).map { it.text } should containExactlyInAnyOrder(
+                "Text for mime-types from 2.0.0 up to 3.0.0."
+            )
+        }
+
+        "return no text if the version matches but not the license id" {
+            provider.getLicenseTextsForId(
+                "Apache-2.0",
+                Identifier("Npm::mime-types:2.2.1")
+            ).map { it.text } should beEmpty()
+        }
+
+        "return no text if the version does not match" {
+            provider.getLicenseTextsForId(
+                "MIT",
+                Identifier("Npm::mime-types:10.0.0")
+            ).map { it.text } should beEmpty()
+        }
+    }
+})
+
+private val CURATIONS_FILE_CONTENT = """
+---
+- id: "Npm::mime-types:2.2.1"
+  curations:
+  - license_id: "MIT"
+    license_text: "Text for mime-types 2.2.1"
+- id: "Npm::mime-types:[2.0.0,3.0.0]"
+  curations:
+  - license_id: "MIT"
+    license_text: "Text for mime-types from 2.0.0 up to 3.0.0."
+- id: "Npm::mime-types:1.0.0"
+  curations:
+  - license_id: "MIT"
+    license_text: "Text for mime-types 1.0.0"      
+""".trimIndent()

--- a/plugins/license-fact-providers/scancode/src/funTest/kotlin/ScanCodeLicenseFactProviderFunTest.kt
+++ b/plugins/license-fact-providers/scancode/src/funTest/kotlin/ScanCodeLicenseFactProviderFunTest.kt
@@ -41,7 +41,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
             val licenseDir = tempdir()
             (licenseDir / "test.LICENSE").writeText("custom license text")
 
-            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
+            val provider = ScanCodeLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
 
             provider.getLicenseText("test")?.text shouldBe "custom license text"
         }
@@ -58,7 +58,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
                 """.trimMargin()
             )
 
-            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
+            val provider = ScanCodeLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
 
             provider.getLicenseText("test")?.text shouldBe "custom license text"
         }
@@ -72,7 +72,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
         }
 
         "return null for an unknown license" {
-            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = tempdir().absolutePath)
+            val provider = ScanCodeLicenseFactProviderFactory.create(licenseTextDir = tempdir().absolutePath)
 
             provider.getLicenseText("UnknownLicense") should beNull()
         }
@@ -88,7 +88,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
                 """.trimMargin()
             )
 
-            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
+            val provider = ScanCodeLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
 
             provider.getLicenseText("test") should beNull()
         }
@@ -102,7 +102,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
         }
 
         "return false for an unknown license" {
-            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = tempdir().absolutePath)
+            val provider = ScanCodeLicenseFactProviderFactory.create(licenseTextDir = tempdir().absolutePath)
 
             provider.hasLicenseText("UnknownLicense") shouldBe false
         }
@@ -118,7 +118,7 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
                 """.trimMargin()
             )
 
-            val provider = ScanCodeLicenseFactProviderFactory.create(scanCodeLicenseTextDir = licenseDir.absolutePath)
+            val provider = ScanCodeLicenseFactProviderFactory.create(licenseTextDir = licenseDir.absolutePath)
 
             provider.hasLicenseText("test") shouldBe false
         }

--- a/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.kotlin.logger
 import org.apache.logging.log4j.kotlin.loggerOf
 
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProviderFactory
@@ -44,7 +45,8 @@ data class ScanCodeLicenseFactProviderConfig(
      * The directory that contains the ScanCode license texts. If not set, the provider will try to locate the ScanCode
      * license text directory using a heuristic based on the path of the ScanCode binary.
      */
-    val scanCodeLicenseTextDir: String?
+    @OrtPluginOption(aliases = ["scanCodeLicenseTextDir"])
+    val licenseTextDir: String?
 )
 
 @OrtPlugin(
@@ -61,12 +63,12 @@ class ScanCodeLicenseFactProvider(
      * The directory that contains the ScanCode license texts. This is located using a heuristic based on the path of
      * the ScanCode binary.
      */
-    private val scanCodeLicenseTextDir: File? by lazy {
-        if (config.scanCodeLicenseTextDir != null) {
-            return@lazy File(config.scanCodeLicenseTextDir).also {
+    private val licenseTextDir: File? by lazy {
+        if (config.licenseTextDir != null) {
+            return@lazy File(config.licenseTextDir).also {
                 require(it.isDirectory) {
-                    "Configured ScanCode license text directory '${config.scanCodeLicenseTextDir}' does not exist or " +
-                        "is not a directory."
+                    "Configured ScanCode license text directory '${config.licenseTextDir}' does not exist or is not " +
+                        "a directory."
                 }
 
                 logger.debug { "Using configured ScanCode license text directory: ${it.absolutePath}" }
@@ -103,7 +105,7 @@ class ScanCodeLicenseFactProvider(
             "${licenseOrExceptionId.removePrefix("LicenseRef-scancode-").lowercase()}.LICENSE"
         }
 
-        return scanCodeLicenseTextDir?.resolve(filename)?.takeIf { it.isFile && it.isNotBlank }
+        return licenseTextDir?.resolve(filename)?.takeIf { it.isFile && it.isNotBlank }
     }
 
     override fun getLicenseText(licenseOrExceptionId: String) =

--- a/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
+++ b/plugins/reporters/freemarker/src/main/kotlin/FreemarkerTemplateProcessor.kt
@@ -197,10 +197,16 @@ class FreemarkerTemplateProcessor(
         @Suppress("unused") // This function is used in the templates.
         @JvmOverloads
         fun licensesNotInLicenseFiles(
-            resolvedLicenses: List<ResolvedLicense> = license.licenses
+            resolvedLicenses: List<ResolvedLicense> = license.licenses,
+            keepLicensesWithLicenseTextCurations: Boolean = false
         ): List<ResolvedLicense> {
             val outputFileLicenses = licenseFiles.files.flatMap { it.licenses }
-            return resolvedLicenses.filter { it !in outputFileLicenses }
+            return resolvedLicenses.filter { resolvedLicense ->
+                val hasCurations = input.licenseFactProvider
+                    .hasLicenseTextsForId(resolvedLicense.license.toString(), id)
+
+                resolvedLicense !in outputFileLicenses || (keepLicensesWithLicenseTextCurations && hasCurations)
+            }
         }
     }
 


### PR DESCRIPTION
See individual commits.

The documentation and `NOTICE_DEFAULT.ftl` adjustments will be done in a following PR.

Note: This PR must be merged after https://github.com/oss-review-toolkit/ort/pull/12034, as it includes that PR.

Part of #11668.