### PR TITLE
feat(common-utils): Limit `ensure{Prefix,Suffix}()` to non-empty strings

### DIFF
--- a/utils/common/src/main/kotlin/StringUtils.kt
+++ b/utils/common/src/main/kotlin/StringUtils.kt
@@ -39,14 +39,14 @@ fun String.encodeOr(emptyValue: String): String {
 }
 
 /**
- * Ensure that this string starts with the specified [prefix].
+ * Ensure that this non-empty string starts with the specified [prefix].
  */
-fun String.ensurePrefix(prefix: String) = takeIf { it.startsWith(prefix) } ?: "$prefix$this"
+fun String.ensurePrefix(prefix: String) = if (isEmpty() || startsWith(prefix)) this else "$prefix$this"
 
 /**
- * Ensure that this string ends with the specified [suffix].
+ * Ensure that this non-empty string ends with the specified [suffix].
  */
-fun String.ensureSuffix(suffix: String) = takeIf { it.endsWith(suffix) } ?: "$this$suffix"
+fun String.ensureSuffix(suffix: String) = if (isEmpty() || endsWith(suffix)) this else "$this$suffix"
 
 /**
  * Return the string encoded for safe use as a file name or "unknown", if the string is empty.


### PR DESCRIPTION
This seems more natural for most use-cases.