### PR TITLE
npm: Fix `ModuleInfo.isProject`

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/workspaces-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/workspaces-expected-output.yml
@@ -32,7 +32,6 @@ projects:
     - id: "NPM:@csstools:css-parser-algorithms:4.0.0"
     - id: "NPM:@csstools:css-tokenizer:4.0.0"
     - id: "NPM:@here:harp-fetch:0.3.6"
-      linkage: "PROJECT_DYNAMIC"
       dependencies:
       - id: "NPM::node-fetch:2.7.0"
         dependencies:
@@ -77,7 +76,6 @@ projects:
       - id: "NPM:@csstools:css-parser-algorithms:4.0.0"
       - id: "NPM:@csstools:css-tokenizer:4.0.0"
       - id: "NPM:@here:harp-fetch:0.3.6"
-        linkage: "PROJECT_DYNAMIC"
         dependencies:
         - id: "NPM::node-fetch:2.7.0"
           dependencies:
@@ -103,7 +101,6 @@ projects:
         - id: "NPM:@csstools:css-parser-algorithms:4.0.0"
         - id: "NPM:@csstools:css-tokenizer:4.0.0"
         - id: "NPM:@here:harp-fetch:0.3.6"
-          linkage: "PROJECT_DYNAMIC"
           dependencies:
           - id: "NPM::node-fetch:2.7.0"
             dependencies:
@@ -157,7 +154,6 @@ projects:
       - id: "NPM:@csstools:css-parser-algorithms:4.0.0"
       - id: "NPM:@csstools:css-tokenizer:4.0.0"
       - id: "NPM:@here:harp-fetch:0.3.6"
-        linkage: "PROJECT_DYNAMIC"
         dependencies:
         - id: "NPM::node-fetch:2.7.0"
           dependencies:
@@ -813,6 +809,36 @@ packages:
     url: "https://github.com/csstools/postcss-plugins.git"
     revision: "9256e22798ff1360e178912af9b57d59d0601c99"
     path: "packages/css-tokenizer"
+- id: "NPM:@here:harp-fetch:0.3.6"
+  purl: "pkg:npm/%40here/harp-fetch@0.3.6"
+  authors:
+  - "HERE Europe B.V."
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  description: "This module adds a subset of the fetch API for Node.js"
+  homepage_url: "https://github.com/heremaps/harp.gl#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/@here/harp-fetch/-/harp-fetch-0.3.6.tgz"
+    hash:
+      value: "703fc8b034f6e0d621cc2c3ded96c6f904723742"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/heremaps/harp.gl.git"
+    revision: "0c2857f958a34ef7638384afada4fceec427d48d"
+    path: "@here/harp-fetch"
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/heremaps/harp.gl.git"
+    revision: "0c2857f958a34ef7638384afada4fceec427d48d"
+    path: "@here/harp-fetch"
 - id: "NPM:@here:harp-fetch:0.11.0"
   purl: "pkg:npm/%40here/harp-fetch@0.11.0"
   authors:

--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
@@ -27,6 +27,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.plugins.packagemanagers.node.ModuleInfoResolver
+import org.ossreviewtoolkit.plugins.packagemanagers.node.NODE_MODULES_DIRNAME
 import org.ossreviewtoolkit.plugins.packagemanagers.node.NodePackageManagerType
 import org.ossreviewtoolkit.plugins.packagemanagers.node.PackageJson
 import org.ossreviewtoolkit.plugins.packagemanagers.node.parsePackage
@@ -73,7 +74,16 @@ internal val ModuleInfo.isInstalled: Boolean
     get() = path != null && File(path).isDirectory
 
 internal val ModuleInfo.isProject: Boolean
-    get() = resolved == null || resolved.startsWith("file:")
+    get(): Boolean {
+        val moduleDir = path?.let { File(it).realFile } ?: return false
+        val baseDir = if (name != null && "/" in name) {
+            moduleDir.parentFile.parentFile
+        } else {
+            moduleDir.parentFile
+        }
+
+        return baseDir.name != NODE_MODULES_DIRNAME
+    }
 
 private val ModuleInfo.packageJsonFile: File get() {
     check(isInstalled) { "The module directory '$path' is null or does not exist." }


### PR DESCRIPTION
In some cases the property returns `true` where it should not. In that case `Npm.kt` adds references to that module using `PROJECT_DYNAMIC` as the linkage type, but it neither adds a package nor a project corresponding to that module, so the reference is dangling.

When running [1], like `Npm.kt` does it, all modules which are dependencies of the `package.json` in the current working directory get placed inside the corresponding `node_modules` directory. In case a dependency is in the project's source tree, the corresponding directory in that `node_modules` directory is a symlink which points to the respective real directory in the project's source tree.

Re-write `ModuleInfo.isProject` to be based on that observation. This properly adds the previously missing packages, and the corresponding references.

[1]: `npm install --legacy-peer-deps`

Part of https://github.com/oss-review-toolkit/ort/issues/12319
