### PR TITLE
refactor!: Move the `ORT_CUSTOM_LICENSE_TEXTS_DIRNAME` constant

### DIFF
--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
-import org.ossreviewtoolkit.utils.ort.ORT_CUSTOM_LICENSE_TEXTS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_FAILURE_STATUS_CODE
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
@@ -83,9 +82,8 @@ data class OrtConfiguration(
     val forceOverwrite: Boolean = false,
 
     /**
-     * The license fact providers, ordered from highest to lowest priority. Defaults to the providers for bundled SPDX
-     * license facts, license facts from a local ScanCode installation, and license facts from the default
-     * [ORT_CUSTOM_LICENSE_TEXTS_DIRNAME].
+     * The license fact providers, ordered from highest to lowest priority. Defaults to the default custom license text
+     * directory, the bundled SPDX license text, and license texts from a local ScanCode installation.
      */
     val licenseFactProviders: List<ProviderPluginConfiguration> = listOf(
         ProviderPluginConfiguration(type = "DefaultDir"),

--- a/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/dir/src/main/kotlin/DirLicenseFactProvider.kt
@@ -28,8 +28,10 @@ import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProvider
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseFactProviderFactory
 import org.ossreviewtoolkit.plugins.licensefactproviders.api.LicenseText
-import org.ossreviewtoolkit.utils.ort.ORT_CUSTOM_LICENSE_TEXTS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
+
+/** The name of the ORT custom license texts configuration directory. */
+const val ORT_CUSTOM_LICENSE_TEXTS_DIRNAME = "custom-license-texts"
 
 /** The configuration for the directory-based license fact provider. */
 data class DirLicenseFactProviderConfig(

--- a/utils/ort/src/main/kotlin/Constants.kt
+++ b/utils/ort/src/main/kotlin/Constants.kt
@@ -70,11 +70,6 @@ const val ORT_REFERENCE_CONFIG_FILENAME = "reference.yml"
 const val ORT_COPYRIGHT_GARBAGE_FILENAME = "copyright-garbage.yml"
 
 /**
- * The name of the ORT custom license texts configuration directory.
- */
-const val ORT_CUSTOM_LICENSE_TEXTS_DIRNAME = "custom-license-texts"
-
-/**
  * The name of the ORT package curations directory.
  */
 const val ORT_PACKAGE_CURATIONS_DIRNAME = "curations"


### PR DESCRIPTION
Move the constant to the plugin it belongs to and the only place it is really being used. Adjust an informational comment to not refer to the constant anymore.

This is a follow-up to f5e3878.