### PR TITLE
feat(evaluated-model): Add the `publishedAt` property

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -701,6 +701,7 @@ packages:
     hash:
       value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
       algorithm: "SHA-1"
+  published_at: "2014-12-04T16:17:28Z"
   vcs:
     type: ""
     url: ""

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.json
@@ -777,6 +777,7 @@
         "algorithm" : "SHA-1"
       }
     },
+    "published_at" : "2014-12-04T16:17:28Z",
     "vcs" : {
       "type" : "",
       "url" : "",

--- a/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/evaluated-model-reporter-test-expected-output.yml
@@ -701,6 +701,7 @@ packages:
     hash:
       value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
       algorithm: "SHA-1"
+  published_at: "2014-12-04T16:17:28Z"
   vcs:
     type: ""
     url: ""

--- a/plugins/reporters/evaluated-model/src/funTest/resources/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/resources/reporter-test-input.yml
@@ -155,6 +155,7 @@ analyzer:
         hash:
           value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
           algorithm: "SHA-1"
+      published_at: "2014-12-04T16:17:28Z"
       vcs:
         type: ""
         url: ""

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedModelMapper.kt
@@ -380,6 +380,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             homepageUrl = pkg.homepageUrl,
             binaryArtifact = pkg.binaryArtifact,
             sourceArtifact = pkg.sourceArtifact,
+            publishedAt = pkg.publishedAt,
             vcs = pkg.vcs,
             vcsProcessed = pkg.vcsProcessed,
             labels = pkg.labels,

--- a/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedPackage.kt
+++ b/plugins/reporters/evaluated-model/src/main/kotlin/EvaluatedPackage.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.plugins.reporters.evaluatedmodel
 import com.fasterxml.jackson.annotation.JsonIdentityReference
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import java.time.Instant
 import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.Identifier
@@ -65,6 +66,8 @@ data class EvaluatedPackage(
     val homepageUrl: String,
     val binaryArtifact: RemoteArtifact,
     val sourceArtifact: RemoteArtifact,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val publishedAt: Instant? = null,
     val vcs: VcsInfo,
     val vcsProcessed: VcsInfo = vcs.normalize(),
     @JsonInclude(JsonInclude.Include.NON_EMPTY)


### PR DESCRIPTION
Map the `publishedAt` property that was added to `Package` in [1] to `EvaluatedPackage`. This is a preparation step for showing the publish date in the web app report.

Relates to #4952.

[1]: https://github.com/oss-review-toolkit/ort/commit/84588206b019518edcefa49991de56f0eb26f014
