### PR TITLE
chore(gradle-plugin): Add a script to dump the ORT model to the console

### DIFF
--- a/plugins/package-managers/gradle-inspector/src/main/resources/template.init.gradle
+++ b/plugins/package-managers/gradle-inspector/src/main/resources/template.init.gradle
@@ -17,6 +17,10 @@
  * License-Filename: LICENSE
  */
 
+import groovy.json.JsonOutput
+
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+
 import org.ossreviewtoolkit.plugins.packagemanagers.gradleplugin.OrtModelPlugin
 
 initscript {
@@ -27,4 +31,18 @@ initscript {
 
 allprojects {
     apply plugin: OrtModelPlugin
+}
+
+def dumpOrtModel = gradle.startParameter.projectProperties['dumpOrtModel'] != null
+
+if (dumpOrtModel) {
+    projectsEvaluated { gradle ->
+        def project = gradle.rootProject
+        def registry = project.services.get(ToolingModelBuilderRegistry.class)
+        def builder = registry.getBuilder('OrtDependencyTreeModel')
+        def model = builder.buildAll('OrtDependencyTreeModel', project) as OrtDependencyTreeModel
+
+        def json = JsonOutput.toJson(model)
+        println(JsonOutput.prettyPrint(json))
+    }
 }

--- a/plugins/package-managers/gradle-plugin/dump_ort_model.sh
+++ b/plugins/package-managers/gradle-plugin/dump_ort_model.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+SELF=${BASH_SOURCE[0]}
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $(basename "$SELF") <GRADLE_PROJECT_DIR>"
+    exit 1
+fi
+
+GRADLE_PROJECT_DIR=$1
+PLUGIN_PROJECT_DIR=$(dirname "$SELF")
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+"$GIT_ROOT"/gradlew -q -p "$PLUGIN_PROJECT_DIR" -Pversion=0 fatJar
+PLUGIN_JAR="$GIT_ROOT"/plugins/package-managers/gradle-plugin/build/libs/gradle-plugin-0-fat.jar
+
+TEMPLATE_INIT_SCRIPT="$GIT_ROOT"/plugins/package-managers/gradle-inspector/src/main/resources/template.init.gradle
+PATCHED_INIT_SCRIPT=$(mktemp --suffix .init.gradle)
+
+sed "s,<REPLACE_PLUGIN_JAR>,$PLUGIN_JAR," "$TEMPLATE_INIT_SCRIPT" > "$PATCHED_INIT_SCRIPT"
+
+echo "Using patched init script at '$PATCHED_INIT_SCRIPT'."
+
+"$GIT_ROOT"/gradlew -q -I "$PATCHED_INIT_SCRIPT" -P dumpOrtModel -p "$GRADLE_PROJECT_DIR"


### PR DESCRIPTION
This script allows to inject the plugin into a build without running ORT and dumping the result of the model builder to the console in JSON format. This allows for very quick turn-around times during debugging.