### PR TITLE
Some VulnerableCode API v3 chores

### DIFF
--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV1.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV1.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.model.vulnerabilities.VulnerabilityReference
 import org.ossreviewtoolkit.plugins.advisors.api.AdviceProvider
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.utils.common.ensureSuffix
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 
 /**
@@ -54,7 +55,12 @@ internal class VulnerableCodeApiV1(
             if (config.readTimeout != null) readTimeout(config.readTimeout, TimeUnit.SECONDS)
         }
 
-        VulnerableCodeService.create(config.serverUrl, config.apiKey?.value, client)
+        // Retrofit requires URLs to end in "/".
+        val urlWithApiSuffix = config.serverUrl.ensureSuffix("/").run {
+            takeIf { it.endsWith("/api/") } ?: "${this}api/"
+        }
+
+        VulnerableCodeService.create(urlWithApiSuffix, config.apiKey?.value, client)
     }
 
     override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeUtils.kt
@@ -69,7 +69,7 @@ internal suspend fun <T> Throwable.handleChunkRequestFailure(
     allVulnerabilities += chunk.associateWith { emptyList() }
     issues += Issue(source = issueSource, message = collectMessages())
 
-    logger.error {
+    logger.error(this) {
         "The request of chunk ${chunkIndex + 1} of $chunkCount failed for the following ${chunk.size} PURL(s):"
     }
 

--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeUtils.kt
@@ -66,7 +66,7 @@ internal suspend fun <T> Throwable.handleChunkRequestFailure(
 ) {
     if (this is CancellationException) currentCoroutineContext().ensureActive()
 
-    allVulnerabilities += chunk.associateWith { emptyList<T>() }
+    allVulnerabilities += chunk.associateWith { emptyList() }
     issues += Issue(source = issueSource, message = collectMessages())
 
     logger.error {

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/TestUtils.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.plugins.advisors.vulnerablecode
 
-import com.github.tomakehurst.wiremock.WireMockServer
-
 import io.kotest.core.TestConfiguration
 
 import org.ossreviewtoolkit.model.AdvisorDetails
@@ -100,16 +98,3 @@ internal fun generateAdvisoriesRequest(id: Identifier): String = generateAdvisor
  * The advisor details expected in results produced by the VulnerableCode test instances.
  */
 internal val details = AdvisorDetails(VulnerableCodeFactory.descriptor.id)
-
-/**
- * Create a configuration for the VulnerableCode implementation with the given [apiVersion] that points to the local
- * [server]. If [apiUrl] is true, append the legacy "/api/" suffix to the server URL.
- */
-internal fun createConfig(
-    server: WireMockServer,
-    apiVersion: VulnerableCodeApiVersion,
-    apiUrl: Boolean = false
-): VulnerableCodeConfiguration {
-    val url = "http://localhost:${server.port()}" + if (apiUrl) "/api/" else ""
-    return VulnerableCodeConfiguration(url, null, null, apiVersion)
-}

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
@@ -291,11 +291,10 @@ private fun WireMockServer.stubPackagesRequest(responseFile: String, request: St
 }
 
 /**
- * Create a test instance of [VulnerableCodeApiV1] that communicates with the local [server].
+ * Create a test instance of [VulnerableCode] for [VulnerableCodeApiV1] that communicates with the local [server].
  */
-private fun createApi(server: WireMockServer, apiUrl: Boolean = false): VulnerableCodeApiV1 =
-    VulnerableCodeApiV1(
-        VulnerableCodeFactory.descriptor,
-        details,
-        createConfig(server, VulnerableCodeApiVersion.V1, apiUrl)
+private fun createApi(server: WireMockServer): VulnerableCode =
+    VulnerableCodeFactory.create(
+        serverUrl = "http://localhost:${server.port()}",
+        apiVersion = VulnerableCodeApiVersion.V1
     )

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
@@ -266,7 +266,7 @@ class VulnerableCodeApiV1Test : WordSpec({
     }
 })
 
-private const val PACKAGES_REQUEST_URL = "/packages/bulk_search"
+private const val PACKAGES_REQUEST_URL = "/api/packages/bulk_search"
 
 /**
  * The JSON request to query the test packages found in the result.

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV1Test.kt
@@ -51,6 +51,13 @@ class VulnerableCodeApiV1Test : WordSpec({
             .dynamicPort()
     )
 
+    val vc by lazy {
+        VulnerableCodeFactory.create(
+            serverUrl = "http://localhost:${server.port()}",
+            apiVersion = VulnerableCodeApiVersion.V1
+        )
+    }
+
     beforeSpec {
         server.start()
     }
@@ -66,10 +73,9 @@ class VulnerableCodeApiV1Test : WordSpec({
     "retrievePackageFindings()" should {
         "return vulnerability information" {
             server.stubPackagesRequest("response_packages.json")
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result shouldNot beEmptyMap()
             result.keys should containExactlyInAnyOrder(idLang, idStruts)
@@ -147,10 +153,9 @@ class VulnerableCodeApiV1Test : WordSpec({
 
         "extract the CVE ID from an alias" {
             server.stubPackagesRequest("response_junit.json", request = generatePackagesRequest(idJUnit))
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromIdentifiers(idJUnit)
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             val expJunitVulnerability = Vulnerability(
                 id = "CVE-2020-15250",
@@ -177,10 +182,9 @@ class VulnerableCodeApiV1Test : WordSpec({
 
         "extract other official identifiers from aliases" {
             server.stubPackagesRequest("response_log4j.json", generatePackagesRequest(idLog4j))
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             val expLog4jVulnerabilities = listOf(
                 Vulnerability(
@@ -223,10 +227,9 @@ class VulnerableCodeApiV1Test : WordSpec({
                         aResponse().withStatus(500)
                     )
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result shouldNotBeNull {
                 keys should containExactly(packageIdentifiers)
@@ -246,20 +249,18 @@ class VulnerableCodeApiV1Test : WordSpec({
 
         "filter out packages without vulnerabilities" {
             server.stubPackagesRequest("response_packages_no_vulnerabilities.json")
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactly(idStruts)
         }
 
         "handle unexpected packages in the query result" {
             server.stubPackagesRequest("response_unexpected_packages.json")
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactlyInAnyOrder(idLang, idStruts)
         }
@@ -289,12 +290,3 @@ private fun WireMockServer.stubPackagesRequest(responseFile: String, request: St
             )
     )
 }
-
-/**
- * Create a test instance of [VulnerableCode] for [VulnerableCodeApiV1] that communicates with the local [server].
- */
-private fun createApi(server: WireMockServer): VulnerableCode =
-    VulnerableCodeFactory.create(
-        serverUrl = "http://localhost:${server.port()}",
-        apiVersion = VulnerableCodeApiVersion.V1
-    )

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV3Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV3Test.kt
@@ -416,11 +416,10 @@ private fun WireMockServer.stubAdvisoriesRequest(responseFile: String, request: 
 }
 
 /**
- * Create a test instance of [VulnerableCode] that communicates with the local [server].
+ * Create a test instance of [VulnerableCode] for [VulnerableCodeApiV3] that communicates with the local [server].
  */
-private fun createApi(server: WireMockServer, apiUrl: Boolean = false): VulnerableCodeApiV3 =
-    VulnerableCodeApiV3(
-        VulnerableCodeFactory.descriptor,
-        details,
-        createConfig(server, VulnerableCodeApiVersion.V3, apiUrl)
+private fun createApi(server: WireMockServer): VulnerableCode =
+    VulnerableCodeFactory.create(
+        serverUrl = "http://localhost:${server.port()}",
+        apiVersion = VulnerableCodeApiVersion.V3
     )

--- a/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV3Test.kt
+++ b/plugins/advisors/vulnerable-code/src/test/kotlin/VulnerableCodeApiV3Test.kt
@@ -56,6 +56,13 @@ class VulnerableCodeApiV3Test : WordSpec({
             .dynamicPort()
     )
 
+    val vc by lazy {
+        VulnerableCodeFactory.create(
+            serverUrl = "http://localhost:${server.port()}",
+            apiVersion = VulnerableCodeApiVersion.V3
+        )
+    }
+
     beforeSpec {
         server.start()
     }
@@ -75,10 +82,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                 "advisories_response_packages.json",
                 generateAdvisoriesRequest(listOf(idLang, idStruts).map { it.toPurl() })
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.values.flatMap { it.summary.issues } should beEmpty()
             result shouldNot beEmptyMap()
@@ -158,10 +164,9 @@ class VulnerableCodeApiV3Test : WordSpec({
         "extract the CVE ID from an alias" {
             server.stubPackagesRequest("packages_response_junit.json", request = generateV3PackagesRequest(idJUnit))
             server.stubAdvisoriesRequest("advisories_response_junit.json", generateAdvisoriesRequest(idJUnit))
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromIdentifiers(idJUnit)
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             val expJunitVulnerability = Vulnerability(
                 id = "CVE-2020-15250",
@@ -206,10 +211,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                 "advisories_response_log4j_no_aliases.json",
                 generateAdvisoriesRequest(idLog4j)
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             val expLog4jVulnerabilities = listOf(
                 Vulnerability(
@@ -232,10 +236,9 @@ class VulnerableCodeApiV3Test : WordSpec({
         "prefer CVE ID from the advisory ID over aliases" {
             server.stubPackagesRequest("packages_response_log4j_cve.json", generateV3PackagesRequest(idLog4j))
             server.stubAdvisoriesRequest("advisories_response_log4j_cve.json", generateAdvisoriesRequest(idLog4j))
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             val expLog4jVulnerabilities = listOf(
                 Vulnerability(
@@ -271,10 +274,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                 "advisories_response_packages_paginated.json",
                 generateAdvisoriesRequest(listOf(idJUnit, idLang, idStruts).map { it.toPurl() })
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.values.flatMap { it.summary.issues } should beEmpty()
             result shouldNot beEmptyMap()
@@ -297,10 +299,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                             .withBodyFile("advisories_response_page2.json")
                     )
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys shouldBe setOf(idLog4j)
             result.getValue(idLog4j).vulnerabilities shouldHaveSize 3
@@ -320,10 +321,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                         aResponse().withStatus(500)
                     )
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result shouldNotBeNull {
                 keys should containExactly(packageIdentifiers)
@@ -348,10 +348,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                 "advisories_response_packages.json",
                 generateAdvisoriesRequest(idStruts)
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactly(idStruts)
         }
@@ -364,10 +363,9 @@ class VulnerableCodeApiV3Test : WordSpec({
                     listOf(idLang.toPurl(), idStruts.toPurl(), "pkg:maven/org.unknown/unexpected@4.2")
                 )
             )
-            val api = createApi(server)
             val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
-            val result = api.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+            val result = vc.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactlyInAnyOrder(idLang, idStruts)
         }
@@ -414,12 +412,3 @@ private fun WireMockServer.stubAdvisoriesRequest(responseFile: String, request: 
             )
     )
 }
-
-/**
- * Create a test instance of [VulnerableCode] for [VulnerableCodeApiV3] that communicates with the local [server].
- */
-private fun createApi(server: WireMockServer): VulnerableCode =
-    VulnerableCodeFactory.create(
-        serverUrl = "http://localhost:${server.port()}",
-        apiVersion = VulnerableCodeApiVersion.V3
-    )

--- a/utils/common/src/main/kotlin/StringUtils.kt
+++ b/utils/common/src/main/kotlin/StringUtils.kt
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+@file:Suppress("TooManyFunctions")
+
 package org.ossreviewtoolkit.utils.common
 
 /**
@@ -35,6 +37,16 @@ fun String.encodeOr(emptyValue: String): String {
 
     return ifEmpty { emptyValue }.fileSystemEncode()
 }
+
+/**
+ * Ensure that this string starts with the specified [prefix].
+ */
+fun String.ensurePrefix(prefix: String) = takeIf { it.startsWith(prefix) } ?: "$prefix$this"
+
+/**
+ * Ensure that this string ends with the specified [suffix].
+ */
+fun String.ensureSuffix(suffix: String) = takeIf { it.endsWith(suffix) } ?: "$this$suffix"
 
 /**
  * Return the string encoded for safe use as a file name or "unknown", if the string is empty.


### PR DESCRIPTION
Do as documented [1] and ensure the API v1 URL has an "/api" suffix.

[1]: https://github.com/oss-review-toolkit/ort/blob/8fe0b5bfa3fb14c397a9f3b121d2c8f670d5955c/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeConfiguration.kt#L38-L43