### PR TITLE
fix(model)!: Maintain custom ID types on PURL conversion

### DIFF
--- a/model/src/main/kotlin/utils/PurlExtensions.kt
+++ b/model/src/main/kotlin/utils/PurlExtensions.kt
@@ -35,11 +35,11 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 
 /**
- * Map an ORT [Identifier] type to the corresponding PURL type string, or fall back to "generic"
- * if there is no direct equivalent.
+ * Map an ORT [Identifier] type to the corresponding PURL type string, or fall back to using the lowercase ORT type if
+ * there is no direct equivalent.
  */
 fun Identifier.getPurlType(): String =
-    when (type.lowercase()) {
+    when (val purlType = type.lowercase()) {
         "bazel" -> "bazel"
         "bower" -> "bower"
         "carthage" -> "carthage"
@@ -57,8 +57,9 @@ fun Identifier.getPurlType(): String =
         "pod" -> "cocoapods"
         "pub" -> "pub"
         "pypi" -> "pypi"
+        "spdx", "spdxdocumentfile" -> "generic"
         "swift" -> "swift"
-        else -> "generic"
+        else -> purlType
     }
 
 /**

--- a/model/src/test/kotlin/utils/PurlExtensionsTest.kt
+++ b/model/src/test/kotlin/utils/PurlExtensionsTest.kt
@@ -60,10 +60,10 @@ class PurlExtensionsTest : WordSpec({
             purl shouldBe purl.lowercase()
         }
 
-        "use the generic type if it is not a known package manager" {
+        "use the lowercase type if it is not a known package manager" {
             val purl = Identifier("FooBar", "namespace", "name", "version").toPurl()
 
-            purl shouldStartWith "pkg:generic"
+            purl shouldStartWith "pkg:foobar"
         }
 
         "not use '/' for empty namespaces" {
@@ -203,8 +203,8 @@ class PurlExtensionsTest : WordSpec({
             Identifier("crate::foo:1.0").getPurlType() shouldBe "cargo"
         }
 
-        "return generic for unknown types" {
-            Identifier("Unknown::foo:1.0").getPurlType() shouldBe "generic"
+        "return the lowercase type if unknown" {
+            Identifier("Unknown::foo:1.0").getPurlType() shouldBe "unknown"
         }
     }
 

--- a/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
+++ b/plugins/reporters/fossid/src/test/kotlin/FossIdReporterTest.kt
@@ -242,7 +242,7 @@ private fun createReporterInput(vararg scanCodes: String): ReporterInput {
 
     val results = scanCodes.associateByTo(
         destination = sortedMapOf(),
-        keySelector = { Identifier.EMPTY.copy(name = it) },
+        keySelector = { Identifier.EMPTY.copy(type = "generic", name = it) },
         valueTransform = { code ->
             val unmatchedScanResult = ScanResult(
                 provenance = UnknownProvenance,


### PR DESCRIPTION
Just because the core of ORT does not know a type, it does not mean that the type is an unknown PURL type. For example, third-party analyzer plugins might depend on not coalescing unknown types to "generic".