### PR TITLE
build(cli-helper): Add Mordant as a direct dependency

### DIFF
--- a/cli-helper/build.gradle.kts
+++ b/cli-helper/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.clikt)
     implementation(libs.commonsCompress)
     implementation(libs.jslt)
+    implementation(libs.mordant)
     implementation(libs.slf4j)
 
     implementation(libs.xz) {


### PR DESCRIPTION
As the `cli-helper` has `com.github.ajalt.mordant` imports, this should have been there before, but for some reason was not detected by the `buildHealth` / `:cli-helper:project` tasks.

It also fixes a misalignment of the Mordant version between the `cli` and `cli-helper` modules, as `clikt` transitively depends on a older version of Mordant than the `cli` module.