### PR TITLE
chore(model): Correct the target type of a sorted set converter

### DIFF
--- a/model/src/main/kotlin/utils/SortedCollectionConverters.kt
+++ b/model/src/main/kotlin/utils/SortedCollectionConverters.kt
@@ -51,7 +51,7 @@ class CopyrightFindingSortedSetConverter : StdConverter<Set<CopyrightFinding>, S
     override fun convert(value: Set<CopyrightFinding>) = value.toSortedSet(CopyrightFinding.COMPARATOR)
 }
 
-class DependencyGraphEdgeSortedSetConverter : StdConverter<Set<DependencyGraphEdge>, Set<DependencyGraphEdge>>() {
+class DependencyGraphEdgeSortedSetConverter : StdConverter<Set<DependencyGraphEdge>, SortedSet<DependencyGraphEdge>>() {
     override fun convert(value: Set<DependencyGraphEdge>) = value.toSortedSet(compareBy({ it.from }, { it.to }))
 }
 


### PR DESCRIPTION
Align with other converters that use `toSortedSet()` and also use `SortedSet` as the target type.