### PR TITLE
fix(yarn2): Avoid failing on ambiguously resolved locators

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2DependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/yarn2/Yarn2DependencyHandler.kt
@@ -44,6 +44,12 @@ internal class Yarn2DependencyHandler(
     private val packageJsonForModuleId = mutableMapOf<String, PackageJson>()
     private val packageInfoForLocator = mutableMapOf<String, PackageInfo>()
 
+    /**
+     * A cache for the results of [resolvePackageInfos], as the same dependency is resolved repeatedly while the
+     * dependency graph is built, and the fallback resolution is expensive.
+     */
+    private val packageInfosForDependency = mutableMapOf<PackageInfo.Dependency, List<PackageInfo>>()
+
     fun setContext(
         workingDir: File,
         packageJsonForModuleId: Map<String, PackageJson>,
@@ -60,6 +66,10 @@ internal class Yarn2DependencyHandler(
             clear()
             putAll(packageJsonForModuleId)
         }
+
+        // Cached resolutions are not reusable across definition files, as they are resolved against
+        // `packageInfoForLocator`, whose content is replaced here.
+        packageInfosForDependency.clear()
     }
 
     override fun identifierFor(dependency: PackageInfo): Identifier =
@@ -71,7 +81,7 @@ internal class Yarn2DependencyHandler(
         )
 
     override fun dependenciesFor(dependency: PackageInfo): List<PackageInfo> =
-        dependency.children.dependencies.map(::packageInfoFor)
+        dependency.children.dependencies.flatMap(::packageInfoFor)
 
     override fun linkageFor(dependency: PackageInfo): PackageLinkage =
         if (dependency.isProject) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
@@ -84,7 +94,15 @@ internal class Yarn2DependencyHandler(
     }
 
     /**
-     * Obtain the [PackageInfo] object for the given [dependency].
+     * Obtain the [PackageInfo] objects for the given [dependency], see [resolvePackageInfos]. Results are cached in
+     * [packageInfosForDependency].
+     */
+    internal fun packageInfoFor(dependency: PackageInfo.Dependency): List<PackageInfo> =
+        packageInfosForDependency.getOrPut(dependency) { resolvePackageInfos(dependency) }
+
+    /**
+     * Resolve the given [dependency] to the [PackageInfo] objects it refers to. Usually the result is a single
+     * object, but in case of an ambiguity, all candidates are returned.
      *
      * Try the `realLocator` first to correctly handle virtual packages. If that fails, try to construct the real
      * locator from the virtual package's actual resolved version (handles virtual packages whose `children.version`
@@ -93,47 +111,60 @@ internal class Yarn2DependencyHandler(
      * If both targeted lookups fail, fall back to searching the map for all installed non-virtual, non-project
      * versions of the same module by name. This handles the case where Yarn's `resolutions` feature (or similar
      * mechanisms) cause a non-virtual dependency locator to reference a version that is not present in the map,
-     * while a different version of the same module was actually installed. If exactly one candidate is found, it
-     * is used. If multiple candidates are found, the semver range from the [dependency]'s descriptor is used to
-     * narrow down the candidates. If after all fallbacks the result is still not unique, an exception is thrown.
+     * while a different version of the same module was actually installed. The candidates found by name are first
+     * narrowed down to those matching the semver range from the [dependency]'s descriptor (keeping all versions if
+     * the range cannot be determined or nothing matches it), and then to those of the locator's patch or non-patch
+     * type (keeping the other type if none matches). The version is checked before the type, as attributing the
+     * correct version has priority. The type check handles packages that exist both as a plain npm package and as a
+     * compat-patched variant (e.g. via `@yarnpkg/plugin-compat`), which would otherwise lead to ambiguous
+     * resolution.
+     *
+     * If the result is still not unique after all fallbacks, all remaining candidates are returned, as Yarn actually
+     * installs all of them in parallel. An exception is only thrown if no candidate for the module exists at all.
      */
-    internal fun packageInfoFor(dependency: PackageInfo.Dependency): PackageInfo {
-        packageInfoForLocator[dependency.realLocator]?.let { return it }
+    private fun resolvePackageInfos(dependency: PackageInfo.Dependency): List<PackageInfo> {
+        packageInfoForLocator[dependency.realLocator]?.let { return listOf(it) }
 
         // Fallback for virtual packages: derive the real locator from the virtual package's resolved version.
         packageInfoForLocator[dependency.locator]?.let { virtualInfo ->
             val moduleName = Locator.parse(dependency.locator).moduleName
-            packageInfoForLocator["$moduleName@npm:${virtualInfo.children.version}"]?.let { return it }
+            packageInfoForLocator["$moduleName@npm:${virtualInfo.children.version}"]?.let { return listOf(it) }
         }
 
         // Fallback for version mismatches caused by Yarn's `resolutions` feature: find installed versions of the
         // same module by name, ignoring the exact version in the locator.
-        val moduleName = Locator.parse(dependency.realLocator).moduleName
-        val candidates = packageInfoForLocator.values.filter {
+        val realLocator = Locator.parse(dependency.realLocator)
+        val moduleName = realLocator.moduleName
+        val installed = packageInfoForLocator.values.filter {
             it.moduleName == moduleName && !it.isProject && !it.isVirtual
         }
 
-        candidates.singleOrNull()?.also {
-            logger.debug {
-                "Resolved locator '${dependency.realLocator}' to '${it.value}' via module name lookup."
-            }
-
-            return it
-        }
-
-        if (candidates.isEmpty()) {
+        if (installed.isEmpty()) {
             error(
                 "Could not find a PackageInfo for locator '${dependency.realLocator}'. No entry for module " +
                     "'$moduleName' exists in ${packageInfoForLocator.keys}."
             )
         }
 
-        candidates.matchVersionRange(dependency)?.let { return it }
+        // Narrow down by the descriptor's semver range first, as attributing the correct version has priority over
+        // matching the locator's patch or non-patch type.
+        val versionMatches = installed.matchingVersionRange(dependency)?.ifEmpty { null } ?: installed
 
-        error(
-            "Could not unambiguously resolve locator '${dependency.realLocator}'. Found ${candidates.size} " +
-                "installed versions of module '$moduleName': ${candidates.map { it.value }}."
-        )
+        // Prefer candidates of the locator's patch or non-patch type, falling back to the other type if none match.
+        val candidates = versionMatches.filter { it.isPatch == realLocator.isPatch }.ifEmpty { versionMatches }
+
+        logger.debug {
+            if (candidates.size == 1) {
+                "Resolved locator '${dependency.realLocator}' to '${candidates.single().value}' via module name " +
+                    "lookup on descriptor '${dependency.descriptor}'."
+            } else {
+                "Could not unambiguously map the locator '${dependency.realLocator}' to one of the installed " +
+                    "versions of '$moduleName'. Adding all candidates to the dependency graph: " +
+                    "${candidates.map { it.value }}."
+            }
+        }
+
+        return candidates
     }
 }
 
@@ -143,10 +174,10 @@ internal val PackageInfo.isProject: Boolean
 internal val PackageInfo.isVirtual: Boolean
     get() = Locator.parse(value).isVirtual
 
+internal val PackageInfo.isPatch: Boolean
+    get() = Locator.parse(value).isPatch
+
 internal val PackageInfo.moduleName: String
-    // TODO: Handle patched packages different than non-patched ones.
-    // Patch packages have locators as e.g. the following, where the first component ends with "@patch".
-    // resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d
     get() = Locator.parse(value).moduleName
 
 internal val PackageInfo.moduleId: String
@@ -177,26 +208,37 @@ internal data class Locator(
         (remainder.startsWith("virtual:") && "#workspace:" in remainder)
 
     val isVirtual: Boolean = remainder.startsWith("virtual:") && !isProject
+
+    val isPatch: Boolean = remainder.startsWith("patch:")
 }
 
 /**
- * Try to find a single [PackageInfo] from this collection that matches the given [dependency] taking semantic
- * version ranges into account.
+ * Narrow this collection down to the entries whose version matches the semver range of the given [dependency]'s
+ * `npm:` or `patch:` descriptor. Return `null` if the range cannot be determined, or the (possibly empty or still
+ * not unique) list of matching entries otherwise.
  */
-private fun Collection<PackageInfo>.matchVersionRange(dependency: PackageInfo.Dependency): PackageInfo? {
+private fun Collection<PackageInfo>.matchingVersionRange(dependency: PackageInfo.Dependency): List<PackageInfo>? {
     val descriptorRemainder = Locator.parse(dependency.descriptor).remainder
-    return descriptorRemainder.withoutPrefix("npm:")?.let { rangeSpec ->
-        runCatching { RangeListFactory.create(rangeSpec) }.getOrNull()?.let { range ->
-            val matchingCandidates = filter { candidate ->
-                Semver.coerce(candidate.children.version)?.let { range.isSatisfiedBy(it) } == true
-            }
+    val rangeSpec = descriptorRemainder.withoutPrefix("npm:")
+        ?: extractNpmRangeFromPatchRemainder(descriptorRemainder)
+        ?: return null
 
-            matchingCandidates.singleOrNull()?.also {
-                logger.debug {
-                    "Resolved locator '${dependency.realLocator}' to '${it.value}' via semver range " +
-                        "matching on descriptor '${dependency.descriptor}'."
-                }
-            }
-        }
+    return runCatching { RangeListFactory.create(rangeSpec) }.getOrNull()?.let { range ->
+        filter { candidate -> Semver.coerce(candidate.children.version)?.let { range.isSatisfiedBy(it) } == true }
     }
+}
+
+/**
+ * Extract the npm version range embedded in a [patchRemainder] like
+ * `patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>`, returning `^2.0.0-next.5`, or `null` if
+ * [patchRemainder] is not a patch descriptor or the range cannot be extracted.
+ */
+private fun extractNpmRangeFromPatchRemainder(patchRemainder: String): String? {
+    if (!patchRemainder.startsWith("patch:")) return null
+    // The npm version range follows "@npm%3A" (URL-encoded "@npm:") or "@npm:" and ends at "#".
+    val afterNpmPrefix = patchRemainder.substringAfter("@npm%3A", "").ifEmpty {
+        patchRemainder.substringAfter("@npm:", "")
+    }
+
+    return afterNpmPrefix.takeIf { it.isNotEmpty() }?.substringBefore("#")
 }

--- a/plugins/package-managers/node/src/test/kotlin/yarn2/Yarn2DependencyHandlerTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/yarn2/Yarn2DependencyHandlerTest.kt
@@ -23,6 +23,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
@@ -94,12 +95,34 @@ class Yarn2DependencyHandlerTest : WordSpec({
         }
     }
 
+    "Locator.isPatch" should {
+        "return true for a compat-patched package" {
+            val locator = Locator.parse(
+                "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+            )
+
+            locator.isPatch shouldBe true
+        }
+
+        "return false for a real npm package" {
+            Locator.parse("resolve@npm:1.22.8").isPatch shouldBe false
+        }
+
+        "return false for a virtual npm package" {
+            val locator = Locator.parse(
+                "cookie@virtual:abc123def456abc123def456abc123def456abc123def456abc123def456abc123de#npm:1.0.2"
+            )
+
+            locator.isPatch shouldBe false
+        }
+    }
+
     "packageInfoFor()" should {
         "resolve a dependency via its realLocator" {
             val info = packageInfo("cookie@npm:1.0.2", "1.0.2")
             val handler = handlerWith(mapOf("cookie@npm:1.0.2" to info))
 
-            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldBe info
+            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldBe listOf(info)
         }
 
         "resolve a virtual dependency via its realLocator" {
@@ -108,7 +131,7 @@ class Yarn2DependencyHandlerTest : WordSpec({
                 "cookie@virtual:abc123def456abc123def456abc123def456abc123def456abc123def456abc123de#npm:1.0.2"
             val handler = handlerWith(mapOf("cookie@npm:1.0.2" to info))
 
-            handler.packageInfoFor(dep(virtualLocator)) shouldBe info
+            handler.packageInfoFor(dep(virtualLocator)) shouldBe listOf(info)
         }
 
         "use the virtual package fallback when the realLocator is not in the map" {
@@ -125,7 +148,7 @@ class Yarn2DependencyHandlerTest : WordSpec({
                 )
             )
 
-            handler.packageInfoFor(dep(virtualLocator)) shouldBe resolvedInfo
+            handler.packageInfoFor(dep(virtualLocator)) shouldBe listOf(resolvedInfo)
         }
 
         "use the module name fallback when only a different version is installed" {
@@ -134,7 +157,7 @@ class Yarn2DependencyHandlerTest : WordSpec({
             val resolvedInfo = packageInfo("cookie@npm:1.1.1", "1.1.1")
             val handler = handlerWith(mapOf("cookie@npm:1.1.1" to resolvedInfo))
 
-            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldBe resolvedInfo
+            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldBe listOf(resolvedInfo)
         }
 
         "ignore virtual packages in the module name fallback" {
@@ -149,7 +172,7 @@ class Yarn2DependencyHandlerTest : WordSpec({
                 )
             )
 
-            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldBe resolvedInfo
+            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldBe listOf(resolvedInfo)
         }
 
         "throw when no entry for the module is found" {
@@ -162,20 +185,33 @@ class Yarn2DependencyHandlerTest : WordSpec({
             exception.message shouldContain "cookie"
         }
 
-        "throw when multiple real versions of the module are found" {
+        "return all candidates when multiple real versions of the module are found" {
+            val info100 = packageInfo("cookie@npm:1.0.0", "1.0.0")
+            val info111 = packageInfo("cookie@npm:1.1.1", "1.1.1")
+            val handler = handlerWith(mapOf("cookie@npm:1.0.0" to info100, "cookie@npm:1.1.1" to info111))
+
+            handler.packageInfoFor(dep("cookie@npm:1.0.2")) shouldContainExactlyInAnyOrder listOf(info100, info111)
+        }
+
+        "resolve an ambiguous virtual locator whose real locator is not installed to all candidates" {
+            // The real locator derived from the virtual locator is not installed, so the module name fallback has to
+            // consider the installed versions, see https://github.com/oss-review-toolkit/ort/issues/12008.
+            val virtualLocator =
+                "debug@virtual:abc123def456abc123def456abc123def456abc123def456abc123def456abc123de#npm:4.4.1"
+            val info327 = packageInfo("debug@npm:3.2.7", "3.2.7")
+            val info437 = packageInfo("debug@npm:4.3.7", "4.3.7")
             val handler = handlerWith(
                 mapOf(
-                    "cookie@npm:1.0.0" to packageInfo("cookie@npm:1.0.0", "1.0.0"),
-                    "cookie@npm:1.1.1" to packageInfo("cookie@npm:1.1.1", "1.1.1")
+                    "debug@npm:3.2.7" to info327,
+                    "debug@npm:4.3.7" to info437,
+                    virtualLocator to packageInfo(virtualLocator, "4.4.1")
                 )
             )
 
-            val exception = shouldThrow<IllegalStateException> {
-                handler.packageInfoFor(dep("cookie@npm:1.0.2"))
-            }
+            // The descriptor's range matches neither installed version, so all candidates have to be considered.
+            val dependency = PackageInfo.Dependency(descriptor = "debug@npm:^4.4.0", locator = virtualLocator)
 
-            exception.message shouldContain "2"
-            exception.message shouldContain "cookie"
+            handler.packageInfoFor(dependency) shouldContainExactlyInAnyOrder listOf(info327, info437)
         }
 
         "use the semver range from the descriptor to disambiguate multiple candidates" {
@@ -186,10 +222,10 @@ class Yarn2DependencyHandlerTest : WordSpec({
             val dependency = PackageInfo.Dependency(descriptor = "cookie@npm:^1.0.0", locator = "cookie@npm:1.0.2")
             val handler = handlerWith(mapOf("cookie@npm:1.0.0" to info100, "cookie@npm:2.0.0" to info200))
 
-            handler.packageInfoFor(dependency) shouldBe info100
+            handler.packageInfoFor(dependency) shouldBe listOf(info100)
         }
 
-        "throw when the semver range from the descriptor still matches multiple candidates" {
+        "return all matching candidates when the semver range still matches multiple candidates" {
             // Both installed versions satisfy the descriptor range.
             val info440 = packageInfo("debug@npm:4.4.0", "4.4.0")
             val info443 = packageInfo("debug@npm:4.4.3", "4.4.3")
@@ -197,12 +233,130 @@ class Yarn2DependencyHandlerTest : WordSpec({
             val dependency = PackageInfo.Dependency(descriptor = "debug@npm:^4.3.0", locator = "debug@npm:4.3.6")
             val handler = handlerWith(mapOf("debug@npm:4.4.0" to info440, "debug@npm:4.4.3" to info443))
 
-            val exception = shouldThrow<IllegalStateException> {
-                handler.packageInfoFor(dependency)
-            }
+            handler.packageInfoFor(dependency) shouldContainExactlyInAnyOrder listOf(info440, info443)
+        }
 
-            exception.message shouldContain "2"
-            exception.message shouldContain "debug"
+        "widen to all installed versions when the descriptor's range cannot be parsed" {
+            val info100 = packageInfo("cookie@npm:1.0.0", "1.0.0")
+            val info111 = packageInfo("cookie@npm:1.1.1", "1.1.1")
+            val info200 = packageInfo("cookie@npm:2.0.0", "2.0.0")
+            // The descriptor's remainder has neither an "npm:" nor a "patch:" prefix, so no range can be extracted.
+            val dependency =
+                PackageInfo.Dependency(descriptor = "cookie@nonsense:whatever", locator = "cookie@npm:1.0.2")
+            val handler = handlerWith(
+                mapOf(
+                    "cookie@npm:1.0.0" to info100,
+                    "cookie@npm:1.1.1" to info111,
+                    "cookie@npm:2.0.0" to info200
+                )
+            )
+
+            handler.packageInfoFor(dependency) shouldContainExactlyInAnyOrder listOf(info100, info111, info200)
+        }
+
+        "resolve a patch locator when only a different patch version is installed" {
+            val patchLocator = "resolve@patch:resolve@npm%3A2.0.0-next.7" +
+                "#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d"
+            val patchInfo = packageInfo(patchLocator, "2.0.0-next.7")
+            val handler = handlerWith(mapOf(patchLocator to patchInfo))
+
+            val depLocator = "resolve@patch:resolve@npm%3A2.0.0-next.5" +
+                "#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=c3c19d"
+            handler.packageInfoFor(dep(depLocator)) shouldBe listOf(patchInfo)
+        }
+
+        "not confuse npm and patch variants when resolving multi-version packages" {
+            // 4 installed locators for the same module name, see
+            // https://github.com/oss-review-toolkit/ort/issues/12008.
+            val patchLocator1 = "resolve@patch:resolve@npm%3A1.22.12" +
+                "#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+            val patchLocator2 = "resolve@patch:resolve@npm%3A2.0.0-next.7" +
+                "#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d"
+            val npmInfo1 = packageInfo("resolve@npm:1.22.12", "1.22.12")
+            val npmInfo2 = packageInfo("resolve@npm:2.0.0-next.7", "2.0.0-next.7")
+            val patchInfo1 = packageInfo(patchLocator1, "1.22.12")
+            val patchInfo2 = packageInfo(patchLocator2, "2.0.0-next.7")
+            val handler = handlerWith(
+                mapOf(
+                    "resolve@npm:1.22.12" to npmInfo1,
+                    "resolve@npm:2.0.0-next.7" to npmInfo2,
+                    patchLocator1 to patchInfo1,
+                    patchLocator2 to patchInfo2
+                )
+            )
+
+            val depLocator = "resolve@patch:resolve@npm%3A2.0.0-next.5" +
+                "#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=c3c19d"
+            val depDescriptor = "resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>"
+            val dependency = PackageInfo.Dependency(descriptor = depDescriptor, locator = depLocator)
+
+            handler.packageInfoFor(dependency) shouldBe listOf(patchInfo2)
+        }
+
+        "resolve an npm locator when both npm and patch variants of the same version are installed" {
+            // When a plain npm dependency is requested, it must not be confused with the patch variant.
+            val patchLocator = "resolve@patch:resolve@npm%3A1.22.12" +
+                "#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+            val npmInfo = packageInfo("resolve@npm:1.22.12", "1.22.12")
+            val patchInfo = packageInfo(patchLocator, "1.22.12")
+            val handler = handlerWith(
+                mapOf(
+                    "resolve@npm:1.22.12" to npmInfo,
+                    patchLocator to patchInfo
+                )
+            )
+
+            handler.packageInfoFor(dep("resolve@npm:1.22.11")) shouldBe listOf(npmInfo)
+        }
+
+        "fall back to the opposite locator type when no candidate of the matching type is installed" {
+            // Only a patch variant is installed, so the npm lookup falls back to it instead of failing.
+            val patchLocator = "resolve@patch:resolve@npm%3A1.22.8" +
+                "#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+            val patchInfo = packageInfo(patchLocator, "1.22.8")
+            val handler = handlerWith(mapOf(patchLocator to patchInfo))
+
+            handler.packageInfoFor(dep("resolve@npm:1.22.9")) shouldBe listOf(patchInfo)
+        }
+
+        "prefer a range-matching candidate of the other type over a wrong-version candidate of the matching type" {
+            // Only a patched variant of the version requested by the descriptor is installed, while the plain npm
+            // variant exists at a different version. The version takes priority over the locator type.
+            val patchLocator =
+                "cookie@patch:cookie@npm%3A2.0.0#optional!builtin<compat/cookie>::version=2.0.0&hash=c3c19d"
+            val npmInfo = packageInfo("cookie@npm:1.0.0", "1.0.0")
+            val patchInfo = packageInfo(patchLocator, "2.0.0")
+            val handler = handlerWith(mapOf("cookie@npm:1.0.0" to npmInfo, patchLocator to patchInfo))
+
+            val dependency = PackageInfo.Dependency(descriptor = "cookie@npm:^2.0.0", locator = "cookie@npm:2.0.0")
+
+            handler.packageInfoFor(dependency) shouldBe listOf(patchInfo)
+        }
+
+        "not cache a failed resolution" {
+            val handler = handlerWith(mapOf("other@npm:1.0.0" to packageInfo("other@npm:1.0.0", "1.0.0")))
+            val dependency = dep("cookie@npm:1.0.2")
+
+            repeat(2) {
+                shouldThrow<IllegalStateException> {
+                    handler.packageInfoFor(dependency)
+                }.message shouldContain "cookie"
+            }
+        }
+
+        "not resolve a dependency from the cache of a previous context" {
+            // The handler instance is reused across definition files, so the cached resolutions of a previous
+            // project must not leak into the next one.
+            val info111 = packageInfo("cookie@npm:1.1.1", "1.1.1")
+            val handler = handlerWith(mapOf("cookie@npm:1.1.1" to info111))
+            val dependency = dep("cookie@npm:1.0.2")
+
+            handler.packageInfoFor(dependency) shouldBe listOf(info111)
+
+            val info200 = packageInfo("cookie@npm:2.0.0", "2.0.0")
+            handler.setContext(tempdir(), emptyMap(), mapOf("cookie@npm:2.0.0" to info200))
+
+            handler.packageInfoFor(dependency) shouldBe listOf(info200)
         }
     }
 })


### PR DESCRIPTION
Previously, ORT aborted the analysis of a definition file with an `IllegalStateException` when a dependency could not be resolved to a single installed package. This happens for valid Yarn Berry trees that install several versions of the same module, for example a package that exists both as a plain npm package and as a compat-patched variant added by `@yarnpkg/plugin-compat`.

The fallback that looks up installed packages by module name now prefers candidates of the same patch or non-patch type as the locator, and reads the npm version range embedded in patch descriptors. If more than one candidate remains, all of them are added to the dependency graph instead of failing the analysis. This mirrors Yarn Berry's actual behavior of installing all of these versions in parallel, and it is the safest option from a license and compliance point of view.

Fixes #12008.