### PR TITLE
feat(cyclonedx): Allow setting supplier-related properties

### DIFF
--- a/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
+++ b/plugins/reporters/cyclonedx/src/funTest/kotlin/CycloneDxReporterFunTest.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 import org.cyclonedx.Format
 import org.cyclonedx.Version
@@ -193,6 +194,20 @@ class CycloneDxReporterFunTest : WordSpec({
             bom should matchJsonSchema(schemaJson)
             bom.patchCycloneDxResult() shouldEqualJson expectedBom
         }
+
+        "support specifying information about the supplier in metadata" {
+            val expectedBom = readResource("/cyclonedx-reporter-expected-result-supplier.json")
+
+            val bom = generateSingleBomReport(
+                ortResult = ORT_RESULT_WITH_VULNERABILITIES,
+                format = Format.JSON,
+                licenseFactProvider = SpdxLicenseFactProviderFactory.create(),
+                supplierName = "Test Supplier",
+                supplierUrl = "https://example.com/supplier"
+            )
+
+            bom.patchCycloneDxResult() shouldEqualJson expectedBom
+        }
     }
 
     "Requesting separate BOMs per project" should {
@@ -227,6 +242,22 @@ class CycloneDxReporterFunTest : WordSpec({
             bomWithoutFindings.patchCycloneDxResult() shouldBe readResource(
                 "/cyclonedx-reporter-expected-result-without-findings.json"
             )
+        }
+
+        "support specifying information about the supplier in metadata" {
+            val boms = generateMultiBomReport(
+                ortResult = ORT_RESULT_WITH_VULNERABILITIES,
+                format = Format.JSON,
+                licenseFactProvider = SpdxLicenseFactProviderFactory.create(),
+                supplierName = "Test Supplier",
+                supplierUrl = "https://example.com/supplier"
+            )
+
+            boms shouldHaveSize 2
+            boms.forAll { bom ->
+                bom shouldContain "\"Test Supplier\""
+                bom shouldContain "\"https://example.com/supplier\""
+            }
         }
     }
 })
@@ -272,12 +303,16 @@ private fun TestConfiguration.generateSingleBomReport(
     format: Format,
     singleBomComponentName: String = "",
     singleBomComponentType: Component.Type = Component.Type.APPLICATION,
+    supplierName: String = "",
+    supplierUrl: String = "",
     licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList())
 ): String {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },
         singleBomComponentName = singleBomComponentName,
         singleBomComponentType = singleBomComponentType,
+        metadataSupplierName = supplierName,
+        metadataSupplierUrl = supplierUrl,
         outputFileFormats = listOf(format)
     )
 
@@ -292,11 +327,15 @@ private fun TestConfiguration.generateSingleBomReport(
 private fun TestConfiguration.generateMultiBomReport(
     ortResult: OrtResult,
     format: Format,
+    supplierName: String = "",
+    supplierUrl: String = "",
     licenseFactProvider: LicenseFactProvider = CompositeLicenseFactProvider(emptyList())
 ): List<String> {
     val reporter = CycloneDxReporterFactory.create(
         schemaVersion = SchemaVersion.entries.single { it.version.versionString == DEFAULT_SCHEMA_VERSION_NAME },
         singleBom = false,
+        metadataSupplierName = supplierName,
+        metadataSupplierUrl = supplierUrl,
         outputFileFormats = listOf(format)
     )
 

--- a/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result-supplier.json
+++ b/plugins/reporters/cyclonedx/src/funTest/resources/cyclonedx-reporter-expected-result-supplier.json
@@ -1,0 +1,526 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "tools" : {
+      "components" : [
+        {
+          "type" : "application",
+          "name" : "OSS Review Toolkit",
+          "version" : "deadbeef"
+        }
+      ]
+    },
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "https://github.com/oss-review-toolkit/ort.git@main",
+      "group" : "@ort",
+      "name" : "https://github.com/oss-review-toolkit/ort.git",
+      "version" : "1.0",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright" : "Copyright 1",
+      "properties" : [
+        {
+          "name" : "ort:effectiveLicense",
+          "value" : "MIT"
+        }
+      ]
+    },
+    "supplier": {
+        "name": "Test Supplier",
+        "url": [ "https://example.com/supplier" ]
+    },
+    "licenses" : [
+      {
+        "expression" : "CC0-1.0"
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type": "library",
+      "bom-ref": "NPM:@ort:project-with-findings:1.0",
+      "group": "@ort",
+      "name": "project-with-findings",
+      "version": "1.0",
+      "description": "",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "text": {
+              "contentType": "plain/text",
+              "content": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties": [
+              {
+                "name": "ort:origin",
+                "value": "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright": "Copyright 1",
+      "purl": "pkg:npm/%40ort/project-with-findings@1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:effectiveLicense",
+          "value": "MIT"
+        },
+        {
+          "name": "ort:dependencyType",
+          "value": "transitive"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "NPM:@ort:project-without-findings:1.0",
+      "group": "@ort",
+      "name": "project-without-findings",
+      "version": "1.0",
+      "description": "",
+      "scope": "required",
+      "purl": "pkg:npm/%40ort/project-without-findings@1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties": [
+        {
+          "name": "ort:effectiveLicense",
+          "value": "NONE"
+        },
+        {
+          "name": "ort:dependencyType",
+          "value": "transitive"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "NPM:@ort:concluded-license:1.0",
+      "group" : "@ort",
+      "name" : "concluded-license",
+      "version" : "1.0",
+      "description" : "",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "SHA-1",
+          "content" : "0000000000000000000000000000000000000000"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "concluded license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "name" : "MIT WITH Libtool-exception",
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "concluded license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "declared license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright" : "Copyright 1, Copyright 2",
+      "purl" : "pkg:npm/%40ort/concluded-license@1.0?classifier=sources",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties" : [
+        {
+          "name" : "ort:effectiveLicense",
+          "value" : "MIT AND MIT WITH Libtool-exception"
+        },
+        {
+          "name" : "ort:dependencyType",
+          "value" : "direct"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "NPM:@ort:declared-license:1.0",
+      "group" : "@ort",
+      "name" : "declared-license",
+      "version" : "1.0",
+      "description" : "",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "SHA-1",
+          "content" : "0000000000000000000000000000000000000000"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "declared license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright" : "Copyright 1",
+      "purl" : "pkg:npm/%40ort/declared-license@1.0?classifier=sources",
+      "pedigree" : {
+        "notes" : "This package's sources has been modified compared to its upstream original."
+      },
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties" : [
+        {
+          "name" : "ort:effectiveLicense",
+          "value" : "MIT AND BSD-3-Clause"
+        },
+        {
+          "name" : "ort:dependencyType",
+          "value" : "direct"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "NPM:@ort:license-file:1.0",
+      "group" : "@ort",
+      "name" : "license-file",
+      "version" : "1.0",
+      "description" : "",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "SHA-1",
+          "content" : "0000000000000000000000000000000000000000"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright" : "Copyright 1, Copyright 2",
+      "purl" : "pkg:npm/%40ort/license-file@1.0?classifier=sources",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties" : [
+        {
+          "name" : "ort:effectiveLicense",
+          "value" : "MIT"
+        },
+        {
+          "name" : "ort:dependencyType",
+          "value" : "direct"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "NPM:@ort:license-file-and-additional-licenses:1.0",
+      "group" : "@ort",
+      "name" : "license-file-and-additional-licenses",
+      "version" : "1.0",
+      "description" : "",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "SHA-1",
+          "content" : "0000000000000000000000000000000000000000"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. Neither the name of the ORGANIZATION nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "name" : "LGPL-3.0-or-later WITH openvpn-openssl-exception",
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "name" : "LicenseRef-scancode-truecrypt-3.1",
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        },
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright" : "Copyright 1, Copyright 2, Copyright 3",
+      "purl" : "pkg:npm/%40ort/license-file-and-additional-licenses@1.0?classifier=sources",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties" : [
+        {
+          "name" : "ort:effectiveLicense",
+          "value" : "MIT AND BSD-3-Clause AND LicenseRef-scancode-truecrypt-3.1 AND LGPL-3.0-or-later WITH openvpn-openssl-exception"
+        },
+        {
+          "name" : "ort:dependencyType",
+          "value" : "direct"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "NPM:@ort:no-license-file:1.0",
+      "group" : "@ort",
+      "name" : "no-license-file",
+      "version" : "1.0",
+      "description" : "",
+      "scope" : "required",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "text" : {
+              "contentType" : "plain/text",
+              "content" : "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+            },
+            "properties" : [
+              {
+                "name" : "ort:origin",
+                "value" : "detected license"
+              }
+            ]
+          }
+        }
+      ],
+      "copyright" : "Copyright 1",
+      "purl" : "pkg:npm/%40ort/no-license-file@1.0",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/oss-review-toolkit/ort"
+        }
+      ],
+      "properties" : [
+        {
+          "name" : "ort:effectiveLicense",
+          "value" : "MIT"
+        },
+        {
+          "name" : "ort:dependencyType",
+          "value" : "direct"
+        }
+      ]
+    }
+  ],
+  "externalReferences" : [
+    {
+      "type" : "vcs",
+      "url" : "https://github.com/oss-review-toolkit/ort.git",
+      "comment" : "URL to the Git repository of the projects"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "https://github.com/oss-review-toolkit/ort.git@main",
+      "dependsOn" : [
+        "NPM:@ort:no-license-file:1.0",
+        "NPM:@ort:license-file:1.0",
+        "NPM:@ort:license-file-and-additional-licenses:1.0",
+        "NPM:@ort:concluded-license:1.0",
+        "NPM:@ort:declared-license:1.0"
+      ]
+    }
+  ],
+  "vulnerabilities" : [
+    {
+      "id" : "CVE-2021-1234",
+      "ratings" : [
+        {
+          "source" : {
+            "url" : "https://cves.example.org/cve1"
+          },
+          "score" : 6.0,
+          "severity" : "medium",
+          "method" : "CVSSv2"
+        }
+      ],
+      "description" : "A vulnerability description",
+      "detail" : "A vulnerability summary",
+      "affects" : [
+        {
+          "ref" : "NPM:@ort:declared-license:1.0"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxModelMapper.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxModelMapper.kt
@@ -237,6 +237,15 @@ internal class CycloneDxModelMapper(
                 )
             }
 
+            if (config.metadataSupplierName.isNotBlank() || config.metadataSupplierName.isNotBlank()) {
+                supplier = OrganizationalEntity().apply {
+                    name = config.metadataSupplierName.takeIf { it.isNotBlank() }
+                    if (config.metadataSupplierUrl.isNotBlank()) {
+                        urls = listOf(config.metadataSupplierUrl)
+                    }
+                }
+            }
+
             licenses = LicenseChoice().apply {
                 val expression = Expression(config.dataLicense)
                 items = listOf(LicenseItem.ofExpression(expression))

--- a/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
+++ b/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt
@@ -112,7 +112,27 @@ data class CycloneDxReporterConfig(
         defaultValue = "JSON",
         aliases = ["output.file.formats"]
     )
-    val outputFileFormats: List<Format>
+    val outputFileFormats: List<Format>,
+
+    /**
+     * Allows specifying a supplier name in the metadata of the generated BOMs.
+     * See https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_supplier_name
+     */
+    @OrtPluginOption(
+        defaultValue = "",
+        aliases = ["metadata.supplier.name"]
+    )
+    val metadataSupplierName: String,
+
+    /**
+     * Allows specifying a supplier URL in the metadata of the generated BOMs.
+     * See https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_supplier_url
+     */
+    @OrtPluginOption(
+        defaultValue = "",
+        aliases = ["metadata.supplier.url"]
+    )
+    val metadataSupplierUrl: String
 )
 
 /**


### PR DESCRIPTION
Extend the plugin configuration for the CycloneDX reporter to support a few properties that define the supplier. If specified, this information is then added to the metadata section of the generated BOMs. In some contexts, when further processing generated BOMs, this information is relevant; so, it is beneficial to give the users a way to specify it.

CycloneDX would support even more supplier-related properties, like address or contact. However, these are composite data structures and would require a larger number of properties to fully define them. Therefore, set the focus on the most important properties for now.

Note: This refers to [this conversation](https://oss-review-toolkit.slack.com/archives/C9NNJ54B1/p1786955435562809) on Slack.