### PR TITLE
feat(scancode): Do not return texts for generic licenses

### DIFF
--- a/plugins/license-fact-providers/scancode/src/funTest/kotlin/ScanCodeLicenseFactProviderFunTest.kt
+++ b/plugins/license-fact-providers/scancode/src/funTest/kotlin/ScanCodeLicenseFactProviderFunTest.kt
@@ -40,6 +40,10 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
         "return null for an existing license which does not have a text" {
             provider.getLicenseText("LicenseRef-scancode-proprietary") shouldBe null
         }
+
+        "return null for a generic license which does have a text" {
+            provider.getLicenseText("LicenseRef-scancode-proprietary-license") shouldBe null
+        }
     }
 
     "hasLicenseText()" should {
@@ -49,6 +53,10 @@ class ScanCodeLicenseFactProviderFunTest : WordSpec({
 
         "return false for an existing license which does not have a text" {
             provider.hasLicenseText("LicenseRef-scancode-proprietary") shouldBe false
+        }
+
+        "return false for a generic license which does have a text" {
+            provider.hasLicenseText("LicenseRef-scancode-proprietary-license") shouldBe false
         }
     }
 })

--- a/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
+++ b/plugins/license-fact-providers/scancode/src/main/kotlin/ScanCodeLicenseFactProvider.kt
@@ -64,7 +64,9 @@ class ScanCodeLicenseFactProvider(
      */
     private val licenseDataDirReader: ScanCodeLicenseDataDirReader? by lazy {
         findLicenseDataDir(config)?.let {
-            ScanCodeLicenseDataDirReader(it) { scanCodeLicense -> scanCodeLicense.text != null }
+            ScanCodeLicenseDataDirReader(it) { scanCodeLicense ->
+                scanCodeLicense.text != null && !scanCodeLicense.isGeneric
+            }
         }
     }
 


### PR DESCRIPTION
ScanCode licenses which are annotated with `is_generic: yes` are artificial licenses, which do not correspond to a particular license text. However, some of these generic license have a text associated. Stop returning texts for these, to ensure no such text gets accidentally used as license text.

------

This is a follow-up for https://github.com/oss-review-toolkit/ort/issues/12369 in context of https://github.com/oss-review-toolkit/ort/issues/12369.