### PR TITLE
chore(scanners): Use a lazy property instead of `get()`

### DIFF
--- a/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
+++ b/plugins/scanners/scanoss/src/test/kotlin/ScanOssResultParserTest.kt
@@ -381,4 +381,4 @@ private val dummyDetails = ScanFileDetails(
     )
 )
 
-private val ScanSummary.licenses: Set<String> get() = licenseFindings.mapTo(mutableSetOf()) { it.license.toString() }
+private val ScanSummary.licenses by lazy { licenseFindings.mapTo(mutableSetOf()) { it.license.toString() } }


### PR DESCRIPTION
As `licenseFindings` is immutable, this only ever needs to be evaluated once.

This is a follow-up to b952ad1.