### PR TITLE
fix(Python): Prevent generation of duplicate identifiers

### DIFF
--- a/plugins/package-managers/python/src/main/kotlin/Pip.kt
+++ b/plugins/package-managers/python/src/main/kotlin/Pip.kt
@@ -25,6 +25,8 @@ import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
+import org.ossreviewtoolkit.analyzer.PackageManagerResult
+import org.ossreviewtoolkit.analyzer.ProjectResults
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
@@ -34,6 +36,7 @@ import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packagemanagers.python.utils.DEFAULT_PYTHON_VERSION
 import org.ossreviewtoolkit.plugins.packagemanagers.python.utils.PythonInspector
+import org.ossreviewtoolkit.plugins.packagemanagers.python.utils.deduplicate
 import org.ossreviewtoolkit.plugins.packagemanagers.python.utils.toOrtPackages
 import org.ossreviewtoolkit.plugins.packagemanagers.python.utils.toOrtProject
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -107,6 +110,9 @@ class Pip internal constructor(
 
         return listOf(ProjectAnalyzerResult(project, packages))
     }
+
+    override fun createPackageManagerResult(projectResults: ProjectResults): PackageManagerResult =
+        super.createPackageManagerResult(projectResults.deduplicate())
 
     internal fun runPythonInspector(
         definitionFile: File,

--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.packagemanagers.python.utils
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.ProjectResults
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
@@ -33,6 +34,7 @@ import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.toPurl
+import org.ossreviewtoolkit.utils.common.getCommonParentFile
 
 private const val PACKAGE_TYPE = "PyPI"
 
@@ -59,6 +61,32 @@ internal fun PythonInspector.Result.toOrtProject(
         homepageUrl = homepageUrl,
         scopeDependencies = scopes
     )
+}
+
+/**
+ * Deduplicate any duplicate project identifiers by not only deriving the name from the direct parent directory
+ * (which is used by default), but prepend path components upwards to the analysis root until all names are unique.
+ */
+internal fun ProjectResults.deduplicate(): ProjectResults {
+    val identifierMap = entries.flatMap { (file, results) -> results.map { file to it } }
+        .groupBy { it.second.project.id }
+
+    val duplicateIds = identifierMap.filterValues { it.size > 1 }
+
+    return if (duplicateIds.isEmpty()) {
+        this
+    } else {
+        val deduplicatedProjects = duplicateIds.flatMap { (_, fileResults) ->
+            val commonParent = getCommonParentFile(fileResults.map { it.first })
+            fileResults.map { (file, result) ->
+                val projectName = PackageManager.getFallbackProjectName(commonParent, file)
+                val newId = result.project.id.copy(name = projectName)
+                file to listOf(result.copy(project = result.project.copy(id = newId)))
+            }
+        }
+
+        this + deduplicatedProjects.toMap()
+    }
 }
 
 private fun PythonInspector.Result.resolveIdentifier(

--- a/plugins/package-managers/python/src/test/kotlin/utils/PythonInspectorExtensionsTest.kt
+++ b/plugins/package-managers/python/src/test/kotlin/utils/PythonInspectorExtensionsTest.kt
@@ -20,11 +20,20 @@
 package org.ossreviewtoolkit.plugins.packagemanagers.python.utils
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
+import org.ossreviewtoolkit.utils.common.div
 
 class PythonInspectorExtensionsTest : WordSpec({
     "toOrtPackages()" should {
@@ -90,6 +99,44 @@ class PythonInspectorExtensionsTest : WordSpec({
             pkg.declaredLicensesProcessed.spdxExpression should beNull()
         }
     }
+
+    "ProjectResults.deduplicate()" should {
+        "return the same result if there are no duplicates" {
+            val resultMap = mapOf(
+                File("foo") to createResult("foo"),
+                File("bar") to createResult("bar")
+            )
+
+            resultMap.deduplicate() shouldBeSameInstanceAs resultMap
+        }
+
+        "return a deduplicated result" {
+            val analysisRoot = tempdir()
+            val definitionFile1 = analysisRoot / "libraries" / "requirements.txt"
+            val definitionFile2 = analysisRoot / "tools" / "requirements.txt"
+            val definitionFile3 = analysisRoot / "app" / "libraries" / "requirements.txt"
+            val definitionFile4 = analysisRoot / "app" / "tools" / "requirements.txt"
+            val definitionFile5 = analysisRoot / "test" / "requirements.txt"
+
+            val resultMap = mapOf(
+                definitionFile1 to createResult("libraries"),
+                definitionFile2 to createResult("tools"),
+                definitionFile3 to createResult("libraries"),
+                definitionFile4 to createResult("tools"),
+                definitionFile5 to createResult("test")
+            )
+
+            val deduplicatedResults = resultMap.deduplicate()
+
+            deduplicatedResults[definitionFile1] shouldContainOnly createResult("libraries/requirements.txt")
+            deduplicatedResults[definitionFile2] shouldContainOnly createResult("tools/requirements.txt")
+            deduplicatedResults[definitionFile3] shouldContainOnly createResult("app/libraries/requirements.txt")
+            deduplicatedResults[definitionFile4] shouldContainOnly createResult("app/tools/requirements.txt")
+            deduplicatedResults[definitionFile5] shouldContainOnly createResult("test")
+
+            deduplicatedResults.deduplicate() shouldBeSameInstanceAs deduplicatedResults
+        }
+    }
 })
 
 private fun createPackage(licenseExpression: String?, declaredLicense: PythonInspector.DeclaredLicense?) =
@@ -120,3 +167,14 @@ private fun createPackage(licenseExpression: String?, declaredLicense: PythonIns
     )
 
 private fun PythonInspector.Package.toOrtPackage() = listOf(this).toOrtPackages().single()
+
+/**
+ * Return a list with a single [ProjectAnalyzerResult] with a project whose identifier has the given [name] component.
+ */
+private fun createResult(name: String): List<ProjectAnalyzerResult> =
+    listOf(
+        ProjectAnalyzerResult(
+            project = Project.EMPTY.copy(id = Project.EMPTY.id.copy(name = name)),
+            packages = emptySet()
+        )
+    )


### PR DESCRIPTION
If `Pip` finds definition files in sub folders of the analysis root directory, it used to derive the project identifier from the name of the containing folder. This could cause duplicate project identifiers in folder structures with a uniform layout. The affected projects could then not be added to the Analyzer result. Prevent this by performing a deduplication of project identifiers if necessary.

Note: There could be easier ways to fix this by guaranteeing uniqueness from the beginning, but I did not want to change the way identifiers are generated for non-affected projects. Hence, the logic to do a deduplication is only invoked if required.