### PR TITLE
cli-helper: Respect curated VCS path in package configuration create

### DIFF
--- a/cli-helper/src/funTest/kotlin/commands/packageconfig/CreateCommandFunTest.kt
+++ b/cli-helper/src/funTest/kotlin/commands/packageconfig/CreateCommandFunTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clihelper.commands.packageconfig
+
+import com.github.ajalt.clikt.testing.test
+
+import io.kotest.core.TestConfiguration
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.clihelper.HelperMain
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.PackageCurationData
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsInfoCurationData
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.config.ProviderPluginConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.scanner.storages.PackageBasedFileStorage
+import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
+
+class CreateCommandFunTest : WordSpec({
+    "The package-configuration create command" should {
+        "apply a VCS path curation configured via --config to stored scan results" {
+            val packageId = Identifier("Maven:example:package:1.0")
+            val repositoryVcs = VcsInfo(VcsType.GIT, "https://example.org/repository.git", "resolved-revision")
+
+            val storageDir = tempdir()
+            val outputDir = tempdir()
+            val ortConfigFile = createOrtConfig()
+
+            val scanResult = ScanResult(
+                provenance = RepositoryProvenance(repositoryVcs, "resolved-revision"),
+                scanner = ScannerDetails("scanner", "1.0", "configuration"),
+                summary = ScanSummary.EMPTY.copy(
+                    licenseFindings = setOf(
+                        LicenseFinding("MIT", TextLocation("module/src/test/ModuleTest.kt", 1)),
+                        LicenseFinding("MIT", TextLocation("other/src/test/OtherTest.kt", 1))
+                    )
+                )
+            )
+
+            val storage = PackageBasedFileStorage(LocalFileStorage(storageDir))
+            storage.add(packageId, scanResult)
+
+            val createResult = HelperMain().test(
+                "package-configuration",
+                "create",
+                "--config",
+                ortConfigFile.absolutePath,
+                "--scan-results-storage-dir",
+                storageDir.absolutePath,
+                "--package-id",
+                packageId.toCoordinates(),
+                "--output-dir",
+                outputDir.absolutePath,
+                "--generate-path-excludes"
+            )
+
+            createResult.statusCode shouldBe 0
+
+            val packageConfiguration = outputDir.resolve("vcs.yml").readValue<PackageConfiguration>()
+            val excludePatterns = packageConfiguration.pathExcludes.map { it.pattern }
+            excludePatterns should
+                containExactly("module/src/test/**")
+        }
+    }
+})
+
+private val PACKAGE_CURATION = PackageCuration(
+    id = Identifier("Maven:example:package:1.0"),
+    data = PackageCurationData(
+        comment = "Example curation.",
+        vcs = VcsInfoCurationData(
+            path = "module"
+        )
+    )
+)
+
+private fun TestConfiguration.createOrtConfig(): File {
+    val packageCurationsFile = tempfile(prefix = "curations", suffix = ".yml").apply {
+        writeText(listOf(PACKAGE_CURATION).toYaml())
+    }
+
+    val config = OrtConfiguration().copy(
+        packageCurationProviders = listOf(
+            ProviderPluginConfiguration(
+                type = "File",
+                options = mapOf(
+                    "path" to packageCurationsFile.absolutePath,
+                    "mustExist" to "true"
+                )
+            )
+        )
+    )
+
+    val ortConfigFile = tempfile(prefix = "config", suffix = ".yml").apply {
+        writeText(mapOf("ort" to config).toYaml())
+    }
+
+    return ortConfigFile
+}

--- a/cli-helper/src/main/kotlin/commands/packageconfig/CreateCommand.kt
+++ b/cli-helper/src/main/kotlin/commands/packageconfig/CreateCommand.kt
@@ -36,15 +36,20 @@ import org.ossreviewtoolkit.clihelper.utils.sortPathExcludes
 import org.ossreviewtoolkit.clihelper.utils.write
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.scanner.storages.PackageBasedFileStorage
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.safeMkdirs
+import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.spdxexpression.SpdxSingleLicenseExpression
 
@@ -53,6 +58,14 @@ internal class CreateCommand : OrtHelperCommand(
         "a corresponding scan result exists in the given ORT result for the respective provenance. The output " +
         "package configuration YAML files are written to the given output directory."
 ) {
+    private val configFile by option(
+        "--config",
+        help = "The path to the ORT configuration file that configures the package curation providers."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .default(ortConfigDirectory.resolve(ORT_CONFIG_FILENAME))
+
     private val scanResultsStorageDir by option(
         "--scan-results-storage-dir",
         help = "The scan results storage to read the scan results from."
@@ -126,8 +139,29 @@ internal class CreateCommand : OrtHelperCommand(
             )
         }
 
+        val ortConfig = OrtConfiguration.load(emptyMap(), configFile)
+        val packageCurationProviders = PackageCurationProviderFactory.create(ortConfig.packageCurationProviders)
+
+        val pkg = Package.EMPTY.copy(id = packageId)
+        val curations = packageCurationProviders.flatMap { (_, provider) ->
+            provider.getCurationsFor(listOf(pkg))
+        }
+
+        val curatedPackage = curations.filter { it.isApplicable(packageId) }
+            .fold(pkg.toCuratedPackage()) { cur, curation ->
+                curation.apply(cur)
+            }
+
+        val vcsPath = curatedPackage.metadata.vcsProcessed.path
+
         scanResults.forEach { scanResult ->
-            createPackageConfiguration(scanResult).writeToFile()
+            val resultToProcess = if (vcsPath.isNotEmpty() && scanResult.provenance is RepositoryProvenance) {
+                scanResult.filterByPath(vcsPath)
+            } else {
+                scanResult
+            }
+
+            createPackageConfiguration(resultToProcess).writeToFile()
         }
     }
 


### PR DESCRIPTION
## Summary

Following review feedback from @fviernau regarding the timescale problem (where curations are authored after scan results are imported):
- Added --config option to package-configuration create (CreateCommand) to load configured package curation providers, following the pattern of CreateAnalyzerResultFromPackageListCommand.
- When generating package configurations for repository scans, query curation providers for the target package and filter scan results by the curated VCS path (csProcessed.path).
- Generated path excludes are thus scoped to the curated subdirectory, resolving #8713 while keeping ImportScanResultsCommand untouched.

Supersedes #12374. Fixes #8713.

## Reproduction & Verification

- Added CreateCommandFunTest verifying that package-configuration create applies VCS path curations configured via --config to stored scan results, properly scoping generated path excludes to module/src/test/**.
- Preserved existing behavior when --config is not passed or no curations match.
