### PR TITLE
Add package namespace based curation provider

### DIFF
--- a/plugins/package-curation-providers/namespaced/build.gradle.kts
+++ b/plugins/package-curation-providers/namespaced/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-plugin-conventions")
+}
+
+dependencies {
+    api(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+
+    implementation(projects.utils.commonUtils)
+
+    ksp(projects.plugins.packageCurationProviders.packageCurationProviderApi)
+}

--- a/plugins/package-curation-providers/namespaced/src/main/kotlin/NamespacedPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/namespaced/src/main/kotlin/NamespacedPackageCurationProvider.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagecurationproviders.namespaced
+
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.PackageCurationData
+import org.ossreviewtoolkit.model.fromYaml
+import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.PluginDescriptor
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProvider
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
+import org.ossreviewtoolkit.utils.common.FileMatcher
+
+/**
+ * A configuration entry mapping a package coordinate pattern to a [PackageCurationData] that should be applied to
+ * all packages matching the pattern.
+ */
+private data class NamespaceCuration(
+    /**
+     * An Ant-style glob pattern used to match a package's full `<type>:<namespace>:<name>:<version>` coordinate
+     * string. For details about the glob syntax see the [FileMatcher] implementation.
+     */
+    val pattern: String,
+
+    /** The [PackageCurationData] to apply to packages matching [pattern]. */
+    val curations: PackageCurationData
+)
+
+data class NamespacedPackageCurationProviderConfig(
+    /**
+     * A YAML string defining a list of namespace-based package curations as configured in `ort.yml`. Each entry has a
+     * `namespace` key — an Ant-style glob pattern matched against a package's full
+     * `<type>:<namespace>:<name>:<version>` coordinate string — and a `curations` key with the [PackageCurationData]
+     * to apply to matching packages. For details about the glob syntax see the [FileMatcher] implementation. Use a
+     * literal `:` to represent an empty namespace or name.
+     */
+    val curations: String
+)
+
+/**
+ * A [PackageCurationProvider] that provides [PackageCuration]s for packages based on a user-defined mapping of
+ * package coordinates to curation data. Each entry's `namespace` key is an Ant-style glob pattern matched against a
+ * package's full `<type>:<namespace>:<name>:<version>` coordinate string. For each matching package, the configured
+ * curation data is applied.
+ */
+@OrtPlugin(
+    displayName = "Namespaced",
+    summary = "A package curation provider that applies curations to packages based on their namespace.",
+    factory = PackageCurationProviderFactory::class
+)
+class NamespacedPackageCurationProvider(
+    override val descriptor: PluginDescriptor = NamespacedPackageCurationProviderFactory.descriptor,
+    config: NamespacedPackageCurationProviderConfig
+) : PackageCurationProvider {
+    private val namespaceCurations: List<NamespaceCuration> = runCatching {
+        config.curations.fromYaml<List<NamespaceCurationConfig>>()
+    }.getOrElse {
+        throw IllegalArgumentException("Failed to parse the 'curations' option as YAML.", it)
+    }.map { entry ->
+        require(entry.namespace.isNotBlank()) {
+            "The namespace must not be blank."
+        }
+
+        NamespaceCuration(pattern = entry.namespace, curations = entry.curations)
+    }
+
+    init {
+        require(namespaceCurations.isNotEmpty()) {
+            "At least one namespace curation must be defined."
+        }
+    }
+
+    override fun getCurationsFor(packages: Collection<Package>): Set<PackageCuration> {
+        val results = mutableSetOf<PackageCuration>()
+
+        packages.forEach { pkg ->
+            val curations = getCurationsForCoordinates(pkg.id.toCoordinates())
+            if (curations != null && curations != PackageCurationData()) {
+                results += PackageCuration(pkg.id, curations)
+            }
+        }
+
+        return results
+    }
+
+    private fun getCurationsForCoordinates(pkgCoordinates: String): PackageCurationData? =
+        namespaceCurations.firstNotNullOfOrNull { entry ->
+            if (FileMatcher.matches(entry.pattern, pkgCoordinates)) entry.curations else null
+        }
+}
+
+/**
+ * The configuration format of a single namespace curation entry as it is read from the inline YAML option.
+ */
+private data class NamespaceCurationConfig(
+    val namespace: String,
+    val curations: PackageCurationData
+)

--- a/plugins/package-curation-providers/namespaced/src/test/kotlin/NamespacedPackageCurationProviderTest.kt
+++ b/plugins/package-curation-providers/namespaced/src/test/kotlin/NamespacedPackageCurationProviderTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagecurationproviders.namespaced
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.PackageCurationData
+
+class NamespacedPackageCurationProviderTest : StringSpec({
+    val id = Identifier("Maven:org.third_party:testpackage:1.0.0")
+    val pkg = Package.EMPTY.copy(id = id)
+
+    val emptyNamespaceId = Identifier("Maven::testpackage:1.0.0")
+    val emptyNamespacePkg = Package.EMPTY.copy(id = emptyNamespaceId)
+
+    val prefixId = Identifier("Maven:org.third_party:testpackage-core:1.0.0")
+    val prefixPkg = Package.EMPTY.copy(id = prefixId)
+
+    val minorVersionId = Identifier("Maven:org.third_party:testpackage:1.1.0")
+    val minorVersionPkg = Package.EMPTY.copy(id = minorVersionId)
+
+    val npmId = Identifier("NPM:react:react:18.2.0")
+    val npmPkg = Package.EMPTY.copy(id = npmId)
+
+    val nugetId = Identifier("NuGet:Newtonsoft.Json:13.0.1")
+    val nugetPkg = Package.EMPTY.copy(id = nugetId)
+
+    val pkgs = setOf(pkg, prefixPkg, minorVersionPkg, npmPkg, nugetPkg)
+
+    val expectedCuration = PackageCuration(
+        id = id,
+        data = PackageCurationData(
+            sourceCodeOrigins = emptyList(),
+            comment = "Third party proprietary closed-sourced package for which no sources are available."
+        )
+    )
+
+    fun provider(pattern: String) =
+        NamespacedPackageCurationProvider(
+            config = NamespacedPackageCurationProviderConfig(
+                curations = """
+                - namespace: "$pattern"
+                  curations:
+                      source_code_origins: []
+                      comment: |
+                        Third party proprietary closed-sourced package for which no sources are available."""
+                    .trimIndent()
+            )
+        )
+
+    "Match the exact coordinate" {
+        provider("Maven:org.third_party:testpackage:1.0.0")
+            .getCurationsFor(pkgs) should containExactly(expectedCuration)
+    }
+
+    "Match packages with a specific name, ignoring namespace and version" {
+        val expectedCurationForMinorVersion = expectedCuration.copy(id = minorVersionId)
+
+        provider("Maven:*:testpackage:*")
+            .getCurationsFor(pkgs) should containExactly(expectedCuration, expectedCurationForMinorVersion)
+    }
+
+    "Match a package with an empty namespace via a double colon" {
+        val expectedCuration = PackageCuration(
+            id = emptyNamespaceId,
+            data = PackageCurationData(
+                sourceCodeOrigins = emptyList(),
+                comment = "Third party proprietary closed-sourced package for which no sources are available."
+            )
+        )
+
+        provider("Maven::testpackage:1.0.0")
+            .getCurationsFor(setOf(emptyNamespacePkg, pkg, prefixPkg, minorVersionPkg, npmPkg, nugetPkg)) should
+            containExactly(expectedCuration)
+    }
+
+    "Match packages with a name prefix" {
+        val expectedCurationForPrefix = expectedCuration.copy(id = prefixId)
+        val expectedCurationForMinorVersion = expectedCuration.copy(id = minorVersionId)
+
+        provider("Maven:org.third_party:testpackage*:*")
+            .getCurationsFor(pkgs) should containExactly(
+            expectedCuration,
+            expectedCurationForPrefix,
+            expectedCurationForMinorVersion
+        )
+    }
+
+    "Match all releases of a specific major version" {
+        val expectedCurationForMinorVersion = expectedCuration.copy(id = minorVersionId)
+
+        provider("Maven:org.third_party:testpackage:1.*")
+            .getCurationsFor(pkgs) should containExactly(expectedCuration, expectedCurationForMinorVersion)
+    }
+
+    "Apply only the first matching curation when multiple patterns match" {
+        val provider = NamespacedPackageCurationProvider(
+            config = NamespacedPackageCurationProviderConfig(
+                curations = """
+                    - namespace: "Maven:org.third_party:testpackage:1.0.0"
+                      curations:
+                        is_metadata_only: false
+                        comment: "Second"
+                    - namespace: "Maven:*:*:*"
+                      curations:
+                        is_metadata_only: true
+                        comment: "First"
+                    - namespace: "Maven:org.third_party:testpackage*:*"
+                      curations:
+                        is_metadata_only: true
+                        comment: "First"
+                    - namespace: "NPM:*:*:*"
+                      curations:
+                        is_metadata_only: true
+                        comment: "First"
+                    - namespace: "NuGet:*:*:*"
+                      curations:
+                        is_metadata_only: true
+                        comment: "First"
+                """.trimIndent()
+            )
+        )
+
+        provider.getCurationsFor(pkgs).map { it.id } shouldContainExactly
+            setOf(id, prefixId, minorVersionId, npmId, nugetId)
+    }
+})


### PR DESCRIPTION
The idea here is to implement package curation provider that allows specifying pattern for which we can automatically apply curations globally for set of packages.

For example, we can have some packages from specific third party provider that don't provide sources, so we can automatically set source_code_origins and comment describing that using specific pattern like `Maven:org.third_party:*:*`