### PR TITLE
feat(model): Add an optional timestamp when a package was published

### DIFF
--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
+import java.time.Instant
+
 import org.ossreviewtoolkit.model.utils.requireNoDuplicates
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -108,6 +110,12 @@ data class Package(
      * The remote artifact where the source package can be downloaded.
      */
     val sourceArtifact: RemoteArtifact,
+
+    /**
+     * The timestamp when the package was published, usually to a package registry like Maven Central.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val publishedAt: Instant? = null,
 
     /**
      * Original VCS-related information as defined in the package's metadata.


### PR DESCRIPTION
Relates to #4952. This deliberately does not fill the property for any package manager yet to first get the data model settled.