### PR TITLE
chore(detekt-rules): Make fewer exceptions to package naming rules

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -91,7 +91,7 @@ style:
     max: 5
   WildcardImport:
     excludeImports:
-      - org.ossreviewtoolkit.helper.commands.*
+      - org.ossreviewtoolkit.clihelper.commands.*
       - org.ossreviewtoolkit.utils.spdx.SpdxLicense.*
       - org.ossreviewtoolkit.utils.spdx.SpdxLicenseException.*
       - kotlinx.html.*

--- a/cli-helper/build.gradle.kts
+++ b/cli-helper/build.gradle.kts
@@ -28,7 +28,7 @@ configurations["runtimeOnly"].extendsFrom(configurations["pluginClasspath"])
 
 application {
     applicationName = "orth"
-    mainClass = "org.ossreviewtoolkit.helper.HelperMainKt"
+    mainClass = "org.ossreviewtoolkit.clihelper.HelperMainKt"
 }
 
 dependencies {

--- a/cli-helper/src/funTest/kotlin/commands/CreateAnalyzerResultFromPackageListCommandFunTest.kt
+++ b/cli-helper/src/funTest/kotlin/commands/CreateAnalyzerResultFromPackageListCommandFunTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.testing.test
 
@@ -29,7 +29,7 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
-import org.ossreviewtoolkit.helper.HelperMain
+import org.ossreviewtoolkit.clihelper.HelperMain
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.PackageCuration

--- a/cli-helper/src/main/kotlin/HelperMain.kt
+++ b/cli-helper/src/main/kotlin/HelperMain.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper
+package org.ossreviewtoolkit.clihelper
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
@@ -37,14 +37,14 @@ import com.github.ajalt.mordant.terminal.Terminal
 
 import kotlin.system.exitProcess
 
-import org.ossreviewtoolkit.helper.commands.*
-import org.ossreviewtoolkit.helper.commands.classifications.LicenseClassificationsCommand
-import org.ossreviewtoolkit.helper.commands.dev.DevCommand
-import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
-import org.ossreviewtoolkit.helper.commands.packagecuration.PackageCurationsCommand
-import org.ossreviewtoolkit.helper.commands.provenancestorage.ProvenanceStorageCommand
-import org.ossreviewtoolkit.helper.commands.repoconfig.RepositoryConfigurationCommand
-import org.ossreviewtoolkit.helper.utils.ORTH_NAME
+import org.ossreviewtoolkit.clihelper.commands.*
+import org.ossreviewtoolkit.clihelper.commands.classifications.LicenseClassificationsCommand
+import org.ossreviewtoolkit.clihelper.commands.dev.DevCommand
+import org.ossreviewtoolkit.clihelper.commands.packageconfig.PackageConfigurationCommand
+import org.ossreviewtoolkit.clihelper.commands.packagecuration.PackageCurationsCommand
+import org.ossreviewtoolkit.clihelper.commands.provenancestorage.ProvenanceStorageCommand
+import org.ossreviewtoolkit.clihelper.commands.repoconfig.RepositoryConfigurationCommand
+import org.ossreviewtoolkit.clihelper.utils.ORTH_NAME
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.ort.printStackTrace
 

--- a/cli-helper/src/main/kotlin/commands/ConvertOrtFileCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ConvertOrtFileCommand.kt
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.writeOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.writeOrtResult
 import org.ossreviewtoolkit.utils.common.expandTilde
 
 internal class ConvertOrtFileCommand : OrtHelperCommand(

--- a/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/CreateAnalyzerResultFromPackageListCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -28,8 +28,8 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.writeOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.writeOrtResult
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.Hash

--- a/cli-helper/src/main/kotlin/commands/DownloadResultsFromPostgresCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/DownloadResultsFromPostgresCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
@@ -33,8 +33,8 @@ import kotlin.time.measureTime
 
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
 
-import org.ossreviewtoolkit.helper.utils.ORTH_NAME
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.ORTH_NAME
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.PostgresStorageConfiguration

--- a/cli-helper/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.utils.common.expandTilde
 
 internal class ExtractRepositoryConfigurationCommand : OrtHelperCommand(

--- a/cli-helper/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,9 +25,9 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceConfig
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceConfig
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.IssueResolutionReason
 import org.ossreviewtoolkit.model.toYaml

--- a/cli-helper/src/main/kotlin/commands/GetPackageLicensesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/GetPackageLicensesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
@@ -26,7 +26,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Package

--- a/cli-helper/src/main/kotlin/commands/GroupScanIssuesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/GroupScanIssuesCommand.kt
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Severity

--- a/cli-helper/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
@@ -30,7 +30,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import java.text.Collator
 import java.util.Locale
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.yamlMapper

--- a/cli-helper/src/main/kotlin/commands/ImportScanResultsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ImportScanResultsCommand.kt
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
 import org.ossreviewtoolkit.scanner.storages.PackageBasedFileStorage
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage

--- a/cli-helper/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,9 +25,9 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.processAllCopyrightStatements
-import org.ossreviewtoolkit.helper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.processAllCopyrightStatements
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.orEmpty

--- a/cli-helper/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,7 +25,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.licenses.LicenseCategorization
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.readValue

--- a/cli-helper/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.options.convert
@@ -31,14 +31,14 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.File
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.downloadSources
-import org.ossreviewtoolkit.helper.utils.getLicenseFindingsById
-import org.ossreviewtoolkit.helper.utils.getScannedProvenance
-import org.ossreviewtoolkit.helper.utils.getSourceCodeOrigin
-import org.ossreviewtoolkit.helper.utils.getViolatedRulesByLicense
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceConfig
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.downloadSources
+import org.ossreviewtoolkit.clihelper.utils.getLicenseFindingsById
+import org.ossreviewtoolkit.clihelper.utils.getScannedProvenance
+import org.ossreviewtoolkit.clihelper.utils.getSourceCodeOrigin
+import org.ossreviewtoolkit.clihelper.utils.getViolatedRulesByLicense
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceConfig
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance

--- a/cli-helper/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
@@ -28,9 +28,9 @@ import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceConfig
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceConfig
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.PackageType.PACKAGE

--- a/cli-helper/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.options.associate
@@ -29,7 +29,7 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import org.apache.logging.log4j.kotlin.logger
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.OrtConfiguration

--- a/cli-helper/src/main/kotlin/commands/MapCopyrightsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/MapCopyrightsCommand.kt
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.processAllCopyrightStatements
-import org.ossreviewtoolkit.helper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.processAllCopyrightStatements
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.utils.common.expandTilde
 

--- a/cli-helper/src/main/kotlin/commands/MergeRepositoryConfigurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/MergeRepositoryConfigurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
@@ -27,9 +27,9 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.File
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.merge
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.merge
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/MergeScannerRunsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/MergeScannerRunsCommand.kt
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.writeOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.writeOrtResult
 import org.ossreviewtoolkit.model.FileList
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.OrtResult

--- a/cli-helper/src/main/kotlin/commands/SetDependencyRepresentationCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/SetDependencyRepresentationCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.options.convert
@@ -33,7 +33,7 @@ import java.util.regex.Pattern
 import org.ossreviewtoolkit.analyzer.AnalyzerResultBuilder
 import org.ossreviewtoolkit.analyzer.PackageManagerResult
 import org.ossreviewtoolkit.analyzer.withResolvedScopes
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult

--- a/cli-helper/src/main/kotlin/commands/SetLabelsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/SetLabelsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
@@ -26,9 +26,9 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.writeOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.writeOrtResult
 import org.ossreviewtoolkit.model.utils.mergeLabels
 import org.ossreviewtoolkit.utils.common.expandTilde
 

--- a/cli-helper/src/main/kotlin/commands/TransformResultCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/TransformResultCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
@@ -26,7 +26,7 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import com.schibsted.spt.data.jslt.Parser
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.readTree
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.clihelper.commands
 
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.argument
@@ -26,7 +26,7 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.IOException
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.collectMessages

--- a/cli-helper/src/main/kotlin/commands/classifications/FilterCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/classifications/FilterCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.classifications
+package org.ossreviewtoolkit.clihelper.commands.classifications
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
@@ -25,7 +25,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.toYaml

--- a/cli-helper/src/main/kotlin/commands/classifications/ImportCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/classifications/ImportCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.classifications
+package org.ossreviewtoolkit.clihelper.commands.classifications
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
@@ -32,7 +32,7 @@ import java.net.URI
 
 import org.apache.logging.log4j.kotlin.logger
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.licenses.LicenseCategorization
 import org.ossreviewtoolkit.model.licenses.LicenseCategory

--- a/cli-helper/src/main/kotlin/commands/classifications/LicenseClassificationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/classifications/LicenseClassificationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.classifications
+package org.ossreviewtoolkit.clihelper.commands.classifications
 
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand

--- a/cli-helper/src/main/kotlin/commands/classifications/MergeCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/classifications/MergeCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.classifications
+package org.ossreviewtoolkit.clihelper.commands.classifications
 
 import com.fasterxml.jackson.module.kotlin.readValue
 
@@ -29,7 +29,7 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.yamlMapper

--- a/cli-helper/src/main/kotlin/commands/dev/DevCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/dev/DevCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.dev
+package org.ossreviewtoolkit.clihelper.commands.dev
 
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand

--- a/cli-helper/src/main/kotlin/commands/dev/RewriteTestAssetsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/dev/RewriteTestAssetsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.dev
+package org.ossreviewtoolkit.clihelper.commands.dev
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -32,7 +32,7 @@ import java.io.File
 import kotlin.reflect.KClass
 
 import org.ossreviewtoolkit.analyzer.PackageManagerResult
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.EvaluatorRun

--- a/cli-helper/src/main/kotlin/commands/packageconfig/CreateCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/CreateCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.options.convert
@@ -30,10 +30,10 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.File
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.PathExcludeGenerator
-import org.ossreviewtoolkit.helper.utils.sortPathExcludes
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.PathExcludeGenerator
+import org.ossreviewtoolkit.clihelper.utils.sortPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.RepositoryProvenance

--- a/cli-helper/src/main/kotlin/commands/packageconfig/ExportLicenseFindingCurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/ExportLicenseFindingCurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,15 +25,15 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.RepositoryLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.findRepositories
-import org.ossreviewtoolkit.helper.utils.getLicenseFindingCurationsByRepository
-import org.ossreviewtoolkit.helper.utils.mapLicenseFindingCurationsVcsUrls
-import org.ossreviewtoolkit.helper.utils.mergeLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.RepositoryLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.findRepositories
+import org.ossreviewtoolkit.clihelper.utils.getLicenseFindingCurationsByRepository
+import org.ossreviewtoolkit.clihelper.utils.mapLicenseFindingCurationsVcsUrls
+import org.ossreviewtoolkit.clihelper.utils.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,15 +25,15 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.RepositoryPathExcludes
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.findRepositories
-import org.ossreviewtoolkit.helper.utils.getPathExcludesByRepository
-import org.ossreviewtoolkit.helper.utils.mapPathExcludesVcsUrls
-import org.ossreviewtoolkit.helper.utils.mergePathExcludes
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.RepositoryPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.findRepositories
+import org.ossreviewtoolkit.clihelper.utils.getPathExcludesByRepository
+import org.ossreviewtoolkit.clihelper.utils.mapPathExcludesVcsUrls
+import org.ossreviewtoolkit.clihelper.utils.mergePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/packageconfig/FindCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/FindCommand.kt
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.PackageConfiguration

--- a/cli-helper/src/main/kotlin/commands/packageconfig/FormatCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/FormatCommand.kt
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,16 +25,16 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.findRepositoryPaths
-import org.ossreviewtoolkit.helper.utils.getScanResultFor
-import org.ossreviewtoolkit.helper.utils.importLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.mergeLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.sortLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.findRepositoryPaths
+import org.ossreviewtoolkit.clihelper.utils.getScanResultFor
+import org.ossreviewtoolkit.clihelper.utils.importLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.sortLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher

--- a/cli-helper/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,15 +25,15 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.findFilesRecursive
-import org.ossreviewtoolkit.helper.utils.findRepositoryPaths
-import org.ossreviewtoolkit.helper.utils.importPathExcludes
-import org.ossreviewtoolkit.helper.utils.mergePathExcludes
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.sortPathExcludes
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.findFilesRecursive
+import org.ossreviewtoolkit.clihelper.utils.findRepositoryPaths
+import org.ossreviewtoolkit.clihelper.utils.importPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.mergePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.sortPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand

--- a/cli-helper/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
@@ -17,17 +17,17 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.getScanResultFor
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.getScanResultFor
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue

--- a/cli-helper/src/main/kotlin/commands/packageconfig/SortCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/SortCommand.kt
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packageconfig
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
 
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.sortEntries
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.sortEntries
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/packagecuration/CreateCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packagecuration/CreateCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packagecuration
+package org.ossreviewtoolkit.clihelper.commands.packagecuration
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
@@ -26,11 +26,11 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.IOException
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.formatComment
-import org.ossreviewtoolkit.helper.utils.getSplitCurationFile
-import org.ossreviewtoolkit.helper.utils.readPackageCurations
-import org.ossreviewtoolkit.helper.utils.writeAsYaml
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.formatComment
+import org.ossreviewtoolkit.clihelper.utils.getSplitCurationFile
+import org.ossreviewtoolkit.clihelper.utils.readPackageCurations
+import org.ossreviewtoolkit.clihelper.utils.writeAsYaml
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.PackageCuration

--- a/cli-helper/src/main/kotlin/commands/packagecuration/PackageCurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packagecuration/PackageCurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packagecuration
+package org.ossreviewtoolkit.clihelper.commands.packagecuration
 
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand

--- a/cli-helper/src/main/kotlin/commands/packagecuration/SetCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packagecuration/SetCommand.kt
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packagecuration
+package org.ossreviewtoolkit.clihelper.commands.packagecuration
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.writeOrtResult
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.writeOrtResult
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCurationProvider
 import org.ossreviewtoolkit.plugins.packagecurationproviders.file.FilePackageCurationProvider

--- a/cli-helper/src/main/kotlin/commands/packagecuration/SplitCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packagecuration/SplitCommand.kt
@@ -17,18 +17,18 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.packagecuration
+package org.ossreviewtoolkit.clihelper.commands.packagecuration
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.formatComment
-import org.ossreviewtoolkit.helper.utils.getSplitCurationFile
-import org.ossreviewtoolkit.helper.utils.readPackageCurations
-import org.ossreviewtoolkit.helper.utils.writeAsYaml
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.formatComment
+import org.ossreviewtoolkit.clihelper.utils.getSplitCurationFile
+import org.ossreviewtoolkit.clihelper.utils.readPackageCurations
+import org.ossreviewtoolkit.clihelper.utils.writeAsYaml
 import org.ossreviewtoolkit.utils.common.expandTilde
 
 internal class SplitCommand : OrtHelperCommand(

--- a/cli-helper/src/main/kotlin/commands/provenancestorage/DeleteCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/provenancestorage/DeleteCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.provenancestorage
+package org.ossreviewtoolkit.clihelper.commands.provenancestorage
 
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.options.associate
@@ -30,7 +30,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.mordant.rendering.Theme
 import com.github.ajalt.mordant.terminal.YesNoPrompt
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.scanner.ScanStorages

--- a/cli-helper/src/main/kotlin/commands/provenancestorage/ProvenanceStorageCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/provenancestorage/ProvenanceStorageCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.provenancestorage
+package org.ossreviewtoolkit.clihelper.commands.provenancestorage
 
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand

--- a/cli-helper/src/main/kotlin/commands/repoconfig/ExportLicenseFindingCurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/ExportLicenseFindingCurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,16 +25,16 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.RepositoryLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.getLicenseFindingCurationsByRepository
-import org.ossreviewtoolkit.helper.utils.mapLicenseFindingCurationsVcsUrls
-import org.ossreviewtoolkit.helper.utils.mergeLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceConfig
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.RepositoryLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.getLicenseFindingCurationsByRepository
+import org.ossreviewtoolkit.clihelper.utils.mapLicenseFindingCurationsVcsUrls
+import org.ossreviewtoolkit.clihelper.utils.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceConfig
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde
 

--- a/cli-helper/src/main/kotlin/commands/repoconfig/ExportPathExcludesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/ExportPathExcludesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,16 +25,16 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.RepositoryPathExcludes
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.getRepositoryPathExcludes
-import org.ossreviewtoolkit.helper.utils.mapPathExcludesVcsUrls
-import org.ossreviewtoolkit.helper.utils.mergePathExcludes
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceConfig
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.RepositoryPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.getRepositoryPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.mapPathExcludesVcsUrls
+import org.ossreviewtoolkit.clihelper.utils.mergePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceConfig
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde
 

--- a/cli-helper/src/main/kotlin/commands/repoconfig/FormatCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/FormatCommand.kt
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/commands/repoconfig/GenerateProjectExcludesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/GenerateProjectExcludesCommand.kt
@@ -17,18 +17,18 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replacePathExcludes
-import org.ossreviewtoolkit.helper.utils.sortPathExcludes
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replacePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.sortPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration

--- a/cli-helper/src/main/kotlin/commands/repoconfig/GenerateRuleViolationResolutionsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/GenerateRuleViolationResolutionsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
@@ -27,10 +27,10 @@ import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceRuleViolationResolutions
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceRuleViolationResolutions
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.RuleViolationResolution

--- a/cli-helper/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
@@ -26,12 +26,12 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import org.apache.logging.log4j.kotlin.logger
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.minimize
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceScopeExcludes
-import org.ossreviewtoolkit.helper.utils.sortScopeExcludes
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.minimize
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceScopeExcludes
+import org.ossreviewtoolkit.clihelper.utils.sortScopeExcludes
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude

--- a/cli-helper/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,16 +25,16 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.getRepositoryPaths
-import org.ossreviewtoolkit.helper.utils.importLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.mergeLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.sortLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.getRepositoryPaths
+import org.ossreviewtoolkit.clihelper.utils.importLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.sortLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration

--- a/cli-helper/src/main/kotlin/commands/repoconfig/ImportPathExcludesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/ImportPathExcludesCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -25,17 +25,17 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.VcsUrlMapping
-import org.ossreviewtoolkit.helper.utils.getRepositoryPath
-import org.ossreviewtoolkit.helper.utils.getRepositoryPaths
-import org.ossreviewtoolkit.helper.utils.importPathExcludes
-import org.ossreviewtoolkit.helper.utils.mergePathExcludes
-import org.ossreviewtoolkit.helper.utils.orEmpty
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replacePathExcludes
-import org.ossreviewtoolkit.helper.utils.sortPathExcludes
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.VcsUrlMapping
+import org.ossreviewtoolkit.clihelper.utils.getRepositoryPath
+import org.ossreviewtoolkit.clihelper.utils.getRepositoryPaths
+import org.ossreviewtoolkit.clihelper.utils.importPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.mergePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.orEmpty
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replacePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.sortPathExcludes
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.readValue

--- a/cli-helper/src/main/kotlin/commands/repoconfig/RemoveEntriesCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/RemoveEntriesCommand.kt
@@ -17,23 +17,23 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.findFilesRecursive
-import org.ossreviewtoolkit.helper.utils.minimize
-import org.ossreviewtoolkit.helper.utils.readOrtResult
-import org.ossreviewtoolkit.helper.utils.replaceIssueResolutions
-import org.ossreviewtoolkit.helper.utils.replaceLicenseFindingCurations
-import org.ossreviewtoolkit.helper.utils.replacePathExcludes
-import org.ossreviewtoolkit.helper.utils.replaceRuleViolationResolutions
-import org.ossreviewtoolkit.helper.utils.replaceScopeExcludes
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.findFilesRecursive
+import org.ossreviewtoolkit.clihelper.utils.minimize
+import org.ossreviewtoolkit.clihelper.utils.readOrtResult
+import org.ossreviewtoolkit.clihelper.utils.replaceIssueResolutions
+import org.ossreviewtoolkit.clihelper.utils.replaceLicenseFindingCurations
+import org.ossreviewtoolkit.clihelper.utils.replacePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.replaceRuleViolationResolutions
+import org.ossreviewtoolkit.clihelper.utils.replaceScopeExcludes
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration

--- a/cli-helper/src/main/kotlin/commands/repoconfig/RepositoryConfigurationCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/RepositoryConfigurationCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand

--- a/cli-helper/src/main/kotlin/commands/repoconfig/SortCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/repoconfig/SortCommand.kt
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands.repoconfig
+package org.ossreviewtoolkit.clihelper.commands.repoconfig
 
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.OrtHelperCommand
-import org.ossreviewtoolkit.helper.utils.sortEntries
-import org.ossreviewtoolkit.helper.utils.write
+import org.ossreviewtoolkit.clihelper.utils.OrtHelperCommand
+import org.ossreviewtoolkit.clihelper.utils.sortEntries
+import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.common.expandTilde

--- a/cli-helper/src/main/kotlin/utils/Extensions.kt
+++ b/cli-helper/src/main/kotlin/utils/Extensions.kt
@@ -19,7 +19,7 @@
 
 @file:Suppress("TooManyFunctions")
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator

--- a/cli-helper/src/main/kotlin/utils/OrtHelperCommand.kt
+++ b/cli-helper/src/main/kotlin/utils/OrtHelperCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context

--- a/cli-helper/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/cli-helper/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import java.io.File
 

--- a/cli-helper/src/main/kotlin/utils/Utils.kt
+++ b/cli-helper/src/main/kotlin/utils/Utils.kt
@@ -19,7 +19,7 @@
 
 @file:Suppress("MatchingDeclarationName", "TooManyFunctions")
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import java.io.File
 

--- a/cli-helper/src/main/kotlin/utils/VcsUrlMapping.kt
+++ b/cli-helper/src/main/kotlin/utils/VcsUrlMapping.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import java.net.URI
 import java.util.SortedMap

--- a/cli-helper/src/test/kotlin/utils/PathExcludeGeneratorTest.kt
+++ b/cli-helper/src/test/kotlin/utils/PathExcludeGeneratorTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
@@ -26,10 +26,10 @@ import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.helper.utils.PathExcludeGenerator.createExcludePatterns
-import org.ossreviewtoolkit.helper.utils.PathExcludeGenerator.generateDirectoryExcludes
-import org.ossreviewtoolkit.helper.utils.PathExcludeGenerator.generateFileExcludes
-import org.ossreviewtoolkit.helper.utils.PathExcludeGenerator.generatePathExcludes
+import org.ossreviewtoolkit.clihelper.utils.PathExcludeGenerator.createExcludePatterns
+import org.ossreviewtoolkit.clihelper.utils.PathExcludeGenerator.generateDirectoryExcludes
+import org.ossreviewtoolkit.clihelper.utils.PathExcludeGenerator.generateFileExcludes
+import org.ossreviewtoolkit.clihelper.utils.PathExcludeGenerator.generatePathExcludes
 import org.ossreviewtoolkit.utils.test.readResource
 
 class PathExcludeGeneratorTest : WordSpec({

--- a/cli-helper/src/test/kotlin/utils/UtilsTest.kt
+++ b/cli-helper/src/test/kotlin/utils/UtilsTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.utils
+package org.ossreviewtoolkit.clihelper.utils
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly

--- a/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
@@ -77,7 +77,6 @@ class OrtPackageNaming(config: Config) : Rule(
         val projectName = when (projectDir) {
             "detekt-rules" -> ".detekt"
             "fossid-webapp" -> ".fossid"
-            "cli-helper" -> ".helper"
             else -> ".${projectDir.replace("-", "")}"
         }
 


### PR DESCRIPTION
Align all CLI modules to follow the package naming rules. This is deliberately not marked as a breaking change as the CLI modules are not supposed to be used programmatically.