### PR TITLE
chore(model)!: Move a property to the only place using it

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -35,7 +34,6 @@ import org.ossreviewtoolkit.model.utils.LicenseFindingSortedSetConverter
 import org.ossreviewtoolkit.model.utils.PathLicenseMatcher
 import org.ossreviewtoolkit.model.utils.SnippetFindingSortedSetConverter
 import org.ossreviewtoolkit.utils.common.FileMatcher
-import org.ossreviewtoolkit.utils.spdxexpression.SpdxExpression
 
 /**
  * A short summary of the scan results.
@@ -94,9 +92,6 @@ data class ScanSummary(
             endTime = Instant.EPOCH
         )
     }
-
-    @get:JsonIgnore
-    val licenses: Set<SpdxExpression> by lazy { licenseFindings.mapTo(mutableSetOf()) { it.license } }
 
     /**
      * Filter all detected licenses and copyrights from this [ScanSummary] which are underneath [path]. Findings which

--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -66,7 +66,7 @@ class ScanOssResultParserTest : WordSpec({
 
             val summary = generateSummary(results)
 
-            summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
+            summary.licenses should containExactlyInAnyOrder(
                 "Apache-2.0",
                 "EPL-1.0",
                 "MIT",
@@ -104,7 +104,7 @@ class ScanOssResultParserTest : WordSpec({
 
             val summary = generateSummary(results)
 
-            summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
+            summary.licenses should containExactlyInAnyOrder(
                 "Apache-2.0",
                 "BSD-2-Clause",
                 "EPL-2.0",
@@ -384,3 +384,5 @@ private val dummyDetails = ScanFileDetails(
         )
     )
 )
+
+private val ScanSummary.licenses: Set<String> get() = licenseFindings.mapTo(mutableSetOf()) { it.license.toString() }


### PR DESCRIPTION
The property is not needed in production code, as it is only used by a test.
