### PR TITLE
refactor: Call a function `requireLockfileForStableVersions()` for clarity

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -372,17 +372,16 @@ abstract class PackageManager(val projectType: String) : Plugin {
         labels: Map<String, String>
     ): List<ProjectAnalyzerResult>
 
-    protected fun requireLockfile(
+    protected fun requireLockfileForStableVersions(
         analysisRoot: File,
-        workingDir: File,
+        definitionFile: File,
         allowDynamicVersions: Boolean,
-        condition: () -> Boolean
+        hasLockfile: () -> Boolean
     ) {
-        require(allowDynamicVersions || condition()) {
-            val relativePathString = workingDir.relativeTo(analysisRoot).invariantSeparatorsPath.ifEmpty { "." }
-
-            "No lockfile found in '$relativePathString'. This potentially results in unstable versions of " +
-                "dependencies. To support this, enable the 'allowDynamicVersions' option in '$ORT_CONFIG_FILENAME'."
+        require(allowDynamicVersions || hasLockfile()) {
+            "No lockfile found for '${definitionFile.relativeTo(analysisRoot)}'. This potentially results in " +
+                "unstable versions of dependencies. To support this, enable the 'allowDynamicVersions' option in " +
+                "'$ORT_CONFIG_FILENAME'."
         }
     }
 

--- a/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
+++ b/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
@@ -55,7 +55,7 @@ class BundlerFunTest : WordSpec({
                 project.definitionFilePath shouldBe
                     "plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/no-lockfile/Gemfile"
                 packages should beEmpty()
-                issues.shouldBeSingle().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+                issues.shouldBeSingle().message should haveSubstring("IllegalArgumentException: No lockfile found")
             }
         }
 

--- a/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
+++ b/plugins/package-managers/bundler/src/main/kotlin/Bundler.kt
@@ -189,7 +189,7 @@ class Bundler(
     ): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
-        requireLockfile(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions) {
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
             workingDir.resolve(BUNDLER_LOCKFILE_NAME).isFile
         }
 

--- a/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
+++ b/plugins/package-managers/cargo/src/main/kotlin/Cargo.kt
@@ -87,13 +87,9 @@ class Cargo(override val descriptor: PluginDescriptor = CargoFactory.descriptor)
      * Cargo.lock is located next to Cargo.toml or in one of the parent directories. The latter is the case when the
      * project is part of a workspace. Cargo.lock is then located next to the Cargo.toml file defining the workspace.
      */
-    private fun resolveLockfile(analysisRoot: File, metadata: CargoMetadata, allowDynamicVersions: Boolean): File {
+    private fun resolveLockfile(metadata: CargoMetadata): File {
         val workspaceRoot = File(metadata.workspaceRoot)
-        val lockfile = workspaceRoot / "Cargo.lock"
-
-        requireLockfile(analysisRoot, workspaceRoot, allowDynamicVersions) { lockfile.isFile }
-
-        return lockfile
+        return workspaceRoot / "Cargo.lock"
     }
 
     /**
@@ -212,7 +208,14 @@ class Cargo(override val descriptor: PluginDescriptor = CargoFactory.descriptor)
             depNodesByKind[BUILD_KIND_NAME]?.let { Scope("build-dependencies", it.toPackageReferences()) }
         )
 
-        val hashes = readHashes(resolveLockfile(analysisRoot, metadata, analyzerConfig.allowDynamicVersions))
+        val lockfile = resolveLockfile(metadata)
+
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
+            lockfile.isFile
+        }
+
+        val hashes = readHashes(lockfile)
+
         val projectPkg = packageById.getValue(projectId).let { cargoPkg ->
             cargoPkg.toPackage(hashes).let { it.copy(id = it.id.copy(type = projectType)) }
         }

--- a/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
+++ b/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
@@ -80,7 +80,7 @@ class ComposerFunTest : StringSpec({
             project.definitionFilePath shouldBe "plugins/package-managers/composer/src/funTest/assets/projects/" +
                 "synthetic/no-lockfile/composer.json"
             packages should beEmpty()
-            issues.shouldBeSingle().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+            issues.shouldBeSingle().message should haveSubstring("IllegalArgumentException: No lockfile found")
         }
     }
 

--- a/plugins/package-managers/composer/src/main/kotlin/Composer.kt
+++ b/plugins/package-managers/composer/src/main/kotlin/Composer.kt
@@ -157,7 +157,7 @@ class Composer(override val descriptor: PluginDescriptor = ComposerFactory.descr
         val lockfile = stashDirectories(workingDir / "vendor").use { _ ->
             val lockfileProvider = LockfileProvider(definitionFile)
 
-            requireLockfile(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions) {
+            requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
                 lockfileProvider.lockfile.isFile
             }
 

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -212,7 +212,7 @@ class Conan(
             configureRemoteAuthentication(conanConfig)
 
             // TODO: Support lockfiles which are located in a different directory than the definition file.
-            requireLockfile(analysisRoot, workingDir, allowDynamicVersions) {
+            requireLockfileForStableVersions(analysisRoot, definitionFile, allowDynamicVersions) {
                 config.lockfileName?.let { hasLockfile(workingDir.resolve(it).path) } == true
             }
 

--- a/plugins/package-managers/gleam/src/funTest/assets/projects/synthetic/no-lockfile-expected-output.yml
+++ b/plugins/package-managers/gleam/src/funTest/assets/projects/synthetic/no-lockfile-expected-output.yml
@@ -21,6 +21,7 @@ issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "Gleam"
   message: "Gleam failed to resolve dependencies for path 'gleam.toml': IllegalArgumentException:\
-    \ No lockfile found in '.'. This potentially results in unstable versions of dependencies.\
-    \ To support this, enable the 'allowDynamicVersions' option in 'config.yml'."
+    \ No lockfile found for 'gleam.toml'. This potentially results in unstable versions\
+    \ of dependencies. To support this, enable the 'allowDynamicVersions' option in\
+    \ 'config.yml'."
   severity: "ERROR"

--- a/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
+++ b/plugins/package-managers/gleam/src/main/kotlin/Gleam.kt
@@ -108,7 +108,7 @@ class Gleam internal constructor(
         val gleamToml = parseGleamToml(definitionFile)
         val hasDependencies = gleamToml.dependencies.isNotEmpty() || gleamToml.devDependencies.isNotEmpty()
 
-        requireLockfile(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions) {
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
             manifestFile.isFile || !hasDependencies
         }
 

--- a/plugins/package-managers/mix/src/main/kotlin/Mix.kt
+++ b/plugins/package-managers/mix/src/main/kotlin/Mix.kt
@@ -73,7 +73,7 @@ class Mix(
     ): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
-        requireLockfile(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions) {
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
             (workingDir / "mix.lock").isFile
         }
 

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/no-lockfile-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/no-lockfile-expected-output.yml
@@ -21,6 +21,7 @@ issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
   message: "NPM failed to resolve dependencies for path 'package.json': IllegalArgumentException:\
-    \ No lockfile found in '.'. This potentially results in unstable versions of dependencies.\
-    \ To support this, enable the 'allowDynamicVersions' option in 'config.yml'."
+    \ No lockfile found for 'package.json'. This potentially results in unstable versions\
+    \ of dependencies. To support this, enable the 'allowDynamicVersions' option in\
+    \ 'config.yml'."
   severity: "ERROR"

--- a/plugins/package-managers/node/src/main/kotlin/bun/Bun.kt
+++ b/plugins/package-managers/node/src/main/kotlin/bun/Bun.kt
@@ -112,9 +112,14 @@ class Bun(override val descriptor: PluginDescriptor = BunFactory.descriptor) :
         labels: Map<String, String>
     ): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
+
         moduleInfoResolver.workingDir = workingDir
 
-        installDependencies(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions)
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
+            managerType.hasLockfile(workingDir)
+        }
+
+        installDependencies(workingDir)
 
         val issues = mutableListOf<Issue>()
 
@@ -156,9 +161,7 @@ class Bun(override val descriptor: PluginDescriptor = BunFactory.descriptor) :
         return parseNpmList(listProcess.stdout).markPackageModules()
     }
 
-    private fun installDependencies(analysisRoot: File, workingDir: File, allowDynamicVersions: Boolean) {
-        requireLockfile(analysisRoot, workingDir, allowDynamicVersions) { managerType.hasLockfile(workingDir) }
-
+    private fun installDependencies(workingDir: File) {
         val options = listOfNotNull(
             "--ignore-scripts",
             // Always use the "hoisted" linker to get the NPM-compatible layout that "npm list" requires. Since Bun

--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -178,11 +178,16 @@ class Npm(override val descriptor: PluginDescriptor = NpmFactory.descriptor, pri
         labels: Map<String, String>
     ): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
+
         moduleInfoResolver.workingDir = workingDir
         command = NodeVersionManagerCommand.useVersion(NpmCommand.DEFAULT, config.nodeVersion, workingDir)
         command.checkVersion()
 
-        val issues = installDependencies(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions).toMutableList()
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
+            managerType.hasLockfile(workingDir)
+        }
+
+        val issues = installDependencies(workingDir).toMutableList()
 
         if (issues.any { it.severity == Severity.ERROR }) {
             val project = runCatching {
@@ -260,9 +265,7 @@ class Npm(override val descriptor: PluginDescriptor = NpmFactory.descriptor, pri
         return parseNpmList(listProcess.stdout)
     }
 
-    private fun installDependencies(analysisRoot: File, workingDir: File, allowDynamicVersions: Boolean): List<Issue> {
-        requireLockfile(analysisRoot, workingDir, allowDynamicVersions) { managerType.hasLockfile(workingDir) }
-
+    private fun installDependencies(workingDir: File): List<Issue> {
         val options = listOfNotNull(
             "--ignore-scripts",
             "--no-audit",

--- a/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
+++ b/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
@@ -100,7 +100,7 @@ class PubFunTest : WordSpec({
 
             with(result) {
                 packages should beEmpty()
-                issues.shouldBeSingle().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+                issues.shouldBeSingle().message should haveSubstring("IllegalArgumentException: No lockfile found")
             }
         }
     }

--- a/plugins/package-managers/pub/src/main/kotlin/Pub.kt
+++ b/plugins/package-managers/pub/src/main/kotlin/Pub.kt
@@ -345,7 +345,11 @@ class Pub(override val descriptor: PluginDescriptor = PubFactory.descriptor, pri
         val projectAnalyzerResults = mutableListOf<ProjectAnalyzerResult>()
 
         if (hasDependencies) {
-            installDependencies(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions)
+            requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
+                definitionFile.resolveSibling(PUB_LOCK_FILE).isFile
+            }
+
+            installDependencies(workingDir)
 
             logger.info { "Reading $PUB_LOCK_FILE file in $workingDir." }
 
@@ -793,9 +797,7 @@ class Pub(override val descriptor: PluginDescriptor = PubFactory.descriptor, pri
         return parsePubspec(definitionFile)
     }
 
-    private fun installDependencies(analysisRoot: File, workingDir: File, allowDynamicVersions: Boolean) {
-        requireLockfile(analysisRoot, workingDir, allowDynamicVersions) { workingDir.resolve(PUB_LOCK_FILE).isFile }
-
+    private fun installDependencies(workingDir: File) {
         if (containsFlutterSdk(workingDir)) {
             // For Flutter projects it is not enough to run `dart pub get`. Instead, use `flutter pub get` which
             // installs the required dependencies and also creates the `local.properties` file which is required for

--- a/plugins/package-managers/rebar3/src/main/kotlin/Rebar3.kt
+++ b/plugins/package-managers/rebar3/src/main/kotlin/Rebar3.kt
@@ -56,7 +56,7 @@ class Rebar3(
     ): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
-        requireLockfile(analysisRoot, workingDir, analyzerConfig.allowDynamicVersions) {
+        requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
             (workingDir / "rebar.lock").isFile
         }
 

--- a/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-project-without-lockfile.yml
+++ b/plugins/package-managers/swiftpm/src/funTest/assets/projects/synthetic/expected-output-project-without-lockfile.yml
@@ -21,7 +21,7 @@ issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "Swift Package Manager"
   message: "Swift Package Manager failed to resolve dependencies for path 'Package.swift':\
-    \ IllegalArgumentException: No lockfile found in '.'. This potentially results\
-    \ in unstable versions of dependencies. To support this, enable the 'allowDynamicVersions'\
+    \ IllegalArgumentException: No lockfile found for 'Package.swift'. This potentially\
+    \ results in unstable versions of dependencies. To support this, enable the 'allowDynamicVersions'\
     \ option in 'config.yml'."
   severity: "ERROR"

--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -96,7 +96,7 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
         labels: Map<String, String>
     ): List<ProjectAnalyzerResult> {
         if (definitionFile.name != PACKAGE_RESOLVED_NAME) {
-            requireLockfile(analysisRoot, definitionFile.parentFile, analyzerConfig.allowDynamicVersions) {
+            requireLockfileForStableVersions(analysisRoot, definitionFile, analyzerConfig.allowDynamicVersions) {
                 definitionFile.resolveSibling(PACKAGE_RESOLVED_NAME).isFile
             }
         }


### PR DESCRIPTION
Change the signature of the original `requireLockfile()` function to clarify that a lockfile is not unconditionally required. Also make more clear what condition callers should implement.

While at it, reduce `File` parameters to only `definitionFile`, which is sufficient to create a proper error message.