### PR TITLE
fix(python): Import PEP 639 license expressions

### DIFF
--- a/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
+++ b/plugins/package-managers/python/src/main/kotlin/utils/PythonInspectorExtensions.kt
@@ -136,7 +136,13 @@ internal fun List<PythonInspector.Package>.toOrtPackages(): Set<Package> =
             } ?: RemoteArtifact.EMPTY
 
         val id = Identifier(type = PACKAGE_TYPE, namespace = "", name = pkg.name, version = pkg.version)
-        val declaredLicenses = pkg.declaredLicense?.getDeclaredLicenses().orEmpty()
+
+        // PEP 639 defines License-Expression as the machine-readable replacement for the legacy License field and
+        // license classifiers. Python Inspector exposes that value separately, so use it only as a fallback to keep
+        // the established handling of legacy package metadata unchanged.
+        val declaredLicenses = pkg.declaredLicense?.getDeclaredLicenses()?.takeUnless { it.isEmpty() }
+            ?: setOfNotNull(pkg.licenseExpression?.takeUnless { it.isBlank() })
+
         val declaredLicensesProcessed = processDeclaredLicenses(id, declaredLicenses)
 
         Package(

--- a/plugins/package-managers/python/src/test/kotlin/utils/PythonInspectorExtensionsTest.kt
+++ b/plugins/package-managers/python/src/test/kotlin/utils/PythonInspectorExtensionsTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.python.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class PythonInspectorExtensionsTest : WordSpec({
+    "toOrtPackages()" should {
+        "use a PEP 639 license expression if legacy license metadata is empty" {
+            val pkg = createPackage(
+                licenseExpression = "Apache-2.0 OR BSD-2-Clause",
+                declaredLicense = PythonInspector.DeclaredLicense()
+            ).toOrtPackage()
+
+            pkg.declaredLicenses should containExactly("Apache-2.0 OR BSD-2-Clause")
+            pkg.declaredLicensesProcessed.spdxExpression.toString() shouldBe "Apache-2.0 OR BSD-2-Clause"
+        }
+
+        "prefer legacy license metadata if it is usable" {
+            val pkg = createPackage(
+                licenseExpression = "MIT",
+                declaredLicense = PythonInspector.DeclaredLicense(license = "BSD-3-Clause")
+            ).toOrtPackage()
+
+            pkg.declaredLicenses should containExactly("BSD-3-Clause")
+            pkg.declaredLicensesProcessed.spdxExpression.toString() shouldBe "BSD-3-Clause"
+        }
+
+        "use a PEP 639 license expression if legacy metadata is UNKNOWN" {
+            val pkg = createPackage(
+                licenseExpression = "MIT",
+                declaredLicense = PythonInspector.DeclaredLicense(license = "UNKNOWN")
+            ).toOrtPackage()
+
+            pkg.declaredLicenses should containExactly("MIT")
+            pkg.declaredLicensesProcessed.spdxExpression.toString() shouldBe "MIT"
+        }
+
+        "preserve unmappable legacy metadata instead of replacing it" {
+            val pkg = createPackage(
+                licenseExpression = "MIT",
+                declaredLicense = PythonInspector.DeclaredLicense(license = "custom legacy terms")
+            ).toOrtPackage()
+
+            pkg.declaredLicenses should containExactly("custom legacy terms")
+            pkg.declaredLicensesProcessed.spdxExpression should beNull()
+            pkg.declaredLicensesProcessed.unmapped should containExactly("custom legacy terms")
+        }
+
+        "retain a malformed PEP 639 expression as unmapped metadata" {
+            val pkg = createPackage(
+                licenseExpression = "not a valid SPDX expression",
+                declaredLicense = null
+            ).toOrtPackage()
+
+            pkg.declaredLicenses should containExactly("not a valid SPDX expression")
+            pkg.declaredLicensesProcessed.spdxExpression should beNull()
+            pkg.declaredLicensesProcessed.unmapped should containExactly("not a valid SPDX expression")
+        }
+
+        "ignore a blank PEP 639 license expression" {
+            val pkg = createPackage(
+                licenseExpression = "  ",
+                declaredLicense = null
+            ).toOrtPackage()
+
+            pkg.declaredLicenses should beEmpty()
+            pkg.declaredLicensesProcessed.spdxExpression should beNull()
+        }
+    }
+})
+
+private fun createPackage(licenseExpression: String?, declaredLicense: PythonInspector.DeclaredLicense?) =
+    PythonInspector.Package(
+        type = "pypi",
+        namespace = null,
+        name = "example",
+        version = "1.0.0",
+        description = "Example package",
+        parties = emptyList(),
+        homepageUrl = null,
+        downloadUrl = "https://example.org/example-1.0.0.tar.gz",
+        size = 1,
+        sha1 = null,
+        md5 = null,
+        sha256 = null,
+        sha512 = null,
+        codeViewUrl = null,
+        vcsUrl = null,
+        copyright = null,
+        licenseExpression = licenseExpression,
+        declaredLicense = declaredLicense,
+        sourcePackages = emptyList(),
+        repositoryHomepageUrl = null,
+        repositoryDownloadUrl = null,
+        apiDataUrl = "https://pypi.org/pypi/example/1.0.0/json",
+        purl = "pkg:pypi/example@1.0.0"
+    )
+
+private fun PythonInspector.Package.toOrtPackage() = listOf(this).toOrtPackages().single()


### PR DESCRIPTION
## What changed

Use Python Inspector's `license_expression` value as the declared-license fallback when the legacy `declared_license` metadata yields no usable declaration.

The legacy metadata remains authoritative when present, including unmappable custom declarations. Blank PEP 639 expressions are ignored, while non-blank malformed values remain visible as unmapped metadata.

## Root cause

Python Inspector already exposes PyPI's PEP 639 `License-Expression` metadata as `Package.licenseExpression`. ORT deserializes that property, but `toOrtPackages()` previously only consumed `declaredLicense`, so the machine-readable expression was dropped during conversion.

## Validation

- Added focused tests for fallback behavior, legacy precedence, `UNKNOWN`, unmappable legacy metadata, malformed expressions, and blank expressions.
- Ran `:plugins:package-managers:python:test --tests '*PythonInspectorExtensionsTest'` on current upstream `main`: all six tests passed.

Fixes #11276.
