### PR TITLE
build(plugins): Only compile against a plugin API

### DIFF
--- a/plugins/package-curation-providers/clearly-defined/build.gradle.kts
+++ b/plugins/package-curation-providers/clearly-defined/build.gradle.kts
@@ -23,14 +23,17 @@ plugins {
 }
 
 dependencies {
-    api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+    api(projects.model)
 
     implementation(projects.clients.clearlyDefinedClient)
     implementation(projects.utils.commonUtils)
     implementation(projects.utils.ortUtils)
     implementation(projects.utils.spdxExpressionUtils)
 
+    compileOnly(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+
     testImplementation(libs.wiremock)
+    testImplementation(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 
     ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
 }


### PR DESCRIPTION
A plugin should only compile against the API for its plugin type to avoid the plugin API itself being a dependency of the plugin, which would cause problems when bundling the dependencies of plugins and using multiple plugins, as the plugin API would duplicate then.