### PR TITLE
feat(evaluated-model)!: Add applied license choices

### DIFF
--- a/model/src/main/kotlin/utils/LicenseChoiceUtils.kt
+++ b/model/src/main/kotlin/utils/LicenseChoiceUtils.kt
@@ -30,13 +30,16 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseChoice
 
 /** License views to compute effective licenses for, to use for filtering license choices. */
-private val FILTER_LICENSE_VIEWS = setOf(
+private val FILTER_LICENSE_VIEWS_DEFAULT = setOf(
     LicenseView.ONLY_DECLARED,
     LicenseView.ONLY_DETECTED,
     LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED
 )
 
-fun LicenseChoices.filterApplicable(ortResult: OrtResult): LicenseChoices {
+fun LicenseChoices.filterApplicable(
+    ortResult: OrtResult,
+    filterLicenseViews: Set<LicenseView> = FILTER_LICENSE_VIEWS_DEFAULT
+): LicenseChoices {
     val packageIds = ortResult.getPackages().mapTo(mutableSetOf()) { it.metadata.id }
 
     val licenseInfoResolver = LicenseInfoResolver(
@@ -50,7 +53,8 @@ fun LicenseChoices.filterApplicable(ortResult: OrtResult): LicenseChoices {
     return copy(
         repositoryLicenseChoices = repositoryLicenseChoices.filterRepositoryLicenseChoices(
             packageIds,
-            licenseInfoResolver
+            licenseInfoResolver,
+            filterLicenseViews
         ),
         packageLicenseChoices = packageLicenseChoices.filter { it.packageId in packageIds }
     )
@@ -58,14 +62,15 @@ fun LicenseChoices.filterApplicable(ortResult: OrtResult): LicenseChoices {
 
 internal fun List<SpdxLicenseChoice>.filterRepositoryLicenseChoices(
     packageIds: Set<Identifier>,
-    licenseInfoResolver: LicenseInfoResolver
+    licenseInfoResolver: LicenseInfoResolver,
+    filterLicenseViews: Set<LicenseView> = FILTER_LICENSE_VIEWS_DEFAULT
 ): List<SpdxLicenseChoice> {
     val licenseInfos = packageIds.map { id -> licenseInfoResolver.resolveLicenseInfo(id).filterExcluded() }
     val remainingChoices = toMutableSet()
 
     return buildSet {
         licenseInfos.forEach { licenseInfo ->
-            FILTER_LICENSE_VIEWS.forEach { view ->
+            filterLicenseViews.forEach { view ->
                 val applicableChoices = licenseInfo.effectiveLicenseAndAppliedChoices(
                     view,
                     remainingChoices.toList()

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -20,6 +20,15 @@ scope_excludes:
   pattern: "testCompile"
   reason: "TEST_DEPENDENCY_OF"
   comment: "The scope only contains test dependencies."
+license_choices:
+  repository_license_choices:
+  - given: "GPL-2.0-only OR MIT"
+    choice: "MIT"
+  package_license_choices:
+  - package_id: "Maven:com.h2database:h2:1.4.200"
+    license_choices:
+    - given: "MPL-2.0 OR EPL-1.0"
+      choice: "MPL-2.0"
 license_finding_curations:
 - _id: 0
   path: "project/file2.java"
@@ -729,6 +738,9 @@ packages:
     - 4
   concluded_license: "GPL-2.0-only OR MIT"
   effective_license: "MIT"
+  applied_license_choices:
+  - given: "GPL-2.0-only OR MIT"
+    choice: "MIT"
   binary_artifact:
     url: ""
     hash:
@@ -779,6 +791,9 @@ packages:
     - 9
   concluded_license: "MPL-2.0 OR EPL-1.0"
   effective_license: "MPL-2.0"
+  applied_license_choices:
+  - given: "MPL-2.0 OR EPL-1.0"
+    choice: "MPL-2.0"
   description: "H2 Database Engine"
   homepage_url: "https://h2database.com"
   binary_artifact:

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
@@ -25,6 +25,19 @@
     "reason" : "TEST_DEPENDENCY_OF",
     "comment" : "The scope only contains test dependencies."
   } ],
+  "license_choices" : {
+    "repository_license_choices" : [ {
+      "given" : "GPL-2.0-only OR MIT",
+      "choice" : "MIT"
+    } ],
+    "package_license_choices" : [ {
+      "package_id" : "Maven:com.h2database:h2:1.4.200",
+      "license_choices" : [ {
+        "given" : "MPL-2.0 OR EPL-1.0",
+        "choice" : "MPL-2.0"
+      } ]
+    } ]
+  },
   "license_finding_curations" : [ {
     "_id" : 0,
     "path" : "project/file2.java",
@@ -796,6 +809,10 @@
     },
     "concluded_license" : "GPL-2.0-only OR MIT",
     "effective_license" : "MIT",
+    "applied_license_choices" : [ {
+      "given" : "GPL-2.0-only OR MIT",
+      "choice" : "MIT"
+    } ],
     "binary_artifact" : {
       "url" : "",
       "hash" : {
@@ -845,6 +862,10 @@
     },
     "concluded_license" : "MPL-2.0 OR EPL-1.0",
     "effective_license" : "MPL-2.0",
+    "applied_license_choices" : [ {
+      "given" : "MPL-2.0 OR EPL-1.0",
+      "choice" : "MPL-2.0"
+    } ],
     "description" : "H2 Database Engine",
     "homepage_url" : "https://h2database.com",
     "binary_artifact" : {

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
@@ -20,6 +20,15 @@ scope_excludes:
   pattern: "testCompile"
   reason: "TEST_DEPENDENCY_OF"
   comment: "The scope only contains test dependencies."
+license_choices:
+  repository_license_choices:
+  - given: "GPL-2.0-only OR MIT"
+    choice: "MIT"
+  package_license_choices:
+  - package_id: "Maven:com.h2database:h2:1.4.200"
+    license_choices:
+    - given: "MPL-2.0 OR EPL-1.0"
+      choice: "MPL-2.0"
 license_finding_curations:
 - _id: 0
   path: "project/file2.java"
@@ -729,6 +738,9 @@ packages:
     - 4
   concluded_license: "GPL-2.0-only OR MIT"
   effective_license: "MIT"
+  applied_license_choices:
+  - given: "GPL-2.0-only OR MIT"
+    choice: "MIT"
   binary_artifact:
     url: ""
     hash:
@@ -779,6 +791,9 @@ packages:
     - 9
   concluded_license: "MPL-2.0 OR EPL-1.0"
   effective_license: "MPL-2.0"
+  applied_license_choices:
+  - given: "MPL-2.0 OR EPL-1.0"
+    choice: "MPL-2.0"
   description: "H2 Database Engine"
   homepage_url: "https://h2database.com"
   binary_artifact:

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModel.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModel.kt
@@ -38,6 +38,7 @@ import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.IssueResolution
+import org.ossreviewtoolkit.model.config.LicenseChoices
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.PathExclude
@@ -94,6 +95,7 @@ import org.ossreviewtoolkit.reporter.Statistics
 data class EvaluatedModel(
     val pathExcludes: List<PathExclude>,
     val scopeExcludes: List<ScopeExclude>,
+    val licenseChoices: LicenseChoices,
     val licenseFindingCurations: List<LicenseFindingCuration>,
     val packageConfigurations: List<PackageConfiguration>,
     val packageCurations: List<PackageCuration>,

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
+import org.ossreviewtoolkit.model.utils.filterApplicable
 import org.ossreviewtoolkit.model.utils.filterByVcsPath
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -59,6 +60,7 @@ import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseChoice
 
 /**
  * Maps the [reporter input][input] to an [EvaluatedModel].
@@ -70,6 +72,11 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private val dependencyTrees = mutableListOf<DependencyTreeNode>()
     private val scanResults = mutableListOf<EvaluatedScanResult>()
     private val copyrights = mutableListOf<CopyrightStatement>()
+    private val licenseChoices = input.ortResult.resolvedConfiguration.licenseChoices.filterApplicable(
+        input.ortResult,
+        setOf(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
+    )
+
     private val licenses = mutableListOf<LicenseId>()
     private val licenseFindingCurations = mutableListOf<LicenseFindingCuration>()
     private val scopes = mutableMapOf<String, EvaluatedScope>()
@@ -172,6 +179,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             issueResolutions = issueResolutions,
             issues = issues,
             copyrights = copyrights,
+            licenseChoices = licenseChoices,
             licenses = licenses,
             licenseFindingCurations = licenseFindingCurations,
             scopes = scopes.values.toList(),
@@ -275,6 +283,12 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                 .flatMap { it.pathExcludes }
         }
 
+    /**
+     * Return the [SpdxLicenseChoice]s applied to the package or project with [id] when computing its effective license.
+     */
+    private fun getAppliedLicenseChoices(id: Identifier): List<SpdxLicenseChoice> =
+        input.getAppliedLicenseChoicesForId(id)
+
     private fun addProject(project: Project) {
         val scanResults = mutableListOf<EvaluatedScanResult>()
         val detectedLicenses = mutableSetOf<LicenseId>()
@@ -295,6 +309,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             detectedLicenses = detectedLicenses,
             detectedExcludedLicenses = detectedExcludedLicenses,
             effectiveLicense = input.getEffectiveLicenseForId(project.id),
+            appliedLicenseChoices = getAppliedLicenseChoices(project.id),
             description = "",
             homepageUrl = project.homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY,
@@ -366,6 +381,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             detectedExcludedLicenses = detectedExcludedLicenses,
             concludedLicense = pkg.concludedLicense,
             effectiveLicense = input.getEffectiveLicenseForId(pkg.id),
+            appliedLicenseChoices = getAppliedLicenseChoices(pkg.id),
             description = pkg.description,
             homepageUrl = pkg.homepageUrl,
             binaryArtifact = pkg.binaryArtifact,
@@ -832,3 +848,10 @@ private fun ReporterInput.getEffectiveLicenseForId(id: Identifier): SpdxExpressi
         ortResult.getPackageLicenseChoices(id),
         ortResult.getRepositoryLicenseChoices()
     )?.sorted()
+
+private fun ReporterInput.getAppliedLicenseChoicesForId(id: Identifier): List<SpdxLicenseChoice> =
+    licenseInfoResolver.resolveLicenseInfo(id).filterExcluded().effectiveLicenseAndAppliedChoices(
+        LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+        ortResult.getPackageLicenseChoices(id),
+        ortResult.getRepositoryLicenseChoices()
+    ).second

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.model.toYaml
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
+import org.ossreviewtoolkit.model.utils.filterApplicable
 import org.ossreviewtoolkit.model.utils.filterByVcsPath
 import org.ossreviewtoolkit.model.vulnerabilities.Vulnerability
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -59,6 +60,7 @@ import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseChoice
 
 /**
  * Maps the [reporter input][input] to an [EvaluatedModel].
@@ -70,6 +72,11 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private val dependencyTrees = mutableListOf<DependencyTreeNode>()
     private val scanResults = mutableListOf<EvaluatedScanResult>()
     private val copyrights = mutableListOf<CopyrightStatement>()
+    private val licenseChoices = input.ortResult.resolvedConfiguration.licenseChoices.filterApplicable(
+        input.ortResult,
+        setOf(LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED)
+    )
+
     private val licenses = mutableListOf<LicenseId>()
     private val licenseFindingCurations = mutableListOf<LicenseFindingCuration>()
     private val scopes = mutableMapOf<String, EvaluatedScope>()
@@ -172,6 +179,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             issueResolutions = issueResolutions,
             issues = issues,
             copyrights = copyrights,
+            licenseChoices = licenseChoices,
             licenses = licenses,
             licenseFindingCurations = licenseFindingCurations,
             scopes = scopes.values.toList(),
@@ -295,6 +303,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             detectedLicenses = detectedLicenses,
             detectedExcludedLicenses = detectedExcludedLicenses,
             effectiveLicense = input.getEffectiveLicenseForId(project.id),
+            appliedLicenseChoices = input.getAppliedLicenseChoicesForId(project.id),
             description = "",
             homepageUrl = project.homepageUrl,
             binaryArtifact = RemoteArtifact.EMPTY,
@@ -366,6 +375,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             detectedExcludedLicenses = detectedExcludedLicenses,
             concludedLicense = pkg.concludedLicense,
             effectiveLicense = input.getEffectiveLicenseForId(pkg.id),
+            appliedLicenseChoices = input.getAppliedLicenseChoicesForId(pkg.id),
             description = pkg.description,
             homepageUrl = pkg.homepageUrl,
             binaryArtifact = pkg.binaryArtifact,
@@ -832,3 +842,10 @@ private fun ReporterInput.getEffectiveLicenseForId(id: Identifier): SpdxExpressi
         ortResult.getPackageLicenseChoices(id),
         ortResult.getRepositoryLicenseChoices()
     )?.sorted()
+
+private fun ReporterInput.getAppliedLicenseChoicesForId(id: Identifier): List<SpdxLicenseChoice> =
+    licenseInfoResolver.resolveLicenseInfo(id).filterExcluded().effectiveLicenseAndAppliedChoices(
+        LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+        ortResult.getPackageLicenseChoices(id),
+        ortResult.getRepositoryLicenseChoices()
+    ).second

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedPackage.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedPackage.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
+import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseChoice
 
 /**
  * The evaluated form of a [Package] used by the [EvaluatedModel].
@@ -56,6 +57,8 @@ data class EvaluatedPackage(
     val concludedLicense: SpdxExpression? = null,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val effectiveLicense: SpdxExpression? = null,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val appliedLicenseChoices: List<SpdxLicenseChoice> = emptyList(),
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val description: String,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)


### PR DESCRIPTION
Add the applicable license choices to the evaluated model, both globally and per package:

* A root-level `licenseChoices` object lists the license choices that apply for the `CONCLUDED_OR_DECLARED_AND_DETECTED` license view, analogous to the resolutions, package configurations and package curations that are already included.
* Each `EvaluatedPackage` gets an `appliedLicenseChoices` property with the choices that were applied when computing its effective license.

This allows a report to explain why a license does not show up in the effective license of a package, and it makes the globally configured license choices visible for end-to-end traceability.