### PR TITLE
fix(license-fact-providers): Work around a license text look-up issue

### DIFF
--- a/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
@@ -101,6 +101,9 @@ class ScanCodeLicenseFactProvider(
             // Work around for https://github.com/aboutcode-org/scancode-toolkit/issues/2813 which affects ScanCode
             // versions below 31.0.0.
             "x11-xconsortium_veillard.LICENSE"
+        } else if (licenseOrExceptionId == "LicenseRef-scancode-unlimited-link-exception-lgpl") {
+            // Work around for https://github.com/oss-review-toolkit/ort/issues/12369.
+            "unlimited-linking-exception-lgpl.LICENSE"
         } else {
             "${licenseOrExceptionId.removePrefix("LicenseRef-scancode-").lowercase()}.LICENSE"
         }


### PR DESCRIPTION
The license text for
`LicenseRef-scancode-unlimited-link-exception-lgpl` can currently not be obtained, because of [1]. Add a work around, so that the license text can be obtained until a proper solution for [1] is implemented.

[1]: https://github.com/oss-review-toolkit/ort/issues/12369

