### PR TITLE
test(stack): Remove dead links from a synthetic project

### DIFF
--- a/plugins/package-managers/stack/src/funTest/assets/projects/synthetic/stack-yesodweb-simple/README.md
+++ b/plugins/package-managers/stack/src/funTest/assets/projects/synthetic/stack-yesodweb-simple/README.md
@@ -33,10 +33,3 @@ stack test --flag stack-yesodweb-simple:library-only --flag stack-yesodweb-simpl
 	* `stack haddock --open` to generate Haddock documentation for your dependencies, and open that documentation in a browser
 	* `stack hoogle <function, module or type signature>` to generate a Hoogle database and search for your query
 * The [Yesod cookbook](https://github.com/yesodweb/yesod-cookbook) has sample code for various needs
-
-## Getting Help
-
-* Ask questions on [Stack Overflow, using the Yesod or Haskell tags](https://stackoverflow.com/questions/tagged/yesod+haskell)
-* Ask the [Yesod Google Group](https://groups.google.com/forum/#!forum/yesodweb)
-* There are several chatrooms you can ask for help:
-	* For IRC, try Freenode#yesod and Freenode#haskell


### PR DESCRIPTION
Remove the whole "Getting Help" section as at least the link to Stack Overflow does not seem to work as expected anymore. This should fix the "markdown-links" CI check.