### PR TITLE
fix(evaluator)!: Change `licenseRule()` to filter excluded licenses

### DIFF
--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -221,10 +221,13 @@ open class PackageRule(
     fun licenseRule(
         name: String,
         licenseView: LicenseView,
+        filterExcluded: Boolean = true,
         separateEvaluationPerSource: Boolean = true,
         block: LicenseRule.() -> Unit
     ) {
-        val effectiveResolvedLicenseInfo = resolvedLicenseInfo.filter(licenseView, filterSources = true)
+        val effectiveResolvedLicenseInfo = resolvedLicenseInfo
+            .run { if (filterExcluded) filterExcluded() else this }
+            .filter(licenseView, filterSources = true)
             .applyChoices(ruleSet.ortResult.getPackageLicenseChoices(pkg.metadata.id), licenseView)
             .applyChoices(ruleSet.ortResult.getRepositoryLicenseChoices(), licenseView)
 


### PR DESCRIPTION
Except for the evaluator, ORT applies license choices and license views to non-excluded licenses; see, for example, the reporters. However, in `licenseRule()`, the evaluator applies license choices on top of all licenses, including the excluded ones. Rule implementations in `evaluator-rules.kts` must use the matcher `-isExcluded()` to operate only on non-excluded licenses. This has the shortcoming that license choices in some cases do not have the desired effect.

For example, when path excludes are used, choosing `MIT` over `Apache-2.0` makes the effective license info a rule operates on cause `-isExcluded()` to return false.

- declared license: `MIT OR Apache-2.0`
- detected license: `Apache-2.0` (excluded)

Enhance `licenseRule()` to optionally apply `filterExcluded()`, as done in the reporters, to obtain the same consistent effective license. Make `filterExcluded()` the default since this is the more common use case.

Breaking change: Policy rules that intend to operate on excluded
                 licenses need to be aligned by passing
                 `filterExcluded = false` as a parameter to
                 `licenseRule()`. For rules which operate only on
                 non-exluded licenses it may be possible to remove
                 the use of `isExcluded()`, but it is not necessary.

Fixes #10867.
