### PR TITLE
Ignore bad gateway errors when accessing the ClearlyDefined service in tests

### DIFF
--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -34,11 +34,14 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 
+import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
+
+import retrofit2.HttpException
 
 class ClearlyDefinedServiceFunTest : WordSpec({
     val service by lazy { ClearlyDefinedService.create() }
@@ -54,7 +57,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
                 revision = "1.7.30"
             )
 
-            val data = withIgnoreTimeout { service.getLatestHarvestToolData(coordinates, "clearlydefined") }
+            val data = withIgnoreUnavailable { service.getLatestHarvestToolData(coordinates, "clearlydefined") }
 
             data.toString() shouldNotContain "0b97c416e42a184ff9728877b461c616187c58f7"
         }
@@ -84,13 +87,13 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         )
 
         "return single curation data" {
-            val curation = withIgnoreTimeout { service.getCuration(coordinates) }
+            val curation = withIgnoreUnavailable { service.getCuration(coordinates) }
 
             curation.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
         }
 
         "return bulk curation data" {
-            val curations = withIgnoreTimeout { service.getCurations(listOf(coordinates)) }
+            val curations = withIgnoreUnavailable { service.getCurations(listOf(coordinates)) }
             val curation = curations[coordinates]?.curations?.get(coordinates)
 
             curation?.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
@@ -154,7 +157,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
                 revision = "0.2.2"
             )
 
-            val defined = withIgnoreTimeout { service.getDefinition(coordinates) }
+            val defined = withIgnoreUnavailable { service.getDefinition(coordinates) }
 
             defined.files?.get(11)?.facets.shouldNotBeNull() shouldContain "tests"
             defined.described.releaseDate shouldBe "2020-02-22"
@@ -169,7 +172,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
                 revision = "0.2.2"
             )
 
-            val definitions = withIgnoreTimeout { service.getDefinitions(listOf(coordinates)) }
+            val definitions = withIgnoreUnavailable { service.getDefinitions(listOf(coordinates)) }
 
             definitions.shouldMatchExactly(
                 coordinates to { defined ->
@@ -189,7 +192,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
                 revision = "1.7.30"
             )
 
-            val defined = withIgnoreTimeout { service.getDefinition(coordinates) }
+            val defined = withIgnoreUnavailable { service.getDefinition(coordinates) }
 
             defined.toString() shouldContain "0b97c416e42a184ff9728877b461c616187c58f7"
         }
@@ -197,19 +200,19 @@ class ClearlyDefinedServiceFunTest : WordSpec({
 })
 
 /**
- * Skip the test in case `SocketTimeoutException` occurred by throwing a `TestAbortedException`. Otherwise, execute the
- * [block] as usual.
+ * Skip the test by throwing a `TestAbortedException` in case the service is unavailable for some reasons. Otherwise,
+ * execute the [block] as usual.
  *
  * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
  * when network is not available.
  */
-private suspend fun <T> withIgnoreTimeout(block: suspend () -> T): T =
+private suspend fun <T> withIgnoreUnavailable(block: suspend () -> T): T =
     runCatching {
         block()
-    }.getOrElse {
-        throw if (it is SocketTimeoutException) {
-            TestAbortedException()
-        } else {
-            it
+    }.getOrElse { e ->
+        throw when (e) {
+            is SocketTimeoutException -> TestAbortedException()
+            is HttpException -> if (e.code() == HttpURLConnection.HTTP_BAD_GATEWAY) TestAbortedException() else e
+            else -> e
         }
     }

--- a/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/funTest/kotlin/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -19,21 +19,23 @@
 
 package org.ossreviewtoolkit.plugins.packagecurationproviders.clearlydefined
 
-import io.kotest.assertions.retry
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.TestAbortedException
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldBeSingle
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
 import java.time.Instant
-
-import kotlin.time.Duration.Companion.seconds
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.utils.spdxexpression.toSpdx
+
+import retrofit2.HttpException
 
 class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
     val provider by lazy { ClearlyDefinedPackageCurationProviderFactory.create() }
@@ -43,7 +45,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
             // https://clearlydefined.io/definitions/sourcearchive/mavencentral/javax.servlet/javax.servlet-api/3.1.0
             val packages = createPackagesFromIds("Maven:javax.servlet:javax.servlet-api:3.1.0")
 
-            val curations = withRetry { provider.getCurationsFor(packages) }
+            val curations = withIgnoreUnavailable { provider.getCurationsFor(packages) }
 
             with(curations.shouldBeSingle().data) {
                 concludedLicense shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0".toSpdx()
@@ -55,7 +57,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
             // https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12/1.7.30
             val packages = createPackagesFromIds("Maven:org.slf4j:slf4j-log4j12:1.7.30")
 
-            val curations = withRetry { provider.getCurationsFor(packages) }
+            val curations = withIgnoreUnavailable { provider.getCurationsFor(packages) }
 
             with(curations.shouldBeSingle().data) {
                 vcs?.revision shouldBe "0b97c416e42a184ff9728877b461c616187c58f7"
@@ -66,7 +68,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
         "return no curation for a non-existing dummy NPM package" {
             val packages = createPackagesFromIds("NPM:@scope:name:1.2.3")
 
-            val curations = withRetry { provider.getCurationsFor(packages) }
+            val curations = withIgnoreUnavailable { provider.getCurationsFor(packages) }
 
             curations should beEmpty()
         }
@@ -83,7 +85,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
             // Use an id which is known to have non-empty results from an earlier test.
             val packages = createPackagesFromIds("Maven:org.slf4j:slf4j-log4j12:1.7.30")
 
-            val curations = withRetry { customProvider.getCurationsFor(packages) }
+            val curations = withIgnoreUnavailable { customProvider.getCurationsFor(packages) }
 
             curations should beEmpty()
         }
@@ -92,7 +94,7 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
             // https://clearlydefined.io/definitions/npm/npmjs/-/acorn/0.6.0
             val packages = createPackagesFromIds("NPM::acorn:0.6.0")
 
-            val curations = withRetry { provider.getCurationsFor(packages) }
+            val curations = withIgnoreUnavailable { provider.getCurationsFor(packages) }
 
             with(curations.shouldBeSingle().data) {
                 publishedAt shouldBe Instant.parse("2014-06-06T00:00:00Z")
@@ -103,11 +105,20 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
 
 private fun createPackagesFromIds(vararg ids: String) = ids.map { Package.EMPTY.copy(id = Identifier(it)) }
 
-private suspend fun <T> withRetry(f: suspend () -> T): T =
-    retry(
-        maxRetry = 5,
-        timeout = (10 + 20 + 40 + 80 + 160).seconds,
-        delay = 10.seconds,
-        multiplier = 2,
-        f = f
-    )
+/**
+ * Skip the test by throwing a `TestAbortedException` in case the service is unavailable for some reasons. Otherwise,
+ * execute the [block] as usual.
+ *
+ * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
+ * when network is not available.
+ */
+private suspend fun <T> withIgnoreUnavailable(block: suspend () -> T): T =
+    runCatching {
+        block()
+    }.getOrElse { e ->
+        throw when (e) {
+            is SocketTimeoutException -> TestAbortedException()
+            is HttpException -> if (e.code() == HttpURLConnection.HTTP_BAD_GATEWAY) TestAbortedException() else e
+            else -> e
+        }
+    }

--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -24,6 +24,7 @@ import io.kotest.engine.TestAbortedException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.result.shouldBeSuccess
 
+import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
 import java.time.Instant
 
@@ -43,6 +44,8 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
 
+import retrofit2.HttpException
+
 class ClearlyDefinedStorageFunTest : StringSpec({
     val storage = ClearlyDefinedStorage(ClearlyDefinedStorageConfiguration(Server.PRODUCTION.apiUrl))
 
@@ -58,7 +61,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        val results = storage.read(pkg).withIgnoreTimeout()
+        val results = storage.read(pkg).withIgnoreUnavailable()
 
         results shouldBeSuccess {
             it shouldContain ScanResult(
@@ -119,7 +122,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        val results = storage.read(pkg).withIgnoreTimeout()
+        val results = storage.read(pkg).withIgnoreUnavailable()
 
         results shouldBeSuccess {
             it shouldContain ScanResult(
@@ -160,7 +163,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
             )
         )
 
-        val results = storage.read(pkg).withIgnoreTimeout()
+        val results = storage.read(pkg).withIgnoreUnavailable()
 
         results shouldBeSuccess { result ->
             result.map { it.provenance } shouldContain RepositoryProvenance(
@@ -176,17 +179,18 @@ class ClearlyDefinedStorageFunTest : StringSpec({
 })
 
 /**
- * Skip the test in case `SocketTimeoutException` occurred by throwing a `TestAbortedException`. Otherwise, return the
- * [Result] as-is.
+ * Skip the test by throwing a `TestAbortedException` in case the service is unavailable for some reasons. Otherwise,
+ * return the [Result] as-is.
  *
  * This way the tests can still act as a reminder to re-align the data model in case it deviated, without making noise
  * when network is not available.
  */
-private fun <T> Result<T>.withIgnoreTimeout(): Result<T> =
-    onFailure { e ->
-        throw if (e.cause is SocketTimeoutException) {
-            TestAbortedException()
-        } else {
-            e
+private fun <T> Result<T>.withIgnoreUnavailable(): Result<T> =
+    onFailure {
+        val e = it.cause
+        throw when (e) {
+            is SocketTimeoutException -> TestAbortedException()
+            is HttpException -> if (e.code() == HttpURLConnection.HTTP_BAD_GATEWAY) TestAbortedException() else it
+            else -> it
         }
     }


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 