### PR TITLE
ci(renovate): Fix regex to match `.env.versions`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/.env.versions$"],
+      "managerFilePatterns": ["/\\.env\\.versions$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\w+_VERSION=(?<currentValue>\\S+)"
       ]


### PR DESCRIPTION
The regex was missing the trailing `/`. While at it, also escape the dots.

This is a fixup for c49d62b.