### PR TITLE
DAGP 3.16.1 preparations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ dependencyAnalysis {
 
         project(projects.cliHelper) {
             onUnusedDependencies {
+                // XZOutputStream is a supertype of XZCompressorOutputStream.
                 exclude(libs.xz)
             }
         }
@@ -92,6 +93,13 @@ dependencyAnalysis {
         project(projects.plugins.packageManagers.bundlerPackageManager) {
             onUnusedDependencies {
                 exclude(libs.jruby)
+            }
+        }
+
+        project(projects.utils.ortUtils) {
+            onUnusedDependencies {
+                // XZOutputStream is a supertype of XZCompressorOutputStream.
+                exclude(libs.xz)
             }
         }
     }

--- a/cli-helper/build.gradle.kts
+++ b/cli-helper/build.gradle.kts
@@ -37,7 +37,11 @@ dependencies {
     implementation(libs.commonsCompress)
     implementation(libs.jslt)
     implementation(libs.slf4j)
-    implementation(libs.xz)
+
+    implementation(libs.xz) {
+        because("XZOutputStream is a supertype of XZCompressorOutputStream.")
+    }
+
     implementation(projects.analyzer)
     implementation(projects.downloader)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ plugin-tapmoc = { module = "com.gradleup.tapmoc:tapmoc-gradle-plugin", version.r
 
 aeSecurity = { module = "org.metaeffekt.core:ae-security", version.ref = "aeSecurity" }
 asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }
+asciidoctorj-api = { module = "org.asciidoctor:asciidoctorj-api", version.ref = "asciidoctorj" }
 asciidoctorj-pdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = "asciidoctorjPdf" }
 awsS3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
 blackduck-common = { module = "com.blackduck.integration:blackduck-common", version.ref = "blackduckCommon" }

--- a/plugins/commands/compare/build.gradle.kts
+++ b/plugins/commands/compare/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 dependencies {
     api(projects.plugins.commands.commandApi)
 
-    implementation(jacksonLibs.jacksonDataformatYaml)
     implementation(jacksonLibs.jacksonModuleKotlin)
     implementation(libs.clikt)
     implementation(libs.diffUtils)

--- a/plugins/commands/migrate/build.gradle.kts
+++ b/plugins/commands/migrate/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 dependencies {
     api(projects.plugins.commands.commandApi)
 
-    implementation(jacksonLibs.jacksonModuleKotlin)
     implementation(libs.clikt)
     implementation(projects.plugins.packageCurationProviders.gitPackageCurationProvider)
     implementation(projects.plugins.packageManagers.nugetPackageManager)

--- a/plugins/commands/upload-result-to-postgres/build.gradle.kts
+++ b/plugins/commands/upload-result-to-postgres/build.gradle.kts
@@ -27,9 +27,7 @@ dependencies {
 
     implementation(libs.clikt)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.json)
     implementation(projects.model)
     implementation(projects.scanner)
     implementation(projects.utils.commonUtils)

--- a/plugins/package-managers/gradle-inspector/build.gradle.kts
+++ b/plugins/package-managers/gradle-inspector/build.gradle.kts
@@ -39,8 +39,9 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     funTestImplementation(testFixtures(projects.analyzer))
-    funTestImplementation(projects.plugins.versionControlSystems.gitVersionControlSystem)
     funTestImplementation(projects.utils.testUtils)
+
+    funTestRuntimeOnly(projects.plugins.versionControlSystems.gitVersionControlSystem)
 
     ksp(projects.analyzer)
 }

--- a/plugins/package-managers/gradle/build.gradle.kts
+++ b/plugins/package-managers/gradle/build.gradle.kts
@@ -35,8 +35,9 @@ dependencies {
     implementation(projects.utils.ortUtils)
 
     funTestImplementation(testFixtures(projects.analyzer))
-    funTestImplementation(projects.plugins.versionControlSystems.gitVersionControlSystem)
     funTestImplementation(projects.utils.testUtils)
+
+    funTestRuntimeOnly(projects.plugins.versionControlSystems.gitVersionControlSystem)
 
     testImplementation(libs.mockk)
 

--- a/plugins/package-managers/maven/build.gradle.kts
+++ b/plugins/package-managers/maven/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     api(projects.analyzer)
     api(projects.model)
 
-    implementation(libs.bouncyCastle)
     implementation(libs.kotlinx.serialization.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.maven.embedder)
@@ -42,6 +41,8 @@ dependencies {
 
     funTestImplementation(testFixtures(projects.analyzer))
     funTestImplementation(projects.utils.testUtils)
+
+    runtimeOnly(libs.bouncyCastle)
 
     // The classes from the maven-resolver dependencies are not used directly but initialized by the Plexus IoC
     // container automatically. They are required on the classpath for Maven dependency resolution to work.

--- a/plugins/package-managers/spdx-document-file/build.gradle.kts
+++ b/plugins/package-managers/spdx-document-file/build.gradle.kts
@@ -36,8 +36,9 @@ dependencies {
     implementation(projects.utils.spdxDocumentUtils)
 
     funTestImplementation(testFixtures(projects.analyzer))
-    funTestImplementation(projects.plugins.packageManagers.conanPackageManager)
     funTestImplementation(projects.utils.testUtils)
+
+    funTestRuntimeOnly(projects.plugins.packageManagers.conanPackageManager)
 
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)

--- a/plugins/reporters/asciidoc/build.gradle.kts
+++ b/plugins/reporters/asciidoc/build.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 }
 
 dependencies {
+    api(libs.asciidoctorj.api)
     api(projects.reporter)
 
-    implementation(libs.asciidoctorj)
     implementation(projects.model)
     implementation(projects.plugins.reporters.freemarkerReporter)
     implementation(projects.utils.commonUtils)
@@ -35,6 +35,7 @@ dependencies {
     funTestImplementation(projects.plugins.licenseFactProviders.spdxLicenseFactProvider)
     funTestImplementation(projects.utils.testUtils)
 
+    runtimeOnly(libs.asciidoctorj)
     runtimeOnly(libs.asciidoctorj.pdf)
 
     ksp(projects.reporter)

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.json)
     implementation(libs.kotlinx.coroutines)
-    implementation(libs.postgres)
     implementation(projects.clients.clearlyDefinedClient)
     implementation(projects.utils.commonUtils)
 

--- a/utils/ort/build.gradle.kts
+++ b/utils/ort/build.gradle.kts
@@ -38,7 +38,11 @@ dependencies {
     api(projects.utils.spdxExpressionUtils)
 
     implementation(libs.awsS3)
-    implementation(libs.xz)
+
+    implementation(libs.xz) {
+        because("XZOutputStream is a supertype of XZCompressorOutputStream.")
+    }
+
     implementation(projects.clients.foojayClient)
     implementation(projects.utils.authenticationUtils)
     implementation(projects.utils.commonUtils)

--- a/utils/spdx-expression/build.gradle.kts
+++ b/utils/spdx-expression/build.gradle.kts
@@ -23,11 +23,10 @@ plugins {
 }
 
 dependencies {
+    api(jacksonLibs.jacksonAnnotations)
     api(jacksonLibs.jacksonDatabind)
     api(projects.utils.spdxUtils)
 
-    implementation(jacksonLibs.jacksonDataformatYaml)
-    implementation(jacksonLibs.jacksonModuleKotlin)
     implementation(projects.utils.commonUtils)
 
     testImplementation(projects.model)


### PR DESCRIPTION
This PR applies preparations for upgrading DAGP (the Dependency Analysis Gradle Plugin) to version 3.16.1, see https://github.com/oss-review-toolkit/ort/pull/12124.