### PR TITLE
feat(Tycho): Allow some configuration of the command line

### DIFF
--- a/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
+++ b/plugins/package-managers/maven/src/main/kotlin/tycho/Tycho.kt
@@ -57,6 +57,7 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.model.utils.isScopeIncluded
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
+import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.PACKAGE_TYPE
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.LocalProjectWorkspaceReader
@@ -71,6 +72,17 @@ import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.parseScm
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.processDeclaredLicenses
 import org.ossreviewtoolkit.plugins.packagemanagers.maven.utils.toOrtProject
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
+
+/**
+ * A data class storing the configuration options supported by the [Tycho] package manager implementation.
+ */
+data class TychoConfig(
+    @OrtPluginOption(defaultValue = "true")
+    val skipTests: Boolean,
+
+    @OrtPluginOption(defaultValue = "false")
+    val enableDebugLogs: Boolean
+)
 
 /**
  * A package manager implementation supporting Maven projects using [Tycho](https://github.com/eclipse-tycho/tycho).
@@ -97,7 +109,10 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempFile
     summary = "The Tycho package manager for Maven projects.",
     factory = PackageManagerFactory::class
 )
-class Tycho(override val descriptor: PluginDescriptor = TychoFactory.descriptor) : PackageManager("Tycho") {
+class Tycho(
+    override val descriptor: PluginDescriptor = TychoFactory.descriptor,
+    private val config: TychoConfig
+) : PackageManager("Tycho") {
     override val globsForDefinitionFiles = listOf("pom.xml")
 
     /**
@@ -326,7 +341,15 @@ class Tycho(override val descriptor: PluginDescriptor = TychoFactory.descriptor)
             // Use pre-Java-24 unlimited JAXP XML processing.
             add("-Djdk.xml.maxGeneralEntitySizeLimit=0")
             add("-Djdk.xml.totalEntitySizeLimit=0")
-        }.toTypedArray()
+
+            if (config.skipTests) {
+                add("-Dmaven.test.skip=true")
+            }
+
+            if (config.enableDebugLogs) {
+                add("-X")
+            }
+        }.toTypedArray().also { logger.debug { "Maven CLI options: ${it.joinToString(" ")}" } }
 }
 
 /**

--- a/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
+++ b/plugins/package-managers/maven/src/test/kotlin/tycho/TychoTest.kt
@@ -27,7 +27,10 @@ import io.kotest.engine.spec.tempfile
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -101,7 +104,7 @@ class TychoTest : WordSpec({
                 tychoSubModule
             )
 
-            val tycho = Tycho()
+            val tycho = createTycho()
             val mappedDefinitionFiles = tycho.mapDefinitionFiles(tempdir(), definitionFiles, AnalyzerConfiguration())
 
             mappedDefinitionFiles should containExactlyInAnyOrder(tychoDefinitionFile1, tychoDefinitionFile2)
@@ -115,7 +118,7 @@ class TychoTest : WordSpec({
             val subProject = createMavenProject("sub")
             val projectsList = listOf(rootProject, subProject)
 
-            val tycho = spyk(Tycho())
+            val tycho = spyk(createTycho())
             injectCliMock(tycho, projectsList.toJson(), projectsList)
 
             val pkg1 = mockk<Package>(relaxed = true)
@@ -159,7 +162,7 @@ class TychoTest : WordSpec({
 
             val buildOutput = listOf(subProject2, rootProject, subProject1).toJson()
 
-            val tycho = spyk(Tycho())
+            val tycho = spyk(createTycho())
             injectCliMock(tycho, buildOutput, listOf(subProject1, subProject2))
 
             val exception = shouldThrow<TychoBuildException> {
@@ -182,7 +185,7 @@ class TychoTest : WordSpec({
             val subProject = createMavenProject("sub")
             val projectsList = listOf(rootProject, subProject)
 
-            val tycho = spyk(Tycho())
+            val tycho = spyk(createTycho())
             injectCliMock(tycho, projectsList.toJson(), projectsList, exitCode = 1)
 
             val results = tycho.resolveDependencies(
@@ -210,7 +213,7 @@ class TychoTest : WordSpec({
             val subProject3 = createMavenProject("sub3")
             val projectsList = listOf(rootProject, subProject1, subProject2, subProject3)
 
-            val tycho = spyk(Tycho())
+            val tycho = spyk(createTycho())
             injectCliMock(tycho, projectsList.take(2).toJson(), projectsList, exitCode = 1)
 
             val results = tycho.resolveDependencies(
@@ -249,7 +252,7 @@ class TychoTest : WordSpec({
             val targetHandler = mockk<TargetHandler>()
             every { TargetHandler.create(definitionFile.parentFile) } returns targetHandler
 
-            val tycho = spyk(Tycho())
+            val tycho = spyk(createTycho())
             injectCliMock(tycho, projectsList.toJson(), projectsList)
 
             tycho.resolveDependencies(
@@ -284,7 +287,7 @@ class TychoTest : WordSpec({
                 every { isFeature(any()) } returns false
             }
 
-            val tycho = spyk(Tycho())
+            val tycho = spyk(createTycho())
             injectCliMock(tycho, projectsList.toJson(), projectsList, resolver = resolver)
 
             val results = tycho.resolveDependencies(
@@ -303,6 +306,72 @@ class TychoTest : WordSpec({
                 // Make sure that the resolver is used for the feature check function.
                 resolver.isFeature(any())
             }
+        }
+
+        "pass correct default options to the CLI" {
+            val definitionFile = tempfile()
+            val rootProject = createMavenProject("root", definitionFile)
+            val projectsList = listOf(rootProject)
+
+            val tycho = spyk(createTycho())
+            val cli = injectCliMock(tycho, projectsList.toJson(), projectsList)
+
+            tycho.resolveDependencies(
+                tempdir(),
+                definitionFile,
+                Excludes.EMPTY,
+                Includes.EMPTY,
+                AnalyzerConfiguration(),
+                emptyMap()
+            )
+
+            val args = cli.args()
+            args shouldContainAll listOf("package", "-Dmaven.test.skip=true")
+            args shouldNotContain "-X"
+        }
+
+        "support a configuration option to enable tests" {
+            val definitionFile = tempfile()
+            val rootProject = createMavenProject("root", definitionFile)
+            val projectsList = listOf(rootProject)
+
+            val config = createTychoConfig(skipTests = false)
+            val tycho = spyk(createTycho(config))
+            val cli = injectCliMock(tycho, projectsList.toJson(), projectsList)
+
+            tycho.resolveDependencies(
+                tempdir(),
+                definitionFile,
+                Excludes.EMPTY,
+                Includes.EMPTY,
+                AnalyzerConfiguration(),
+                emptyMap()
+            )
+
+            val args = cli.args()
+            args shouldNotContain "-Dmaven.test.skip=true"
+        }
+
+        "support a configuration option to enable debug logs" {
+            val definitionFile = tempfile()
+            val rootProject = createMavenProject("root", definitionFile)
+            val projectsList = listOf(rootProject)
+
+            val config = createTychoConfig(enableDebugLogs = true)
+            val tycho = spyk(createTycho(config))
+            val cli = injectCliMock(tycho, projectsList.toJson(), projectsList)
+
+            tycho.resolveDependencies(
+                tempdir(),
+                definitionFile,
+                Excludes.EMPTY,
+                Includes.EMPTY,
+                AnalyzerConfiguration(),
+                emptyMap()
+            )
+
+            val args = cli.args()
+            args shouldContain "-X"
         }
     }
 
@@ -698,6 +767,14 @@ private fun injectCliMock(
     return cli
 }
 
+/**
+ * Return the command line arguments that were passed to this [MavenCli] mock.
+ */
+private fun MavenCli.args(): Array<String> =
+    slot<Array<String>>().also { slot ->
+        verify { doMain(capture(slot), any(), any(), any()) }
+    }.captured
+
 /** The test artifact used by many tests. */
 private val testArtifact = DefaultArtifact(TEST_GROUP_ID, TEST_ARTIFACT_ID, "jar", TEST_VERSION)
 
@@ -762,3 +839,17 @@ private fun createArtifactMock(id: Identifier): Artifact =
         every { artifactId } returns id.name
         every { version } returns id.version
     }
+
+/**
+ * Create a [Tycho] instance for testing with the specified [config].
+ */
+private fun createTycho(config: TychoConfig = createTychoConfig()): Tycho = Tycho(config = config)
+
+/**
+ * Create a [TychoConfig] instance with the provided parameters.
+ */
+private fun createTychoConfig(skipTests: Boolean = true, enableDebugLogs: Boolean = false): TychoConfig =
+    TychoConfig(
+        skipTests = skipTests,
+        enableDebugLogs = enableDebugLogs
+    )


### PR DESCRIPTION
Introduce a new plugin configuration class for the `Tycho` package manager with some options to adapt the command line. For now, the following options are supported:

- An option to skip tests, which is enabled by default, since test execution is typically not needed for an analysis. This is also an optimization which can reduce execution times.
- An option to enable debug logs which may be useful to diagnose build problems.
