### PR TITLE
fix(scanner): `getCheckoutPathsForProvenance()`

### DIFF
--- a/scanner/src/main/kotlin/ScanContext.kt
+++ b/scanner/src/main/kotlin/ScanContext.kt
@@ -88,6 +88,11 @@ data class ScanContext(
         require(checkoutPaths.isNotEmpty()) {
             "The checkout paths must not be empty."
         }
+
+        val invalidCheckoutPaths = checkoutPaths.filter { it.startsWith("/") || it.endsWith("/") }
+        require(invalidCheckoutPaths.isEmpty()) {
+            "The following checkout paths start or end with a '/' which is not allowed: $invalidCheckoutPaths"
+        }
     }
 
     /**

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -67,6 +67,7 @@ import org.ossreviewtoolkit.scanner.utils.alignRevisions
 import org.ossreviewtoolkit.scanner.utils.filterScanResultsByVcsPaths
 import org.ossreviewtoolkit.scanner.utils.getVcsPathsForProvenances
 import org.ossreviewtoolkit.utils.common.collectMessages
+import org.ossreviewtoolkit.utils.common.ensureSuffix
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.showStackTrace
@@ -936,13 +937,13 @@ private fun ScanController.getCheckoutPathsForProvenance(
 
         val provenanceCheckoutPath = projectDirRelativeToAnalysisRoot
             .removeSuffix(pkg.vcsProcessed.path)
-            .removeSuffix("/")
+            .ensureSuffix("/")
 
         result.getOrPut(projectProvenance) { mutableSetOf() } += provenanceCheckoutPath
 
         val projectNestedProvenance = getNestedProvenance(pkg.id) ?: return@forEach
         projectNestedProvenance.subRepositories.forEach { (path, submoduleProvenance) ->
-            result.getOrPut(submoduleProvenance) { mutableSetOf() } += "$provenanceCheckoutPath/$path"
+            result.getOrPut(submoduleProvenance) { mutableSetOf() } += "$provenanceCheckoutPath$path"
         }
     }
 


### PR DESCRIPTION
The returned checkout paths for submodules were accidentally prefixes with a `'/'` which rendered `ScanContext.isPathExcluded()` to always return `false`, which in turn deaktived the exclusion mechanism in `ScanOss`.

Also add a `require` check to `ScanContext` to ensure that the existing tests in `ScanContextTest` are sufficient.
