### PR TITLE
docs: fix dead link to declared-license-mapping.yml

### DIFF
--- a/website/docs/guides/license-handling.md
+++ b/website/docs/guides/license-handling.md
@@ -15,7 +15,7 @@ There are so-called "envelope cases" where the license visible from the outside 
 For example, a package might have declared itself to be licensed under the MIT license, but in the source code a file might contain a BSD-3-Clause license header.
 
 Declared licenses often come in non-SPDX form or contain typos.
-For universally valid cases, ORT has built-in [mappings](https://github.com/oss-review-toolkit/ort/blob/main/utils/spdx/src/main/resources/declared-license-mapping.yml).
+For universally valid cases, ORT has built-in [mappings](https://github.com/oss-review-toolkit/ort/blob/main/utils/spdx-expression/src/main/resources/declared-license-mapping.yml).
 For cases that might be ambiguous in general but are valid in the specific context of a package, [curations](../configuration/package-curations.md) can be used to define a `declared_license_mapping`.
 
 ### Detected license


### PR DESCRIPTION
Fixes a dead link in the license handling guide.

## Motivation

The guide [website/docs/guides/license-handling.md](https://github.com/oss-review-toolkit/ort/blob/main/website/docs/guides/license-handling.md) links to the built-in declared-license mappings resource at `utils/spdx/src/main/resources/declared-license-mapping.yml`. That resource moved to the new `spdx-expression` Gradle module in db57349de ("refactor(spdx)!: Split out expression-related code to a new Gradle module"), so the documented URL has been returning **404** since then.

This was not caught by the repo's linkspector check because `.linkspector.yml` excludes the whole `website/` directory on the assumption that Docusaurus validates its own links — but Docusaurus only validates relative links, not absolute GitHub blob URLs.

## Modifications

- One line in `website/docs/guides/license-handling.md`: repoint the mappings link from `utils/spdx/src/main/resources/...` to its current location `utils/spdx-expression/src/main/resources/declared-license-mapping.yml`.

## Verification

- Old URL verified HTTP 404; replacement path confirmed present in the repository index (`git ls-files`) and verified reachable.
- Docs-only change, no code affected. Docusaurus builds relative links independently, so no other doc content is touched.

## AI

This fix was developed with AI assistance (repro and verification automated), disclosed per the project's contribution guidelines.