### PR TITLE
feat(nuget): Read the project license(s) from csproj file

### DIFF
--- a/plugins/package-managers/nuget/src/funTest/assets/dotnet-license-identifier-expected-output.yml
+++ b/plugins/package-managers/nuget/src/funTest/assets/dotnet-license-identifier-expected-output.yml
@@ -1,0 +1,54 @@
+---
+project:
+  id: "NuGet::test.csproj:"
+  definition_file_path: "plugins/package-managers/nuget/src/funTest/assets/dotnet/subProjectTestWithLicenseExpression/test.csproj"
+  declared_licenses:
+  - "LicenseRef-My-License OR MIT"
+  declared_licenses_processed:
+    spdx_expression: "LicenseRef-My-License OR MIT"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_VCS_PROCESSED_URL>"
+    revision: "<REPLACE_VCS_REVISION>"
+    path: "<REPLACE_VCS_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "netstandard2.0"
+    dependencies:
+    - id: "NuGet:Newtonsoft:Json:13.0.2"
+packages:
+- id: "NuGet:Newtonsoft:Json:13.0.2"
+  purl: "pkg:nuget/Newtonsoft.Json@13.0.2"
+  authors:
+  - "James Newton-King"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Json.NET is a popular high-performance JSON framework for .NET"
+  homepage_url: "https://www.newtonsoft.com/json"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.2/newtonsoft.json.13.0.2.nupkg"
+    hash:
+      value: "d743ae673bac17fdbf53c05983dba2ffdb99d7e6af8cf5fe008d57aa30b6c6ca615d672c4140eec516e529eb6ad5acf29c20b5cc059c86f98c80865652acdde1"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: "git+https://github.com/JamesNK/Newtonsoft.Json"
+    revision: "4fba53a324c445f06ee08e45a015c346000a7ef2"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/JamesNK/Newtonsoft.Json.git"
+    revision: "4fba53a324c445f06ee08e45a015c346000a7ef2"
+    path: ""

--- a/plugins/package-managers/nuget/src/funTest/assets/dotnet/subProjectTestWithLicenseExpression/test.csproj
+++ b/plugins/package-managers/nuget/src/funTest/assets/dotnet/subProjectTestWithLicenseExpression/test.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageLicenseExpression>LicenseRef-My-License OR MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+  </ItemGroup>
+</Project>

--- a/plugins/package-managers/nuget/src/funTest/kotlin/NuGetFunTest.kt
+++ b/plugins/package-managers/nuget/src/funTest/kotlin/NuGetFunTest.kt
@@ -49,6 +49,15 @@ class NuGetFunTest : StringSpec({
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 
+    "Project license expression is correct".config(enabled = false) {
+        val definitionFile = getAssetFile("dotnet/subProjectTestWithLicenseExpression/test.csproj")
+        val expectedResultFile = getAssetFile("dotnet-license-identifier-expected-output.yml")
+
+        val result = NuGetFactory.create().resolveSingleProject(definitionFile)
+
+        result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
     "A .csproj file with an accompanying .nuspec file is detected correctly".config(enabled = false) {
         val definitionFile = getAssetFile("dotnet/subProjectTestWithNuspec/test.csproj")
         val expectedResultFile = getAssetFile("dotnet-with-nuspec-expected-output.yml")

--- a/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
+++ b/plugins/package-managers/nuget/src/main/kotlin/utils/NuGetInspectorExtensions.kt
@@ -77,7 +77,7 @@ internal fun NuGetInspector.Result.toOrtProject(
         vcs = VcsInfo.EMPTY,
         authors = emptySet(),
         vcsProcessed = PackageManager.processProjectVcs(definitionFile.parentFile),
-        declaredLicenses = emptySet(),
+        declaredLicenses = setOfNotNull(packages.first().licenseExpression),
         homepageUrl = "",
         scopeDependencies = scopes
     )


### PR DESCRIPTION
Right now for dotnet projects if no other files
then the csproj file are scanned the project license is resolved to NONE.

The licenseExpression xml tag of the csproj is used to determine the license or more licenses for the project it self.

This needs a not yet released/private nuget-inspector, but does not change current behaviour.

This is similiar to the maven/pom.xml approach.