### PR TITLE
ci(renovate): Configure automatic tool upgrades for the scanner tools

### DIFF
--- a/.env.versions
+++ b/.env.versions
@@ -23,9 +23,13 @@ SBT_VERSION=1.10.0
 SWIFT_VERSION=6.3.1
 
 # Scanner tools
+# renovate: datasource=github-releases depName=jpeddicord/askalono
 ASKALONO_VERSION=0.5.0
+# renovate: datasource=rubygems depName=licensee
 LICENSEE_VERSION=10.0.0
+# renovate: datasource=github-releases depName=getprovenant/provenant extractVersion=^v(?<version>.*)$
 PROVENANT_VERSION=1.0.3
+# renovate: datasource=pypi depName=scancode-toolkit
 SCANCODE_VERSION=32.5.0
 
 # Operating system
@@ -36,6 +40,7 @@ JAVA_VERSION=25
 NODEJS_VERSION=24.15.0
 PHP_VERSION=8.3
 PYTHON_VERSION=3.13.5
+# renovate: datasource=ruby-version depName=ruby
 RUBY_VERSION=3.4.4
 RUST_VERSION=1.94.0
 

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,15 @@
     "github>oss-review-toolkit/.github//renovate-config",
     "docker:disable"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/.env.versions$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\w+_VERSION=(?<currentValue>\\S+)"
+      ]
+    }
+  ],
   "ignorePaths": [
     "plugins/reporters/web-app-template",
     "**/src/funTest/assets/**",


### PR DESCRIPTION
Add a Renovate custom regex manager [1] to automate updating the scanner tool versions in the `.env.versions` file. To simplify matching the versions, use inline `# renovate:` annotations.

These annotations allow to specify the datasource and package name Renovate should use for the update, and optionally a custom regex to extract the version.

This is only implemented for the scanner tools to test how well the approach works before applying it to other Docker dependencies as well. The Ruby version is included, because it is the runtime for Licensee.

[1]: https://docs.renovatebot.com/modules/manager/regex/

Note that a similar change was done for ORT Server in https://github.com/eclipse-apoapsis/ort-server/pull/5484.