### PR TITLE
Improve VulnerableCode logging

### DIFF
--- a/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV3.kt
+++ b/plugins/advisors/vulnerable-code/src/main/kotlin/VulnerableCodeApiV3.kt
@@ -175,9 +175,11 @@ internal class VulnerableCodeApiV3(
         val missingAdvisoryUids = advisoryUidsByPurl.values.flatMapTo(mutableSetOf()) { it.keys } - advisoriesByUid.keys
 
         missingAdvisoryUids.forEach { advisoryUid ->
+            val correspondingPurls = advisoryUidsByPurl.filter { it.value.keys.any { id -> id == advisoryUid } }.keys
             issues += createAndLogIssue(
-                "The v3/packages response referenced advisory '$advisoryUid', but the v3/advisories response did " +
-                    "not contain its details.",
+                "The v3/packages response referenced advisory '$advisoryUid' for the following packages, " +
+                    "but the v3/advisories response did not contain its details: \n\n" +
+                    correspondingPurls.joinToString("\n"),
                 Severity.WARNING
             )
         }


### PR DESCRIPTION
Previously, when the v3/advisories response was missing details for an advisory UID referenced by v3/packages, ORT logged a generic warning and attached the resulting issue to every package associated with the "purls" parameter. This made it hard to pinpoint which package(s) actually triggered the discrepancy.

Include the list of affected PURLs in the issue message so that users can immediately identify the package(s) with the missing advisory details.