### PR TITLE
refactor: Do not use `ProcessCapture` in tests

### DIFF
--- a/plugins/package-managers/sbt/src/funTest/kotlin/SbtFunTest.kt
+++ b/plugins/package-managers/sbt/src/funTest/kotlin/SbtFunTest.kt
@@ -23,11 +23,12 @@ import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
+import java.io.File
+
 import org.ossreviewtoolkit.analyzer.analyze
 import org.ossreviewtoolkit.analyzer.getAnalyzerResult
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.toYaml
-import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.matchExpectedResult
 import org.ossreviewtoolkit.utils.test.patchActualResult
@@ -40,7 +41,7 @@ class SbtFunTest : StringSpec({
         val expectedResult = matchExpectedResult(expectedResultFile, definitionFile)
 
         // Clean any previously generated POM files / target directories.
-        ProcessCapture("git", "clean", "-fd", workingDir = definitionFile.parentFile).requireSuccess()
+        runGit("clean", "-fd", workingDir = definitionFile.parentFile)
 
         val result = analyze(
             definitionFile.parentFile,
@@ -59,7 +60,7 @@ class SbtFunTest : StringSpec({
         val expectedResult = matchExpectedResult(expectedResultFile, definitionFile)
 
         // Clean any previously generated POM files / target directories.
-        ProcessCapture("git", "clean", "-fd", workingDir = definitionFile.parentFile).requireSuccess()
+        runGit("clean", "-fd", workingDir = definitionFile.parentFile)
 
         val result = analyze(
             definitionFile.parentFile,
@@ -72,3 +73,6 @@ class SbtFunTest : StringSpec({
         patchActualResult(result.toYaml()) shouldBe expectedResult
     }
 })
+
+private fun runGit(vararg args: String, workingDir: File) =
+    check(ProcessBuilder("git", *args).directory(workingDir).start().waitFor() == 0)

--- a/utils/common/src/test/kotlin/FileUtilsTest.kt
+++ b/utils/common/src/test/kotlin/FileUtilsTest.kt
@@ -113,7 +113,7 @@ class FileUtilsTest : WordSpec({
         }
 
         "return 'false' for hard links on Windows".config(enabled = Os.isWindows) {
-            ProcessCapture(tempDir, "cmd", "/c", "mklink", "/h", "hardlink", "file")
+            runCmdBuiltIn("mklink", "/h", "hardlink", "file", workingDir = tempDir)
 
             tempDir.resolve("hardlink").let { hardlink ->
                 hardlink shouldBe aFile()
@@ -122,7 +122,7 @@ class FileUtilsTest : WordSpec({
         }
 
         "return 'true' for junctions on Windows".config(enabled = Os.isWindows) {
-            ProcessCapture(tempDir, "cmd", "/c", "mklink", "/j", "junction", "directory")
+            runCmdBuiltIn("mklink", "/j", "junction", "directory", workingDir = tempDir)
 
             tempDir.resolve("junction").let { junction ->
                 junction.isDirectory shouldBe true
@@ -131,7 +131,7 @@ class FileUtilsTest : WordSpec({
         }
 
         "return 'true' for symbolic links to files on Windows".config(enabled = Os.isWindows) {
-            ProcessCapture(tempDir, "cmd", "/c", "mklink", "symlink-to-file", "file")
+            runCmdBuiltIn("mklink", "symlink-to-file", "file", workingDir = tempDir)
 
             tempDir.resolve("symlink-to-file").let { symlinkToFile ->
                 symlinkToFile shouldBe aFile()
@@ -140,7 +140,7 @@ class FileUtilsTest : WordSpec({
         }
 
         "return 'true' for symbolic links to directories on Windows".config(enabled = Os.isWindows) {
-            ProcessCapture(tempDir, "cmd", "/c", "mklink", "/d", "symlink-to-directory", "directory")
+            runCmdBuiltIn("mklink", "/d", "symlink-to-directory", "directory", workingDir = tempDir)
 
             tempDir.resolve("symlink-to-directory").let { symlinkToDirectory ->
                 symlinkToDirectory.isDirectory shouldBe true
@@ -215,3 +215,6 @@ class FileUtilsTest : WordSpec({
         }
     }
 })
+
+private fun runCmdBuiltIn(vararg args: String, workingDir: File) =
+    check(ProcessBuilder("cmd", "/c", *args).directory(workingDir).start().waitFor() == 0)


### PR DESCRIPTION
Start removing a dependency on a class that might eventually go away
(see issue #4668) by only depending on Java's built-in `ProcessBuilder`.