### PR TITLE
feat(node): Allow to specify the target platfrom (os + cpu) for the NPM analysis

### DIFF
--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific-darwin-x64-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific-darwin-x64-expected-output.yml
@@ -1,0 +1,80 @@
+---
+project:
+  id: "NPM::project-with-platform-specific-optional-dependenies:1.0.0"
+  definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific/package.json"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_VCS_PROCESSED_URL>"
+    revision: "<REPLACE_VCS_REVISION>"
+    path: "<REPLACE_VCS_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "devDependencies"
+    dependencies:
+    - id: "NPM::esbuild:0.28.2"
+      dependencies:
+      - id: "NPM:@esbuild:darwin-x64:0.28.2"
+packages:
+- id: "NPM::esbuild:0.28.2"
+  purl: "pkg:npm/esbuild@0.28.2"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "An extremely fast JavaScript and CSS bundler and minifier."
+  homepage_url: "https://github.com/evanw/esbuild#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz"
+    hash:
+      value: "0f43bd1bad955b72d24e2261e3abe5957ccf0816"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""
+- id: "NPM:@esbuild:darwin-x64:0.28.2"
+  purl: "pkg:npm/%40esbuild/darwin-x64@0.28.2"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "The macOS 64-bit binary for esbuild, a JavaScript bundler."
+  homepage_url: "https://github.com/evanw/esbuild#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz"
+    hash:
+      value: "510147c055a795588dbbe14fd6b1b8ad0a2f30de"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific-openbsd-arm64-expected-output.yml
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific-openbsd-arm64-expected-output.yml
@@ -1,0 +1,80 @@
+---
+project:
+  id: "NPM::project-with-platform-specific-optional-dependenies:1.0.0"
+  definition_file_path: "plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific/package.json"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_VCS_PROCESSED_URL>"
+    revision: "<REPLACE_VCS_REVISION>"
+    path: "<REPLACE_VCS_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "devDependencies"
+    dependencies:
+    - id: "NPM::esbuild:0.28.2"
+      dependencies:
+      - id: "NPM:@esbuild:openbsd-arm64:0.28.2"
+packages:
+- id: "NPM::esbuild:0.28.2"
+  purl: "pkg:npm/esbuild@0.28.2"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "An extremely fast JavaScript and CSS bundler and minifier."
+  homepage_url: "https://github.com/evanw/esbuild#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz"
+    hash:
+      value: "0f43bd1bad955b72d24e2261e3abe5957ccf0816"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""
+- id: "NPM:@esbuild:openbsd-arm64:0.28.2"
+  purl: "pkg:npm/%40esbuild/openbsd-arm64@0.28.2"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "The OpenBSD ARM 64-bit binary for esbuild, a JavaScript bundler."
+  homepage_url: "https://github.com/evanw/esbuild#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz"
+    hash:
+      value: "9eb32af104ac3dacf4edca01f596664aab0c73ef"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/evanw/esbuild.git"
+    revision: "609683d892977362a0f99026cb74b96263d728a9"
+    path: ""

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific/package-lock.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific/package-lock.json
@@ -1,0 +1,499 @@
+{
+  "name": "project-with-platform-specific-optional-dependenies",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "project-with-platform-specific-optional-dependenies",
+      "version": "1.0.0",
+      "devDependencies": {
+        "esbuild": "0.28.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    }
+  }
+}

--- a/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific/package.json
+++ b/plugins/package-managers/node/src/funTest/assets/projects/synthetic/npm/platform-specific/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "project-with-platform-specific-optional-dependenies",
+  "version": "1.0.0",
+  "devDependencies": {
+    "esbuild": "0.28.2"
+  },
+  "packageManager": "npm@11.17.0"
+}

--- a/plugins/package-managers/node/src/funTest/kotlin/npm/NpmFunTest.kt
+++ b/plugins/package-managers/node/src/funTest/kotlin/npm/NpmFunTest.kt
@@ -184,6 +184,32 @@ class NpmFunTest : StringSpec({
         result.toYaml() should matchExpectedResult(expectedResultFile, definitionFile)
     }
 
+    "Resolve platform-specific dependencies for 'openbsd', 'arm64'" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/platform-specific/package.json")
+        val expectedResultFile = getAssetFile(
+            "projects/synthetic/npm/platform-specific-openbsd-arm64-expected-output.yml"
+        )
+
+        val result = NpmFactory.create(
+            os = NpmConfig.Platform.OPENBSD,
+            cpu = NpmConfig.ProcessorArchitecture.ARM64
+        ).resolveSingleProject(definitionFile, resolveScopes = true)
+
+        patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
+    "Resolve platform-specific dependencies for 'darwin', 'x64'" {
+        val definitionFile = getAssetFile("projects/synthetic/npm/platform-specific/package.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/npm/platform-specific-darwin-x64-expected-output.yml")
+
+        val result = NpmFactory.create(
+            os = NpmConfig.Platform.DARWIN,
+            cpu = NpmConfig.ProcessorArchitecture.X64
+        ).resolveSingleProject(definitionFile, resolveScopes = true)
+
+        patchActualResult(result.toYaml()) should matchExpectedResult(expectedResultFile, definitionFile)
+    }
+
     "Use an explicitly specified Node.js version" {
         // The test processes a project that depends on a deprecated native library which is incompatible with newer
         // versions of Node.js. In Node.js >= 16, the `install` step fails. With version 14, the project can be

--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -244,6 +244,16 @@ class Npm(override val descriptor: PluginDescriptor = NpmFactory.descriptor, pri
             if (config.legacyPeerDeps) {
                 add("--legacy-peer-deps")
             }
+
+            if (config.os != null) {
+                add("--os")
+                add(config.os.name.lowercase())
+            }
+
+            if (config.cpu != null) {
+                add("--cpu")
+                add(config.cpu.name.lowercase())
+            }
         }
 
         val subcommand = if (managerType.hasLockfile(workingDir)) "ci" else "install"

--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -237,11 +237,14 @@ class Npm(override val descriptor: PluginDescriptor = NpmFactory.descriptor, pri
     }
 
     private fun installDependencies(workingDir: File): List<Issue> {
-        val options = listOfNotNull(
-            "--ignore-scripts",
-            "--no-audit",
-            "--legacy-peer-deps".takeIf { config.legacyPeerDeps }
-        )
+        val options = buildList {
+            add("--ignore-scripts")
+            add("--no-audit")
+
+            if (config.legacyPeerDeps) {
+                add("--legacy-peer-deps")
+            }
+        }
 
         val subcommand = if (managerType.hasLockfile(workingDir)) "ci" else "install"
 

--- a/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/Npm.kt
@@ -35,7 +35,6 @@ import org.ossreviewtoolkit.model.config.Includes
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.model.utils.isPathIncluded
 import org.ossreviewtoolkit.plugins.api.OrtPlugin
-import org.ossreviewtoolkit.plugins.api.OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor
 import org.ossreviewtoolkit.plugins.packagemanagers.node.ModuleInfoResolver
 import org.ossreviewtoolkit.plugins.packagemanagers.node.NPM_RUNTIME_CONFIGURATION_FILENAME
@@ -81,34 +80,6 @@ internal class NpmCommand(nodePath: String? = null, nodeVersion: String? = null)
             }
         }
 }
-
-data class NpmConfig(
-    /**
-     * If true, ignore any project-specific `.npmrc` files.
-     */
-    @OrtPluginOption(defaultValue = "false")
-    val ignoreProjectNpmrcFiles: Boolean,
-
-    /**
-     * If true, the "--legacy-peer-deps" flag is passed to NPM to ignore conflicts in peer dependencies which are
-     * reported since NPM 7. This allows to analyze NPM 6 projects with peer dependency conflicts. For more information
-     * see the [documentation](https://docs.npmjs.com/cli/v8/commands/npm-install#strict-peer-deps) and the
-     * [NPM Blog](https://blog.npmjs.org/post/626173315965468672/npm-v7-series-beta-release-and-semver-major).
-     */
-    @OrtPluginOption(defaultValue = "false")
-    val legacyPeerDeps: Boolean,
-
-    /**
-     * Allows configuring the version of Node.js to be used for the analysis. This implicitly also sets the NPM version
-     * because NPM is bundled with Node.js. The property is interpreted as follows: If it is unspecified, ORT uses the
-     * version of Node.js that is currently installed (or ships with the container image if using the ORT Docker
-     * image). If the property has the special value "*", ORT tries to set up the version requested by the project, in
-     * a `.node-version` or `.nvmrc` file, or in the `engines` field of the `package.json` file. Any other value of the
-     * property is interpreted as a specific version of Node.js to be used for the analysis.
-     */
-    @OrtPluginOption(defaultValue = "")
-    val nodeVersion: String
-)
 
 /**
  * The [Node package manager](https://www.npmjs.com/).

--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmConfig.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmConfig.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 The ORT Project Copyright Holders <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.plugins.packagemanagers.node.npm
+
+import org.ossreviewtoolkit.plugins.api.OrtPluginOption
+
+data class NpmConfig(
+    /**
+     * If true, ignore any project-specific `.npmrc` files.
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val ignoreProjectNpmrcFiles: Boolean,
+
+    /**
+     * If true, the "--legacy-peer-deps" flag is passed to NPM to ignore conflicts in peer dependencies which are
+     * reported since NPM 7. This allows to analyze NPM 6 projects with peer dependency conflicts. For more information
+     * see the [documentation](https://docs.npmjs.com/cli/v8/commands/npm-install#strict-peer-deps) and the
+     * [NPM Blog](https://blog.npmjs.org/post/626173315965468672/npm-v7-series-beta-release-and-semver-major).
+     */
+    @OrtPluginOption(defaultValue = "false")
+    val legacyPeerDeps: Boolean,
+
+    /**
+     * Allows configuring the version of Node.js to be used for the analysis. This implicitly also sets the NPM version
+     * because NPM is bundled with Node.js. The property is interpreted as follows: If it is unspecified, ORT uses the
+     * version of Node.js that is currently installed (or ships with the container image if using the ORT Docker
+     * image). If the property has the special value "*", ORT tries to set up the version requested by the project, in
+     * a `.node-version` or `.nvmrc` file, or in the `engines` field of the `package.json` file. Any other value of the
+     * property is interpreted as a specific version of Node.js to be used for the analysis.
+     */
+    @OrtPluginOption(defaultValue = "")
+    val nodeVersion: String
+)

--- a/plugins/package-managers/node/src/main/kotlin/npm/NpmConfig.kt
+++ b/plugins/package-managers/node/src/main/kotlin/npm/NpmConfig.kt
@@ -46,5 +46,44 @@ data class NpmConfig(
      * property is interpreted as a specific version of Node.js to be used for the analysis.
      */
     @OrtPluginOption(defaultValue = "")
-    val nodeVersion: String
-)
+    val nodeVersion: String,
+
+    /**
+     * Override OS of native modules to install. See also https://nodejs.org/api/process.html#processplatform.
+     */
+    val os: Platform?,
+
+    /**
+     * Override CPU architecture of native modules to install. See also https://nodejs.org/api/process.html#processarch.
+     */
+    val cpu: ProcessorArchitecture?
+) {
+    /**
+     * See https://nodejs.org/api/process.html#processarch.
+     */
+    enum class ProcessorArchitecture {
+        ARM,
+        ARM64,
+        IA32,
+        LOONG64,
+        MIPSEL,
+        PPC64,
+        RISCV64,
+        S390,
+        S390X,
+        X64
+    }
+
+    /**
+     * See https://nodejs.org/api/process.html#processplatform.
+     */
+    enum class Platform {
+        AIX,
+        DARWIN,
+        FREEBSD,
+        LINUX,
+        OPENBSD,
+        SUNOS,
+        WIN32
+    }
+}

--- a/plugins/package-managers/node/src/test/kotlin/NodePackageManagerDetectionTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/NodePackageManagerDetectionTest.kt
@@ -194,6 +194,7 @@ class NodePackageManagerDetectionTest : WordSpec({
                 "npm/list-issues/package.json",
                 "npm/no-lockfile/package.json",
                 "npm/node-modules/package.json",
+                "npm/platform-specific/package.json",
                 "npm/project-with-lockfile/package.json",
                 "npm/shrinkwrap/package.json",
                 "npm/version-urls/package.json",

--- a/plugins/package-managers/node/src/test/kotlin/NodePackageManagerDetectionTest.kt
+++ b/plugins/package-managers/node/src/test/kotlin/NodePackageManagerDetectionTest.kt
@@ -189,16 +189,16 @@ class NodePackageManagerDetectionTest : WordSpec({
             val filteredFiles = NodePackageManagerDetection(definitionFiles).filterApplicable(NPM)
 
             filteredFiles.map { it.relativeTo(projectDir).invariantSeparatorsPath } should containExactlyInAnyOrder(
+                "npm/babel/package.json",
+                "npm/fix-version/package.json",
+                "npm/list-issues/package.json",
                 "npm/no-lockfile/package.json",
                 "npm/node-modules/package.json",
                 "npm/project-with-lockfile/package.json",
                 "npm/shrinkwrap/package.json",
-                "npm/list-issues/package.json",
-                "npm/babel/package.json",
                 "npm/version-urls/package.json",
                 "npm/workspaces/non-workspace/pkg3/package.json",
-                "npm/workspaces/package.json",
-                "npm/fix-version/package.json"
+                "npm/workspaces/package.json"
             )
         }
     }


### PR DESCRIPTION
This implements one approach found in scope of #11782.

For example, it enables to run an analysis on `linux arm64` (on CI) for target platform `darwin, x64` .
