### PR TITLE
fix(spdxdocumentfile): Handle referenced documents urls properly

### DIFF
--- a/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxResolvedDocument.kt
+++ b/plugins/package-managers/spdx-document-file/src/main/kotlin/utils/SpdxResolvedDocument.kt
@@ -277,7 +277,8 @@ private fun URI.toDefinitionFile(): File? =
 internal fun SpdxExternalDocumentReference.resolve(cache: SpdxDocumentCache, baseUri: URI): ResolutionResult {
     val uri = runCatching {
         val resolvedUri = baseUri.resolve(spdxDocument)
-        resolvedUri.takeUnless { baseUri.query != null } ?: URI("$resolvedUri?${baseUri.query}")
+        resolvedUri.takeUnless { baseUri.query != null && resolvedUri.query == null }
+            ?: URI("$resolvedUri?${baseUri.query}")
     }.getOrElse {
         return ResolutionResult(
             document = null,


### PR DESCRIPTION
If references inside referenced documents are absolute urls, scan will fail because of wrong urls with duplicated ?querystring
