### PR TITLE
fix(evaluator): Take qualitative severity into account

### DIFF
--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -118,27 +118,35 @@ open class PackageRule(
                     .flatMap { it.references }
                     .filter { it.scoringSystem == scoringSystem }
 
-                val scores = matchingSystems.mapNotNull { it.score }
-                if (scores.any()) return scores.any { it >= scoreThreshold }
+                val scores = matchingSystems.mapNotNull {
+                    it.score ?: scoreFromSeverity(it)
+                }
 
-                // Fall back to a more coarse comparison of qualitative severity ratings if no scores are available.
-                val severityThreshold = VulnerabilityReference.getQualitativeRating(scoringSystem, scoreThreshold)
-                    ?: return false
+                return scores.any { it >= scoreThreshold }
+            }
 
-                val severities = matchingSystems
-                    .mapNotNull { it.severity }
-                    .mapNotNull { severity ->
-                        val system = scoringSystem.uppercase()
+            /**
+             * Map the qualitative severity of the given [reference] to a numeric score according to the ratings
+             * defined for the scoring systems. Return *null* if no severity is defined or the scoring system is not
+             * supported.
+             */
+            private fun scoreFromSeverity(reference: VulnerabilityReference): Float? =
+                reference.scoringSystem?.let { system ->
+                    reference.severity?.let { severity ->
                         when {
-                            Cvss2Rating.PREFIXES.any { system.startsWith(it) } -> enumValueOf<Cvss2Rating>(severity)
-                            Cvss3Rating.PREFIXES.any { system.startsWith(it) } -> enumValueOf<Cvss3Rating>(severity)
-                            Cvss4Rating.PREFIXES.any { system.startsWith(it) } -> enumValueOf<Cvss4Rating>(severity)
+                            Cvss2Rating.PREFIXES.any { system.startsWith(it) } ->
+                                enumValueOf<Cvss2Rating>(severity).upperBound
+
+                            Cvss3Rating.PREFIXES.any { system.startsWith(it) } ->
+                                enumValueOf<Cvss3Rating>(severity).upperBound
+
+                            Cvss4Rating.PREFIXES.any { system.startsWith(it) } ->
+                                enumValueOf<Cvss4Rating>(severity).upperBound
+
                             else -> null
                         }
                     }
-
-                return severities.any { it.ordinal >= severityThreshold.ordinal }
-            }
+                }
         }
 
     /**

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -22,16 +22,24 @@ package org.ossreviewtoolkit.evaluator
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorRun
+import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.CuratedPackage
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicense
 import org.ossreviewtoolkit.model.licenses.ResolvedOriginalExpression
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
+import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression.Strictness
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxLicenseIdExpression
@@ -39,8 +47,8 @@ import org.ossreviewtoolkit.utils.spdxexpression.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.spdxexpression.toSpdx
 
 class PackageRuleTest : WordSpec() {
-    private fun createPackageRule(pkg: Package): PackageRule {
-        val ruleSet = ruleSet(ortResult.addPackage(pkg))
+    private fun createPackageRule(pkg: Package, result: OrtResult = ortResult): PackageRule {
+        val ruleSet = ruleSet(result.addPackage(pkg))
 
         return PackageRule(
             ruleSet = ruleSet,
@@ -291,6 +299,41 @@ class PackageRuleTest : WordSpec() {
                 val matcher = rule.hasVulnerability(10.0f, "fake-scoring-system")
 
                 matcher.matches() shouldBe false
+            }
+
+            "return true if a vulnerability with a qualitative severity is found" {
+                val qualitativeCriticalVulnerability = criticalVulnerability.copy(
+                    references = criticalVulnerability.references.map { reference ->
+                        if (reference.severity == "CRITICAL") {
+                            reference.copy(score = null)
+                        } else {
+                            reference
+                        }
+                    }
+                )
+                val advisor = AdvisorRun(
+                    startTime = Instant.EPOCH,
+                    endTime = Instant.EPOCH,
+                    environment = Environment(),
+                    config = AdvisorConfiguration(),
+                    results = mapOf(
+                        packageWithVulnerabilities.id to listOf(
+                            AdvisorResult(
+                                advisor = AdvisorDetails("Advisor"),
+                                summary = AdvisorSummary(startTime = Instant.EPOCH, endTime = Instant.EPOCH),
+                                vulnerabilities = listOf(
+                                    qualitativeCriticalVulnerability,
+                                    lowVulnerability
+                                )
+                            )
+                        )
+                    )
+                )
+                val ortResultWithQualitativeVulnerability = ortResult.copy(advisor = advisor)
+                val rule = createPackageRule(packageWithVulnerabilities, ortResultWithQualitativeVulnerability)
+                val matcher = rule.hasVulnerability(10.0f, "CVSS3")
+
+                matcher.matches() shouldBe true
             }
         }
     }

--- a/evaluator/src/testFixtures/kotlin/TestData.kt
+++ b/evaluator/src/testFixtures/kotlin/TestData.kt
@@ -191,6 +191,32 @@ val licenseChoices = LicenseChoices(
     )
 )
 
+val criticalVulnerability = Vulnerability(
+    id = "CVE-2021-critical",
+    references = listOf(
+        VulnerabilityReference(
+            url = URI("https://oss-review-toolkit.org"),
+            scoringSystem = "CVSS3",
+            severity = "CRITICAL",
+            score = 9.0f,
+            vector = null
+        )
+    )
+)
+
+val lowVulnerability = Vulnerability(
+    id = "CVE-2021-low",
+    references = listOf(
+        VulnerabilityReference(
+            url = URI("https://oss-review-toolkit.org"),
+            scoringSystem = "CVSS3",
+            severity = "LOW",
+            score = 2.0f,
+            vector = null
+        )
+    )
+)
+
 val ortResult = OrtResult(
     repository = Repository(
         vcs = VcsInfo.EMPTY,
@@ -226,30 +252,8 @@ val ortResult = OrtResult(
                     advisor = AdvisorDetails("Advisor"),
                     summary = AdvisorSummary(startTime = Instant.EPOCH, endTime = Instant.EPOCH),
                     vulnerabilities = listOf(
-                        Vulnerability(
-                            id = "CVE-2021-critical",
-                            references = listOf(
-                                VulnerabilityReference(
-                                    url = URI("https://oss-review-toolkit.org"),
-                                    scoringSystem = "CVSS3",
-                                    severity = "CRITICAL",
-                                    score = 9.0f,
-                                    vector = null
-                                )
-                            )
-                        ),
-                        Vulnerability(
-                            id = "CVE-2021-trivial",
-                            references = listOf(
-                                VulnerabilityReference(
-                                    url = URI("https://oss-review-toolkit.org"),
-                                    scoringSystem = "CVSS3",
-                                    severity = "LOW",
-                                    score = 2.0f,
-                                    vector = null
-                                )
-                            )
-                        )
+                        criticalVulnerability,
+                        lowVulnerability
                     )
                 )
             )

--- a/model/src/main/kotlin/vulnerabilities/Cvss2Rating.kt
+++ b/model/src/main/kotlin/vulnerabilities/Cvss2Rating.kt
@@ -23,7 +23,7 @@ package org.ossreviewtoolkit.model.vulnerabilities
  * The rating attaches human-readable semantics to the score number according to CVSS version 2, see
  * https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6.
  */
-enum class Cvss2Rating(private val upperBound: Float) {
+enum class Cvss2Rating(val upperBound: Float) {
     LOW(4.0f),
     MEDIUM(7.0f),
     HIGH(10.0f);

--- a/model/src/main/kotlin/vulnerabilities/Cvss3Rating.kt
+++ b/model/src/main/kotlin/vulnerabilities/Cvss3Rating.kt
@@ -23,7 +23,7 @@ package org.ossreviewtoolkit.model.vulnerabilities
  * The rating attaches human-readable semantics to the score number according to CVSS version 3, see
  * https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale.
  */
-enum class Cvss3Rating(private val upperBound: Float) {
+enum class Cvss3Rating(val upperBound: Float) {
     NONE(0.0f),
     LOW(4.0f),
     MEDIUM(7.0f),

--- a/model/src/main/kotlin/vulnerabilities/Cvss4Rating.kt
+++ b/model/src/main/kotlin/vulnerabilities/Cvss4Rating.kt
@@ -23,7 +23,7 @@ package org.ossreviewtoolkit.model.vulnerabilities
  * The rating attaches human-readable semantics to the score number according to CVSS version 4, see
  * https://www.first.org/cvss/v4.0/specification-document#Qualitative-Severity-Rating-Scale.
  */
-enum class Cvss4Rating(private val upperBound: Float) {
+enum class Cvss4Rating(val upperBound: Float) {
     NONE(0.0f),
     LOW(4.0f),
     MEDIUM(7.0f),


### PR DESCRIPTION
The `hasVulnerability()` function in `PackageRule` ignored the qualitative severity in vulnerability references as soon as a single numeric score was found. It could therefore miss vulnerabilities with references that declared a high severity, but no numerical score.

Fix this by mapping qualitative severities to numeric values based on the existing rating enums. To make this possible, expose the `upperBound` property of these enums.
