### PR TITLE
chore(node): Remove unneeded prefix checks for the `version`

### DIFF
--- a/plugins/package-managers/node/src/main/kotlin/bun/BunDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/bun/BunDependencyHandler.kt
@@ -51,7 +51,7 @@ internal class BunDependencyHandler(
 
             packageJson.version.orEmpty()
         } else {
-            dependency.version?.takeUnless { it.startsWith("link:") || it.startsWith("file:") }.orEmpty()
+            dependency.version.orEmpty()
         }
 
         return Identifier(type, namespace, name, version)

--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmDependencyHandler.kt
@@ -50,7 +50,7 @@ internal class NpmDependencyHandler(
 
             packageJson.version.orEmpty()
         } else {
-            moduleInfo.version?.takeUnless { it.startsWith("link:") || it.startsWith("file:") }.orEmpty()
+            moduleInfo.version.orEmpty()
         }
 
         return Identifier(type, namespace, name, version)


### PR DESCRIPTION
The `npm list --json` command never emits a prefix for the `version` field, but only for the `resolved` field. This has been confirmed by both a discussion with Fable 5.1 AI, and by manually running the command on a local setup with two sibling projects `pkg1` and `pkg2`, where `pkg1` has `"pkg2": "file:../pkg2"` as part of its `dependencies`.

As the `Bun` implementation also runs `npm list --json`, remove the same check there as well.