### PR TITLE
fix(npm): Evaluate local packages when in workspace mode

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
@@ -72,7 +72,7 @@ internal val ModuleInfo.isInstalled: Boolean
     get() = path != null && File(path).isDirectory
 
 internal val ModuleInfo.isProject: Boolean
-    get() = resolved == null
+    get() = resolved == null || resolved.startsWith("file:")
 
 private val ModuleInfo.packageJsonFile: File get() {
     check(isInstalled) { "The module directory '$path' is null or does not exist." }


### PR DESCRIPTION
NPM workspaces can have local packages with their own dependencies.

Current package manager plugin for NPM is returning null on cases that this local package is found and/or decided by developers to not be published ( "private": true ), therefore ignoring the subsequent dependencies, despite properly detected by npm own tooling.

The resulting issue endup in a report where analyzer contains the dependencies itself, but metadata *npm info* was never realized.

This is exemplifying the case:

<img width="622" height="750" alt="image" src="https://github.com/user-attachments/assets/6ac8eaa3-1fde-46be-b44f-18e22b190e9b" />

NPM::buffers is detected until the top workspace parent, and all transient packages are detected by *npm list*.
But as a result of the plugin parser stopped the analysis on workspace package.json, it end up not analyzed by *npm info* and became metadata less, ending up not  having licenses, and not be shown on report notice or spdx.

<img width="2400" height="104" alt="image" src="https://github.com/user-attachments/assets/8966506e-ccfc-4cc1-aa0f-5f6dff0456a6" />

Solution is respect the resolved by npm *file://* when present.

```yaml
    "@se/shared-resources": {
      "version": "0.1.0",
      "resolved": "file:../../packages/shared-resources",
      "overridden": false,
      "name": "@se/shared-resources",
      "private": true,
       ....
```
