### PR TITLE
feat(scanoss): Allow to disable the use of a proxy

### DIFF
--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOss.kt
@@ -30,6 +30,7 @@ import com.scanoss.settings.ScanossSettings
 import com.scanoss.utils.JsonUtils
 
 import java.io.File
+import java.net.Proxy
 import java.time.Instant
 
 import org.apache.logging.log4j.kotlin.logger
@@ -59,6 +60,7 @@ class ScanOss(
         // As there is only a single endpoint, the SCANOSS API client expects the path to be part of the API URL.
         .url(config.apiUrl.removeSuffix("/") + "/scan/direct")
         .apiKey(config.apiKey.value)
+        .apply { if (config.noProxy) proxy(Proxy.NO_PROXY) }
         .obfuscate(config.enablePathObfuscation)
 
     override val version: String by lazy {

--- a/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
+++ b/plugins/scanners/scanoss/src/main/kotlin/ScanOssConfig.kt
@@ -33,6 +33,10 @@ data class ScanOssConfig(
     @OrtPluginOption(defaultValue = "")
     val apiKey: Secret,
 
+    /** Whether to use a proxy defined by the dedicated environment variable(s). */
+    @OrtPluginOption(defaultValue = "false")
+    val noProxy: Boolean,
+
     /**
      * Whether to write scan results to the storage.
      */

--- a/plugins/scanners/scanoss/src/test/kotlin/TestUtils.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/TestUtils.kt
@@ -56,6 +56,7 @@ internal fun createScanOssConfig(
     ScanOssConfig(
         apiUrl = apiUrl,
         apiKey = apiKey,
+        noProxy = false,
         writeToStorage = writeToStorage,
         chosenSnippetModel = listOf(ScanOssConfig.SnippetModel.LICENSE_AND_COPYRIGHT_FINDING),
         enablePathObfuscation = enablePathObfuscation,


### PR DESCRIPTION
The `ScanOSS` Java library sets the proxy for its `okhttp` client instance according to the dedicated environment variable(s). However, it does not adhere to the `no_proxy` environment variable, so it is not possible to disable the proxy just for ScanOSS. Add a config toggle to support that.
