### PR TITLE
fix(scanner): Stop calling `put()` on the file list map from different threads

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -736,24 +736,27 @@ class Scanner(
                             "Creating file list for provenance ${index + 1} of ${provenances.size}."
                         }
 
-                        runCatching {
-                            val fileList = fileListResolver.resolve(provenance)
-                            controller.putFileList(provenance, fileList)
-                        }.onFailure { e ->
-                            e.showStackTrace()
-
-                            idsByProvenance.getValue(provenance).forEach { id ->
-                                val issue = createAndLogIssue(
-                                    source = "Downloader",
-                                    message = "Could not create file list for " +
-                                        "'${id.toCoordinates()}': ${e.collectMessages()}"
-                                )
-
-                                controller.addIssue(id, issue)
-                            }
+                        provenance to runCatching {
+                            fileListResolver.resolve(provenance)
                         }
                     }
-                }.awaitAll()
+                }.awaitAll().forEach { (provenance, result) ->
+                    result.onSuccess { fileList ->
+                        controller.putFileList(provenance, fileList)
+                    }.onFailure { e ->
+                        e.showStackTrace()
+
+                        idsByProvenance.getValue(provenance).forEach { id ->
+                            val issue = createAndLogIssue(
+                                source = "Downloader",
+                                message = "Could not create file list for " +
+                                    "'${id.toCoordinates()}': ${e.collectMessages()}"
+                            )
+
+                            controller.addIssue(id, issue)
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Align `createFileLists()` with `resolvePackageProvenances()` with regard to how concurrency is handled. Run only the file list creation concurrently, but call `controller.putFileList()` always from the same thread.

This probably fixes [1][2], but cannot be verified as that problem happens only rarely and randomly.

Could not create file list for 'NPM:{"$namespace:$name:$version"}': ClassCastException: class java.util.LinkedHashMap$Entry cannot be cast to class java.util.HashMap$TreeNode (java.util.LinkedHashMap$Entry and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')

Fixes: #12435.

[1]: https://github.com/cariad-optima/optima/issues/2207 [2]: Could not create file list for 'NPM:{"$namespace:$name:$version"}':
       ClassCastException: class java.util.LinkedHashMap$Entry cannot
         be cast to class java.util.HashMap$TreeNode
         (java.util.LinkedHashMap$Entry and java.util.HashMap$TreeNode
         are in module java.base of loader 'bootstrap')

