### PR TITLE
scan-oss: Fix the broken handling of includes and excludes

### DIFF
--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -35,11 +35,9 @@ import java.time.Instant
 import org.apache.logging.log4j.kotlin.logger
 
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoice
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoiceReason
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
-import org.ossreviewtoolkit.model.utils.isPathIncluded
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.scanner.PathScannerWrapper
@@ -94,11 +92,7 @@ class ScanOss(
                 // This is provided by the Scanner and represents individual files/directories during traversal.
                 try {
                     val relativePath = currentPath.toFile().toRelativeString(path)
-                    val isExcluded = !isPathIncluded(
-                        relativePath,
-                        context.excludes.orEmpty(),
-                        context.includes.orEmpty()
-                    )
+                    val isExcluded = context.isPathExcluded(relativePath)
 
                     logger.debug { "Path: $currentPath, relative: $relativePath, isExcluded: $isExcluded" }
                     isExcluded

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssScannerDirectoryTest.kt
@@ -152,7 +152,7 @@ class ScanOssScannerDirectoryTest : StringSpec({
             pathToDir,
             ScanContext(
                 labels = emptyMap(),
-                packageType = PackageType.PACKAGE,
+                packageType = PackageType.PROJECT,
                 excludes = Excludes(paths = pathExcludes)
             )
         )

--- a/scanner/src/main/kotlin/ScanContext.kt
+++ b/scanner/src/main/kotlin/ScanContext.kt
@@ -46,6 +46,14 @@ data class ScanContext(
     val packageType: PackageType,
 
     /**
+     * Relative paths of all directories in the root provenance source tree of the project to scan, to which the root
+     * directory of the provenance corresponding to the scan is checked out to. This should only be set to non-default,
+     * if the [packageType] is [PackageType.PROJECT] and must never be empty, because there always is at least one
+     * checkout path.
+     */
+    val checkoutPaths: Set<String> = setOf(""),
+
+    /**
      * The [Excludes] of the project to scan. Only set if [packageType] is [PackageType.PROJECT].
      */
     val excludes: Excludes? = null,
@@ -76,14 +84,33 @@ data class ScanContext(
      */
     val snippetChoices: List<SnippetChoices> = emptyList()
 ) {
+    init {
+        require(checkoutPaths.isNotEmpty()) {
+            "The checkout paths must not be empty."
+        }
+    }
+
     /**
-     * Returns true if the given [relativePath] is excluded. The [relativePath] is relative to root directory of the
-     * provenance corresponding to the scan.
+     * Returns true if the given [pathRelativeToProvenanceRoot] is excluded.
      */
-    fun isPathExcluded(relativePath: String): Boolean =
-        !isPathIncluded(
-            relativePath,
-            excludes.orEmpty(),
-            includes.orEmpty()
-        )
+    fun isPathExcluded(pathRelativeToProvenanceRoot: String): Boolean {
+        // For package scans, includes and excludes should not be set anyway. But return early to be on the safe side.
+        if (packageType != PackageType.PROJECT) return false
+
+        val pathsInRootProvenanceSourceTree = checkoutPaths.map {
+            if (it.isEmpty()) {
+                pathRelativeToProvenanceRoot
+            } else {
+                "${it.removeSuffix("/")}/$pathRelativeToProvenanceRoot"
+            }
+        }
+
+        return pathsInRootProvenanceSourceTree.all { path ->
+            !isPathIncluded(
+                path,
+                excludes.orEmpty(),
+                includes.orEmpty()
+            )
+        }
+    }
 }

--- a/scanner/src/main/kotlin/ScanContext.kt
+++ b/scanner/src/main/kotlin/ScanContext.kt
@@ -26,7 +26,9 @@ import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.Includes
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.config.snippet.SnippetChoices
+import org.ossreviewtoolkit.model.utils.isPathIncluded
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
 
 /**
@@ -73,4 +75,15 @@ data class ScanContext(
      * The [SnippetChoices] of the project to scan. Only set if [packageType] is [PackageType.PROJECT].
      */
     val snippetChoices: List<SnippetChoices> = emptyList()
-)
+) {
+    /**
+     * Returns true if the given [relativePath] is excluded. The [relativePath] is relative to root directory of the
+     * provenance corresponding to the scan.
+     */
+    fun isPathExcluded(relativePath: String): Boolean =
+        !isPathIncluded(
+            relativePath,
+            excludes.orEmpty(),
+            includes.orEmpty()
+        )
+}

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -312,6 +312,8 @@ internal class ScanController(
 
     fun getPackageProvenance(id: Identifier): KnownProvenance? = packageProvenances[id]
 
+    fun getPackageProvenanceWithoutVcsPath(id: Identifier): KnownProvenance? = packageProvenancesWithoutVcsPath[id]
+
     /**
      * Return the package provenanceResolutionIssue associated with the given [id].
      */

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -73,6 +73,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxexpression.toSpdx
 
+@Suppress("LargeClass")
 class Scanner(
     val scannerConfig: ScannerConfiguration,
     val downloaderConfig: DownloaderConfiguration,
@@ -108,16 +109,22 @@ class Scanner(
     suspend fun scan(ortResult: OrtResult, skipExcluded: Boolean, labels: Map<String, String>): OrtResult {
         val projects = ortResult.getProjects(skipExcluded)
         val projectPackages = projects.mapTo(mutableSetOf()) { it.toPackage() }
+
+        val projectDirRelativeToAnalysisRootForId = projects.associate { project ->
+            project.id to ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project).substringBeforeLast("/", "")
+        }
+
         val projectResults = scan(
-            projectPackages,
-            ScanContext(
+            packages = projectPackages,
+            context = ScanContext(
                 labels = ortResult.labels + labels,
                 packageType = PackageType.PROJECT,
                 excludes = ortResult.repository.config.excludes,
                 includes = ortResult.repository.config.includes,
                 detectedLicenseMapping = scannerConfig.detectedLicenseMapping,
                 snippetChoices = ortResult.repository.config.snippetChoices
-            )
+            ),
+            projectDirRelativeToAnalysisRootForId = projectDirRelativeToAnalysisRootForId
         )
 
         val packages = ortResult.getPackages(skipExcluded)
@@ -128,8 +135,8 @@ class Scanner(
             .toSet()
 
         val packageResults = scan(
-            packages,
-            ScanContext(
+            packages = packages,
+            context = ScanContext(
                 labels = ortResult.labels + labels,
                 packageType = PackageType.PACKAGE,
                 detectedLicenseMapping = scannerConfig.detectedLicenseMapping
@@ -144,7 +151,11 @@ class Scanner(
         return ortResult.copy(scanner = paddedScannerRun)
     }
 
-    internal suspend fun scan(packages: Set<Package>, context: ScanContext): ScannerRun? {
+    internal suspend fun scan(
+        packages: Set<Package>,
+        context: ScanContext,
+        projectDirRelativeToAnalysisRootForId: Map<Identifier, String> = emptyMap()
+    ): ScannerRun? {
         val scannerWrappers = scannerWrappers[context.packageType]
         if (scannerWrappers.isNullOrEmpty()) {
             logger.info { "Skipping ${context.packageType} scan as no according scanner is configured." }
@@ -162,9 +173,15 @@ class Scanner(
 
         readStoredResults(controller)
 
+        val checkoutPathsForProvenance = if (context.packageType == PackageType.PROJECT) {
+            controller.getCheckoutPathsForProvenance(projectDirRelativeToAnalysisRootForId)
+        } else {
+            emptyMap()
+        }
+
         runPackageScanners(controller, context)
-        runProvenanceScanners(controller, context)
-        runPathScanners(controller, context)
+        runProvenanceScanners(controller, context, checkoutPathsForProvenance)
+        runPathScanners(controller, context, checkoutPathsForProvenance)
 
         createFileLists(controller)
         createMissingArchives(controller)
@@ -387,7 +404,11 @@ class Scanner(
     /**
      * Run provenance scanners for provenances with missing scan results.
      */
-    private fun runProvenanceScanners(controller: ScanController, context: ScanContext) {
+    private fun runProvenanceScanners(
+        controller: ScanController,
+        context: ScanContext,
+        checkoutPathsForProvenance: Map<KnownProvenance, Set<String>>
+    ) {
         val provenances = controller.getAllProvenances()
 
         provenances.forEachIndexed { index, provenance ->
@@ -407,7 +428,9 @@ class Scanner(
                         "'${scanner.descriptor.displayName}'."
                 }
 
-                val adjustedContext = context.clearPropertiesIfNeeded(scanner.matcher)
+                val adjustedContext = context
+                    .clearPropertiesIfNeeded(scanner.matcher)
+                    .setCheckoutPaths(provenance, checkoutPathsForProvenance)
 
                 runCatching {
                     scanner.scanProvenance(provenance, adjustedContext)
@@ -441,7 +464,11 @@ class Scanner(
     /**
      * Run path scanners for provenances with missing scan results.
      */
-    private fun runPathScanners(controller: ScanController, context: ScanContext) {
+    private fun runPathScanners(
+        controller: ScanController,
+        context: ScanContext,
+        checkoutPathsForProvenance: Map<KnownProvenance, Set<String>>
+    ) {
         val provenances = controller.getAllProvenances()
 
         provenances.forEachIndexed { index, provenance ->
@@ -459,7 +486,12 @@ class Scanner(
 
             logger.info { "Scanning $provenance (${index + 1} of ${provenances.size})..." }
 
-            val scanResults = scanPath(provenance, scannersWithoutResults, context, controller)
+            val scanResults = scanPath(
+                provenance = provenance,
+                scanners = scannersWithoutResults,
+                context = context.setCheckoutPaths(provenance, checkoutPathsForProvenance),
+                controller = controller
+            )
 
             scanResults.forEach { (scanner, scanResult) ->
                 val completedPackages = controller.getPackagesCompletedByProvenance(scanner, provenance)
@@ -889,3 +921,38 @@ private fun ScanContext.clearPropertiesIfNeeded(matcher: ScannerMatcher?) =
     } else {
         copy(excludes = null, includes = null, snippetChoices = emptyList())
     }
+
+private fun ScanController.getCheckoutPathsForProvenance(
+    projectDirRelativeToAnalysisRootForId: Map<Identifier, String>
+): Map<KnownProvenance, Set<String>> {
+    val result = mutableMapOf<KnownProvenance, MutableSet<String>>()
+
+    packages.forEach { pkg ->
+        val projectProvenance = getPackageProvenanceWithoutVcsPath(pkg.id) ?: return@forEach
+        val projectDirRelativeToAnalysisRoot = projectDirRelativeToAnalysisRootForId[pkg.id] ?: run {
+            logger.warn { "Could not determine project checkout path for {${pkg.id}." }
+            return@forEach
+        }
+
+        val provenanceCheckoutPath = projectDirRelativeToAnalysisRoot
+            .removeSuffix(pkg.vcsProcessed.path)
+            .removeSuffix("/")
+
+        result.getOrPut(projectProvenance) { mutableSetOf() } += provenanceCheckoutPath
+
+        val projectNestedProvenance = getNestedProvenance(pkg.id) ?: return@forEach
+        projectNestedProvenance.subRepositories.forEach { (path, submoduleProvenance) ->
+            result.getOrPut(submoduleProvenance) { mutableSetOf() } += "$provenanceCheckoutPath/$path"
+        }
+    }
+
+    return result
+}
+
+private fun ScanContext.setCheckoutPaths(
+    provenance: KnownProvenance,
+    checkoutPathsForProvenance: Map<KnownProvenance, Set<String>>
+): ScanContext =
+    copy(
+        checkoutPaths = checkoutPathsForProvenance[provenance].orEmpty().ifEmpty { setOf("") }
+    )

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -106,7 +106,8 @@ class Scanner(
     )
 
     suspend fun scan(ortResult: OrtResult, skipExcluded: Boolean, labels: Map<String, String>): OrtResult {
-        val projectPackages = ortResult.getProjects(skipExcluded).mapTo(mutableSetOf()) { it.toPackage() }
+        val projects = ortResult.getProjects(skipExcluded)
+        val projectPackages = projects.mapTo(mutableSetOf()) { it.toPackage() }
         val projectResults = scan(
             projectPackages,
             ScanContext(

--- a/scanner/src/test/kotlin/MultipleScannersTest.kt
+++ b/scanner/src/test/kotlin/MultipleScannersTest.kt
@@ -70,18 +70,18 @@ private fun createAnalyzerResult(): OrtResult {
         type = VcsType.GIT,
         url = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git",
         revision = "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
-    )
+    ).normalize()
 
     val pkg = Package.EMPTY.copy(
         id = PACKAGE_ID,
         vcs = vcs,
-        vcsProcessed = vcs.normalize()
+        vcsProcessed = vcs
     )
 
     val project = Project.EMPTY.copy(
         id = PROJECT_ID,
         vcs = vcs,
-        vcsProcessed = vcs.normalize()
+        vcsProcessed = vcs
     )
 
     val analyzerRun = AnalyzerRun.EMPTY.copy(

--- a/scanner/src/test/kotlin/MultipleScannersTest.kt
+++ b/scanner/src/test/kotlin/MultipleScannersTest.kt
@@ -72,24 +72,24 @@ private fun createAnalyzerResult(): OrtResult {
         revision = "97d57bb4795bc41f496e1a8e2c7751cefc7da7ec"
     ).normalize()
 
-    val pkg = Package.EMPTY.copy(
-        id = PACKAGE_ID,
-        vcs = vcs,
-        vcsProcessed = vcs
-    )
-
-    val project = Project.EMPTY.copy(
-        id = PROJECT_ID,
-        vcs = vcs,
-        vcsProcessed = vcs
-    )
-
-    val analyzerRun = AnalyzerRun.EMPTY.copy(
-        result = AnalyzerResult.EMPTY.copy(
-            projects = setOf(project),
-            packages = setOf(pkg)
+    return OrtResult.EMPTY.copy(
+        analyzer = AnalyzerRun.EMPTY.copy(
+            result = AnalyzerResult.EMPTY.copy(
+                projects = setOf(
+                    Project.EMPTY.copy(
+                        id = PROJECT_ID,
+                        vcs = vcs,
+                        vcsProcessed = vcs
+                    )
+                ),
+                packages = setOf(
+                    Package.EMPTY.copy(
+                        id = PACKAGE_ID,
+                        vcs = vcs,
+                        vcsProcessed = vcs
+                    )
+                )
+            )
         )
     )
-
-    return OrtResult.EMPTY.copy(analyzer = analyzerRun)
 }

--- a/scanner/src/test/kotlin/MultipleScannersTest.kt
+++ b/scanner/src/test/kotlin/MultipleScannersTest.kt
@@ -31,6 +31,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 
@@ -73,6 +74,10 @@ private fun createAnalyzerResult(): OrtResult {
     ).normalize()
 
     return OrtResult.EMPTY.copy(
+        repository = Repository(
+            vcs = vcs,
+            vcsProcessed = vcs
+        ),
         analyzer = AnalyzerRun.EMPTY.copy(
             result = AnalyzerResult.EMPTY.copy(
                 projects = setOf(

--- a/scanner/src/test/kotlin/ScanContextTest.kt
+++ b/scanner/src/test/kotlin/ScanContextTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.PackageType
+import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.PathExcludeReason
+
+class ScanContextTest : WordSpec({
+    "the constructor" should {
+        "throw if checkout paths is empty" {
+            PackageType.entries.forAll { packageType ->
+                shouldThrow<IllegalArgumentException> {
+                    createScanContext(packageType = packageType, checkoutPaths = emptySet())
+                }
+            }
+        }
+    }
+
+    "isPathExcluded() for a project of a root provenance" should {
+        "return true if the file path relative to analysis root is excluded" {
+            val context = createScanContext(
+                packageType = PackageType.PROJECT,
+                pathExcludes = setOf("src/main.java"),
+                checkoutPaths = setOf("")
+            )
+
+            context.isPathExcluded("src/main.java") shouldBe true
+            context.isPathExcluded("src/main2.java") shouldBe false
+        }
+    }
+
+    "isPathExcluded() for a project of a submodule provenance" should {
+        "return true if the file path relative to analysis root is excluded" {
+            val context = createScanContext(
+                packageType = PackageType.PROJECT,
+                pathExcludes = setOf("submodules/module-1-root/src/main.java"),
+                checkoutPaths = setOf("submodules/module-1-root")
+            )
+
+            context.isPathExcluded("src/main.java") shouldBe true
+            context.isPathExcluded("src/main2.java") shouldBe false
+        }
+
+        "return false if only a subset of the occurrences of a file in the source tree are excluded" {
+            val context = createScanContext(
+                packageType = PackageType.PROJECT,
+                pathExcludes = setOf("submodules/module-1-root/src/main.java"),
+                checkoutPaths = setOf(
+                    "submodules/module-1-root",
+                    "submodules/module-1-root-duplicate"
+                )
+            )
+
+            context.isPathExcluded("src/main.java") shouldBe false
+        }
+
+        "return true if all occurrences of a file in the source tree are excluded" {
+            val context = createScanContext(
+                packageType = PackageType.PROJECT,
+                pathExcludes = setOf(
+                    "submodules/module-1-root/src/main.java",
+                    "submodules/module-1-root-duplicate/src/main.java"
+                ),
+                checkoutPaths = setOf(
+                    "submodules/module-1-root",
+                    "submodules/module-1-root-duplicate"
+                )
+            )
+
+            context.isPathExcluded("src/main.java") shouldBe true
+        }
+
+        "not interpret path excludes as being relative to the provenance root" {
+            val context = createScanContext(
+                packageType = PackageType.PROJECT,
+                pathExcludes = setOf(
+                    "src/main.java"
+                ),
+                checkoutPaths = setOf(
+                    "submodules/module-1-root"
+                )
+            )
+
+            context.isPathExcluded("src/main.java") shouldBe false
+        }
+    }
+
+    "isPathExcluded() for a package scan" should {
+        "always return false" {
+            val context = createScanContext(
+                packageType = PackageType.PACKAGE,
+                pathExcludes = setOf("submodules/module-1-root/src/main.java"),
+                checkoutPaths = setOf("submodules/module-1-root")
+            )
+
+            context.isPathExcluded("src/main.java") shouldBe false
+        }
+    }
+})
+
+private fun createScanContext(
+    packageType: PackageType,
+    pathExcludes: Set<String> = emptySet(),
+    checkoutPaths: Set<String>
+): ScanContext =
+    ScanContext(
+        labels = emptyMap(),
+        packageType = packageType,
+        excludes = Excludes(
+            paths = pathExcludes.map {
+                PathExclude(
+                    pattern = it,
+                    reason = PathExcludeReason.OTHER
+                )
+            }
+        ),
+        checkoutPaths = checkoutPaths
+    )


### PR DESCRIPTION
See individual commit.

Note: In order to make the analog fix for `FossId`, in theory only `ScanContext.isPathExcluded()` needs to be taken into use. This is deliberately left to an upcoming PR, to limit the effort and risk of this PR.

Fixes #12207.