### PR TITLE
fix(model): Stop silently dropping snippets with same source loctions

### DIFF
--- a/model/src/main/kotlin/utils/SortedCollectionConverters.kt
+++ b/model/src/main/kotlin/utils/SortedCollectionConverters.kt
@@ -104,8 +104,8 @@ class ScopeSortedSetConverter : StdConverter<Set<Scope>, SortedSet<Scope>>() {
     override fun convert(value: Set<Scope>) = value.toSortedSet(compareBy { it.name })
 }
 
-class SnippetFindingSortedSetConverter : StdConverter<Set<SnippetFinding>, SortedSet<SnippetFinding>>() {
-    override fun convert(value: Set<SnippetFinding>) = value.toSortedSet(compareBy { it.sourceLocation })
+class SnippetFindingSortedSetConverter : StdConverter<Set<SnippetFinding>, Set<SnippetFinding>>() {
+    override fun convert(value: Set<SnippetFinding>) = value.sortedBy { it.sourceLocation }.toSet()
 }
 
 private fun Provenance.getSortKey(): String =


### PR DESCRIPTION
The sorted set uses the comparator not only sorting, but also for equality, which leads to the undesired removals.
