### PR TITLE
test(scanner): Reduce the flakyness of ClearlyDefined storage tests

### DIFF
--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.clients.clearlydefined
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.TestAbortedException
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.comparables.shouldBeGreaterThan
@@ -30,6 +31,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.include
 import io.kotest.matchers.string.shouldStartWith
+
+import java.net.SocketTimeoutException
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
@@ -59,11 +62,13 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         )
 
         "return single curation data" {
-            val service = ClearlyDefinedService.create()
+            withIgnoreTimeout {
+                val service = ClearlyDefinedService.create()
 
-            val curation = service.getCuration(coordinates)
+                val curation = service.getCuration(coordinates)
 
-            curation.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+                curation.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+            }
         }
 
         // TODO: Enable again once HTTP 429 "Too Many Requests" errors are resolved.
@@ -143,3 +148,22 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         }
     }
 })
+
+/**
+ * Skips the test in case `SocketTimeoutException` occurred, by throwing a `TestAbortedException`.
+ * Otherwise, execute [block] as usual.
+ *
+ * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
+ * when network is not available.
+ */
+private suspend fun withIgnoreTimeout(block: suspend () -> Unit) {
+    runCatching {
+        block()
+    }.onFailure { e ->
+        throw if (e is SocketTimeoutException) {
+            TestAbortedException()
+        } else {
+            e
+        }
+    }
+}

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.clients.clearlydefined
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.TestAbortedException
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.comparables.shouldBeGreaterThan
@@ -30,6 +31,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.include
 import io.kotest.matchers.string.shouldStartWith
+
+import java.net.SocketTimeoutException
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
@@ -61,7 +64,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         "return single curation data" {
             val service = ClearlyDefinedService.create()
 
-            val curation = service.getCuration(coordinates)
+            val curation = withIgnoreTimeout { service.getCuration(coordinates) }
 
             curation.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
         }
@@ -143,3 +146,21 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         }
     }
 })
+
+/**
+ * Skip the test in case `SocketTimeoutException` occurred by throwing a `TestAbortedException`. Otherwise, execute the
+ * [block] as usual.
+ *
+ * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
+ * when network is not available.
+ */
+private suspend fun <T> withIgnoreTimeout(block: suspend () -> T): T =
+    runCatching {
+        block()
+    }.getOrElse {
+        throw if (it is SocketTimeoutException) {
+            TestAbortedException()
+        } else {
+            it
+        }
+    }

--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -19,14 +19,13 @@
 
 package org.ossreviewtoolkit.scanner.storages
 
-import io.kotest.assertions.retry
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.TestAbortedException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.result.shouldBeSuccess
 
+import java.net.SocketTimeoutException
 import java.time.Instant
-
-import kotlin.time.Duration.Companion.seconds
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Hash
@@ -59,7 +58,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        withRetry {
+        withIgnoreTimeout {
             val results = storage.read(pkg)
 
             results shouldBeSuccess {
@@ -122,7 +121,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        withRetry {
+        withIgnoreTimeout {
             val results = storage.read(pkg)
 
             results shouldBeSuccess {
@@ -165,7 +164,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        withRetry {
+        withIgnoreTimeout {
             val results = storage.read(pkg)
 
             results shouldBeSuccess { result ->
@@ -182,11 +181,21 @@ class ClearlyDefinedStorageFunTest : StringSpec({
     }
 })
 
-private suspend fun <T> withRetry(f: suspend () -> T): T =
-    retry(
-        maxRetry = 5,
-        timeout = (10 + 20 + 40 + 80 + 160).seconds,
-        delay = 10.seconds,
-        multiplier = 2,
-        f = f
-    )
+/**
+ * Skips the test in case `SocketTimeoutException` occurred, by throwing a `TestAbortedException`.
+ * Otherwise, execute [block] as usual.
+ *
+ * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
+ * when network is not available.
+ */
+private suspend fun withIgnoreTimeout(block: suspend () -> Unit) {
+    runCatching {
+        block()
+    }.onFailure { e ->
+        throw if (e is SocketTimeoutException) {
+            TestAbortedException()
+        } else {
+            e
+        }
+    }
+}

--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -19,14 +19,13 @@
 
 package org.ossreviewtoolkit.scanner.storages
 
-import io.kotest.assertions.retry
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.TestAbortedException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.result.shouldBeSuccess
 
+import java.net.SocketTimeoutException
 import java.time.Instant
-
-import kotlin.time.Duration.Companion.seconds
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Hash
@@ -59,54 +58,52 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        withRetry {
-            val results = storage.read(pkg)
+        val results = storage.read(pkg).withIgnoreTimeout()
 
-            results shouldBeSuccess {
-                it shouldContain ScanResult(
-                    provenance = RepositoryProvenance(
-                        vcsInfo = VcsInfo(
-                            type = VcsType.GIT,
-                            url = "https://github.com/vdurmont/semver4j.git",
-                            revision = "88912638db3f6112a2b345f1638ced33a0a606e1"
-                        ),
-                        resolvedRevision = "88912638db3f6112a2b345f1638ced33a0a606e1"
+        results shouldBeSuccess {
+            it shouldContain ScanResult(
+                provenance = RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "https://github.com/vdurmont/semver4j.git",
+                        revision = "88912638db3f6112a2b345f1638ced33a0a606e1"
                     ),
-                    scanner = ScannerDetails(
-                        name = "ScanCode",
-                        version = "30.1.0",
-                        configuration = "--classify true --copyright true --email true " +
-                            "--generated true --info true --is-license-text true --json-pp /tmp/cd-d8WH1p " +
-                            "--license true --license-clarity-score true --license-text true " +
-                            "--license-text-diagnostics true --package true --processes 2 --strip-root true " +
-                            "--summary true --summary-key-files true --timeout 1000.0 --url true"
-                    ),
-                    summary = ScanSummary.EMPTY.copy(
-                        startTime = Instant.parse("2023-09-27T08:28:44.000244665Z"),
-                        endTime = Instant.parse("2023-09-27T08:29:22.000369368Z"),
-                        licenseFindings = setOf(
-                            LicenseFinding(
-                                license = "BSD-3-Clause",
-                                location = TextLocation(
-                                    path = "META-INF/maven/com.vdurmont/semver4j/pom.xml",
-                                    startLine = 28,
-                                    endLine = 34
-                                ),
-                                score = 75.0f
+                    resolvedRevision = "88912638db3f6112a2b345f1638ced33a0a606e1"
+                ),
+                scanner = ScannerDetails(
+                    name = "ScanCode",
+                    version = "30.1.0",
+                    configuration = "--classify true --copyright true --email true " +
+                        "--generated true --info true --is-license-text true --json-pp /tmp/cd-d8WH1p " +
+                        "--license true --license-clarity-score true --license-text true " +
+                        "--license-text-diagnostics true --package true --processes 2 --strip-root true " +
+                        "--summary true --summary-key-files true --timeout 1000.0 --url true"
+                ),
+                summary = ScanSummary.EMPTY.copy(
+                    startTime = Instant.parse("2023-09-27T08:28:44.000244665Z"),
+                    endTime = Instant.parse("2023-09-27T08:29:22.000369368Z"),
+                    licenseFindings = setOf(
+                        LicenseFinding(
+                            license = "BSD-3-Clause",
+                            location = TextLocation(
+                                path = "META-INF/maven/com.vdurmont/semver4j/pom.xml",
+                                startLine = 28,
+                                endLine = 34
                             ),
-                            LicenseFinding(
-                                license = "MIT",
-                                location = TextLocation(
-                                    path = "META-INF/maven/com.vdurmont/semver4j/pom.xml",
-                                    startLine = 30,
-                                    endLine = 31
-                                ),
-                                score = 83.33f
-                            )
+                            score = 75.0f
+                        ),
+                        LicenseFinding(
+                            license = "MIT",
+                            location = TextLocation(
+                                path = "META-INF/maven/com.vdurmont/semver4j/pom.xml",
+                                startLine = 30,
+                                endLine = 31
+                            ),
+                            score = 83.33f
                         )
                     )
                 )
-            }
+            )
         }
     }
 
@@ -122,34 +119,32 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        withRetry {
-            val results = storage.read(pkg)
+        val results = storage.read(pkg).withIgnoreTimeout()
 
-            results shouldBeSuccess {
-                it shouldContain ScanResult(
-                    provenance = RepositoryProvenance(
-                        vcsInfo = VcsInfo(
-                            type = VcsType.GIT,
-                            url = "https://github.com/sksamuel/hoplite.git",
-                            revision = "b3bf5d7bd3814cb7576091acfecd097cb3a79e72"
-                        ),
-                        resolvedRevision = "b3bf5d7bd3814cb7576091acfecd097cb3a79e72"
+        results shouldBeSuccess {
+            it shouldContain ScanResult(
+                provenance = RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "https://github.com/sksamuel/hoplite.git",
+                        revision = "b3bf5d7bd3814cb7576091acfecd097cb3a79e72"
                     ),
-                    scanner = ScannerDetails(
-                        name = "ScanCode",
-                        version = "30.1.0",
-                        configuration = "--classify true --copyright true --email true " +
-                            "--generated true --info true --is-license-text true --json-pp /tmp/cd-ZLZNNN " +
-                            "--license true --license-clarity-score true --license-text true " +
-                            "--license-text-diagnostics true --package true --processes 2 --strip-root true " +
-                            "--summary true --summary-key-files true --timeout 1000.0 --url true"
-                    ),
-                    summary = ScanSummary.EMPTY.copy(
-                        startTime = Instant.parse("2022-05-02T07:34:28.000784295Z"),
-                        endTime = Instant.parse("2022-05-02T07:34:59.000958218Z")
-                    )
+                    resolvedRevision = "b3bf5d7bd3814cb7576091acfecd097cb3a79e72"
+                ),
+                scanner = ScannerDetails(
+                    name = "ScanCode",
+                    version = "30.1.0",
+                    configuration = "--classify true --copyright true --email true " +
+                        "--generated true --info true --is-license-text true --json-pp /tmp/cd-ZLZNNN " +
+                        "--license true --license-clarity-score true --license-text true " +
+                        "--license-text-diagnostics true --package true --processes 2 --strip-root true " +
+                        "--summary true --summary-key-files true --timeout 1000.0 --url true"
+                ),
+                summary = ScanSummary.EMPTY.copy(
+                    startTime = Instant.parse("2022-05-02T07:34:28.000784295Z"),
+                    endTime = Instant.parse("2022-05-02T07:34:59.000958218Z")
                 )
-            }
+            )
         }
     }
 
@@ -165,28 +160,33 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        withRetry {
-            val results = storage.read(pkg)
+        val results = storage.read(pkg).withIgnoreTimeout()
 
-            results shouldBeSuccess { result ->
-                result.map { it.provenance } shouldContain RepositoryProvenance(
-                    vcsInfo = VcsInfo(
-                        type = VcsType.GIT,
-                        url = "https://github.com/bropat/ioBroker.eusec.git",
-                        revision = "327b125548c9b806490085a2dacfdfc6e7776803"
-                    ),
-                    resolvedRevision = "327b125548c9b806490085a2dacfdfc6e7776803"
-                )
-            }
+        results shouldBeSuccess { result ->
+            result.map { it.provenance } shouldContain RepositoryProvenance(
+                vcsInfo = VcsInfo(
+                    type = VcsType.GIT,
+                    url = "https://github.com/bropat/ioBroker.eusec.git",
+                    revision = "327b125548c9b806490085a2dacfdfc6e7776803"
+                ),
+                resolvedRevision = "327b125548c9b806490085a2dacfdfc6e7776803"
+            )
         }
     }
 })
 
-private suspend fun <T> withRetry(f: suspend () -> T): T =
-    retry(
-        maxRetry = 5,
-        timeout = (10 + 20 + 40 + 80 + 160).seconds,
-        delay = 10.seconds,
-        multiplier = 2,
-        f = f
-    )
+/**
+ * Skip the test in case `SocketTimeoutException` occurred by throwing a `TestAbortedException`. Otherwise, return the
+ * [Result] as-is.
+ *
+ * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
+ * when network is not available.
+ */
+private fun <T> Result<T>.withIgnoreTimeout(): Result<T> =
+    onFailure { e ->
+        throw if (e.cause is SocketTimeoutException) {
+            TestAbortedException()
+        } else {
+            e
+        }
+    }

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -165,7 +165,7 @@ class ClearlyDefinedStorage(
                 }
             }
 
-            throw ScanStorageException(message)
+            throw ScanStorageException(message, e)
         }
     }
 

--- a/scanner/src/main/kotlin/storages/PackageBasedFileStorage.kt
+++ b/scanner/src/main/kotlin/storages/PackageBasedFileStorage.kt
@@ -67,7 +67,7 @@ class PackageBasedFileStorage(
 
             logger.info { message }
 
-            throw ScanStorageException(message)
+            throw ScanStorageException(message, it)
         }
     }
 
@@ -104,7 +104,7 @@ class PackageBasedFileStorage(
 
                 logger.warn { message }
 
-                return Result.failure(ScanStorageException(message))
+                return Result.failure(ScanStorageException(message, it))
             }
         }
     }

--- a/scanner/src/main/kotlin/storages/PackageBasedPostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PackageBasedPostgresStorage.kt
@@ -159,7 +159,7 @@ class PackageBasedPostgresStorage(
 
                 logger.info { message }
 
-                return Result.failure(ScanStorageException(message))
+                return Result.failure(ScanStorageException(message, it))
             }
         }
     }
@@ -183,7 +183,7 @@ class PackageBasedPostgresStorage(
 
             logger.warn { message }
 
-            throw ScanStorageException(message)
+            throw ScanStorageException(message, it)
         }.map { /* Unit */ }
     }
 }


### PR DESCRIPTION
These tests keep on failing randomly since years, but the failure is not locally reproducible. Simply ignore any timeout issues. The test will anyway bed executed later again once the network is ok, which serves the purpose of getting reminded when the upstream data model changes.
